### PR TITLE
Moved device.prepare() to __init__

### DIFF
--- a/composer/trainer/devices/device.py
+++ b/composer/trainer/devices/device.py
@@ -18,14 +18,10 @@ class Device(Serializable, ABC):
     """
 
     @abstractmethod
-    def prepare(self, state: State) -> None:
+    def prepare(self) -> None:
         """Used for device initialization.
 
         Invoked by the trainer at the beginning of the training loop.
-        It should not modify the state.
-
-        Args:
-            state (State): The global state variable.
         """
 
     @abstractmethod

--- a/composer/trainer/devices/device_cpu.py
+++ b/composer/trainer/devices/device_cpu.py
@@ -8,7 +8,6 @@ from typing import Generator, Optional, Union
 
 import torch
 
-from composer.core.state import State
 from composer.core.types import Batch, DataLoader, Precision, StateDict, Tensor, TPrefetchFn
 from composer.datasets.dataloader import WrappedDataLoader
 from composer.trainer.devices.device import Device, T_nnModule
@@ -34,7 +33,7 @@ class PrefetchedDataLoader(WrappedDataLoader):
 class DeviceCPU(Device):
     """An extension of :class:`~composer.trainer.devices.device.Device` for CPUs."""
 
-    def prepare(self, state: State) -> None:
+    def prepare(self) -> None:
         logger.info("Preparing CPU worker")
         # No preperation required
         return

--- a/composer/trainer/devices/device_gpu.py
+++ b/composer/trainer/devices/device_gpu.py
@@ -9,11 +9,10 @@ import torch
 import torch.cuda.amp
 import torch.utils.data
 
-from composer.core.state import State
 from composer.core.types import Batch, BatchPair, DataLoader, Precision, StateDict, Tensor, Tensors, TPrefetchFn
 from composer.datasets.dataloader import WrappedDataLoader
 from composer.trainer.devices.device import Device, T_nnModule
-from composer.utils import map_collection
+from composer.utils import ddp, map_collection
 
 
 class CudaDataLoader(WrappedDataLoader):
@@ -109,10 +108,10 @@ class DeviceGPU(Device):
         self.prefetch_in_cuda_stream = prefetch_in_cuda_stream
         self._device: Optional[torch.device] = None
 
-    def prepare(self, state: State) -> None:
+    def prepare(self) -> None:
         if self._device is not None:
             raise ValueError("device is already set")
-        gpu = state.local_rank
+        gpu = ddp.get_local_rank()
         self._device = torch.device(f"cuda:{gpu}")
         torch.cuda.set_device(self._device)
         assert torch.cuda.current_device() == gpu

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -179,6 +179,7 @@ class Trainer:
         if not device:
             device = DeviceCPU()
         self.device = device
+        self.device.prepare()
 
         if not seed:
             # Set a deterministic seed in the hparams
@@ -473,7 +474,6 @@ class Trainer:
         assert state.optimizers is not None
         assert state.schedulers is not None
         # place the state, model in the proper devices
-        self.device.prepare(state)
         state.model = self.device.module_to_device(state.model)
         state.optimizers = map_collection(state.optimizers, self.device.optimizer_to_device)
 


### PR DESCRIPTION
Since dataloaders are created in `__init__`, the device must also be prepared in `__init__`