### PR TITLE
Add a linear learning rate decay

### DIFF
--- a/composer/optim/pytorch_future.py
+++ b/composer/optim/pytorch_future.py
@@ -122,3 +122,69 @@ class WarmUpLR(_LRScheduler):
 
     def scale_schedule(self, ssr: float) -> None:
         pass
+
+class LinearLR(_LRScheduler):
+    """Decays the learning rate of each parameter group by linearly changing small
+    multiplicative factor until the number of epoch reaches a pre-defined milestone: total_iters.
+    Notice that such decay can happen simultaneously with other changes to the learning rate
+    from outside this scheduler. When last_epoch=-1, sets initial lr as lr.
+
+    Args:
+        optimizer (Optimizer): Wrapped optimizer.
+        start_factor (float): The number we multiply learning rate in the first epoch.
+            The multiplication factor changes towards end_factor in the following epochs.
+            Default: 1./3.
+        end_factor (float): The number we multiply learning rate at the end of linear changing
+            process. Default: 1.0.
+        total_iters (int): The number of iterations that multiplicative factor reaches to 1.
+            Default: 5.
+        last_epoch (int): The index of the last epoch. Default: -1.
+        verbose (bool): If ``True``, prints a message to stdout for
+            each update. Default: ``False``.
+
+    Example:
+        >>> # Assuming optimizer uses lr = 0.05 for all groups
+        >>> # lr = 0.025    if epoch == 0
+        >>> # lr = 0.03125  if epoch == 1
+        >>> # lr = 0.0375   if epoch == 2
+        >>> # lr = 0.04375  if epoch == 3
+        >>> # lr = 0.005    if epoch >= 4
+        >>> scheduler = LinearLR(self.opt, start_factor=0.5, total_iters=4)
+        >>> for epoch in range(100):
+        >>>     train(...)
+        >>>     validate(...)
+        >>>     scheduler.step()
+    """
+
+    def __init__(self, optimizer, start_factor=1.0 / 3, end_factor=1.0, total_iters=5, last_epoch=-1,
+                 verbose=False):
+        if start_factor > 1.0 or start_factor < 0:
+            raise ValueError('Starting multiplicative factor expected to be between 0 and 1.')
+
+        if end_factor > 1.0 or end_factor < 0:
+            raise ValueError('Ending multiplicative factor expected to be between 0 and 1.')
+
+        self.start_factor = start_factor
+        self.end_factor = end_factor
+        self.total_iters = total_iters
+        super(LinearLR, self).__init__(optimizer, last_epoch, verbose)
+
+    def get_lr(self):
+        if not self._get_lr_called_within_step:
+            warnings.warn("To get the last learning rate computed by the scheduler, "
+                          "please use `get_last_lr()`.", UserWarning)
+
+        if self.last_epoch == 0:
+            return [group['lr'] * self.start_factor for group in self.optimizer.param_groups]
+
+        if (self.last_epoch > self.total_iters):
+            return [group['lr'] for group in self.optimizer.param_groups]
+
+        return [group['lr'] * (1. + (self.end_factor - self.start_factor) /
+                (self.total_iters * self.start_factor + (self.last_epoch - 1) * (self.end_factor - self.start_factor)))
+                for group in self.optimizer.param_groups]
+
+    def _get_closed_form_lr(self):
+        return [base_lr * (self.start_factor +
+                (self.end_factor - self.start_factor) * min(self.total_iters, self.last_epoch) / self.total_iters)
+                for base_lr in self.base_lrs]

--- a/composer/optim/pytorch_future.py
+++ b/composer/optim/pytorch_future.py
@@ -123,6 +123,7 @@ class WarmUpLR(_LRScheduler):
     def scale_schedule(self, ssr: float) -> None:
         pass
 
+
 class LinearLR(_LRScheduler):
     """Decays the learning rate of each parameter group by linearly changing small
     multiplicative factor until the number of epoch reaches a pre-defined milestone: total_iters.
@@ -156,8 +157,7 @@ class LinearLR(_LRScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, optimizer, start_factor=1.0 / 3, end_factor=1.0, total_iters=5, last_epoch=-1,
-                 verbose=False):
+    def __init__(self, optimizer, start_factor=1.0 / 3, end_factor=1.0, total_iters=5, last_epoch=-1, verbose=False):
         if start_factor > 1.0 or start_factor < 0:
             raise ValueError('Starting multiplicative factor expected to be between 0 and 1.')
 
@@ -180,11 +180,16 @@ class LinearLR(_LRScheduler):
         if (self.last_epoch > self.total_iters):
             return [group['lr'] for group in self.optimizer.param_groups]
 
-        return [group['lr'] * (1. + (self.end_factor - self.start_factor) /
-                (self.total_iters * self.start_factor + (self.last_epoch - 1) * (self.end_factor - self.start_factor)))
-                for group in self.optimizer.param_groups]
+        return [
+            group['lr'] * (1. + (self.end_factor - self.start_factor) /
+                           (self.total_iters * self.start_factor + (self.last_epoch - 1) *
+                            (self.end_factor - self.start_factor))) for group in self.optimizer.param_groups
+        ]
 
     def _get_closed_form_lr(self):
-        return [base_lr * (self.start_factor +
-                (self.end_factor - self.start_factor) * min(self.total_iters, self.last_epoch) / self.total_iters)
-                for base_lr in self.base_lrs]
+        return [
+            base_lr *
+            (self.start_factor +
+             (self.end_factor - self.start_factor) * min(self.total_iters, self.last_epoch) / self.total_iters)
+            for base_lr in self.base_lrs
+        ]

--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 import torch
 import yahp as hp
 from torch.optim.lr_scheduler import (CosineAnnealingLR, CosineAnnealingWarmRestarts, ExponentialLR, MultiStepLR,
-                                      StepLR, _LRScheduler)
+                                      LinearLR, StepLR, _LRScheduler)
 
 from composer.core.types import Optimizer, Scheduler
 from composer.optim.pytorch_future import WarmUpLR
@@ -293,6 +293,20 @@ class CosineAnnealingWarmRestartsHparams(SchedulerHparams):
     def initialize_object(self, optimizer: Optimizer, steps_per_epoch: Optional[int] = None):
         self.convert_time_fields(steps_per_epoch)
         return super().initialize_object(optimizer, steps_per_epoch)
+
+@dataclass
+class LinearLRHparams(SchedulerHparams):
+    """Hyperparameters for the `LinearLRHparams <https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.LinearLR.html>`_
+    scheduler.
+    """
+
+    start_factor: float = hp.optional("Number to multiply learning rate at the start.", default=1.0 / 3)
+    end_factor: float = hp.optional("Number to multiply learning rate at the end .", default=1.0)
+    total_iters: Time = hp.optional("Number of linear decay steps. Default: 5 iterations.", default="5ba")
+    verbose: bool = hp.optional('Prints message to stdout', default=False)
+    interval: str = hp.optional(default='epoch', doc=_interval_doc)
+
+    scheduler_object = LinearLR
 
 
 @dataclass

--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -9,10 +9,10 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 import torch
 import yahp as hp
 from torch.optim.lr_scheduler import (CosineAnnealingLR, CosineAnnealingWarmRestarts, ExponentialLR, MultiStepLR,
-                                      LinearLR, StepLR, _LRScheduler)
+                                      StepLR, _LRScheduler)
 
 from composer.core.types import Optimizer, Scheduler
-from composer.optim.pytorch_future import WarmUpLR
+from composer.optim.pytorch_future import LinearLR, WarmUpLR
 
 log = logging.getLogger(__name__)
 
@@ -294,6 +294,7 @@ class CosineAnnealingWarmRestartsHparams(SchedulerHparams):
         self.convert_time_fields(steps_per_epoch)
         return super().initialize_object(optimizer, steps_per_epoch)
 
+
 @dataclass
 class LinearLRHparams(SchedulerHparams):
     """Hyperparameters for the `LinearLRHparams <https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.LinearLR.html>`_
@@ -437,7 +438,7 @@ class ComposedScheduler(_LRScheduler):
             self.warmup_iters = 0
 
         # these schedulers need to be silent during warmup
-        self.delay_schedulers = [CosineAnnealingLR, CosineAnnealingWarmRestarts, ExponentialLR]
+        self.delay_schedulers = [CosineAnnealingLR, CosineAnnealingWarmRestarts, ExponentialLR, LinearLR]
         self._warmup_counter = 0  # counter to track warmups
 
     def step(self, interval: str = 'epoch'):

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -47,6 +47,7 @@ scheduler_registry = {
     "step": scheduler.StepLRHparams,
     "multistep": scheduler.MultiStepLRHparams,
     "exponential": scheduler.ExponentialLRHparams,
+    "linear_decay": scheduler.LinearLRHparams,
     "cosine_decay": scheduler.CosineAnnealingLRHparams,
     "cosine_warmrestart": scheduler.CosineAnnealingWarmRestartsHparams,
     "warmup": scheduler.WarmUpLRHparams,

--- a/tests/trainer/test_scheduler.py
+++ b/tests/trainer/test_scheduler.py
@@ -10,8 +10,8 @@ from torch.optim.lr_scheduler import ExponentialLR, MultiStepLR, StepLR
 from composer.core.types import ModelParameters
 from composer.optim.pytorch_future import WarmUpLR
 from composer.optim.scheduler import (ComposedScheduler, ConstantLRHparams, CosineAnnealingLRHparams,
-                                      CosineAnnealingWarmRestartsHparams, ExponentialLRHparams, MultiStepLRHparams,
-                                      SchedulerHparams, StepLRHparams, WarmUpLRHparams, LinearLRHparams)
+                                      CosineAnnealingWarmRestartsHparams, ExponentialLRHparams, LinearLRHparams,
+                                      MultiStepLRHparams, SchedulerHparams, StepLRHparams, WarmUpLRHparams)
 from composer.trainer.trainer_hparams import scheduler_registry
 
 # for testing, we provide values for required hparams fields

--- a/tests/trainer/test_scheduler.py
+++ b/tests/trainer/test_scheduler.py
@@ -11,7 +11,7 @@ from composer.core.types import ModelParameters
 from composer.optim.pytorch_future import WarmUpLR
 from composer.optim.scheduler import (ComposedScheduler, ConstantLRHparams, CosineAnnealingLRHparams,
                                       CosineAnnealingWarmRestartsHparams, ExponentialLRHparams, MultiStepLRHparams,
-                                      SchedulerHparams, StepLRHparams, WarmUpLRHparams)
+                                      SchedulerHparams, StepLRHparams, WarmUpLRHparams, LinearLRHparams)
 from composer.trainer.trainer_hparams import scheduler_registry
 
 # for testing, we provide values for required hparams fields
@@ -20,6 +20,7 @@ schedulers: Dict[Type[SchedulerHparams], SchedulerHparams] = {
     MultiStepLRHparams: MultiStepLRHparams(milestones=["5ep", "10ep"],),
     ExponentialLRHparams: ExponentialLRHparams(gamma=0.5,),
     CosineAnnealingLRHparams: CosineAnnealingLRHparams(T_max="1000ep",),
+    LinearLRHparams: LinearLRHparams(total_iters="1000ep",),
     CosineAnnealingWarmRestartsHparams: CosineAnnealingWarmRestartsHparams(T_0="1000ep",),
     WarmUpLRHparams: WarmUpLRHparams(),
     ConstantLRHparams: ConstantLRHparams()
@@ -30,6 +31,7 @@ time_field: Dict[Type[SchedulerHparams], str] = {
     MultiStepLRHparams: '',
     ExponentialLRHparams: '',
     CosineAnnealingLRHparams: 'T_max',
+    LinearLRHparams: 'total_iters',
     CosineAnnealingWarmRestartsHparams: 'T_0',
     WarmUpLRHparams: 'warmup_iters',
     ConstantLRHparams: ''


### PR DESCRIPTION
# Motivation
BERT models need a linear decay in the learning rate. This PR serves to add that.

# Tests
See [this](https://wandb.ai/mosaic-ml/bert/runs/tq9oxvb3?workspace=user-moin-mosaic) WandB project to show that it is working.

# Points for Discussion

- [ ] Should we add a unit test for this?
- [ ] Are there any concerns with the implementation details?