### PR TITLE
label smoothing will not work without alpha set

### DIFF
--- a/examples/run_mosaic_trainer.py
+++ b/examples/run_mosaic_trainer.py
@@ -9,7 +9,7 @@ Example that trains MNIST with label smoothing::
 
     >>> python examples/run_mosaic_trainer.py
     -f composer/yamls/models/classify_mnist_cpu.yaml
-    --algorithms label_smoothing
+    --algorithms label_smoothing --alpha 0.1
     --datadir ~/datasets
 """
 import argparse


### PR DESCRIPTION
simple comment fix so that example will run out of the box. It may be useful to have a sane default alpha set for label smoothing in the future.