### PR TITLE
Remove argparse from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ install_requires = [
     "torch_optimizer==0.1.0",
     "torchvision>=0.9.0",
     "torch>=1.9",
-    "argparse>=1.4.0",
     "yahp>=0.0.14",
 ]
 extra_deps = {}


### PR DESCRIPTION
Argparse is included in the stdlib for python 3.2+, so no need to install from pip. It generates a warning when using colab that you need to restart the runtime.

![image](https://user-images.githubusercontent.com/87037432/144650292-66ad80df-028a-4fc0-99f8-e74d10abdc09.png)
