### PR TITLE
Conditionally skip tests when installed with mosaicml[dev]

### DIFF
--- a/tests/callbacks/test_run_directory_uploader.py
+++ b/tests/callbacks/test_run_directory_uploader.py
@@ -15,6 +15,11 @@ from composer.utils.run_directory import get_run_directory
 @pytest.mark.parametrize("use_procs", [False, True])
 @pytest.mark.timeout(15)
 def test_run_directory_uploader(tmpdir: pathlib.Path, use_procs: bool, dummy_state: State, dummy_logger: Logger):
+    try:
+        import libcloud
+        del libcloud
+    except ImportError:
+        pytest.skip("Run directory uploader test won't work without libcloud")
     dummy_state.epoch = 0
     dummy_state.step = 0
     remote_dir = str(tmpdir / "run_directory_copy")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -98,7 +98,12 @@ def test_tqdm_logger(mosaic_trainer_hparams: TrainerHparams, monkeypatch: Monkey
     pytest.param(2, marks=pytest.mark.world_size(2)),
 ])
 @pytest.mark.timeout(10)
-def test_wandb_logger(mosaic_trainer_hparams: TrainerHparams, world_size: int, monkeypatch: MonkeyPatch):
+def test_wandb_logger(mosaic_trainer_hparams: TrainerHparams, world_size: int):
+    try:
+        import wandb
+        del wandb
+    except ImportError:
+        pytest.skip("wandb is not installed")
     del world_size  # unused. Set via launcher script
     mosaic_trainer_hparams.loggers = [WandBLoggerBackendHparams(log_artifacts=True, log_artifacts_every_n_batches=1)]
     trainer = mosaic_trainer_hparams.initialize_object()


### PR DESCRIPTION
* The wandb test should be skipped as wandb is installed with mosaicml[logging]
* The run directory uploader test should be skipped as libcloud is installed with mosaicml[logging]