### PR TITLE
Multiple calls to `.fit`

### DIFF
--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -166,7 +166,7 @@ class SeqLengthWarmup(Algorithm):
             # ensure that input_ids is a valid model input. since we don't need the
             # results, we don't use all inputs.
 
-            original_model = state.model.module
+            original_model = ddp.get_original_model(state.model)
             assert isinstance(original_model, MosaicTransformer)
             model_inputs = original_model.get_model_inputs()  # type: ignore
             assert 'input_ids' in model_inputs

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -62,6 +62,7 @@ class Engine():
         self.state = state
         self.algorithms = algorithms
         self.callbacks = callbacks or []
+        self._closed = False
 
     def run_event(
         self,
@@ -216,3 +217,8 @@ class Engine():
                     callback.post_close()
                 except Exception as e:
                     log.error(f"Error running {callback.__class__.__name__}.post_close().", exc_info=e, stack_info=True)
+        self._closed = True
+
+    @property
+    def closed(self):
+        return self._closed

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Callable, ContextManager, Optional, Sequence, 
 import torch
 import torch.nn.modules.utils
 from torch.nn.parallel import DistributedDataParallel
+from torchmetrics.collections import MetricCollection
 
 import composer.core.types as types
 from composer.core.precision import Precision
@@ -42,6 +43,7 @@ STATE_DICT_SERIALIZATION_FIELDS = [
     "_algorithms",
     "_callbacks",
     "scaler",
+    "train_metrics",
 ]
 
 # These fields will not be serialized
@@ -112,6 +114,7 @@ class State(Serializable):
             # algorithms and callbacks
             algorithms: Sequence[Algorithm] = tuple(),
             callbacks: Sequence[Callback] = tuple(),
+            train_metrics: Optional[MetricCollection] = None,
     ):
         self.model = model
         self.grad_accum = grad_accum
@@ -140,6 +143,7 @@ class State(Serializable):
             self._schedulers = list(ensure_tuple(schedulers))
 
         self.scaler = scaler
+        self.train_metrics = train_metrics
         self._algorithms = list(algorithms)
         self._callbacks = list(callbacks)
 

--- a/composer/datasets/dataloader.py
+++ b/composer/datasets/dataloader.py
@@ -73,7 +73,8 @@ class DDPDataLoader(WrappedDataLoader):
         return self
 
     def __next__(self) -> Batch:
-        assert self._iterator is not None
+        if self._iterator is None:
+            raise StopIteration
         try:
             return next(self._iterator)
         except StopIteration:

--- a/tests/algorithms/test_blurpool_algorithm.py
+++ b/tests/algorithms/test_blurpool_algorithm.py
@@ -26,8 +26,6 @@ def state(simple_conv_model: Model, dummy_train_dataloader: DataLoader, dummy_va
         train_dataloader=dummy_train_dataloader,
         eval_dataloader=dummy_val_dataloader,
     )
-    state.epoch = 50
-    state.step = 50
     return state
 
 

--- a/tests/algorithms/test_stochastic_depth.py
+++ b/tests/algorithms/test_stochastic_depth.py
@@ -36,8 +36,6 @@ def dummy_state(dummy_dataloader_hparams: DataloaderHparams):
                   model=model,
                   eval_dataloader=train_dataloader,
                   precision=Precision.FP32)
-    state.epoch = 50
-    state.step = 50
     return state
 
 

--- a/tests/fixtures/dummy_fixtures.py
+++ b/tests/fixtures/dummy_fixtures.py
@@ -86,8 +86,6 @@ def dummy_state_without_rank(dummy_model: SimpleBatchPairModel, dummy_train_data
         eval_dataloader=dummy_val_dataloader,
         max_epochs=10,
     )
-    state.epoch = 5
-    state.step = 50
 
     return state
 
@@ -207,8 +205,6 @@ def state_with_model(simple_conv_model: Model, dummy_train_dataloader: DataLoade
         train_dataloader=dummy_train_dataloader,
         eval_dataloader=dummy_val_dataloader,
     )
-    state.epoch = 50
-    state.step = 50
     return state
 
 

--- a/tests/test_hparams.py
+++ b/tests/test_hparams.py
@@ -44,5 +44,10 @@ class TestHparamsCreate:
         _configure_dataset_for_synthetic(hparams.train_dataset)
         _configure_dataset_for_synthetic(hparams.val_dataset)
         hparams.device = CPUDeviceHparams()
+        hparams.train_batch_size = 1
+        hparams.eval_batch_size = 1
+        hparams.dataloader.persistent_workers = False
+        hparams.dataloader.pin_memory = False
+        hparams.dataloader.num_workers = 0
 
         hparams.initialize_object()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -2,7 +2,6 @@
 
 import glob
 import os
-from typing import List
 
 import pytest
 
@@ -19,23 +18,13 @@ model_names = glob.glob(os.path.join(modeldir_path, '*.yaml'))
 model_names = [os.path.basename(os.path.splitext(mn)[0]) for mn in model_names]
 
 
-def get_model_algs(model_name: str) -> List[str]:
-    algs = algorithms.list_algorithms()
-    is_image_model = any(x in model_name for x in ("resnet", "mnist", "efficientnet"))
-    if is_image_model:
-        algs.remove("alibi")
-    if model_name in ("unet", "gpt2_52m", "gpt2_83m", 'gpt2_125m'):
-        algs.remove("mixup")
-        algs.remove("cutmix")
-    return algs
-
-
 @pytest.mark.parametrize('model_name', model_names)
 @pytest.mark.timeout(15)
 def test_load(model_name: str):
     trainer_hparams = trainer.load(model_name)
     trainer_hparams.precision = Precision.FP32
-    trainer_hparams.algorithms = algorithms.load_multiple(*get_model_algs(model_name))
+    # TODO(issue 76): Load all compatible algorithms for this model
+    # trainer_hparams.algorithms = algorithms.load_multiple(*algorithms.list_algorithms())
     if not isinstance(trainer_hparams.train_dataset, SyntheticHparamsMixin):
         pytest.skip(f"Model {model_name} uses a train dataset that doesn't support synthetic")
     assert isinstance(trainer_hparams.train_dataset, SyntheticHparamsMixin)
@@ -47,6 +36,11 @@ def test_load(model_name: str):
     assert isinstance(trainer_hparams.val_dataset, SyntheticHparamsMixin)
     trainer_hparams.eval_subset_num_batches = 1
     trainer_hparams.val_dataset.use_synthetic = True
+    trainer_hparams.train_batch_size = 1
+    trainer_hparams.eval_batch_size = 1
+    trainer_hparams.dataloader.num_workers = 0
+    trainer_hparams.dataloader.pin_memory = False
+    trainer_hparams.dataloader.persistent_workers = False
 
     trainer_hparams.device = CPUDeviceHparams()
     my_trainer = trainer_hparams.initialize_object()
@@ -66,8 +60,13 @@ def test_scale_schedule_load(ssr: str):
 
     assert isinstance(trainer_hparams.val_dataset, SyntheticHparamsMixin)
     trainer_hparams.eval_subset_num_batches = 1
+    trainer_hparams.train_batch_size = 1
+    trainer_hparams.eval_batch_size = 1
     trainer_hparams.val_dataset.use_synthetic = True
     trainer_hparams.device = CPUDeviceHparams()
+    trainer_hparams.dataloader.num_workers = 0
+    trainer_hparams.dataloader.pin_memory = False
+    trainer_hparams.dataloader.persistent_workers = False
     assert len(trainer_hparams.algorithms) == 1
     alg = trainer_hparams.algorithms[0]
     assert isinstance(alg, ScaleScheduleHparams)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -70,6 +70,8 @@ def assert_state_equivalent(state1: State, state2: State):
                 torch.testing.assert_allclose(p, q, atol=1e-2, rtol=1e-2)
         elif isinstance(var1, types.Tensor):
             assert (var1 == var2).all()
+        elif field_name in STATE_DICT_SERIALIZATION_FIELDS:
+            assert var1 == var2 or var1.state_dict() == var2.state_dict()
         else:
             assert var1 == var2
 


### PR DESCRIPTION
Support multiple calls to .fit for partial training, as discussed in #138. Specifically, this PR:
* Moves most initialization logic to `Trainer.__init__`, so it is invoked only once
* Added `num_epochs` and `num_batches` as optional parameters to `Trainer.fit`
* Significant refactor of the training loop to support the above
* Added test cases (and updated the synthetic dataloader to use a deterministic generator, so the model from the tests would be identical)