### PR TITLE
Guard artifact uploading in wandb with ddp barriers

### DIFF
--- a/composer/callbacks/run_directory_uploader.py
+++ b/composer/callbacks/run_directory_uploader.py
@@ -20,7 +20,7 @@ from composer.core.logging import Logger
 from composer.core.logging.logger import LogLevel
 from composer.core.state import State
 from composer.utils import ddp
-from composer.utils.run_directory import get_run_directory
+from composer.utils.run_directory import get_modified_files, get_run_directory
 
 log = logging.getLogger(__name__)
 
@@ -206,47 +206,43 @@ class RunDirectoryUploader(Callback):
         # Assuming only the main thread on each rank writes to the run directory, then the barrier here will ensure
         # that the run directory is not being modified after we pass this barrier
         ddp.barrier()
-        if not ddp.get_local_rank() == 0:
-            return
-        run_directory = get_run_directory()
-        assert run_directory is not None, "invariant error"
-        # the disk time can differ from system time, so going to touch a file and then read the timestamp from it to get the real time
-        python_time = time.time()
-        touch_file = (pathlib.Path(run_directory) / f".{python_time}")
-        touch_file.touch()
-        new_last_uploaded_timestamp = os.path.getmtime(str(touch_file))
+        if ddp.get_local_rank() == 0:
+            run_directory = get_run_directory()
+            assert run_directory is not None, "invariant error"
+            # the disk time can differ from system time, so going to touch a file and then read the timestamp from it to get the real time
+            python_time = time.time()
+            touch_file = (pathlib.Path(run_directory) / f".{python_time}")
+            touch_file.touch()
+            new_last_uploaded_timestamp = os.path.getmtime(str(touch_file))
 
-        # Now, for each file that was modified since self._last_upload_timestamp, copy it to the temporary directory
-        files_to_be_uploaded = []
+            # Now, for each file that was modified since self._last_upload_timestamp, copy it to the temporary directory
+            files_to_be_uploaded = []
 
-        # check if any upload threads have crashed. if so, then shutdown the training process
-        for worker in self._workers:
-            if not worker.is_alive():
-                assert self._finished is not None, "invariant error"
-                self._finished.set()
-                raise RuntimeError("Upload worker crashed unexpectedly")
-        for root, dirs, files in os.walk(run_directory):
-            del dirs  # unused
-            for file in files:
-                if any(x.startswith(".") for x in file.split(os.path.sep)):
-                    # skip hidden files and folders
-                    continue
-                filepath = os.path.join(root, file)
+            # check if any upload threads have crashed. if so, then shutdown the training process
+            for worker in self._workers:
+                if not worker.is_alive():
+                    assert self._finished is not None, "invariant error"
+                    self._finished.set()
+                    raise RuntimeError("Upload worker crashed unexpectedly")
+            modified_files = get_modified_files(self._last_upload_timestamp)
+            for filepath in modified_files:
                 relpath = os.path.relpath(filepath, run_directory)  # chop off the run directory
-                modified_time = os.path.getmtime(filepath)
-                if modified_time > self._last_upload_timestamp:
-                    copied_path = os.path.join(self._upload_staging_folder, str(new_last_uploaded_timestamp), relpath)
-                    files_to_be_uploaded.append(relpath)
-                    copied_path_dirname = os.path.dirname(copied_path)
-                    os.makedirs(copied_path_dirname, exist_ok=True)
-                    shutil.copy2(filepath, copied_path)
-                    self._file_upload_queue.put_nowait(copied_path)
-        self._last_upload_timestamp = new_last_uploaded_timestamp
-        if logger is not None and log_level is not None:
-            # now log which files are being uploaded. OK to do, since we're done reading the directory,
-            # and any logfiles will now have their last modified timestamp
-            # incremented past self._last_upload_timestamp
-            logger.metric(log_level, {"run_directory/uploaded_files": files_to_be_uploaded})
+                copied_path = os.path.join(self._upload_staging_folder, str(new_last_uploaded_timestamp), relpath)
+                files_to_be_uploaded.append(relpath)
+                copied_path_dirname = os.path.dirname(copied_path)
+                os.makedirs(copied_path_dirname, exist_ok=True)
+                shutil.copy2(filepath, copied_path)
+                self._file_upload_queue.put_nowait(copied_path)
+
+            self._last_upload_timestamp = new_last_uploaded_timestamp
+            if logger is not None and log_level is not None:
+                # now log which files are being uploaded. OK to do, since we're done reading the directory,
+                # and any logfiles will now have their last modified timestamp
+                # incremented past self._last_upload_timestamp
+                logger.metric(log_level, {"run_directory/uploaded_files": files_to_be_uploaded})
+
+        # Ensure that other callbacks do not start writing to the run directory until we copying everything
+        ddp.barrier()
 
 
 def _validate_credentials(

--- a/composer/utils/run_directory.py
+++ b/composer/utils/run_directory.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import pathlib
+import time
 
 log = logging.getLogger(__name__)
 
@@ -12,8 +14,56 @@ def get_run_directory():
     return os.environ.get(_RUN_DIRECTORY_KEY)
 
 
-def get_relative_to_run_directory(path: str, base: str = ".") -> str:
+def get_relative_to_run_directory(*path: str, base: str = ".") -> str:
     run_directory = get_run_directory()
     if run_directory is None:
-        return os.path.join(base, path)
-    return os.path.join(run_directory, path)
+        raise ValueError("shouldn't be triggered")
+        return os.path.join(base, *path)
+    return os.path.join(run_directory, *path)
+
+
+def get_modified_files(modified_since_timestamp: float, *, ignore_hidden: bool = True):
+    """Returns a list of files (recursively) in the run directory that have been modified since
+    ``modified_since_timestamp``.
+
+    Args:
+        modified_since_timestamp (float): Minimum last modified timestamp(in seconds since EPOCH)
+            of files to include.
+        ignore_hidden (bool, optional): Whether to ignore hidden files and folders (default: ``True``)
+    Returns:
+        List[str]: List of filepaths that have been modified since ``modified_since_timestamp``
+    """
+    modified_files = []
+    run_directory = get_run_directory()
+    if run_directory is None:
+        raise RuntimeError("Run directory is not defined")
+    for root, dirs, files in os.walk(run_directory):
+        del dirs  # unused
+        for file in files:
+            if ignore_hidden and any(x.startswith(".") for x in file.split(os.path.sep)):
+                # skip hidden files and folders
+                continue
+            filepath = os.path.join(root, file)
+            modified_time = os.path.getmtime(filepath)
+            if modified_time >= modified_since_timestamp:
+                modified_files.append(filepath)
+    return modified_files
+
+
+def get_run_directory_timestamp() -> float:
+    """Returns the current timestamp on the run directory filesystem.
+    Note that the disk time can differ from system time (e.g. when using
+    network filesystems).
+
+    Returns:
+        float: the current timestamp on the run directory filesystem.
+    """
+    run_directory = get_run_directory()
+    if run_directory is None:
+        raise RuntimeError("Run directory is not defined")
+    python_time = time.time()
+    touch_file = (pathlib.Path(run_directory) / f".{python_time}")
+    touch_file.touch()
+    new_last_uploaded_timestamp = os.path.getmtime(str(touch_file))
+    os.remove(str(touch_file))
+    return new_last_uploaded_timestamp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,16 +13,16 @@ import _pytest.fixtures
 import _pytest.mark
 import pytest
 import torch.distributed
+from _pytest.monkeypatch import MonkeyPatch
 
 import composer
-from composer.utils.run_directory import get_relative_to_run_directory
+from composer.utils import run_directory
 
 # Allowed options for pytest.mark.world_size()
 # Important: when updating this list, make sure to also up scripts/test.sh
 # so tests of all world sizes will be executed
 WORLD_SIZE_OPTIONS = (1, 2)
 
-PYTEST_DDP_LOCKFILE_DIR = get_relative_to_run_directory(os.path.join("pytest_lockfiles"))
 DDP_TIMEOUT = datetime.timedelta(seconds=5)
 
 # Add the path of any pytest fixture files you want to make global
@@ -112,12 +112,13 @@ def set_loglevels():
     logging.getLogger(composer.__name__).setLevel(logging.DEBUG)
 
 
-@pytest.fixture
-def ddp_tmpdir(tmpdir: pathlib.Path) -> str:
+@pytest.fixture(autouse=True)
+def subfolder_run_directory(tmpdir: pathlib.Path, monkeypatch: MonkeyPatch) -> None:
     tmpdir_test_folder_name = os.path.basename(os.path.normpath(str(tmpdir)))
-    test_folder_tmpdir = get_relative_to_run_directory(tmpdir_test_folder_name, base=os.path.join(str(tmpdir), ".."))
+    test_folder_tmpdir = run_directory.get_relative_to_run_directory(tmpdir_test_folder_name,
+                                                                     base=os.path.join(str(tmpdir), ".."))
+    monkeypatch.setenv(run_directory._RUN_DIRECTORY_KEY, test_folder_tmpdir)
     os.makedirs(test_folder_tmpdir, exist_ok=True)
-    return os.path.abspath(test_folder_tmpdir)
 
 
 @pytest.fixture(autouse=True)
@@ -139,24 +140,24 @@ def configure_ddp(request: pytest.FixtureRequest):
 
 
 @pytest.fixture(autouse=True)
-def wait_for_all_procs(ddp_tmpdir: str):
+def wait_for_all_procs(subfolder_run_directory: None):
     yield
     if not 'RANK' in os.environ:
         # Not running in a DDP environment
         return
     global_rank = int(os.environ['RANK'])
     world_size = int(os.environ['WORLD_SIZE'])
-    proc_lockfile = os.path.join(ddp_tmpdir, f"{global_rank}_finished")
+    proc_lockfile = run_directory.get_relative_to_run_directory(f"{global_rank}_finished")
     pathlib.Path(proc_lockfile).touch(exist_ok=False)
     # other processes shouldn't be (too) far behind the current one
     end_time = datetime.datetime.now() + datetime.timedelta(seconds=15)
     for rank in range(world_size):
-        if not os.path.exists(os.path.join(ddp_tmpdir, f"{rank}_finished")):
+        if not os.path.exists(run_directory.get_relative_to_run_directory(f"{rank}_finished")):
             # sleep for the other procs to write their finished file
             if datetime.datetime.now() < end_time:
                 time.sleep(0.1)
             else:
-                test_name = os.path.basename(os.path.normpath(ddp_tmpdir))
+                test_name = os.path.basename(os.path.normpath(str(run_directory.get_run_directory())))
                 raise RuntimeError(f"Rank {rank} did not finish test {test_name}")
 
 

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -32,7 +32,7 @@ def run_and_measure_memory(precision: Precision) -> int:
 
 @pytest.mark.timeout(60)
 @pytest.mark.gpu
-def test_fp16_mixed(ddp_tmpdir: str):
+def test_fp16_mixed():
     memory_full = run_and_measure_memory(Precision.FP32)
     memory_amp = run_and_measure_memory(Precision.AMP)
     assert memory_amp < 0.7 * memory_full

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -13,7 +13,8 @@ from composer.core.event import Event
 from composer.core.logging import Logger, LogLevel
 from composer.core.state import State
 from composer.loggers.file_logger import FileLoggerBackend
-from composer.loggers.logger_hparams import FileLoggerBackendHparams, TQDMLoggerBackendHparams
+from composer.loggers.logger_hparams import (FileLoggerBackendHparams, TQDMLoggerBackendHparams,
+                                             WandBLoggerBackendHparams)
 from composer.trainer.trainer_hparams import TrainerHparams
 
 
@@ -90,3 +91,14 @@ def test_tqdm_logger(mosaic_trainer_hparams: TrainerHparams, monkeypatch: Monkey
     for mock_tqdm in is_train_to_mock_tqdms[False]:
         assert mock_tqdm.update.call_count == trainer._eval_subset_num_batches
         mock_tqdm.close.assert_called_once()
+
+
+@pytest.mark.parametrize("world_size", [
+    pytest.param(1),
+    pytest.param(2, marks=pytest.mark.world_size(2)),
+])
+def test_wandb_logger(mosaic_trainer_hparams: TrainerHparams, world_size: int):
+    del world_size  # unused. Set via launcher script
+    mosaic_trainer_hparams.loggers = [WandBLoggerBackendHparams(log_artifacts=True, log_artifacts_every_n_batches=1)]
+    trainer = mosaic_trainer_hparams.initialize_object()
+    trainer.fit()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -97,6 +97,7 @@ def test_tqdm_logger(mosaic_trainer_hparams: TrainerHparams, monkeypatch: Monkey
     pytest.param(1),
     pytest.param(2, marks=pytest.mark.world_size(2)),
 ])
+@pytest.mark.timeout(10)
 def test_wandb_logger(mosaic_trainer_hparams: TrainerHparams, world_size: int):
     del world_size  # unused. Set via launcher script
     mosaic_trainer_hparams.loggers = [WandBLoggerBackendHparams(log_artifacts=True, log_artifacts_every_n_batches=1)]

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -98,7 +98,7 @@ def test_tqdm_logger(mosaic_trainer_hparams: TrainerHparams, monkeypatch: Monkey
     pytest.param(2, marks=pytest.mark.world_size(2)),
 ])
 @pytest.mark.timeout(10)
-def test_wandb_logger(mosaic_trainer_hparams: TrainerHparams, world_size: int):
+def test_wandb_logger(mosaic_trainer_hparams: TrainerHparams, world_size: int, monkeypatch: MonkeyPatch):
     del world_size  # unused. Set via launcher script
     mosaic_trainer_hparams.loggers = [WandBLoggerBackendHparams(log_artifacts=True, log_artifacts_every_n_batches=1)]
     trainer = mosaic_trainer_hparams.initialize_object()

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -2,9 +2,8 @@
 
 import collections.abc
 import os
-import pathlib
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional
 
 import pytest
 import torch
@@ -20,22 +19,25 @@ from composer.core.logging import Logger
 from composer.core.state import State
 from composer.datasets import DataloaderHparams, SyntheticBatchPairDataset, SyntheticHparamsMixin
 from composer.datasets.hparams import DatasetHparams
-from composer.models import ModelHparams
 from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.trainer.trainer_hparams import TrainerHparams, callback_registry, dataset_registry
-from composer.utils import ddp
+from composer.utils import ddp, run_directory
 from tests.fixtures.models import SimpleBatchPairModel
 
 
-def get_file_path(tmpdir: Union[str, pathlib.Path], *, rank: int, is_train: bool) -> str:
+def get_file_path(*, rank: int, is_train: bool) -> str:
     train_str = "train" if is_train else "val"
-    return os.path.join(tmpdir, f"{train_str}_rank_{rank}_num_accesses")
+    rundir = run_directory.get_run_directory()
+    assert rundir is not None
+    return os.path.join(rundir, f"{train_str}_rank_{rank}_num_accesses")
 
 
-def get_batch_file_path(tmpdir: Union[str, pathlib.Path], *, rank: int, epoch: int, is_train: bool) -> str:
+def get_batch_file_path(*, rank: int, epoch: int, is_train: bool) -> str:
     train_str = "train" if is_train else "val"
-    return os.path.join(tmpdir, f"{train_str}-rank-{rank}-epoch-{epoch}-batch0.pt")
+    rundir = run_directory.get_run_directory()
+    assert rundir is not None
+    return os.path.join(rundir, f"{train_str}-rank-{rank}-epoch-{epoch}-batch0.pt")
 
 
 class TrackedDataset(types.Dataset):
@@ -45,15 +47,14 @@ class TrackedDataset(types.Dataset):
     Because of atomic file writes, it is slow and should not be used in any performance measurements.
     """
 
-    def __init__(self, is_train: bool, tmpdir: str, synthetic_dataset: SyntheticBatchPairDataset):
+    def __init__(self, is_train: bool, synthetic_dataset: SyntheticBatchPairDataset):
         self.dataset = synthetic_dataset
         self.is_train = is_train
-        self.tmpdir = tmpdir
         self.counter = 0
 
     def __getitem__(self, idx: int):
         self.counter += 1
-        with open(get_file_path(self.tmpdir, rank=ddp.get_global_rank(), is_train=self.is_train), "w+") as f:
+        with open(get_file_path(rank=ddp.get_global_rank(), is_train=self.is_train), "w+") as f:
             f.write(str(self.counter))
         return self.dataset[idx]
 
@@ -63,12 +64,10 @@ class TrackedDataset(types.Dataset):
 
 @dataclass
 class TrackedDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
-    tmpdir: Optional[str] = hp.optional("tmpdir", default=None)
     num_classes: Optional[int] = hp.optional("num_classes", default=None)
     data_shape: Optional[List[int]] = hp.optional("data_shape", default=None)
 
     def initialize_object(self, batch_size: int, dataloader_hparams: DataloaderHparams) -> types.DataLoader:
-        assert self.tmpdir is not None
         assert self.num_classes is not None
         assert self.data_shape is not None
         synthetic_dataset = SyntheticBatchPairDataset(
@@ -78,9 +77,7 @@ class TrackedDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
             num_classes=self.num_classes,
         )
         drop_last = False
-        tracked_dataset = TrackedDataset(is_train=self.is_train,
-                                         tmpdir=self.tmpdir,
-                                         synthetic_dataset=synthetic_dataset)
+        tracked_dataset = TrackedDataset(is_train=self.is_train, synthetic_dataset=synthetic_dataset)
         sampler = ddp.get_sampler(tracked_dataset, drop_last=drop_last, shuffle=True)
         return dataloader_hparams.initialize_object(
             dataset=tracked_dataset,
@@ -92,16 +89,12 @@ class TrackedDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
 
 class CheckBatch0(Callback):
 
-    def __init__(self, tmpdir: str):
+    def __init__(self):
         super().__init__()
-        self.tmpdir = tmpdir
 
     def _run_event(self, event: Event, state: State, logger: Logger) -> None:
         if event in (Event.BEFORE_FORWARD, Event.EVAL_BEFORE_FORWARD):
-            filepath = get_batch_file_path(self.tmpdir,
-                                           rank=ddp.get_global_rank(),
-                                           epoch=state.epoch,
-                                           is_train=state.model.training)
+            filepath = get_batch_file_path(rank=ddp.get_global_rank(), epoch=state.epoch, is_train=state.model.training)
             if os.path.exists(filepath):
                 return
             last_input, last_target = state.batch_pair
@@ -114,10 +107,9 @@ class CheckBatch0(Callback):
 
 @dataclass
 class CheckBatch0Hparams(CallbackHparams):
-    tmpdir: str = hp.required("tmpdir")
 
     def initialize_object(self) -> Callback:
-        return CheckBatch0(self.tmpdir)
+        return CheckBatch0()
 
 
 @pytest.fixture(autouse=True)
@@ -136,8 +128,7 @@ def patch_registries(monkeypatch: MonkeyPatch):
     pytest.param(1),
     pytest.param(2, marks=pytest.mark.world_size(2)),
 ])
-def test_ddp(device: DeviceHparams, world_size: int, ddp_tmpdir: str, mosaic_trainer_hparams: TrainerHparams,
-             SimpleBatchPairModelHparams: Type[ModelHparams], deepspeed: bool) -> None:
+def test_ddp(device: DeviceHparams, world_size: int, mosaic_trainer_hparams: TrainerHparams, deepspeed: bool) -> None:
     """
     test strategy for ddp:
     1) Train a dummy model on two gps, for two epochs, using the tracked dataset.
@@ -166,7 +157,6 @@ def test_ddp(device: DeviceHparams, world_size: int, ddp_tmpdir: str, mosaic_tra
     hparams.train_dataset = TrackedDatasetHparams(
         synthetic_num_unique_samples=hparams.train_batch_size * hparams.train_subset_num_batches,
         is_train=True,
-        tmpdir=ddp_tmpdir,
         data_shape=list(model.in_shape),
         num_classes=model.num_classes,
     )
@@ -176,7 +166,6 @@ def test_ddp(device: DeviceHparams, world_size: int, ddp_tmpdir: str, mosaic_tra
     hparams.val_dataset = TrackedDatasetHparams(
         synthetic_num_unique_samples=hparams.eval_batch_size * hparams.eval_subset_num_batches,
         is_train=False,
-        tmpdir=ddp_tmpdir,
         data_shape=list(model.in_shape),
         num_classes=model.num_classes,
     )
@@ -193,7 +182,7 @@ def test_ddp(device: DeviceHparams, world_size: int, ddp_tmpdir: str, mosaic_tra
     hparams.loggers = []
     hparams.validate_every_n_batches = 0
     hparams.validate_every_n_epochs = 1
-    hparams.callbacks.append(CheckBatch0Hparams(tmpdir=ddp_tmpdir))
+    hparams.callbacks.append(CheckBatch0Hparams())
     if deepspeed:
         hparams.deepspeed = DeepSpeedHparams(enabled=True)
     trainer = hparams.initialize_object()
@@ -211,9 +200,9 @@ def test_ddp(device: DeviceHparams, world_size: int, ddp_tmpdir: str, mosaic_tra
     actual_val_num_loads = 0
 
     for i in range(ddp.get_world_size()):
-        with open(get_file_path(ddp_tmpdir, is_train=True, rank=i), "r") as f:
+        with open(get_file_path(is_train=True, rank=i), "r") as f:
             actual_train_num_loads += int(f.read())
-        with open(get_file_path(ddp_tmpdir, is_train=False, rank=i), "r") as f:
+        with open(get_file_path(is_train=False, rank=i), "r") as f:
             actual_val_num_loads += int(f.read())
     assert actual_train_num_loads == expected_train_num_loads, f"actual_train_num_loads({actual_train_num_loads}) != expected_train_num_loads({expected_train_num_loads})"
     assert actual_val_num_loads == expected_val_num_loads, f"actual_val_num_loads({actual_val_num_loads}) != expected_val_num_loads({expected_val_num_loads})"
@@ -224,7 +213,7 @@ def test_ddp(device: DeviceHparams, world_size: int, ddp_tmpdir: str, mosaic_tra
         for local_rank in range(ddp.get_local_world_size()):
             for is_train in (True, False):
                 data: Dict[str, types.Tensor] = torch.load(  # type: ignore
-                    get_batch_file_path(ddp_tmpdir, rank=local_rank, epoch=epoch, is_train=is_train),
+                    get_batch_file_path(rank=local_rank, epoch=epoch, is_train=is_train),
                     map_location='cpu',
                 )
                 for pickle in is_train_to_pickles[is_train]:


### PR DESCRIPTION
Ensuring that the run directory is not being modified while wandb is uploading artifacts.

Hopefully closes #90 