### PR TITLE
Cleanup dataloader threads to allow termination

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -642,6 +642,10 @@ class Trainer:
 
         self.engine.run_event(Event.TRAINING_END)
 
+        # Deleting the dataloaders ensures their worker threads get cleaned up.
+        del state.train_dataloader
+        del state.eval_dataloader
+
     def _train_batch(self, microbatches: Sequence[Batch], ddp_sync: bool = True):
         """Run training on a full batch of data.
 


### PR DESCRIPTION
Resolves #51 .

Seems that the problem was that the threads initialized by the dataloaders were preventing processes from exiting. I'm a little confused why this only became a problem after launch, but I've been able to confirm that this is definitely the issue.