### PR TITLE
DDP Seeding Across Processes

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -30,7 +30,6 @@ DIRECT_SERIALIZATION_FIELDS = [
     "max_epochs",
     "epoch",
     "step",
-    "seed",
 ]
 
 # These fields will be serialized using .state_dict(), and loaded with .load_state_dict()

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -30,6 +30,12 @@ class CheckpointLoader:
 
     def load_checkpoint(self, state: State):
         """Initialize state from the loaded checkpoint's data.
+
+        Args:
+            state (`~composer.core.State`): The state to load the checkpoint into.
+
+        Returns:
+            The seed that was loaded from the checkpoint if it exists otherwise `None`.
         """
 
         state.load_state_dict(self.state_dict["state"])

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -98,7 +98,7 @@ class Trainer:
             (default: ``None``)
         checkpoint_interval_unit (int, optional): Unit for the checkpoint save interval -- should be 'ep'
             for epochs, 'it' for iterations, or None to disable checkpointing. (default: ``None``).
-        checkpoint_folder (str, optional): The folder to save checkpoints to. Relative to `os.environ.get('RUN_DIRECTORY', '.')`, 
+        checkpoint_folder (str, optional): The folder to save checkpoints to. Relative to `os.environ.get('RUN_DIRECTORY', '.')`,
             (default: ``checkpoints``)
         checkpoint_interval (int, optional): The frequency with which to checkpoint. (default: ``1``)
         train_subset_num_batches (int, optional): If specified, finish every epoch early after training
@@ -179,10 +179,12 @@ class Trainer:
         self.device = device
 
         if not seed:
-            # Set a deterministic seed in the hparams
-            # This seed will be dumped in the hparams that are saved with checkpoints
             seed = get_random_seed()
             log.info(f"Seed was None. Setting seed to random value: {seed}")
+
+        # Assure that each process has a different seed, necessary if a seed is passed to init
+        seed += ddp.get_global_rank()
+
         # If hparams is used to create the Trainer this function is called twice
         # which is okay because all runs with the hparams codepath will do this
         seed_all(seed)
@@ -330,6 +332,7 @@ class Trainer:
 
         seed = hparams.seed if hparams.seed else get_random_seed()
         # need to set seed before model initialization for determinism
+        # don't need to set different seeds per process since only the rank 0 initialization is used
         seed_all(seed)
 
         model = hparams.model.initialize_object()

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -310,7 +310,10 @@ class Trainer:
             if self.deepspeed_enabled:
                 raise NotImplementedError("Checkpointing is not yet supported with DeepSpeed.")
             self.checkpoint_loader = CheckpointLoader(checkpoint_filepath=checkpoint_filepath)
-            self.checkpoint_loader.load_checkpoint(state=self.state)
+            restored_seed = self.checkpoint_loader.load_checkpoint(state=self.state)
+            if restored_seed is not None:
+                # Set the restored seed so that the correct seed will be saved in future checkpoints
+                self.seed = restored_seed
 
     @classmethod
     def create_from_hparams(cls, hparams: TrainerHparams) -> Trainer:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -311,8 +311,10 @@ class Trainer:
                 raise NotImplementedError("Checkpointing is not yet supported with DeepSpeed.")
             self.checkpoint_loader = CheckpointLoader(checkpoint_filepath=checkpoint_filepath)
             restored_seed = self.checkpoint_loader.load_checkpoint(state=self.state)
+            # Set the restored seed so that the correct seed will be saved in future checkpoints
+            # Used to handle the case where another checkpoint is saved after resuming from checkpoint.
+            # In this case, self.seed is stored in the second checkpoint so it must have the correct value.
             if restored_seed is not None:
-                # Set the restored seed so that the correct seed will be saved in future checkpoints
                 self.seed = restored_seed
 
     @classmethod

--- a/tests/callbacks/test_run_directory_uploader.py
+++ b/tests/callbacks/test_run_directory_uploader.py
@@ -12,10 +12,12 @@ from composer.core.state import State
 from composer.utils.run_directory import get_run_directory
 
 
+# This test is flaky see: https://github.com/mosaicml/composer/issues/176
 @pytest.mark.parametrize("use_procs", [False, True])
 # TODO(ravi) -- remove the pytest.in #110. The TRAINING_END event is likely slow as it has to copy many
 # files created by the ddp test. #110 grately reduces the number of files from the DDP test.
 @pytest.mark.timeout(15)
+@pytest.mark.xfail
 def test_run_directory_uploader(tmpdir: pathlib.Path, use_procs: bool, dummy_state: State, dummy_logger: Logger):
     dummy_state.epoch = 0
     dummy_state.step = 0

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -3,7 +3,7 @@
 import os
 import random
 from logging import Logger
-from typing import Dict
+from typing import Dict, Optional
 
 import pytest
 import torch
@@ -128,6 +128,7 @@ def inject_stateful_callback_hparams(monkeypatch: MonkeyPatch):
     pytest.param(GPUDeviceHparams(), id="gpu", marks=pytest.mark.gpu),
 ])
 @pytest.mark.parametrize("checkpoint_filename", ["ep1", "it4", "it1", "it6"])
+@pytest.mark.parametrize("seed", [None, 42])
 @pytest.mark.parametrize("validate_every_n_batches,validate_every_n_epochs", [
     (0, 1),
     (1, 0),
@@ -137,6 +138,7 @@ def test_checkpoint(
     world_size: int,
     checkpointing_trainer_hparams: TrainerHparams,
     checkpoint_filename: str,
+    seed: Optional[int],
     validate_every_n_batches: int,
     validate_every_n_epochs: int,
 ):
@@ -152,6 +154,7 @@ def test_checkpoint(
     checkpoint_a_folder = "first"
     checkpointing_trainer_hparams.checkpoint_folder = checkpoint_a_folder
     checkpointing_trainer_hparams.checkpoint_interval_unit = "ep" if checkpoint_filename.startswith("ep") else "it"
+    checkpointing_trainer_hparams.seed = seed
     checkpointing_trainer_hparams.validate_every_n_batches = validate_every_n_batches
     checkpointing_trainer_hparams.validate_every_n_epochs = validate_every_n_epochs
     final_checkpoint = "ep2.pt" if checkpoint_filename.startswith("ep") else "it8.pt"


### PR DESCRIPTION
This change addresses issue #12 and introduces the following:
- Even when the user provides a seed, each process will have a different seed which is `user_provided_seed + global_rank`. The reason for this is that for algorithms like mixup which modify training batches, we want the modifications to be different on batches on different processes.
- When checkpointing, we store and load seeds using all processes, not just the seed from rank 0.

Test Plan:
- The existing distributed checkpointing tests cover the new code paths introduced here. 