### PR TITLE
Running callbacks befor algorithms for the INIT event in the engine

### DIFF
--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -96,8 +96,15 @@ class Engine():
         Returns:
             Dict[str, Trace]: dictionary of trace for each algorithm.
         """
-        traces = self._run_algorithms(event)
-        self._run_callbacks(event)
+        if event == Event.INIT:
+            # For the INIT event, run the callbacks first to initialize the loggers
+            # For other events, run the algorithms first, so the callbacks have the state
+            # after algorithms modify it
+            self._run_callbacks(event)
+            traces = self._run_algorithms(event)
+        else:
+            traces = self._run_algorithms(event)
+            self._run_callbacks(event)
         return traces
 
     def _run_algorithms(


### PR DESCRIPTION
* For the INIT event, run the callbacks first to initialize the loggers.
* For other events, run the algorithms first, so the callbacks have the state  after algorithms modify it.