### PR TITLE
Add the ability to load a checkpoint without restoring state

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -221,10 +221,10 @@ class State(Serializable):
             state_dict (types.StateDict): object returned from call to :meth:`state_dict`.
             strict (bool): whether the keys in the state_dict should perfectly match the keys in the model.
         """
-        if state_dict['state']["_is_model_ddp_wrapped"] and not isinstance(self.model, DistributedDataParallel):
-            torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(state_dict['state']['model'], "module.")
+        if state_dict["_is_model_ddp_wrapped"] and not isinstance(self.model, DistributedDataParallel):
+            torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(state_dict['model'], "module.")
 
-            missing_keys, unexpected_keys = self.model.load_state_dict(state_dict['state']['model'], strict=strict)
+            missing_keys, unexpected_keys = self.model.load_state_dict(state_dict['model'], strict=strict)
             if len(missing_keys) > 0:
                 logger.warning(f"Found these missing keys in the checkpoint: {', '.join(missing_keys)}")
             if len(unexpected_keys) > 0:
@@ -246,7 +246,7 @@ class State(Serializable):
                 serialized_value = state[state_field_name]
 
                 if state_field_name == "model":
-                    self.load_model_state(serialized_value, strict=strict)
+                    self.load_model_state(state, strict=strict)
                 else:
                     for target in ensure_tuple(state_field_value):
                         if target is None:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -213,7 +213,24 @@ class State(Serializable):
         state_dict["_is_model_ddp_wrapped"] = isinstance(self.model, DistributedDataParallel)
         return state_dict
 
-    def load_state_dict(self, state: types.StateDict):
+    def load_model_state(self, state_dict: types.StateDict, strict: bool):
+        """
+        Loads the model's state from a state_dict.
+
+        Args:
+            state_dict (types.StateDict): object returned from call to :meth:`state_dict`.
+            strict (bool): whether the keys in the state_dict should perfectly match the keys in the model.
+        """
+        if state_dict['state']["_is_model_ddp_wrapped"] and not isinstance(self.model, DistributedDataParallel):
+            torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(state_dict['state']['model'], "module.")
+
+            missing_keys, unexpected_keys = self.model.load_state_dict(state_dict['state']['model'], strict=strict)
+            if len(missing_keys) > 0:
+                logger.warning(f"Found these missing keys in the checkpoint: {', '.join(missing_keys)}")
+            if len(unexpected_keys) > 0:
+                logger.warning(f"Found these unexpected keys in the checkpoint: {', '.join(unexpected_keys)}")
+
+    def load_state_dict(self, state: types.StateDict, strict: bool = False):
         """Loads the state.
 
         Args:
@@ -229,9 +246,7 @@ class State(Serializable):
                 serialized_value = state[state_field_name]
 
                 if state_field_name == "model":
-                    if state["_is_model_ddp_wrapped"] and not isinstance(self.model, DistributedDataParallel):
-                        torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(serialized_value, "module.")
-                    state_field_value.load_state_dict(serialized_value)
+                    self.load_model_state(serialized_value, strict=strict)
                 else:
                     for target in ensure_tuple(state_field_value):
                         if target is None:

--- a/composer/datasets/hparams.py
+++ b/composer/datasets/hparams.py
@@ -40,7 +40,7 @@ def _split_fn(batch: Batch, n_microbatches: int) -> List[Batch]:
 class DataloaderSpec(NamedTuple):
     """Specification for initializing a dataloader when a device transformation function or split function
     is required
-    
+
     Parameters:
         dataloader (DataLoader): The initialized dataloader.
         device_transform_fn (TDeviceTransformFn, optional):
@@ -104,12 +104,12 @@ class DatasetHparams(hp.Hparams, abc.ABC, metaclass=metaclass):
     def initialize_object(self, batch_size: int,
                           dataloader_hparams: DataloaderHparams) -> Union[DataLoader, DataloaderSpec]:
         """Creates a :class:`DataLoader` or :class:`DataloaderSpec` for this dataset.
-        
+
         Parameters:
             batch_size (int): The size of the batch the dataloader should yield. This batch size is
                 device-specific and already incorporates the world size.
             dataloader_hparams (DataloaderHparams): The dataset-independent hparams for the dataloader
-        
+
         Returns:
             Dataloader or DataloaderSpec: The dataloader, or if a custom device transformation
                 or split function is required, a :class:`DataloaderSpec` tuple

--- a/composer/optim/pytorch_future.py
+++ b/composer/optim/pytorch_future.py
@@ -70,6 +70,7 @@ class WarmUpLR(_LRScheduler):
                  interval='step'):
         if warmup_method not in ("constant", "linear"):
             raise ValueError("Only 'constant' or 'linear' warmup_method accepted, but got {}".format(warmup_method))
+
         self.warmup_factor = warmup_factor
         self.warmup_iters = warmup_iters
         self.warmup_method = warmup_method

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -43,7 +43,7 @@ class CheckpointLoader:
         """
 
         if self.load_weights_only:
-            state.load_model_state(self.state_dict, strict=self.strict_model_weights)
+            state.load_model_state(self.state_dict['state'], strict=self.strict_model_weights)
         else:
             state.load_state_dict(self.state_dict["state"])
         self.checkpoint_rng_state = self._get_checkpoint_rng_state(state, self.state_dict["rng"])

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -46,18 +46,18 @@ class CheckpointLoader:
             state.load_model_state(self.state_dict['state'], strict=self.strict_model_weights)
         else:
             state.load_state_dict(self.state_dict["state"])
-        self.checkpoint_rng_state = self._get_checkpoint_rng_state(state, self.state_dict["rng"])
+            self.checkpoint_rng_state = self._get_checkpoint_rng_state(state, self.state_dict["rng"])
 
-        if "seed" in self.state_dict:
-            world_size = ddp.get_world_size()
-            checkpointed_world_size = len(self.state_dict["seed"])
-            if world_size != checkpointed_world_size:
-                warnings.warn(f"Current world size {world_size} does not match the checkpointed world size "
-                              f"{checkpointed_world_size}. The seed will not be restored.")
-                return
-            seed_to_restore = self.state_dict["seed"][ddp.get_global_rank()]
-            seed_all(seed_to_restore)
-            return seed_to_restore
+            if "seed" in self.state_dict:
+                world_size = ddp.get_world_size()
+                checkpointed_world_size = len(self.state_dict["seed"])
+                if world_size != checkpointed_world_size:
+                    warnings.warn(f"Current world size {world_size} does not match the checkpointed world size "
+                                  f"{checkpointed_world_size}. The seed will not be restored.")
+                    return
+                seed_to_restore = self.state_dict["seed"][ddp.get_global_rank()]
+                seed_all(seed_to_restore)
+                return seed_to_restore
 
     def restore_checkpoint_rng_state(self, state: State, device: Device):
         """Restore the state of all RNG objects in this context from the loaded checkpoint's data.

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -23,15 +23,14 @@ class CheckpointLoader:
 
     Args:
         checkpoint_filepath (str): The path to an existing checkpoint file.
+        load_weights_only (bool): Whether to only restore the weights from the checkpoint without restoring the associated state.
+        strict_model_weights (bool): Whether to force that the checkpointed weights must exactly match the model weights.
     """
 
-    def __init__(self,
-                 checkpoint_filepath: str,
-                 load_weights_only: Optional[bool] = False,
-                 strict: Optional[bool] = False):
+    def __init__(self, checkpoint_filepath: str, load_weights_only: bool = False, strict_model_weights: bool = False):
         self.state_dict = torch.load(checkpoint_filepath, map_location='cpu')
         self.load_weights_only = load_weights_only
-        self.strict = strict
+        self.strict_model_weights = strict_model_weights
 
     def load_checkpoint(self, state: State):
         """Initialize state from the loaded checkpoint's data.
@@ -44,7 +43,7 @@ class CheckpointLoader:
         """
 
         if self.load_weights_only:
-            state.load_model_state(self.state_dict, strict=self.strict)
+            state.load_model_state(self.state_dict, strict=self.strict_model_weights)
         else:
             state.load_state_dict(self.state_dict["state"])
         self.checkpoint_rng_state = self._get_checkpoint_rng_state(state, self.state_dict["rng"])
@@ -89,7 +88,7 @@ class CheckpointLoader:
                           f"RNG state will not be restored.")
 
 
-class Checkpointer:
+class CheckpointSaver:
     """Manager for saving state to checkpoint files.
 
     Args:

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -42,17 +42,7 @@ class CheckpointLoader:
         """
 
         if self.load_weights_only:
-
-            if self.state_dict['state']["_is_model_ddp_wrapped"] and not isinstance(state.model,
-                                                                                    DistributedDataParallel):
-                torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(self.state_dict['state']['model'],
-                                                                               "module.")
-
-            missing_keys, unexpected_keys = state.model.load_state_dict(self.state_dict['state']['model'], strict=False)
-            if len(missing_keys) > 0:
-                log.warning(f"Found these missing keys in the checkpoint: {', '.join(missing_keys)}")
-            if len(unexpected_keys) > 0:
-                log.warning(f"Found these unexpected keys in the checkpoint: {', '.join(unexpected_keys)}")
+            state.load_model_state(self.state_dict, strict=self.strict)
         else:
             state.load_state_dict(self.state_dict["state"])
         self.checkpoint_rng_state = self._get_checkpoint_rng_state(state, self.state_dict["rng"])

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -92,7 +92,7 @@ class CheckpointSaver:
     """Manager for saving state to checkpoint files.
 
     Args:
-        checkpoint_folder (str): The path to the folder to store checkpoints in.
+        checkpoint_folder (str): The path to store checkpoints in.
         checkpoint_interval (int): The amount of time units to wait between checkpoints.
         checkpoint_interval_unit (str): The unit (`"ep"` or `"it"`) that
             `checkpoint_interval` should be measured in.

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Optional
 import numpy as np
 import torch
 import yaml
-from torch.nn.parallel import DistributedDataParallel
 
 from composer.core import Event, State
 from composer.core.types import StateDict
@@ -26,7 +25,10 @@ class CheckpointLoader:
         checkpoint_filepath (str): The path to an existing checkpoint file.
     """
 
-    def __init__(self, checkpoint_filepath: str, load_weights_only: bool = False, strict: bool = False):
+    def __init__(self,
+                 checkpoint_filepath: str,
+                 load_weights_only: Optional[bool] = False,
+                 strict: Optional[bool] = False):
         self.state_dict = torch.load(checkpoint_filepath, map_location='cpu')
         self.load_weights_only = load_weights_only
         self.strict = strict

--- a/composer/trainer/checkpoint_hparams.py
+++ b/composer/trainer/checkpoint_hparams.py
@@ -1,20 +1,12 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 import logging
-import os
-import random
-import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Optional
 
-import numpy as np
-import torch
 import yahp as hp
-import yaml
 
-from composer.core.types import StateDict
-from composer.trainer.checkpoint import CheckpointLoader, Checkpointer
-from composer.trainer.devices.device import Device
+from composer.trainer.checkpoint import Checkpointer, CheckpointLoader
 
 log = logging.getLogger(__name__)
 
@@ -42,13 +34,15 @@ class CheckpointLoaderHparams(hp.Hparams):
                                 load_weights_only=self.load_weights_only,
                                 strict=self.strict)
 
+
 @dataclass
 class CheckpointerHparams(hp.Hparams):
     """Hparams for the :class:`Checkpointer`.
 
     See the documentation for the :class:`Checkpointer`.
     """
-    checkpoint_interval_unit: Optional[str] = hp.required(doc="Unit for the checkpoint save interval -- should be 'ep' for epochs; 'it' for iterations")
+    checkpoint_interval_unit: str = hp.required(
+        doc="Unit for the checkpoint save interval -- should be 'ep' for epochs; 'it' for iterations")
     checkpoint_interval: int = hp.required(doc="Interval for checkpointing.")
     checkpoint_folder: str = hp.optional(
         doc="Folder in which to save checkpoint files. Relative to the run directory, if set."
@@ -61,7 +55,7 @@ class CheckpointerHparams(hp.Hparams):
         if self.checkpoint_interval_unit not in ['ep', 'it']:
             raise ValueError("Checkpointing interval unit must be one of 'ep' for epochs, or 'it' for iterations.")
 
-    def initialize_object(self) -> CheckpointLoader:
+    def initialize_object(self) -> Checkpointer:
         return Checkpointer(checkpoint_interval_unit=self.checkpoint_interval_unit,
-                checkpoint_interval=self.checkpoint_interval,
-                checkpoint_folder=self.checkpoint_folder)
+                            checkpoint_interval=self.checkpoint_interval,
+                            checkpoint_folder=self.checkpoint_folder)

--- a/composer/trainer/checkpoint_hparams.py
+++ b/composer/trainer/checkpoint_hparams.py
@@ -1,0 +1,41 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+import logging
+import os
+import random
+import warnings
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+import yahp as hp
+import yaml
+
+from composer.core.types import StateDict
+from composer.trainer.checkpoint import CheckpointLoader
+from composer.trainer.devices.device import Device
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class CheckpointLoaderHparams(hp.Hparams):
+    """Hparams for the :class:`CheckpointLoader`.
+
+    See the documentation for the :class:`CheckpointLoader`.
+    """
+    checkpoint_filepath: Optional[str] = hp.optional(doc="Path to the serialized state_dict to recover state from.",
+                                                     default=None)
+    load_weights_only: Optional[bool] = hp.optional(doc="Whether to only load the weights from the model.",
+                                                    default=False)
+    strict: Optional[bool] = hp.optional(
+        doc="Ensure that the set of weights in the checkpoint and model must exactly match.", default=True)
+
+    def initialize_object(self) -> CheckpointLoader:
+        print(self.checkpoint_filepath, "filepath")
+        if self.checkpoint_filepath:
+            return CheckpointLoader(checkpoint_filepath=self.checkpoint_filepath,
+                                    load_weights_only=self.load_weights_only,
+                                    strict=self.strict)
+        return None

--- a/composer/trainer/checkpoint_hparams.py
+++ b/composer/trainer/checkpoint_hparams.py
@@ -17,7 +17,7 @@ class CheckpointLoaderHparams(hp.Hparams):
 
     See the documentation for the :class:`CheckpointLoader`.
     """
-    checkpoint_filepath: str = hp.required(doc="Path to the serialized state_dict to recover state from.")
+    filepath: str = hp.required(doc="Path to the serialized state_dict to recover state from.")
     load_weights_only: Optional[bool] = hp.optional(doc="Whether to only load the weights from the model.",
                                                     default=False)
     strict: Optional[bool] = hp.optional(
@@ -30,7 +30,7 @@ class CheckpointLoaderHparams(hp.Hparams):
             )
 
     def initialize_object(self) -> CheckpointLoader:
-        return CheckpointLoader(checkpoint_filepath=self.checkpoint_filepath,
+        return CheckpointLoader(checkpoint_filepath=self.filepath,
                                 load_weights_only=self.load_weights_only,
                                 strict=self.strict)
 
@@ -41,21 +41,21 @@ class CheckpointerHparams(hp.Hparams):
 
     See the documentation for the :class:`Checkpointer`.
     """
-    checkpoint_interval_unit: str = hp.required(
+    interval_unit: str = hp.required(
         doc="Unit for the checkpoint save interval -- should be 'ep' for epochs; 'it' for iterations")
-    checkpoint_interval: int = hp.required(doc="Interval for checkpointing.")
-    checkpoint_folder: str = hp.optional(
+    interval: int = hp.required(doc="Interval for checkpointing.")
+    folder: str = hp.optional(
         doc="Folder in which to save checkpoint files. Relative to the run directory, if set."
         "Defaults to `checkpoints`.",
         default="checkpoints")
 
     def validate(self):
-        if self.checkpoint_interval < 0:
+        if self.interval < 0:
             raise ValueError("Checkpointing interval must be greater than zero.")
-        if self.checkpoint_interval_unit not in ['ep', 'it']:
+        if self.interval_unit not in ['ep', 'it']:
             raise ValueError("Checkpointing interval unit must be one of 'ep' for epochs, or 'it' for iterations.")
 
     def initialize_object(self) -> Checkpointer:
-        return Checkpointer(checkpoint_interval_unit=self.checkpoint_interval_unit,
-                            checkpoint_interval=self.checkpoint_interval,
-                            checkpoint_folder=self.checkpoint_folder)
+        return Checkpointer(checkpoint_interval_unit=self.interval_unit,
+                            checkpoint_interval=self.interval,
+                            checkpoint_folder=self.folder)

--- a/composer/trainer/checkpoint_hparams.py
+++ b/composer/trainer/checkpoint_hparams.py
@@ -56,7 +56,7 @@ class CheckpointerHparams(hp.Hparams):
         default="checkpoints")
 
     def validate(self):
-        if self.checkpoint_interval > 0:
+        if self.checkpoint_interval < 0:
             raise ValueError("Checkpointing interval must be greater than zero.")
         if self.checkpoint_interval_unit not in ['ep', 'it']:
             raise ValueError("Checkpointing interval unit must be one of 'ep' for epochs, or 'it' for iterations.")

--- a/composer/trainer/checkpoint_hparams.py
+++ b/composer/trainer/checkpoint_hparams.py
@@ -13,7 +13,7 @@ import yahp as hp
 import yaml
 
 from composer.core.types import StateDict
-from composer.trainer.checkpoint import CheckpointLoader
+from composer.trainer.checkpoint import CheckpointLoader, Checkpointer
 from composer.trainer.devices.device import Device
 
 log = logging.getLogger(__name__)
@@ -25,16 +25,43 @@ class CheckpointLoaderHparams(hp.Hparams):
 
     See the documentation for the :class:`CheckpointLoader`.
     """
-    checkpoint_filepath: Optional[str] = hp.optional(doc="Path to the serialized state_dict to recover state from.",
-                                                     default=None)
+    checkpoint_filepath: str = hp.required(doc="Path to the serialized state_dict to recover state from.")
     load_weights_only: Optional[bool] = hp.optional(doc="Whether to only load the weights from the model.",
                                                     default=False)
     strict: Optional[bool] = hp.optional(
         doc="Ensure that the set of weights in the checkpoint and model must exactly match.", default=True)
 
+    def validate(self):
+        if not self.load_weights_only and self.strict:
+            raise ValueError(
+                "Strict cannot be used when load_weights_only is true. Restoring a checkpoint from previous state assumes that the checkpoint should perfectly match the model."
+            )
+
     def initialize_object(self) -> CheckpointLoader:
-        if self.checkpoint_filepath:
-            return CheckpointLoader(checkpoint_filepath=self.checkpoint_filepath,
-                                    load_weights_only=self.load_weights_only,
-                                    strict=self.strict)
-        return None
+        return CheckpointLoader(checkpoint_filepath=self.checkpoint_filepath,
+                                load_weights_only=self.load_weights_only,
+                                strict=self.strict)
+
+@dataclass
+class CheckpointerHparams(hp.Hparams):
+    """Hparams for the :class:`Checkpointer`.
+
+    See the documentation for the :class:`Checkpointer`.
+    """
+    checkpoint_interval_unit: Optional[str] = hp.required(doc="Unit for the checkpoint save interval -- should be 'ep' for epochs; 'it' for iterations")
+    checkpoint_interval: int = hp.required(doc="Interval for checkpointing.")
+    checkpoint_folder: str = hp.optional(
+        doc="Folder in which to save checkpoint files. Relative to the run directory, if set."
+        "Defaults to `checkpoints`.",
+        default="checkpoints")
+
+    def validate(self):
+        if self.checkpoint_interval > 0:
+            raise ValueError("Checkpointing interval must be greater than zero.")
+        if self.checkpoint_interval_unit not in ['ep', 'it']:
+            raise ValueError("Checkpointing interval unit must be one of 'ep' for epochs, or 'it' for iterations.")
+
+    def initialize_object(self) -> CheckpointLoader:
+        return Checkpointer(checkpoint_interval_unit=self.checkpoint_interval_unit,
+                checkpoint_interval=self.checkpoint_interval,
+                checkpoint_folder=self.checkpoint_folder)

--- a/composer/trainer/checkpoint_hparams.py
+++ b/composer/trainer/checkpoint_hparams.py
@@ -44,10 +44,9 @@ class CheckpointerHparams(hp.Hparams):
     interval_unit: str = hp.required(
         doc="Unit for the checkpoint save interval -- should be 'ep' for epochs; 'it' for iterations")
     interval: int = hp.required(doc="Interval for checkpointing.")
-    folder: str = hp.optional(
-        doc="Folder in which to save checkpoint files. Relative to the run directory, if set."
-        "Defaults to `checkpoints`.",
-        default="checkpoints")
+    folder: str = hp.optional(doc="Folder in which to save checkpoint files. Relative to the run directory, if set."
+                              "Defaults to `checkpoints`.",
+                              default="checkpoints")
 
     def validate(self):
         if self.interval < 0:

--- a/composer/trainer/checkpoint_hparams.py
+++ b/composer/trainer/checkpoint_hparams.py
@@ -2,11 +2,10 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Optional
 
 import yahp as hp
 
-from composer.trainer.checkpoint import Checkpointer, CheckpointLoader
+from composer.trainer.checkpoint import CheckpointLoader, CheckpointSaver
 
 log = logging.getLogger(__name__)
 
@@ -18,13 +17,12 @@ class CheckpointLoaderHparams(hp.Hparams):
     See the documentation for the :class:`CheckpointLoader`.
     """
     filepath: str = hp.required(doc="Path to the serialized state_dict to recover state from.")
-    load_weights_only: Optional[bool] = hp.optional(doc="Whether to only load the weights from the model.",
-                                                    default=False)
-    strict: Optional[bool] = hp.optional(
-        doc="Ensure that the set of weights in the checkpoint and model must exactly match.", default=True)
+    load_weights_only: bool = hp.optional(doc="Whether to only load the weights from the model.", default=False)
+    strict_model_weights: bool = hp.optional(
+        doc="Ensure that the set of weights in the checkpoint and model must exactly match.", default=False)
 
     def validate(self):
-        if not self.load_weights_only and self.strict:
+        if not self.load_weights_only and self.strict_model_weights:
             raise ValueError(
                 "Strict cannot be used when load_weights_only is true. Restoring a checkpoint from previous state assumes that the checkpoint should perfectly match the model."
             )
@@ -32,14 +30,14 @@ class CheckpointLoaderHparams(hp.Hparams):
     def initialize_object(self) -> CheckpointLoader:
         return CheckpointLoader(checkpoint_filepath=self.filepath,
                                 load_weights_only=self.load_weights_only,
-                                strict=self.strict)
+                                strict_model_weights=self.strict_model_weights)
 
 
 @dataclass
-class CheckpointerHparams(hp.Hparams):
-    """Hparams for the :class:`Checkpointer`.
+class CheckpointSaverHparams(hp.Hparams):
+    """Hparams for the :class:`CheckpointSaver`.
 
-    See the documentation for the :class:`Checkpointer`.
+    See the documentation for the :class:`CheckpointSaver`.
     """
     interval_unit: str = hp.required(
         doc="Unit for the checkpoint save interval -- should be 'ep' for epochs; 'it' for iterations")
@@ -54,7 +52,7 @@ class CheckpointerHparams(hp.Hparams):
         if self.interval_unit not in ['ep', 'it']:
             raise ValueError("Checkpointing interval unit must be one of 'ep' for epochs, or 'it' for iterations.")
 
-    def initialize_object(self) -> Checkpointer:
-        return Checkpointer(checkpoint_interval_unit=self.interval_unit,
-                            checkpoint_interval=self.interval,
-                            checkpoint_folder=self.folder)
+    def initialize_object(self) -> CheckpointSaver:
+        return CheckpointSaver(checkpoint_interval_unit=self.interval_unit,
+                               checkpoint_interval=self.interval,
+                               checkpoint_folder=self.folder)

--- a/composer/trainer/checkpoint_hparams.py
+++ b/composer/trainer/checkpoint_hparams.py
@@ -33,7 +33,6 @@ class CheckpointLoaderHparams(hp.Hparams):
         doc="Ensure that the set of weights in the checkpoint and model must exactly match.", default=True)
 
     def initialize_object(self) -> CheckpointLoader:
-        print(self.checkpoint_filepath, "filepath")
         if self.checkpoint_filepath:
             return CheckpointLoader(checkpoint_filepath=self.checkpoint_filepath,
                                     load_weights_only=self.load_weights_only,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -100,8 +100,8 @@ class Trainer:
             match the model weights.
         checkpoint_folder (str): The path to store checkpoints in.
         checkpoint_interval (int): The amount of time units to wait between creating checkpoints.
-        checkpoint_interval_unit (str): The unit (`"ep"` or `"it"`) that
-            `checkpoint_interval` should be measured in.
+        checkpoint_interval_unit (str, optional): The unit (`"ep"` or `"it"`) that
+            `checkpoint_interval` should be measured in. Set to ``None`` disables checkpointing. (default: ``None``)
         train_subset_num_batches (int, optional): If specified, finish every epoch early after training
             on this many batches. This parameter has no effect if it is greater than ``len(train_dataloader)``.
             If None (the default), then the entire dataloader will be iterated over.

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -31,7 +31,6 @@ from composer.optim import (ComposedScheduler, CosineAnnealingLRHparams, Decoupl
                             SchedulerHparams, WarmUpLRHparams)
 from composer.optim.scheduler import ensure_warmup_last
 from composer.trainer.checkpoint import Checkpointer, CheckpointLoader
-from composer.trainer.checkpoint_hparams import CheckpointLoaderHparams
 from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices.device import Device
 from composer.trainer.devices.device_cpu import DeviceCPU
@@ -39,7 +38,6 @@ from composer.trainer.devices.device_gpu import DeviceGPU
 from composer.trainer.scaler import ClosureGradScaler
 from composer.trainer.trainer_hparams import TrainerHparams
 from composer.utils import ddp, ensure_tuple, get_random_seed, map_collection, seed_all
-from composer.utils.run_directory import get_relative_to_run_directory
 
 log = logging.getLogger(__name__)
 
@@ -398,7 +396,7 @@ class Trainer:
             # Checkpointing hparams
             checkpoint_loader=checkpoint_loader,
             checkpointer=checkpointer,
-            
+
             # Subset parameters
             train_subset_num_batches=hparams.train_subset_num_batches,
             eval_subset_num_batches=hparams.eval_subset_num_batches,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -293,15 +293,12 @@ class Trainer:
         self.state.optimizers = optimizer
         self.state.schedulers = ComposedScheduler(schedulers=schedulers)
 
-        self.checkpointer = None
+        self.checkpointer = checkpointer 
         # TODO(#121): get checkpointing working with DeepSpeed.
-        if checkpoint_folder and checkpoint_interval and checkpoint_interval_unit:
+        if self.checkpointer: 
             if self.deepspeed_enabled:
                 raise NotImplementedError("Checkpointing is not yet supported with DeepSpeed.")
-            self.checkpointer = Checkpointer(checkpoint_folder=get_relative_to_run_directory(checkpoint_folder),
-                                             checkpoint_interval=checkpoint_interval,
-                                             checkpoint_interval_unit=checkpoint_interval_unit)
-
+            
         self.checkpoint_loader = checkpoint_loader
         # TODO(#121): get checkpointing working with DeepSpeed.
         if checkpoint_loader:
@@ -365,7 +362,7 @@ class Trainer:
             (set to {hparams.eval_subset_num_batches}), val_dataset.shuffle should be set to False. Otherwise,
             each evaluation epoch may load a different subset of samples."""))
         eval_dataloader = hparams.val_dataset.initialize_object(eval_device_batch_size, hparams.dataloader)
-        checkpoint_loader = hparams.checkpoint_loader.initialize_object()
+        checkpoint_loader = hparams.checkpoint_loader.initialize_object() if hparams.checkpoint_loader else None
 
         trainer = cls(
             model=model,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -149,7 +149,7 @@ class Trainer:
             callbacks: Sequence[Callback] = tuple(),
 
             # Checkpoint hparams
-            checkpoint_loader: Optional[CheckpointLoaderHparams] = None,
+            checkpoint_loader: Optional[CheckpointLoader] = None,
             checkpoint_interval_unit: Optional[str] = None,
             checkpoint_folder: Optional[str] = "checkpoints",
             checkpoint_interval: Optional[int] = 1,
@@ -302,12 +302,9 @@ class Trainer:
                                              checkpoint_interval=checkpoint_interval,
                                              checkpoint_interval_unit=checkpoint_interval_unit)
 
-        print("Before loading:", self.checkpoint_loader)
-        self.checkpoint_loader = CheckpointLoaderHparams().initialize_object()
-        print("Checkpoint Loader:", self.checkpoint_loader)
-        input("Press any key to continue..")
+        self.checkpoint_loader = checkpoint_loader
         # TODO(#121): get checkpointing working with DeepSpeed.
-        if self.checkpoint_loader:
+        if checkpoint_loader:
             if self.deepspeed_enabled:
                 raise NotImplementedError("Checkpointing is not yet supported with DeepSpeed.")
             self.checkpoint_loader = CheckpointLoader(checkpoint_filepath=checkpoint_filepath)
@@ -368,6 +365,7 @@ class Trainer:
             (set to {hparams.eval_subset_num_batches}), val_dataset.shuffle should be set to False. Otherwise,
             each evaluation epoch may load a different subset of samples."""))
         eval_dataloader = hparams.val_dataset.initialize_object(eval_device_batch_size, hparams.dataloader)
+        checkpoint_loader = hparams.checkpoint_loader.initialize_object()
 
         trainer = cls(
             model=model,
@@ -402,6 +400,7 @@ class Trainer:
             callbacks=tuple(callbacks),
 
             # Checkpointing hparams
+            checkpoint_loader=checkpoint_loader,
             checkpoint_interval_unit=hparams.checkpoint_interval_unit,
             checkpoint_folder=hparams.checkpoint_folder,
             checkpoint_interval=hparams.checkpoint_interval,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -92,9 +92,9 @@ class Trainer:
         log_destinations (List[BaseLoggerBackend], optional): The destinations to log training information to.
             (default ``[TQDMLoggerBackend()]``).
         callbacks (Sequence[Callback], optional): The callbacks to run during training. (default: ``[]``)
-        checkpoint_loader (CheckpointLoader, optional): The CheckpointLoaderHparams used to load checkpoints of state
+        checkpoint_loader (CheckpointLoader, optional): The CheckpointLoader used to load checkpoints of state
             from disk. (default: ``None``)
-        checkpoint_saver (CheckpointSaver, optional): The CheckpointSaverHparams used to save checkpoints of state
+        checkpoint_saver (CheckpointSaver, optional): The CheckpointSaver used to save checkpoints of state
             to disk. (default: ``None``)
         train_subset_num_batches (int, optional): If specified, finish every epoch early after training
             on this many batches. This parameter has no effect if it is greater than ``len(train_dataloader)``.

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -38,6 +38,7 @@ from composer.trainer.devices.device_gpu import DeviceGPU
 from composer.trainer.scaler import ClosureGradScaler
 from composer.trainer.trainer_hparams import TrainerHparams
 from composer.utils import ddp, ensure_tuple, get_random_seed, map_collection, seed_all
+from composer.utils.run_directory import get_relative_to_run_directory
 
 log = logging.getLogger(__name__)
 
@@ -300,15 +301,17 @@ class Trainer:
         self.state.schedulers = ComposedScheduler(schedulers=schedulers)
 
         # TODO(#121): get checkpointing working with DeepSpeed.
+        self.checkpoint_saver = None
         if checkpoint_interval is not None and checkpoint_interval_unit is not None:
             self.checkpoint_saver = CheckpointSaver(checkpoint_interval_unit=checkpoint_interval_unit,
                                                     checkpoint_interval=checkpoint_interval,
-                                                    checkpoint_folder=checkpoint_folder)
+                                                    checkpoint_folder=get_relative_to_run_directory(checkpoint_folder))
 
             if self.deepspeed_enabled:
                 raise NotImplementedError("Checkpointing is not yet supported with DeepSpeed.")
 
         # TODO(#121): get checkpointing working with DeepSpeed.
+        self.checkpoint_loader = None
         if checkpoint_filepath is not None:
             if self.deepspeed_enabled:
                 raise NotImplementedError("Checkpointing is not yet supported with DeepSpeed.")

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -381,15 +381,15 @@ class Trainer:
         # Checkpoint loading hparams
         checkpoint_filepath = hparams.load_checkpoint.filepath if hparams.load_checkpoint is not None else None
         checkpoint_load_weights_only = hparams.load_checkpoint.load_weights_only \
-                                       if hparams.load_checkpoint is not None else None
+                                       if hparams.load_checkpoint is not None else False
         checkpoint_strict_model_weights = hparams.load_checkpoint.strict_model_weights \
-                                          if hparams.load_checkpoint is not None else None
+                                          if hparams.load_checkpoint is not None else False
 
         # Checkpoint saving hparams
         checkpoint_interval_unit = hparams.save_checkpoint.interval_unit \
                                    if hparams.save_checkpoint is not None else None
         checkpoint_interval = hparams.save_checkpoint.interval if hparams.save_checkpoint is not None else None
-        checkpoint_folder = hparams.save_checkpoint.folder if hparams.save_checkpoint is not None else None
+        checkpoint_folder = hparams.save_checkpoint.folder if hparams.save_checkpoint is not None else "checkpoints"
 
         trainer = cls(
             model=model,

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -26,7 +26,7 @@ from composer.models import (CIFARResNetHparams, EfficientNetB0Hparams, GPT2Hpar
                              ModelHparams, ResNet18Hparams, ResNet50Hparams, ResNet101Hparams, UnetHparams)
 from composer.optim import (AdamHparams, AdamWHparams, DecoupledAdamWHparams, DecoupledSGDWHparams, OptimizerHparams,
                             RAdamHparams, RMSPropHparams, SchedulerHparams, SGDHparams, scheduler)
-from composer.trainer.checkpoint_hparams import CheckpointLoaderHparams
+from composer.trainer.checkpoint_hparams import CheckpointLoaderHparams, CheckpointerHparams
 from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.utils import ddp
@@ -170,8 +170,8 @@ class TrainerHparams(hp.Hparams):
         default=-1)
     callbacks: List[CallbackHparams] = hp.optional(doc="Callback hparams", default_factory=list)
 
-    checkpoint_loader: Optional[CheckpointLoaderHparams] = hp.optional(doc="Checkpoint loading hparams", default=None)
-    checkpointer: Optional[CheckpointerHparams] = hp.optional(doc="Checkpointing hparams", default=None)
+    load_checkpoint: Optional[CheckpointLoaderHparams] = hp.optional(doc="Checkpoint loading hparams", default=None)
+    save_checkpoint: Optional[CheckpointerHparams] = hp.optional(doc="Checkpointing hparams", default=None)
     
     train_subset_num_batches: Optional[int] = hp.optional(textwrap.dedent("""If specified,
         finish every epoch early after training on this many batches."""),

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -26,6 +26,7 @@ from composer.models import (CIFARResNetHparams, EfficientNetB0Hparams, GPT2Hpar
                              ModelHparams, ResNet18Hparams, ResNet50Hparams, ResNet101Hparams, UnetHparams)
 from composer.optim import (AdamHparams, AdamWHparams, DecoupledAdamWHparams, DecoupledSGDWHparams, OptimizerHparams,
                             RAdamHparams, RMSPropHparams, SchedulerHparams, SGDHparams, scheduler)
+from composer.trainer.checkpoint_hparams import CheckpointLoaderHparams
 from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.utils import ddp
@@ -169,9 +170,7 @@ class TrainerHparams(hp.Hparams):
         default=-1)
     callbacks: List[CallbackHparams] = hp.optional(doc="Callback hparams", default_factory=list)
 
-    checkpoint_filepath: Optional[str] = hp.optional(doc="Path to an existing checkpoint file to load from.",
-                                                     default=None)
-
+    checkpoint_loader: Optional[CheckpointLoaderHparams] = hp.optional(doc="Checkpointing Hparams", default=None)
     checkpoint_interval_unit: Optional[str] = hp.optional(
         doc=
         "Unit for the checkpoint save interval -- should be 'ep' for epochs; 'ba' for batches, or None to disable checkpointing",

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -26,7 +26,7 @@ from composer.models import (CIFARResNetHparams, EfficientNetB0Hparams, GPT2Hpar
                              ModelHparams, ResNet18Hparams, ResNet50Hparams, ResNet101Hparams, UnetHparams)
 from composer.optim import (AdamHparams, AdamWHparams, DecoupledAdamWHparams, DecoupledSGDWHparams, OptimizerHparams,
                             RAdamHparams, RMSPropHparams, SchedulerHparams, SGDHparams, scheduler)
-from composer.trainer.checkpoint_hparams import CheckpointSaverHparams, CheckpointLoaderHparams
+from composer.trainer.checkpoint_hparams import CheckpointLoaderHparams, CheckpointSaverHparams
 from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.utils import ddp

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -26,7 +26,7 @@ from composer.models import (CIFARResNetHparams, EfficientNetB0Hparams, GPT2Hpar
                              ModelHparams, ResNet18Hparams, ResNet50Hparams, ResNet101Hparams, UnetHparams)
 from composer.optim import (AdamHparams, AdamWHparams, DecoupledAdamWHparams, DecoupledSGDWHparams, OptimizerHparams,
                             RAdamHparams, RMSPropHparams, SchedulerHparams, SGDHparams, scheduler)
-from composer.trainer.checkpoint_hparams import CheckpointerHparams, CheckpointLoaderHparams
+from composer.trainer.checkpoint_hparams import CheckpointSaverHparams, CheckpointLoaderHparams
 from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.utils import ddp
@@ -171,7 +171,7 @@ class TrainerHparams(hp.Hparams):
     callbacks: List[CallbackHparams] = hp.optional(doc="Callback hparams", default_factory=list)
 
     load_checkpoint: Optional[CheckpointLoaderHparams] = hp.optional(doc="Checkpoint loading hparams", default=None)
-    save_checkpoint: Optional[CheckpointerHparams] = hp.optional(doc="Checkpointing hparams", default=None)
+    save_checkpoint: Optional[CheckpointSaverHparams] = hp.optional(doc="Checkpointing hparams", default=None)
 
     train_subset_num_batches: Optional[int] = hp.optional(textwrap.dedent("""If specified,
         finish every epoch early after training on this many batches."""),

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -26,7 +26,7 @@ from composer.models import (CIFARResNetHparams, EfficientNetB0Hparams, GPT2Hpar
                              ModelHparams, ResNet18Hparams, ResNet50Hparams, ResNet101Hparams, UnetHparams)
 from composer.optim import (AdamHparams, AdamWHparams, DecoupledAdamWHparams, DecoupledSGDWHparams, OptimizerHparams,
                             RAdamHparams, RMSPropHparams, SchedulerHparams, SGDHparams, scheduler)
-from composer.trainer.checkpoint_hparams import CheckpointLoaderHparams, CheckpointerHparams
+from composer.trainer.checkpoint_hparams import CheckpointerHparams, CheckpointLoaderHparams
 from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.utils import ddp
@@ -172,7 +172,7 @@ class TrainerHparams(hp.Hparams):
 
     load_checkpoint: Optional[CheckpointLoaderHparams] = hp.optional(doc="Checkpoint loading hparams", default=None)
     save_checkpoint: Optional[CheckpointerHparams] = hp.optional(doc="Checkpointing hparams", default=None)
-    
+
     train_subset_num_batches: Optional[int] = hp.optional(textwrap.dedent("""If specified,
         finish every epoch early after training on this many batches."""),
                                                           default=None)

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -170,17 +170,9 @@ class TrainerHparams(hp.Hparams):
         default=-1)
     callbacks: List[CallbackHparams] = hp.optional(doc="Callback hparams", default_factory=list)
 
-    checkpoint_loader: Optional[CheckpointLoaderHparams] = hp.optional(doc="Checkpointing Hparams", default=None)
-    checkpoint_interval_unit: Optional[str] = hp.optional(
-        doc=
-        "Unit for the checkpoint save interval -- should be 'ep' for epochs; 'ba' for batches, or None to disable checkpointing",
-        default=None)
-    checkpoint_interval: int = hp.optional(doc="Interval for checkpointing.", default=1)
-    checkpoint_folder: str = hp.optional(
-        doc="Folder in which to save checkpoint files. Relative to the run directory, if set."
-        "Defaults to `checkpoints`.",
-        default="checkpoints")
-
+    checkpoint_loader: Optional[CheckpointLoaderHparams] = hp.optional(doc="Checkpoint loading hparams", default=None)
+    checkpointer: Optional[CheckpointerHparams] = hp.optional(doc="Checkpointing hparams", default=None)
+    
     train_subset_num_batches: Optional[int] = hp.optional(textwrap.dedent("""If specified,
         finish every epoch early after training on this many batches."""),
                                                           default=None)

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -123,9 +123,12 @@ def assert_checkpoints_equivalent(hparams_file_a: str, checkpoint_file_a: str, h
     hparams_b = TrainerHparams.create(hparams_file_b, cli_args=False)
     assert isinstance(hparams_b, TrainerHparams)
 
+    assert hparams_b.load_checkpoint is not None
+    assert hparams_b.save_checkpoint is not None
     hparams_a.load_checkpoint = CheckpointLoaderHparams(filepath=hparams_b.load_checkpoint.filepath,
                                                         load_weights_only=False,
                                                         strict_model_weights=False)
+    assert hparams_a.save_checkpoint is not None
     hparams_a.save_checkpoint.folder = hparams_b.save_checkpoint.folder
 
     assert hparams_a.to_dict() == hparams_b.to_dict()
@@ -184,6 +187,7 @@ def test_load_weights(
     checkpointing_trainer_hparams.device = device_hparams
 
     checkpoint_a_folder = "first"
+    assert checkpointing_trainer_hparams.save_checkpoint is not None
     checkpointing_trainer_hparams.save_checkpoint.folder = checkpoint_a_folder
     checkpointing_trainer_hparams.save_checkpoint.interval_unit = "ep" if checkpoint_filename.startswith("ep") else "it"
     checkpointing_trainer_hparams.seed = seed
@@ -259,6 +263,7 @@ def test_checkpoint(
     checkpointing_trainer_hparams.device = device_hparams
 
     checkpoint_a_folder = "first"
+    assert checkpointing_trainer_hparams.save_checkpoint is not None
     checkpointing_trainer_hparams.save_checkpoint.folder = checkpoint_a_folder
     checkpointing_trainer_hparams.save_checkpoint.interval_unit = "ep" if checkpoint_filename.startswith("ep") else "it"
     checkpointing_trainer_hparams.seed = seed


### PR DESCRIPTION
# Motivation
This pull request enables the ability to load a checkpoint without loading the associated state. It does so via the following YAML changes:
1. Introduces a `CheckpointLoaderHparams` object, with three fields: `checkpoint_filepath`, `load_weights_only`, and `strict`. 
2. If `load_weights_only = False`, then nothing changes and the previous codepaths are used. The `strict` value isn't considered if `load_weights_only = False`, since restoring a checkpoint with state should ensure that the model exactly matches up. YAML validation ensures that the `strict` value cannot be set without `load_weights_only = True`.
3. If `load_weights_only = True`, then it loads the checkpoint and avoids recovering the state via a new codepath. If `strict = False`, it also prints the keys that did not match up for user safety.

It creates the `CheckpointLoader` object when the `Trainer` is created via `create_from_hparams`, and passes the CheckpointLoader in as well.

# Discussion Points
1. Are we happy with the YAML API change?
2. Should we add any tests for these new codepaths?