### PR TITLE
Fixed batch pair

### DIFF
--- a/composer/core/types.py
+++ b/composer/core/types.py
@@ -23,7 +23,10 @@ from composer.core.state import State as State
 
 Tensor = torch.Tensor
 Tensors = Union[Tensor, Tuple[Tensor, ...], List[Tensor]]
-BatchPair = Tuple[Tensors, Tensors]
+
+# For BatchPar, if it is a list, then it should always be of length 2.
+# Pytorch's default collate_fn returns a list even when the dataset returns a tuple.
+BatchPair = Union[Tuple[Tensors, Tensors], List[Tensor]]
 BatchDict = Dict[str, Tensor]
 Batch = Union[BatchPair, BatchDict, Tensor]
 

--- a/composer/trainer/devices/device_gpu.py
+++ b/composer/trainer/devices/device_gpu.py
@@ -86,7 +86,7 @@ class CudaDataLoader(WrappedDataLoader):
         """
         if isinstance(batch, Tensor):
             return cast(Tensor, self._to_device(batch))
-        if isinstance(batch, tuple):  # BatchPair
+        if isinstance(batch, (tuple, list)):  # BatchPair
             return cast(BatchPair, tuple(self._to_device(x) for x in batch))
         if isinstance(batch, dict):  # BatchDict
             return {k: cast(Tensor, self._to_device(v)) for k, v in batch.items()}


### PR DESCRIPTION
Allowing lists for batch pair, as pytoch's default collate_fn returns a list, even when the dataset returns a tuple. See https://github.com/pytorch/pytorch/blob/a72a6365c9f4f1cebfcb6a686bbcc7e8647c14d5/torch/utils/data/_utils/collate.py#L84