### PR TITLE
Added repeat to the torch profiler

### DIFF
--- a/composer/callbacks/callback_hparams.py
+++ b/composer/callbacks/callback_hparams.py
@@ -134,6 +134,7 @@ class TorchProfilerHparams(CallbackHparams):
     warmup: int = hp.optional("Number of warmup batches in a cycle", default=1)
     active: int = hp.optional("Number of batches to profile in a cycle", default=5)
     wait: int = hp.optional("Number of batches to skip at the end of each cycle", default=0)
+    repeat: int = hp.optional("Maximum number of profiling cycle repetitions per epoch (0 for no maximum)", default=0)
 
     def initialize_object(self) -> TorchProfiler:
         from composer.callbacks.torch_profiler import TorchProfiler

--- a/composer/callbacks/torch_profiler.py
+++ b/composer/callbacks/torch_profiler.py
@@ -120,7 +120,6 @@ class TorchProfiler(Callback):
             if torch_scheduler_action == ProfilerAction.RECORD:
                 # force saving at epoch boundaries
                 torch_scheduler_action = ProfilerAction.RECORD_AND_SAVE
-        print("ACTION", torch_scheduler_action)
         return torch_scheduler_action
 
     def training_start(self, state: State, logger: Logger) -> None:

--- a/composer/callbacks/torch_profiler.py
+++ b/composer/callbacks/torch_profiler.py
@@ -73,6 +73,7 @@ class TorchProfiler(Callback):
         warmup: int = 1,
         active: int = 5,
         wait: int = 0,
+        repeat: int = 0,
     ) -> None:
         super().__init__()
         self.hparams = TorchProfilerHparams(
@@ -86,6 +87,7 @@ class TorchProfiler(Callback):
             profile_memory=profile_memory,
             with_stack=with_stack,
             with_flops=with_flops,
+            repeat=repeat,
         )
         self.profiler: Optional[torch.profiler.profile] = None
         self.profiler_state: _TorchProfilerState = _TorchProfilerState()
@@ -94,6 +96,7 @@ class TorchProfiler(Callback):
             warmup=self.hparams.warmup,
             active=self.hparams.active,
             skip_first=self.hparams.skip,
+            repeat=self.hparams.repeat,
         )
 
     def state_dict(self) -> StateDict:
@@ -117,6 +120,7 @@ class TorchProfiler(Callback):
             if torch_scheduler_action == ProfilerAction.RECORD:
                 # force saving at epoch boundaries
                 torch_scheduler_action = ProfilerAction.RECORD_AND_SAVE
+        print("ACTION", torch_scheduler_action)
         return torch_scheduler_action
 
     def training_start(self, state: State, logger: Logger) -> None:


### PR DESCRIPTION
Added the repeat argument to the hparams for the torch profiler callback

This makes it possible to profile only N times per epoch. Profiling slows down the training process significantly!