### PR TITLE
Fix Tests and setup.py

### DIFF
--- a/composer/core/logging/logger.py
+++ b/composer/core/logging/logger.py
@@ -48,13 +48,13 @@ class Logger:
             The global :class:`~composer.core.state.State` object.
         backends (Sequence[BaseLoggerBackend]):
             A sequence of
-            :class:`~composer.core.logging.base_backend.BaseLoggerBackend`\s
+            :class:`~composer.core.logging.base_backend.BaseLoggerBackend`\\s
             to which logging calls will be sent.
 
     Attributes:
         backends (Sequence[BaseLoggerBackend]):
             A sequence of
-            :class:`~composer.core.logging.base_backend.BaseLoggerBackend`\s
+            :class:`~composer.core.logging.base_backend.BaseLoggerBackend`\\s
             to which logging calls will be sent.
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ filterwarnings = [
 # Coverage
 [tool.coverage.run]
 parallel = true
+branch = true
+concurrency = thread,multiprocessing
 source = [
     "composer"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ filterwarnings = [
 [tool.coverage.run]
 parallel = true
 branch = true
-concurrency = thread,multiprocessing
+concurrency = ["thread", "multiprocessing"]
 source = [
     "composer"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ include = [
     "composer/**",
     "tests/**"
 ]
+exclude = [
+    "build/**"
+]
 
 reportImportCycles = "none"
 reportUnnecessaryIsInstance = "none"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ filterwarnings = [
 parallel = true
 branch = true
 concurrency = ["thread", "multiprocessing"]
-source = [
-    "composer"
+include = [
+    "composer/*"
 ]
 
 # Yapf

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,19 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
+import os
+
 import setuptools
 from setuptools import setup
+
+
+def package_files(directory):
+    # from https://stackoverflow.com/a/36693250
+    paths = []
+    for (path, directories, filenames) in os.walk(directory):
+        for filename in filenames:
+            paths.append(os.path.join('..', path, filename))
+    return paths
+
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
@@ -67,16 +79,14 @@ setup(
     url="https://github.com/mosaicml/composer",
     include_package_data=True,
     package_data={
-        "": ["*.yaml", "*.yml"],
+        "composer": ['py.typed'],
+        "": package_files('composer/yamls'),
     },
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
     ],
     install_requires=install_requires,
-    entry_points={
-        'console_scripts': ['composer = examples.run_mosaic_trainer:main',],
-    },
     extras_require=extra_deps,
     dependency_links=['https://developer.download.nvidia.com/compute/redist'],
     python_requires='>=3.8',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extra_deps['base'] = []
 
 extra_deps['dev'] = [
     'junitparser>=2.1.1',
-    'coverage[toml]>=5.5',
+    'coverage[toml]>=6.1.1',
     'pytest>=6.2.0',
     'yapf>=0.13.0',
     'isort>=5.9.3',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 import os
+import sys
 
 import setuptools
 from setuptools import setup
@@ -82,7 +83,7 @@ setup(
         "composer": ['py.typed'],
         "": package_files('composer/yamls'),
     },
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(include=["composer"]),
     classifiers=[
         "Programming Language :: Python :: 3",
     ],
@@ -94,8 +95,11 @@ setup(
 )
 
 # only visible if user installs with verbose -v flag
-print("*" * 20)
-print("\nNOTE: For best performance, we recommend installing Pillow-SIMD "
-      "\nfor accelerated image processing operations. To install:"
-      "\n\n\t pip uninstall pillow && pip install pillow-simd\n")
-print("*" * 20)
+# Printing to stdout as not to interfere with setup.py CLI flags (e.g. --version)
+print("*" * 20, file=sys.stderr)
+print(
+    "\nNOTE: For best performance, we recommend installing Pillow-SIMD "
+    "\nfor accelerated image processing operations. To install:"
+    "\n\n\t pip uninstall pillow && pip install pillow-simd\n",
+    file=sys.stderr)
+print("*" * 20, file=sys.stderr)

--- a/tests/callbacks/test_memory_monitor.py
+++ b/tests/callbacks/test_memory_monitor.py
@@ -41,7 +41,6 @@ def _do_trainer_fit(mosaic_trainer_hparams: TrainerHparams, testing_with_gpu: bo
 
 
 @pytest.mark.timeout(60)
-@pytest.mark.run_long
 def test_memory_monitor_cpu(mosaic_trainer_hparams: TrainerHparams):
     log_destination, _ = _do_trainer_fit(mosaic_trainer_hparams, testing_with_gpu=False)
 
@@ -56,7 +55,6 @@ def test_memory_monitor_cpu(mosaic_trainer_hparams: TrainerHparams):
 
 
 @pytest.mark.timeout(60)
-@pytest.mark.run_long
 def test_memory_monitor_gpu(mosaic_trainer_hparams: TrainerHparams):
     n_cuda_devices = device_count()
     if n_cuda_devices > 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 import atexit
+import logging
 from typing import Callable, List, Optional
 
 import _pytest.config
@@ -10,6 +11,8 @@ import _pytest.mark
 import pytest
 import torch
 from _pytest.monkeypatch import MonkeyPatch
+
+import composer
 
 N_GPU_OPTIONS = (0, 1, 2, 4, 8)
 
@@ -129,3 +132,9 @@ def atexit_at_test_end(monkeypatch: MonkeyPatch):
     yield
     for func, args, kwargs in atexit_callbacks:
         func(*args, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def set_loglevels():
+    logging.basicConfig()
+    logging.getLogger(composer.__name__).setLevel(logging.DEBUG)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -23,6 +23,7 @@ model_names = [name for name in model_names if name not in EXCLUDE_MODELS]
 
 
 @pytest.mark.parametrize('model_name', model_names)
+@pytest.mark.timeout(5)
 def test_load(model_name: str):
     if "gpt" in model_name:
         pytest.skip("GPT doesn't work on the no-op model class")


### PR DESCRIPTION
1. Fixed settings for coverage reports so source code can be included
2. Fixed package_data so yaml files are properly included. 
3. Added `py.typed` to indicate that the repository has typing annotations
4. Printing the `pillow-simd` warning in setup.py to stderr so it does not interfere with `setup.py --version` and other CLI args
5. Logging at the debug level when running tests
6. Increasing timeout for `test_load`, since that sometimes takes longer than 2 seconds.
7. Only bundling the `composer` package in setup.py so the `tests/` folder isn't included as well