### PR TITLE
Remove seed from state

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -148,9 +148,6 @@ class State(Serializable):
     world_size: int = 1
     nproc_per_node: int = 1
 
-    # random seed
-    seed: Optional[int] = None
-
     @property
     def global_rank(self) -> int:
         return get_global_rank()

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -183,6 +183,7 @@ class Trainer:
         # If hparams is used to create the Trainer this function is called twice
         # which is okay because all runs with the hparams codepath will do this
         seed_all(seed)
+        self.seed = seed
 
         if not algorithms:
             algorithms = []
@@ -210,8 +211,7 @@ class Trainer:
                            precision=precision,
                            precision_context=self.device.precision_context,
                            nproc_per_node=self.device.nproc_per_node,
-                           world_size=self.ddp.world_size,
-                           seed=seed)
+                           world_size=self.ddp.world_size)
 
         if not log_destinations:
             log_destinations = [TQDMLoggerBackend()]
@@ -618,6 +618,7 @@ class Trainer:
                     state.step += 1
                     if self.checkpointer and self.checkpointer.should_checkpoint(state=state, event=Event.BATCH_END):
                         self.checkpointer.save_checkpoint(state=state,
+                                                          seed=self.seed,
                                                           device=self.device,
                                                           ddp=self.ddp,
                                                           config=self.config)
@@ -633,7 +634,11 @@ class Trainer:
             state.epoch += 1
 
             if self.checkpointer and self.checkpointer.should_checkpoint(state=state, event=Event.EPOCH_END):
-                self.checkpointer.save_checkpoint(state=state, device=self.device, ddp=self.ddp, config=self.config)
+                self.checkpointer.save_checkpoint(state=state,
+                                                  seed=self.seed,
+                                                  device=self.device,
+                                                  ddp=self.ddp,
+                                                  config=self.config)
 
         self.engine.run_event(Event.TRAINING_END)
 


### PR DESCRIPTION
Removed the seed from the state and stored it in the `checkpoint_rng` object. This PR is a simple refactor and doesn't change any checkpointing logic which currently does not have properly defined behavior in the case where a user does not specify a seed and then resumes from checkpoint (see below). 

Related issues: #10 

Note that a follow up to this is addressing #12 so resuming from checkpoint behaves correctly. Not including that change here because it involves a major DDP refactor. 