### PR TITLE
Added explicit cli_args=False for `load_model` and `load_algorithms`

### DIFF
--- a/composer/algorithms/algorithm_hparams.py
+++ b/composer/algorithms/algorithm_hparams.py
@@ -35,7 +35,7 @@ class AlgorithmHparams(hp.Hparams, ABC):
         else:
             hparams_file = os.path.join(alg_folder, alg_name, f"{alg_params}.yaml")
         if os.path.exists(hparams_file):
-            alg_hparams = cls.create(hparams_file)
+            alg_hparams = cls.create(hparams_file, cli_args=False)
             assert isinstance(alg_hparams, AlgorithmHparams), "hparams.create should return an instance of its type"
             return alg_hparams
         return cls()

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -222,6 +222,6 @@ class TrainerHparams(hp.Hparams):
             "models",
             f"{model}.yaml",
         )
-        trainer_hparams = TrainerHparams.create(model_hparams_file)
+        trainer_hparams = TrainerHparams.create(model_hparams_file, cli_args=False)
         assert isinstance(trainer_hparams, TrainerHparams), "trainer hparams should return an instance of self"
         return trainer_hparams

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -16,7 +16,7 @@ from composer.trainer.devices import GPUDeviceHparams
 def run_and_measure_memory(precision: Precision, file_store_path: str) -> int:
     hparams_f = os.path.join(os.path.dirname(composer.__file__), "yamls", "models", "resnet56_cifar10",
                              "hparams_synthetic.yaml")
-    hparams = TrainerHparams.create(f=hparams_f)
+    hparams = TrainerHparams.create(f=hparams_f, cli_args=False)
     assert isinstance(hparams, TrainerHparams)
     assert isinstance(hparams.device, GPUDeviceHparams)
     hparams.device.n_gpus = 1

--- a/tests/test_hparams.py
+++ b/tests/test_hparams.py
@@ -23,5 +23,5 @@ def walk_model_yamls():
 class TestHparamsCreate:
 
     def test_hparams_create(self, hparams_file: str):
-        hparams = TrainerHparams.create(hparams_file)
+        hparams = TrainerHparams.create(hparams_file, cli_args=False)
         assert isinstance(hparams, TrainerHparams)


### PR DESCRIPTION
When using preset models or algorithms (e.g. via `load_model` or `load_algorithms`), CLI args were also being read, which lead to runtime errors in Colab (where the CLI arguments it was started with conflicted with the CLI arguments for the mosaic trainer. Instead, this change disables parsing of CLI arguments when using `load_model` and `load_algorithms`.