### PR TITLE
Additional`SyntheticDataset` Customization

### DIFF
--- a/composer/datasets/synthetic.py
+++ b/composer/datasets/synthetic.py
@@ -126,7 +126,9 @@ class SyntheticDatasetHparams(DatasetHparams):
     memory_format: MemoryFormat = hp.optional("Memory format for the sample pool",
                                               default=MemoryFormat.CONTIGUOUS_FORMAT)
     sample_pool_size: int = hp.optional("Number of samples", default=100)
-    total_dataset_size: int = hp.optional("Total size of the dataset to emulate", default=100)
+    total_dataset_size: int = hp.optional(
+        "Total size of the dataset to emulate. "
+        "If None defaults to sample_pool_size.", default=None)
     drop_last: bool = hp.optional("Whether to drop the last samples for the last batch", default=True)
     shuffle: bool = hp.optional("Whether to shuffle the dataset for each epoch", default=True)
     data_type: SyntheticDataType = hp.optional("Type of synthetic data to create.", default=SyntheticDataType.GAUSSIAN)

--- a/composer/datasets/synthetic.py
+++ b/composer/datasets/synthetic.py
@@ -141,6 +141,7 @@ class SyntheticDatasetHparams(DatasetHparams):
                 memory_format=self.memory_format,
                 sample_pool_size=self.sample_pool_size,
                 data_type=self.data_type,
+                total_dataset_size=self.total_dataset_size,
             ),
             drop_last=self.drop_last,
             shuffle=False,

--- a/composer/datasets/synthetic.py
+++ b/composer/datasets/synthetic.py
@@ -72,9 +72,7 @@ class SyntheticDataset(torch.utils.data.Dataset):
         self.memory_format = getattr(torch, MemoryFormat(memory_format).value)
         self.transform = transform
 
-        _validate_label_inputs(label_type=self.label_type,
-                               num_classes=self.num_classes,
-                               label_shape=self.label_shape)
+        _validate_label_inputs(label_type=self.label_type, num_classes=self.num_classes, label_shape=self.label_shape)
 
         # The synthetic data
         self.input_data = None
@@ -179,9 +177,7 @@ class SyntheticDatasetHparams(DatasetHparams):
     def validate(self):
         super().validate()
 
-        _validate_label_inputs(label_type=self.label_type,
-                               num_classes=self.num_classes,
-                               label_shape=self.label_shape)
+        _validate_label_inputs(label_type=self.label_type, num_classes=self.num_classes, label_shape=self.label_shape)
 
     def initialize_object(self) -> DataloaderSpec:
         return DataloaderSpec(
@@ -201,8 +197,7 @@ class SyntheticDatasetHparams(DatasetHparams):
         )
 
 
-def _validate_label_inputs(label_type: SyntheticDataLabelType,
-                           num_classes: Optional[int],
+def _validate_label_inputs(label_type: SyntheticDataLabelType, num_classes: Optional[int],
                            label_shape: Optional[Sequence[int]]):
     if label_type == SyntheticDataLabelType.CLASSIFICATION_INT or label_type == SyntheticDataLabelType.CLASSIFICATION_ONE_HOT:
         if num_classes is None or num_classes <= 0:

--- a/composer/datasets/synthetic.py
+++ b/composer/datasets/synthetic.py
@@ -53,7 +53,7 @@ class SyntheticDataset(torch.utils.data.Dataset):
         return self.total_dataset_size
 
     def __getitem__(self, idx: int):
-        idx = idx % self.total_dataset_size
+        idx = idx % self.batch_size
         if self.input_data is None:
             # Generating data on the first call to __getitem__ so that data is stored on the correct gpu,
             # after DeviceSingleGPU calls torch.cuda.set_device

--- a/composer/datasets/synthetic.py
+++ b/composer/datasets/synthetic.py
@@ -99,13 +99,17 @@ class SyntheticDataset(torch.utils.data.Dataset):
                 self.data_type == SyntheticDataType.SEPARABLE:
                 input_data = torch.randn(self.num_unique_samples_to_create, *self.data_shape, device=self.device)
             elif self.data_type == SyntheticDataType.INCREASING:
-                input_data = torch.arange(start=0, end=self.num_unique_samples_to_create, step=1, dtype=torch.float, device=self.device)
+                input_data = torch.arange(start=0,
+                                          end=self.num_unique_samples_to_create,
+                                          step=1,
+                                          dtype=torch.float,
+                                          device=self.device)
                 input_data = input_data.reshape(self.num_unique_samples_to_create, *(1 for _ in self.data_shape))
                 input_data = input_data.expand(self.num_unique_samples_to_create, *self.data_shape)  # returns a view
             else:
                 raise ValueError(f"Unsupported data type {self.data_type}")
 
-            input_data = torch.clone(input_data) # allocate actual memory
+            input_data = torch.clone(input_data)  # allocate actual memory
             input_data = input_data.contiguous(memory_format=self.memory_format)
 
             if self.label_type == SyntheticDataLabelType.CLASSIFICATION:
@@ -113,11 +117,15 @@ class SyntheticDataset(torch.utils.data.Dataset):
                     input_target = torch.empty(self.num_unique_samples_to_create, self.num_classes, device=self.device)
                     input_target[:, 0] = 1.0
                 else:
-                    input_target = torch.randint(0, self.num_classes, (self.num_unique_samples_to_create,), device=self.device)
+                    input_target = torch.randint(0,
+                                                 self.num_classes, (self.num_unique_samples_to_create,),
+                                                 device=self.device)
             elif self.label_type == SyntheticDataLabelType.RANDOM_INT:
                 # use a dummy value for max int value
                 dummy_max = 10
-                input_target = torch.randint(0, dummy_max, (self.num_unique_samples_to_create, *self.label_shape), device=self.device)
+                input_target = torch.randint(0,
+                                             dummy_max, (self.num_unique_samples_to_create, *self.label_shape),
+                                             device=self.device)
             else:
                 raise ValueError(f"Unsupported label type {self.data_type}")
 
@@ -151,8 +159,7 @@ class SyntheticDatasetHparams(DatasetHparams):
 
     total_dataset_size: int = hp.required("The total size of the dataset to emulate.")
     data_shape: List[int] = hp.required("Shape of the data tensor.")
-    num_unique_samples_to_create: int = hp.optional(
-        "The number of unique samples to allocate memory for.", default=100)
+    num_unique_samples_to_create: int = hp.optional("The number of unique samples to allocate memory for.", default=100)
     data_type: SyntheticDataType = hp.optional("Type of synthetic data to create.", default=SyntheticDataType.GAUSSIAN)
     label_type: SyntheticDataLabelType = hp.optional("Type of synthetic label to create.",
                                                      default=SyntheticDataLabelType.CLASSIFICATION)

--- a/composer/datasets/synthetic.py
+++ b/composer/datasets/synthetic.py
@@ -108,6 +108,7 @@ class SyntheticDataset(torch.utils.data.Dataset):
             input_data = input_data.contiguous(memory_format=self.memory_format)
 
             if self.label_type == SyntheticDataLabelType.CLASSIFICATION_ONE_HOT:
+                assert self.num_classes is not None
                 input_target = torch.empty((self.num_unique_samples_to_create, self.num_classes), device=self.device)
                 input_target[:, 0] = 1.0
             elif self.label_type == SyntheticDataLabelType.CLASSIFICATION_INT:

--- a/composer/yamls/models/resnet101_synthetic.yaml
+++ b/composer/yamls/models/resnet101_synthetic.yaml
@@ -3,7 +3,6 @@ train_dataset:
     total_dataset_size: 4096
     data_shape: [3, 224, 224]
     num_classes: 1000
-    one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
     shuffle: true
@@ -13,7 +12,6 @@ val_dataset:
     total_dataset_size: 2000
     data_shape: [3, 224, 224]
     num_classes: 1000
-    one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
     shuffle: true

--- a/composer/yamls/models/resnet101_synthetic.yaml
+++ b/composer/yamls/models/resnet101_synthetic.yaml
@@ -1,8 +1,8 @@
 train_dataset:
   synthetic:
+    total_dataset_size: 4096
+    data_shape: [3, 224, 224]
     num_classes: 1000
-    shape: [3, 224, 224]
-    sample_pool_size: 4096
     one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
@@ -10,9 +10,9 @@ train_dataset:
     drop_last: true
 val_dataset:
   synthetic:
+    total_dataset_size: 2000
+    data_shape: [3, 224, 224]
     num_classes: 1000
-    shape: [3, 224, 224]
-    sample_pool_size: 2000
     one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT

--- a/composer/yamls/models/resnet18_synthetic.yaml
+++ b/composer/yamls/models/resnet18_synthetic.yaml
@@ -3,7 +3,6 @@ train_dataset:
     total_dataset_size: 4096
     data_shape: [3, 224, 224]
     num_classes: 1000
-    one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
     shuffle: true
@@ -13,7 +12,6 @@ val_dataset:
     total_dataset_size: 2000
     data_shape: [3, 224, 224]
     num_classes: 1000
-    one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
     shuffle: true

--- a/composer/yamls/models/resnet18_synthetic.yaml
+++ b/composer/yamls/models/resnet18_synthetic.yaml
@@ -1,8 +1,8 @@
 train_dataset:
   synthetic:
+    total_dataset_size: 4096
+    data_shape: [3, 224, 224]
     num_classes: 1000
-    shape: [3, 224, 224]
-    sample_pool_size: 4096
     one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
@@ -10,9 +10,9 @@ train_dataset:
     drop_last: true
 val_dataset:
   synthetic:
+    total_dataset_size: 2000
+    data_shape: [3, 224, 224]
     num_classes: 1000
-    shape: [3, 224, 224]
-    sample_pool_size: 2000
     one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT

--- a/composer/yamls/models/resnet50_synthetic.yaml
+++ b/composer/yamls/models/resnet50_synthetic.yaml
@@ -3,7 +3,6 @@ train_dataset:
     total_dataset_size: 12288
     data_shape: [3, 224, 224]
     num_classes: 1000
-    one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
     shuffle: true
@@ -13,7 +12,6 @@ val_dataset:
     total_dataset_size: 2000
     data_shape: [3, 224, 224]
     num_classes: 1000
-    one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
     shuffle: true

--- a/composer/yamls/models/resnet50_synthetic.yaml
+++ b/composer/yamls/models/resnet50_synthetic.yaml
@@ -1,8 +1,8 @@
 train_dataset:
   synthetic:
+    total_dataset_size: 12288
+    data_shape: [3, 224, 224]
     num_classes: 1000
-    shape: [3, 224, 224]
-    sample_pool_size: 12288
     one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
@@ -10,9 +10,9 @@ train_dataset:
     drop_last: true
 val_dataset:
   synthetic:
+    total_dataset_size: 2000
+    data_shape: [3, 224, 224]
     num_classes: 1000
-    shape: [3, 224, 224]
-    sample_pool_size: 2000
     one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT

--- a/composer/yamls/models/resnet56_cifar10_synthetic.yaml
+++ b/composer/yamls/models/resnet56_cifar10_synthetic.yaml
@@ -1,8 +1,8 @@
 train_dataset:
   synthetic:
+    total_dataset_size: 4096
+    data_shape: [3, 32, 32]
     num_classes: 10
-    shape: [3, 32, 32]
-    sample_pool_size: 4096
     one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
@@ -10,9 +10,9 @@ train_dataset:
     drop_last: true
 val_dataset:
   synthetic:
+    total_dataset_size: 2000
+    data_shape: [3, 32, 32]
     num_classes: 10
-    shape: [3, 32, 32]
-    sample_pool_size: 2000
     one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT

--- a/composer/yamls/models/resnet56_cifar10_synthetic.yaml
+++ b/composer/yamls/models/resnet56_cifar10_synthetic.yaml
@@ -3,7 +3,6 @@ train_dataset:
     total_dataset_size: 4096
     data_shape: [3, 32, 32]
     num_classes: 10
-    one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
     shuffle: true
@@ -13,7 +12,6 @@ val_dataset:
     total_dataset_size: 2000
     data_shape: [3, 32, 32]
     num_classes: 10
-    one_hot: false
     device: cpu
     memory_format: CONTIGUOUS_FORMAT
     shuffle: true

--- a/tests/algorithms/test_stochastic_depth.py
+++ b/tests/algorithms/test_stochastic_depth.py
@@ -24,7 +24,6 @@ def dummy_state(dummy_dataloader_hparams: DataloaderHparams):
                                               data_shape=[3, 32, 32],
                                               num_classes=10,
                                               device="cpu",
-                                              one_hot=False,
                                               drop_last=True,
                                               shuffle=False)
     train_dataloader = get_dataloader(dataset_hparams.initialize_object(), dummy_dataloader_hparams, batch_size=100)

--- a/tests/algorithms/test_stochastic_depth.py
+++ b/tests/algorithms/test_stochastic_depth.py
@@ -20,9 +20,9 @@ from tests.fixtures.dummy_fixtures import get_dataloader
 @pytest.fixture()
 def dummy_state(dummy_dataloader_hparams: DataloaderHparams):
     model = ResNet50Hparams(num_classes=100).initialize_object()
-    dataset_hparams = SyntheticDatasetHparams(num_classes=10,
-                                              shape=[3, 32, 32],
-                                              sample_pool_size=1000000,
+    dataset_hparams = SyntheticDatasetHparams(batch_size=1000000,
+                                              data_shape=[3, 32, 32],
+                                              num_classes=10,
                                               device="cpu",
                                               one_hot=False,
                                               drop_last=True,

--- a/tests/algorithms/test_stochastic_depth.py
+++ b/tests/algorithms/test_stochastic_depth.py
@@ -20,7 +20,7 @@ from tests.fixtures.dummy_fixtures import get_dataloader
 @pytest.fixture()
 def dummy_state(dummy_dataloader_hparams: DataloaderHparams):
     model = ResNet50Hparams(num_classes=100).initialize_object()
-    dataset_hparams = SyntheticDatasetHparams(batch_size=1000000,
+    dataset_hparams = SyntheticDatasetHparams(total_dataset_size=1000000,
                                               data_shape=[3, 32, 32],
                                               num_classes=10,
                                               device="cpu",

--- a/tests/callbacks/test_grad_monitor.py
+++ b/tests/callbacks/test_grad_monitor.py
@@ -21,7 +21,7 @@ def _do_trainer_fit(mosaic_trainer_hparams: TrainerHparams, log_layers=False):
     trainer.fit()
 
     assert isinstance(mosaic_trainer_hparams.train_dataset, SyntheticDatasetHparams)
-    num_train_samples = mosaic_trainer_hparams.train_dataset.sample_pool_size
+    num_train_samples = mosaic_trainer_hparams.train_dataset.total_dataset_size
     num_train_steps = num_train_samples // mosaic_trainer_hparams.total_batch_size
 
     return log_destination, num_train_steps

--- a/tests/callbacks/test_memory_monitor.py
+++ b/tests/callbacks/test_memory_monitor.py
@@ -41,7 +41,6 @@ def _do_trainer_fit(mosaic_trainer_hparams: TrainerHparams, testing_with_gpu: bo
 
 
 @pytest.mark.timeout(60)
-@pytest.mark.run_long
 def test_memory_monitor_cpu(mosaic_trainer_hparams: TrainerHparams):
     log_destination, _ = _do_trainer_fit(mosaic_trainer_hparams, testing_with_gpu=False)
 
@@ -56,7 +55,6 @@ def test_memory_monitor_cpu(mosaic_trainer_hparams: TrainerHparams):
 
 
 @pytest.mark.timeout(60)
-@pytest.mark.run_long
 def test_memory_monitor_gpu(mosaic_trainer_hparams: TrainerHparams):
     n_cuda_devices = device_count()
     if n_cuda_devices > 0:

--- a/tests/callbacks/test_memory_monitor.py
+++ b/tests/callbacks/test_memory_monitor.py
@@ -32,7 +32,7 @@ def _do_trainer_fit(mosaic_trainer_hparams: TrainerHparams, testing_with_gpu: bo
     trainer.fit()
 
     assert isinstance(mosaic_trainer_hparams.train_dataset, SyntheticDatasetHparams)
-    num_train_samples = mosaic_trainer_hparams.train_dataset.sample_pool_size
+    num_train_samples = mosaic_trainer_hparams.train_dataset.total_dataset_size
     num_train_steps = num_train_samples // mosaic_trainer_hparams.total_batch_size
 
     expected_calls = num_train_steps * mosaic_trainer_hparams.max_epochs

--- a/tests/datasets/__init__.py
+++ b/tests/datasets/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2021 MosaicML. All Rights Reserved.

--- a/tests/datasets/test_synthetic_data.py
+++ b/tests/datasets/test_synthetic_data.py
@@ -49,6 +49,9 @@ def test_synthetic_data_creation(data_type: SyntheticDataType, label_type: Synth
     elif label_type == SyntheticDataLabelType.RANDOM_INT:
         assert y.size() == label_shape
 
+    # check that points were allocated in memory after the first call to __getitem__
+    assert dataset.input_data is not None
+    assert dataset.input_target is not None
     # check that the correct number of points were allocated in memory
     assert dataset.input_data.size()[0] == num_samples_to_create
     assert dataset.input_target.size()[0] == num_samples_to_create

--- a/tests/datasets/test_synthetic_data.py
+++ b/tests/datasets/test_synthetic_data.py
@@ -1,0 +1,70 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+from typing import Optional
+
+import pytest
+
+from composer.datasets import SyntheticDataset
+from composer.datasets.synthetic import SyntheticDataLabelType, SyntheticDataType
+
+
+@pytest.mark.parametrize('data_type', [
+    SyntheticDataType.GAUSSIAN,
+    SyntheticDataLabelType.CLASSIFICATION_INT,
+])
+@pytest.mark.parametrize('label_type', [
+    SyntheticDataLabelType.CLASSIFICATION_ONE_HOT,
+    SyntheticDataLabelType.CLASSIFICATION_INT,
+    SyntheticDataLabelType.RANDOM_INT,
+])
+def test_synthetic_data_creation(data_type: SyntheticDataType, label_type: SyntheticDataLabelType):
+    if data_type == SyntheticDataType.SEPARABLE and label_type != SyntheticDataLabelType.CLASSIFICATION_INT:
+        # skip because not supported
+        return
+
+    dataset_size = 1000
+    data_shape = (3, 32, 32)
+    num_samples_to_create = 10
+    num_classes = 10
+    label_shape = (1, 10, 12)
+    dataset = SyntheticDataset(total_dataset_size=dataset_size,
+                               data_shape=data_shape,
+                               num_unique_samples_to_create=num_samples_to_create,
+                               data_type=data_type,
+                               label_type=label_type,
+                               num_classes=num_classes,
+                               label_shape=label_shape)
+
+    assert len(dataset) == dataset_size
+
+    # verify datapoints are correct
+    x, y = dataset[0]
+    assert x.size() == data_shape
+    if label_type == SyntheticDataLabelType.CLASSIFICATION_INT:
+        assert isinstance(y.item(), int)
+    elif label_type == SyntheticDataLabelType.CLASSIFICATION_ONE_HOT:
+        assert y.size() == (num_classes,)
+        assert min(y) == 0
+        assert max(y) == 1
+    elif label_type == SyntheticDataLabelType.RANDOM_INT:
+        assert y.size() == label_shape
+
+    # check that the correct number of points were allocated in memory
+    assert dataset.input_data.size()[0] == num_samples_to_create
+    assert dataset.input_target.size()[0] == num_samples_to_create
+
+    # verify that you can getch points outside the num_samples_to_create range
+    # (still within the total dataset size range)
+    x, y = dataset[num_samples_to_create + 1]
+    assert x is not None
+    assert y is not None
+
+
+@pytest.mark.parametrize('label_type', [
+    SyntheticDataLabelType.CLASSIFICATION_ONE_HOT,
+    SyntheticDataLabelType.CLASSIFICATION_INT,
+])
+@pytest.mark.parametrize('num_classes', [None, 0])
+def test_synthetic_classification_param_validation(label_type: SyntheticDataLabelType, num_classes: Optional[int]):
+    with pytest.raises(ValueError):
+        SyntheticDataset(total_dataset_size=10, data_shape=(2, 2), label_type=label_type, num_classes=num_classes)

--- a/tests/fixtures/dummy_fixtures.py
+++ b/tests/fixtures/dummy_fixtures.py
@@ -54,12 +54,12 @@ def dummy_model(dummy_model_hparams: SimpleBatchPairModelHparams) -> SimpleBatch
 
 @pytest.fixture
 def dummy_train_dataset_hparams(dummy_model: SimpleBatchPairModel) -> SyntheticDatasetHparams:
-    return dummy_model.get_dataset_hparams(sample_pool_size=300, drop_last=True, shuffle=True)
+    return dummy_model.get_dataset_hparams(total_dataset_size=300, drop_last=True, shuffle=True)
 
 
 @pytest.fixture
 def dummy_val_dataset_hparams(dummy_model: SimpleBatchPairModel) -> SyntheticDatasetHparams:
-    return dummy_model.get_dataset_hparams(sample_pool_size=100, drop_last=False, shuffle=False)
+    return dummy_model.get_dataset_hparams(total_dataset_size=100, drop_last=False, shuffle=False)
 
 
 @pytest.fixture

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -9,7 +9,7 @@ import torchmetrics
 import yahp as hp
 
 from composer.core.types import BatchPair, Metrics, Tensor, Tensors
-from composer.datasets.synthetic import SyntheticDatasetHparams
+from composer.datasets.synthetic import SyntheticDataLabelType, SyntheticDatasetHparams
 from composer.models import BaseMosaicModel, ModelHparams
 from composer.trainer.trainer_hparams import TrainerHparams
 
@@ -63,11 +63,12 @@ class SimpleBatchPairModel(BaseMosaicModel):
 
     def get_dataset_hparams(self, sample_pool_size: int, drop_last: bool, shuffle: bool) -> SyntheticDatasetHparams:
         return SyntheticDatasetHparams(
+            batch_size=sample_pool_size,
+            data_shape=list(self.in_shape),
+            label_type=SyntheticDataLabelType.CLASSIFICATION,
             num_classes=self.num_classes,
-            shape=list(self.in_shape),
-            device="cpu",
-            sample_pool_size=sample_pool_size,
             one_hot=False,
+            device="cpu",
             drop_last=drop_last,
             shuffle=shuffle,
         )

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -65,9 +65,8 @@ class SimpleBatchPairModel(BaseMosaicModel):
         return SyntheticDatasetHparams(
             total_dataset_size=total_dataset_size,
             data_shape=list(self.in_shape),
-            label_type=SyntheticDataLabelType.CLASSIFICATION,
+            label_type=SyntheticDataLabelType.CLASSIFICATION_INT,
             num_classes=self.num_classes,
-            one_hot=False,
             device="cpu",
             drop_last=drop_last,
             shuffle=shuffle,

--- a/tests/fixtures/models.py
+++ b/tests/fixtures/models.py
@@ -61,9 +61,9 @@ class SimpleBatchPairModel(BaseMosaicModel):
         else:
             return self.val_acc
 
-    def get_dataset_hparams(self, sample_pool_size: int, drop_last: bool, shuffle: bool) -> SyntheticDatasetHparams:
+    def get_dataset_hparams(self, total_dataset_size: int, drop_last: bool, shuffle: bool) -> SyntheticDatasetHparams:
         return SyntheticDatasetHparams(
-            batch_size=sample_pool_size,
+            total_dataset_size=total_dataset_size,
             data_shape=list(self.in_shape),
             label_type=SyntheticDataLabelType.CLASSIFICATION,
             num_classes=self.num_classes,

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -47,10 +47,10 @@ default_required_fields: Dict[Type[DatasetHparams], Callable[[], DatasetHparams]
         ),
     SyntheticDatasetHparams:
         lambda: SyntheticDatasetHparams(
+            batch_size=20,
+            data_shape=[256, 256],
             num_classes=100,
-            shape=[256, 256],
             one_hot=False,
-            sample_pool_size=20,
             device="cpu",
         ),
     LMDatasetHparams:

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -47,7 +47,7 @@ default_required_fields: Dict[Type[DatasetHparams], Callable[[], DatasetHparams]
         ),
     SyntheticDatasetHparams:
         lambda: SyntheticDatasetHparams(
-            batch_size=20,
+            total_dataset_size=20,
             data_shape=[256, 256],
             num_classes=100,
             one_hot=False,

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -50,7 +50,6 @@ default_required_fields: Dict[Type[DatasetHparams], Callable[[], DatasetHparams]
             total_dataset_size=20,
             data_shape=[256, 256],
             num_classes=100,
-            one_hot=False,
             device="cpu",
         ),
     LMDatasetHparams:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -32,9 +32,9 @@ def test_load(model_name: str):
     trainer_hparams = trainer.load(model_name)
     # TODO(ravi) -- add a get_synthetic_dataset(num_samples) on BaseMosaicModel
     dummy_dataset_hparams = SyntheticDatasetHparams(
+        batch_size=4096,
+        data_shape=[1, 28, 28],  # mnist input shape
         num_classes=trainer_hparams.model.num_classes,
-        shape=[1, 28, 28],  # mnist input shape
-        sample_pool_size=4096,
         one_hot=False,
         device="cpu",
     )
@@ -54,9 +54,9 @@ def test_scale_schedule_load(ssr: str):
     trainer_hparams = trainer.load("classify_mnist")
     # TODO(ravi) -- add a get_synthetic_dataset(num_samples) on BaseMosaicModel
     dummy_dataset_hparams = SyntheticDatasetHparams(
+        batch_size=4096,
+        data_shape=[1, 28, 28],  # mnist input shape
         num_classes=trainer_hparams.model.num_classes,
-        shape=[1, 28, 28],  # mnist input shape
-        sample_pool_size=4096,
         one_hot=False,
         device="cpu",
     )

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -32,7 +32,7 @@ def test_load(model_name: str):
     trainer_hparams = trainer.load(model_name)
     # TODO(ravi) -- add a get_synthetic_dataset(num_samples) on BaseMosaicModel
     dummy_dataset_hparams = SyntheticDatasetHparams(
-        batch_size=4096,
+        total_dataset_size=4096,
         data_shape=[1, 28, 28],  # mnist input shape
         num_classes=trainer_hparams.model.num_classes,
         one_hot=False,
@@ -54,7 +54,7 @@ def test_scale_schedule_load(ssr: str):
     trainer_hparams = trainer.load("classify_mnist")
     # TODO(ravi) -- add a get_synthetic_dataset(num_samples) on BaseMosaicModel
     dummy_dataset_hparams = SyntheticDatasetHparams(
-        batch_size=4096,
+        total_dataset_size=4096,
         data_shape=[1, 28, 28],  # mnist input shape
         num_classes=trainer_hparams.model.num_classes,
         one_hot=False,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -35,7 +35,6 @@ def test_load(model_name: str):
         total_dataset_size=4096,
         data_shape=[1, 28, 28],  # mnist input shape
         num_classes=trainer_hparams.model.num_classes,
-        one_hot=False,
         device="cpu",
     )
     trainer_hparams.precision = Precision.FP32
@@ -57,7 +56,6 @@ def test_scale_schedule_load(ssr: str):
         total_dataset_size=4096,
         data_shape=[1, 28, 28],  # mnist input shape
         num_classes=trainer_hparams.model.num_classes,
-        one_hot=False,
         device="cpu",
     )
     trainer_hparams.precision = Precision.FP32

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -5,7 +5,6 @@ import os
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence
 from unittest import mock
-from composer.datasets.synthetic import SyntheticDataLabelType, SyntheticDataType
 
 import pytest
 import torch
@@ -43,10 +42,9 @@ class TrackedDataset(SyntheticDataset):
     """
 
     def __init__(self, *, total_dataset_size: int, data_shape: Sequence[int], memory_format: MemoryFormat, device: str,
-                 one_hot: bool, num_classes: int, is_train: bool, tmpdir: str):
+                 num_classes: int, is_train: bool, tmpdir: str):
         super().__init__(total_dataset_size=total_dataset_size,
                          data_shape=data_shape,
-                         one_hot=one_hot,
                          num_classes=num_classes,
                          memory_format=memory_format,
                          device=device)
@@ -77,7 +75,6 @@ class TrackedDatasetHparams(SyntheticDatasetHparams):
                 total_dataset_size=self.total_dataset_size,
                 data_shape=self.data_shape,
                 num_classes=self.num_classes,
-                one_hot=self.one_hot,
                 device=self.device,
                 memory_format=self.memory_format,
                 is_train=self.is_train,
@@ -164,7 +161,6 @@ def test_ddp(is_gpu: bool, num_procs: int, fork_rank_0: bool, *, ddp_tmpdir: str
         total_dataset_size=300,
         data_shape=shape,
         num_classes=model.num_classes,
-        one_hot=False,
         device="cpu",
         is_train=True,
         memory_format=MemoryFormat.CONTIGUOUS_FORMAT,
@@ -174,7 +170,6 @@ def test_ddp(is_gpu: bool, num_procs: int, fork_rank_0: bool, *, ddp_tmpdir: str
         total_dataset_size=300,
         data_shape=shape,
         num_classes=model.num_classes,
-        one_hot=False,
         device="cpu",
         is_train=False,
         memory_format=MemoryFormat.CONTIGUOUS_FORMAT,

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -161,7 +161,7 @@ def test_ddp(is_gpu: bool, num_procs: int, fork_rank_0: bool, *, ddp_tmpdir: str
     model = model_hparams.initialize_object()
     shape = list(model.in_shape)  # type: ignore
     mosaic_trainer_hparams.train_dataset = TrackedDatasetHparams(
-        total_dataset_size == 300,
+        total_dataset_size=300,
         data_shape=shape,
         num_classes=model.num_classes,
         one_hot=False,

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -42,9 +42,9 @@ class TrackedDataset(SyntheticDataset):
     Because of atomic file writes, it is slow and should not be used in any performance measurements.
     """
 
-    def __init__(self, *, batch_size: int, data_shape: Sequence[int], memory_format: MemoryFormat, device: str,
+    def __init__(self, *, total_dataset_size: int, data_shape: Sequence[int], memory_format: MemoryFormat, device: str,
                  one_hot: bool, num_classes: int, is_train: bool, tmpdir: str):
-        super().__init__(batch_size=batch_size,
+        super().__init__(total_dataset_size=total_dataset_size,
                          data_shape=data_shape,
                          one_hot=one_hot,
                          num_classes=num_classes,
@@ -74,7 +74,7 @@ class TrackedDatasetHparams(SyntheticDatasetHparams):
         assert self.tmpdir is not None
         return DataloaderSpec(
             TrackedDataset(
-                batch_size=self.batch_size,
+                total_dataset_size=self.total_dataset_size,
                 data_shape=self.data_shape,
                 num_classes=self.num_classes,
                 one_hot=self.one_hot,
@@ -161,7 +161,7 @@ def test_ddp(is_gpu: bool, num_procs: int, fork_rank_0: bool, *, ddp_tmpdir: str
     model = model_hparams.initialize_object()
     shape = list(model.in_shape)  # type: ignore
     mosaic_trainer_hparams.train_dataset = TrackedDatasetHparams(
-        batch_size=300,
+        total_dataset_size==300,
         data_shape=shape,
         num_classes=model.num_classes,
         one_hot=False,
@@ -171,7 +171,7 @@ def test_ddp(is_gpu: bool, num_procs: int, fork_rank_0: bool, *, ddp_tmpdir: str
         tmpdir=ddp_tmpdir,
     )
     hparams.val_dataset = TrackedDatasetHparams(
-        batch_size=300,
+        total_dataset_size=300,
         data_shape=shape,
         num_classes=model.num_classes,
         one_hot=False,

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -161,7 +161,7 @@ def test_ddp(is_gpu: bool, num_procs: int, fork_rank_0: bool, *, ddp_tmpdir: str
     model = model_hparams.initialize_object()
     shape = list(model.in_shape)  # type: ignore
     mosaic_trainer_hparams.train_dataset = TrackedDatasetHparams(
-        total_dataset_size==300,
+        total_dataset_size == 300,
         data_shape=shape,
         num_classes=model.num_classes,
         one_hot=False,

--- a/tests/utils/trainer_fit.py
+++ b/tests/utils/trainer_fit.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 import torch
 
 from composer.core.types import DataLoader
-from composer.datasets.synthetic import SyntheticDatasetHparams, SyntheticDataType
+from composer.datasets.synthetic import SyntheticDataLabelType, SyntheticDatasetHparams, SyntheticDataType
 from composer.models.base import BaseMosaicModel
 from composer.models.classify_mnist.mnist_hparams import MnistClassifierHparams
 from composer.optim.optimizer_hparams import SGDHparams
@@ -28,20 +28,23 @@ def get_total_loss(model: BaseMosaicModel, dataloader: DataLoader):
 
 def train_model(mosaic_trainer_hparams: TrainerHparams, max_epochs: int = 2, run_loss_check: bool = False):
     total_dataset_size = 16
-    mosaic_trainer_hparams.train_dataset = SyntheticDatasetHparams(num_classes=2,
-                                                                   shape=[1, 28, 28],
-                                                                   device="cpu",
-                                                                   sample_pool_size=total_dataset_size,
+    mosaic_trainer_hparams.train_dataset = SyntheticDatasetHparams(batch_size=total_dataset_size,
+                                                                   data_shape=[1, 28, 28],
+                                                                   data_type=SyntheticDataType.SEPARABLE,
+                                                                   label_type=SyntheticDataLabelType.CLASSIFICATION,
+                                                                   num_classes=2,
                                                                    one_hot=False,
+                                                                   device="cpu",
                                                                    drop_last=True,
-                                                                   shuffle=False,
-                                                                   data_type=SyntheticDataType.SEPARABLE)
+                                                                   shuffle=False)
     # Not used in the training loop only being set because it is required
-    mosaic_trainer_hparams.val_dataset = SyntheticDatasetHparams(num_classes=2,
-                                                                 shape=[1, 28, 28],
-                                                                 device="cpu",
-                                                                 sample_pool_size=total_dataset_size,
+    mosaic_trainer_hparams.val_dataset = SyntheticDatasetHparams(batch_size=total_dataset_size,
+                                                                 data_shape=[1, 28, 28],
+                                                                 data_type=SyntheticDataType.SEPARABLE,
+                                                                 label_type=SyntheticDataLabelType.CLASSIFICATION,
+                                                                 num_classes=2,
                                                                  one_hot=False,
+                                                                 device="cpu",
                                                                  drop_last=True,
                                                                  shuffle=False)
 

--- a/tests/utils/trainer_fit.py
+++ b/tests/utils/trainer_fit.py
@@ -28,7 +28,7 @@ def get_total_loss(model: BaseMosaicModel, dataloader: DataLoader):
 
 def train_model(mosaic_trainer_hparams: TrainerHparams, max_epochs: int = 2, run_loss_check: bool = False):
     total_dataset_size = 16
-    mosaic_trainer_hparams.train_dataset = SyntheticDatasetHparams(batch_size=total_dataset_size,
+    mosaic_trainer_hparams.train_dataset = SyntheticDatasetHparams(total_dataset_size=total_dataset_size,
                                                                    data_shape=[1, 28, 28],
                                                                    data_type=SyntheticDataType.SEPARABLE,
                                                                    label_type=SyntheticDataLabelType.CLASSIFICATION,
@@ -38,7 +38,7 @@ def train_model(mosaic_trainer_hparams: TrainerHparams, max_epochs: int = 2, run
                                                                    drop_last=True,
                                                                    shuffle=False)
     # Not used in the training loop only being set because it is required
-    mosaic_trainer_hparams.val_dataset = SyntheticDatasetHparams(batch_size=total_dataset_size,
+    mosaic_trainer_hparams.val_dataset = SyntheticDatasetHparams(total_dataset_size=total_dataset_size,
                                                                  data_shape=[1, 28, 28],
                                                                  data_type=SyntheticDataType.SEPARABLE,
                                                                  label_type=SyntheticDataLabelType.CLASSIFICATION,
@@ -50,7 +50,7 @@ def train_model(mosaic_trainer_hparams: TrainerHparams, max_epochs: int = 2, run
 
     mosaic_trainer_hparams.model = MnistClassifierHparams(num_classes=2)
     mosaic_trainer_hparams.optimizer = SGDHparams(lr=1e-2)
-    mosaic_trainer_hparams.total_batch_size = total_dataset_size
+    mosaic_trainer_hparams.total_batch_size = total_dataset_size # one batch per epoch
     mosaic_trainer_hparams.max_epochs = max_epochs
     # Don't validate
     mosaic_trainer_hparams.validate_every_n_epochs = max_epochs + 1

--- a/tests/utils/trainer_fit.py
+++ b/tests/utils/trainer_fit.py
@@ -50,7 +50,7 @@ def train_model(mosaic_trainer_hparams: TrainerHparams, max_epochs: int = 2, run
 
     mosaic_trainer_hparams.model = MnistClassifierHparams(num_classes=2)
     mosaic_trainer_hparams.optimizer = SGDHparams(lr=1e-2)
-    mosaic_trainer_hparams.total_batch_size = total_dataset_size # one batch per epoch
+    mosaic_trainer_hparams.total_batch_size = total_dataset_size  # one batch per epoch
     mosaic_trainer_hparams.max_epochs = max_epochs
     # Don't validate
     mosaic_trainer_hparams.validate_every_n_epochs = max_epochs + 1

--- a/tests/utils/trainer_fit.py
+++ b/tests/utils/trainer_fit.py
@@ -31,9 +31,8 @@ def train_model(mosaic_trainer_hparams: TrainerHparams, max_epochs: int = 2, run
     mosaic_trainer_hparams.train_dataset = SyntheticDatasetHparams(total_dataset_size=total_dataset_size,
                                                                    data_shape=[1, 28, 28],
                                                                    data_type=SyntheticDataType.SEPARABLE,
-                                                                   label_type=SyntheticDataLabelType.CLASSIFICATION,
+                                                                   label_type=SyntheticDataLabelType.CLASSIFICATION_INT,
                                                                    num_classes=2,
-                                                                   one_hot=False,
                                                                    device="cpu",
                                                                    drop_last=True,
                                                                    shuffle=False)
@@ -41,9 +40,8 @@ def train_model(mosaic_trainer_hparams: TrainerHparams, max_epochs: int = 2, run
     mosaic_trainer_hparams.val_dataset = SyntheticDatasetHparams(total_dataset_size=total_dataset_size,
                                                                  data_shape=[1, 28, 28],
                                                                  data_type=SyntheticDataType.SEPARABLE,
-                                                                 label_type=SyntheticDataLabelType.CLASSIFICATION,
+                                                                 label_type=SyntheticDataLabelType.CLASSIFICATION_INT,
                                                                  num_classes=2,
-                                                                 one_hot=False,
                                                                  device="cpu",
                                                                  drop_last=True,
                                                                  shuffle=False)


### PR DESCRIPTION
Right now, `SyntheticDataset` can only represent an epoch that consists of a single batch. This change allows `SyntheticDataset` to emulate a dataset that consists of multiple batches. This functionality is useful for benchmarking workloads that use a `SyntheticDataset`.

Additionally, `SyntheticDataset` only supports classification labels. This PR adds functionality for custom label shapes so that `SyntheticDataset` can be used for tasks such as image segmentation and NLP. 