### PR TITLE
Fixed the run directory uploader test

### DIFF
--- a/composer/callbacks/run_directory_uploader.py
+++ b/composer/callbacks/run_directory_uploader.py
@@ -308,7 +308,6 @@ def _upload_worker(
         retry_counter = 0
         while True:
             try:
-                assert os.path.exists(file_path_to_upload)
                 provider.upload_object(
                     file_path=file_path_to_upload,
                     container=container,

--- a/composer/utils/run_directory.py
+++ b/composer/utils/run_directory.py
@@ -17,7 +17,6 @@ def get_run_directory():
 def get_relative_to_run_directory(*path: str, base: str = ".") -> str:
     run_directory = get_run_directory()
     if run_directory is None:
-        raise ValueError("shouldn't be triggered")
         return os.path.join(base, *path)
     return os.path.join(run_directory, *path)
 

--- a/tests/callbacks/test_run_directory_uploader.py
+++ b/tests/callbacks/test_run_directory_uploader.py
@@ -12,12 +12,7 @@ from composer.core.state import State
 from composer.utils.run_directory import get_run_directory
 
 
-# This test is flaky see: https://github.com/mosaicml/composer/issues/176
 @pytest.mark.parametrize("use_procs", [False, True])
-# TODO(ravi) -- remove the pytest.in #110. The TRAINING_END event is likely slow as it has to copy many
-# files created by the ddp test. #110 grately reduces the number of files from the DDP test.
-@pytest.mark.timeout(15)
-@pytest.mark.xfail
 def test_run_directory_uploader(tmpdir: pathlib.Path, use_procs: bool, dummy_state: State, dummy_logger: Logger):
     dummy_state.epoch = 0
     dummy_state.step = 0

--- a/tests/callbacks/test_run_directory_uploader.py
+++ b/tests/callbacks/test_run_directory_uploader.py
@@ -13,6 +13,7 @@ from composer.utils.run_directory import get_run_directory
 
 
 @pytest.mark.parametrize("use_procs", [False, True])
+@pytest.mark.timeout(15)
 def test_run_directory_uploader(tmpdir: pathlib.Path, use_procs: bool, dummy_state: State, dummy_logger: Logger):
     dummy_state.epoch = 0
     dummy_state.step = 0


### PR DESCRIPTION
The issue was introduced in #162 with how the run directory was monkeypatched for the tests. This monkeypatching did not apply to subprocessing. Changed uploading to use UUIDs when copying to the staging directory to avoid conflicts.

Closes #176 