### PR TITLE
Replaced `atexit` with cleanup methods

### DIFF
--- a/composer/callbacks/torch_profiler.py
+++ b/composer/callbacks/torch_profiler.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import atexit
 import warnings
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Optional
@@ -132,7 +131,7 @@ class TorchProfiler(Callback):
                 torch_scheduler_action = ProfilerAction.RECORD_AND_SAVE
         return torch_scheduler_action
 
-    def training_start(self, state: State, logger: Logger) -> None:
+    def init(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
         assert self.profiler is None, _PROFILE_MISSING_ERROR
         self.profiler = torch.profiler.profile(
@@ -149,7 +148,6 @@ class TorchProfiler(Callback):
             with_flops=self.hparams.with_flops,
         )
         self.profiler.__enter__()
-        atexit.register(self._close_profiler)
 
     def batch_end(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
@@ -165,6 +163,6 @@ class TorchProfiler(Callback):
         assert self.profiler is not None, _PROFILE_MISSING_ERROR
         logger.metric_batch({"profiler/state": self.profiler.current_action.name})
 
-    def _close_profiler(self) -> None:
-        assert self.profiler is not None
-        self.profiler.__exit__(None, None, None)
+    def close(self) -> None:
+        if self.profiler is not None:
+            self.profiler.__exit__(None, None, None)

--- a/composer/core/callback.py
+++ b/composer/core/callback.py
@@ -302,6 +302,25 @@ class Callback(Serializable, abc.ABC):
         del state, logger  # unused
         pass
 
+    def close(self) -> None:
+        """Called whenever the trainer finishes training.
+        Unlike the :attr:`~Event.TRAINING_END` event, :meth:`close` is
+        invoked even when there was an exception.
+
+        It should be used for flushing and closing any files, etc...
+        that may have been opened during the :attr:`~Event.INIT` event.
+        """
+        pass
+
+    def post_close(self) -> None:
+        """This hook is called after :meth:`close` has been invoked for each callback.
+        Very few callbacks should need to implement :meth:`post_close`.
+
+        This callback can be used to back up any data that may have been written by other
+        callbacks during :meth:`close`.
+        """
+        pass
+
 
 class RankZeroCallback(Callback, abc.ABC):
     """Base class for callbacks that only run on the local rank zero process.

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -180,3 +180,32 @@ class Engine():
 
         for cb in self.callbacks:
             cb.run_event(event, self.state, self.logger)
+
+    def close(self) -> None:
+        """Invoke :meth:`~Callback.close` and :meth:`~Callback.post_close` for each callback.
+
+        :meth:`~Callback.close` is invoked for each callback.
+        For all callbacks where :meth:`~Callback.close` did not raise an exception, then
+        :meth:`~Callback.post_close` is invoked.
+        
+        Does not re-raise any exceptions from :meth:`~Callback.close` and :meth:`~Callback.post_close`.
+        Instead, these exceptions are logged.
+        """
+        callback_to_has_exception: Dict[Callback, bool] = {}
+        for callback in self.callbacks:
+            try:
+                callback.close()
+            except Exception as e:
+                log.error(
+                    f"Error running {callback.__class__.__name__}.close(). Skipping {callback.__class__.__name__}.post_close().",
+                    exc_info=e,
+                    stack_info=True)
+                callback_to_has_exception[callback] = True
+            else:
+                callback_to_has_exception[callback] = False
+        for callback in self.callbacks:
+            if callback_to_has_exception[callback] is False:
+                try:
+                    callback.post_close()
+                except Exception as e:
+                    log.error(f"Error running {callback.__class__.__name__}.post_close().", exc_info=e, stack_info=True)

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import atexit
 import os
 import sys
 from typing import Any, Dict, Optional
@@ -49,7 +48,6 @@ class WandBLoggerBackend(RankZeroLoggerBackend):
     def init(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
         wandb.init(**self._init_params)
-        atexit.register(self._close_wandb)
 
     def batch_end(self, state: State, logger: Logger) -> None:
         del logger  # unused
@@ -85,7 +83,8 @@ class WandBLoggerBackend(RankZeroLoggerBackend):
                     artifact.add_file(full_path)
                 wandb.log_artifact(artifact)
 
-    def _close_wandb(self) -> None:
+    def post_close(self) -> None:
+        # Cleaning up on post_close so all artifacts are uploaded
         if self._log_artifacts:
             self._upload_artifacts()
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -369,7 +369,10 @@ class Trainer:
 
     def fit(self):
         """Train and evaluate the model on the provided data."""
-        self._train_loop()
+        try:
+            self._train_loop()
+        finally:
+            self.engine.close()
 
     def _create_dataloaders(self) -> None:
         """Create the dataloaders.

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -13,7 +13,7 @@ def test_callbacks_map_to_events():
     # callback methods must be 1:1 mapping with events
     # exception for private methods
     cb = Callback()
-    excluded_methods = ["state_dict", "load_state_dict", "run_event"]
+    excluded_methods = ["state_dict", "load_state_dict", "run_event", "close", "post_close"]
     methods = set(m for m in dir(cb) if (m not in excluded_methods and not m.startswith("_")))
     event_names = set(e.value for e in Event)
     assert methods == event_names

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-import atexit
 import datetime
 import logging
 import os
@@ -14,7 +13,6 @@ import _pytest.fixtures
 import _pytest.mark
 import pytest
 import torch.distributed
-from _pytest.monkeypatch import MonkeyPatch
 
 import composer
 from composer.utils.run_directory import get_relative_to_run_directory
@@ -106,20 +104,6 @@ def pytest_collection_modifyitems(session: pytest.Session, config: _pytest.confi
     del session  # unused
     _filter_items_for_world_size(items)
     _filter_items_for_timeout(config, items)
-
-
-@pytest.fixture(autouse=True)
-def atexit_at_test_end(monkeypatch: MonkeyPatch):
-    # monkeypatch atexit so it is called when a test exits, not when the python process exits
-    atexit_callbacks = []
-
-    def register(func, *args, **kwargs):
-        atexit_callbacks.append((func, args, kwargs))
-
-    monkeypatch.setattr(atexit, "register", register)
-    yield
-    for func, args, kwargs in atexit_callbacks:
-        func(*args, **kwargs)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
When running the trainer multiple times, such as in interactive enviroments, `atexit` does not fire. Instead, replaced it with `.close()` and `.post_close()` hooks on callbacks.

`.close()` can be used to write and flush files.
`.post_close()` can be used to backup the run directory and capture any changes that may have been made on `.close()`