### PR TITLE
Add ResNet-9 for CIFAR-10

### DIFF
--- a/composer/models/__init__.py
+++ b/composer/models/__init__.py
@@ -10,6 +10,8 @@ from composer.models.gpt2 import GPT2Hparams as GPT2Hparams
 from composer.models.gpt2 import GPT2Model as GPT2Model
 from composer.models.model_hparams import Initializer as Initializer
 from composer.models.model_hparams import ModelHparams as ModelHparams
+from composer.models.resnet9_cifar10 import CIFAR10_ResNet9 as CIFAR10_ResNet9
+from composer.models.resnet9_cifar10 import CIFARResNet9Hparams as CIFARResNet9Hparams
 from composer.models.resnet18 import ResNet18 as ResNet18
 from composer.models.resnet18 import ResNet18Hparams as ResNet18Hparams
 from composer.models.resnet50 import ResNet50 as ResNet50

--- a/composer/models/resnet9_cifar10/__init__.py
+++ b/composer/models/resnet9_cifar10/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+from composer.models.resnet9_cifar10.model import CIFAR10_ResNet9 as CIFAR10_ResNet9
+from composer.models.resnet9_cifar10.resnet9_cifar10_hparams import CIFARResNet9Hparams as CIFARResNet9Hparams
+
+_task = 'Image Classification'
+_dataset = 'CIFAR10'
+_name = 'ResNet9'
+_quality = '92'
+_metric = 'Top-1 Accuracy'
+_ttt = '5m'
+_hparams = 'resnet9_cifar10.yaml'

--- a/composer/models/resnet9_cifar10/__init__.py
+++ b/composer/models/resnet9_cifar10/__init__.py
@@ -6,7 +6,7 @@ from composer.models.resnet9_cifar10.resnet9_cifar10_hparams import CIFARResNet9
 _task = 'Image Classification'
 _dataset = 'CIFAR10'
 _name = 'ResNet9'
-_quality = '92'
+_quality = '92.9'
 _metric = 'Top-1 Accuracy'
 _ttt = '5m'
 _hparams = 'resnet9_cifar10.yaml'

--- a/composer/models/resnet9_cifar10/model.py
+++ b/composer/models/resnet9_cifar10/model.py
@@ -1,0 +1,76 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+from typing import List, Optional
+
+import torch.nn as nn
+
+from composer.models.base import MosaicClassifier
+from composer.models.model_hparams import Initializer
+from composer.models.resnets import BasicBlock, CIFAR_ResNet
+
+
+# adapted from https://raw.githubusercontent.com/matthias-wright/cifar10-resnet/master/model.py
+# under the MIT license
+class ResNet9(nn.Module):
+    """
+    A 9-layer residual network, excluding BatchNorms and activation functions,
+    as described in this blog post: https://myrtle.ai/learn/how-to-train-your-resnet-4-architecture/
+    """
+    def __init__(self, num_classes: int):
+        super().__init__()
+
+        self.body = nn.Sequential(
+            nn.Conv2d(in_channels=3, out_channels=64, kernel_size=3, stride=1, padding=1, bias=False),
+            nn.BatchNorm2d(num_features=64, momentum=0.9),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(in_channels=64, out_channels=128, kernel_size=3, stride=1, padding=1, bias=False),
+            nn.BatchNorm2d(num_features=128, momentum=0.9),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+            BasicBlock(inplanes=128, planes=128, stride=1),
+            nn.Conv2d(in_channels=128, out_channels=256, kernel_size=3, stride=1, padding=1, bias=False),
+            nn.BatchNorm2d(num_features=256, momentum=0.9),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+            nn.Conv2d(in_channels=256, out_channels=256, kernel_size=3, stride=1, padding=1, bias=False),
+            nn.BatchNorm2d(num_features=256, momentum=0.9),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+            BasicBlock(inplanes=256, planes=256, stride=1),
+            nn.MaxPool2d(kernel_size=2, stride=2),
+        )
+
+        self.fc = nn.Linear(in_features=1024, out_features=num_classes, bias=True)
+
+    def forward(self, x):
+        out = self.body(x)
+        out = out.view(-1, out.shape[1] * out.shape[2] * out.shape[3])
+        out = self.fc(out)
+        return out
+
+
+class CIFAR10_ResNet9(MosaicClassifier):
+    """A ResNet-9 model extending :class:`MosaicClassifier`.
+
+    See this blog post for details regarding the architecture:
+    https://myrtle.ai/learn/how-to-train-your-resnet-4-architecture/
+
+    Args:
+        num_classes (int): The number of classes for the model.
+        initializers (List[Initializer], optional): Initializers
+            for the model. ``None`` for no initialization.
+            (default: ``None``)
+    """
+
+    def __init__(
+        self,
+        num_classes: int,
+        initializers: Optional[List[Initializer]] = None,
+    ) -> None:
+        if initializers is None:
+            initializers = []
+
+        model = ResNet9(num_classes)
+        super().__init__(module=model)
+
+

--- a/composer/models/resnet9_cifar10/model.py
+++ b/composer/models/resnet9_cifar10/model.py
@@ -16,6 +16,7 @@ class ResNet9(nn.Module):
     A 9-layer residual network, excluding BatchNorms and activation functions,
     as described in this blog post: https://myrtle.ai/learn/how-to-train-your-resnet-4-architecture/
     """
+
     def __init__(self, num_classes: int):
         super().__init__()
 
@@ -72,5 +73,3 @@ class CIFAR10_ResNet9(MosaicClassifier):
 
         model = ResNet9(num_classes)
         super().__init__(module=model)
-
-

--- a/composer/models/resnet9_cifar10/model.py
+++ b/composer/models/resnet9_cifar10/model.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 
 from composer.models.base import MosaicClassifier
 from composer.models.model_hparams import Initializer
-from composer.models.resnets import BasicBlock, CIFAR_ResNet
+from composer.models.resnets import BasicBlock
 
 
 # adapted from https://raw.githubusercontent.com/matthias-wright/cifar10-resnet/master/model.py

--- a/composer/models/resnet9_cifar10/resnet9_cifar10_hparams.py
+++ b/composer/models/resnet9_cifar10/resnet9_cifar10_hparams.py
@@ -1,0 +1,13 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+from dataclasses import asdict, dataclass
+
+from composer.models.model_hparams import ModelHparams
+
+
+@dataclass
+class CIFARResNet9Hparams(ModelHparams):
+
+    def initialize_object(self):
+        from composer.models import CIFAR10_ResNet9
+        return CIFAR10_ResNet9(**asdict(self))

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -22,8 +22,9 @@ from composer.core.types import Precision
 from composer.datasets import DataloaderHparams
 from composer.loggers import (BaseLoggerBackendHparams, FileLoggerBackendHparams, MosaicMLLoggerBackendHparams,
                               TQDMLoggerBackendHparams, WandBLoggerBackendHparams)
-from composer.models import (CIFARResNetHparams, EfficientNetB0Hparams, GPT2Hparams, MnistClassifierHparams,
-                             ModelHparams, ResNet18Hparams, ResNet50Hparams, ResNet101Hparams, UnetHparams)
+from composer.models import (CIFARResNet9Hparams, CIFARResNetHparams, EfficientNetB0Hparams, GPT2Hparams,
+                             MnistClassifierHparams, ModelHparams, ResNet18Hparams, ResNet50Hparams, ResNet101Hparams,
+                             UnetHparams)
 from composer.optim import (AdamHparams, AdamWHparams, DecoupledAdamWHparams, DecoupledSGDWHparams, OptimizerHparams,
                             RAdamHparams, RMSPropHparams, SchedulerHparams, SGDHparams, scheduler)
 from composer.trainer.deepspeed import DeepSpeedHparams
@@ -58,6 +59,7 @@ model_registry = {
     "unet": UnetHparams,
     "efficientnetb0": EfficientNetB0Hparams,
     "resnet56_cifar10": CIFARResNetHparams,
+    "resnet9_cifar10": CIFARResNet9Hparams,
     "resnet101": ResNet101Hparams,
     "resnet50": ResNet50Hparams,
     "resnet18": ResNet18Hparams,

--- a/composer/yamls/models/resnet9_cifar10.yaml
+++ b/composer/yamls/models/resnet9_cifar10.yaml
@@ -1,0 +1,61 @@
+train_dataset:
+  cifar10:
+    datadir: /datasets/CIFAR10
+    is_train: true
+    download: false
+    shuffle: true
+    drop_last: true
+val_dataset:
+  cifar10:
+    datadir: /datasets/CIFAR10
+    is_train: false
+    download: false
+    shuffle: false
+    drop_last: false
+optimizer:
+  decoupled_sgdw:
+    lr: 1.2
+    momentum: 0.9
+    weight_decay: 2.0e-3
+schedulers:
+  - warmup:
+      warmup_iters: "5ep"
+      warmup_method: linear
+      warmup_factor: 0
+      verbose: false
+      interval: step
+  - multistep:
+      milestones:
+        - "80ep"
+        - "120ep"
+      gamma: 0.1
+      interval: epoch
+model:
+  resnet9_cifar10:
+    initializers:
+      - kaiming_normal
+      - bn_uniform
+    num_classes: 10
+loggers:
+  - file:
+      log_level: epoch
+      filename: stdout
+      buffer_size: 1
+      flush_every_n_batches: 100
+      every_n_epochs: 1
+      every_n_batches: 100
+max_epochs: 160
+train_batch_size: 1024
+eval_batch_size: 1000
+seed: 17
+validate_every_n_epochs: 1
+grad_accum: 1
+device:
+  gpu: {}
+dataloader:
+  pin_memory: true
+  timeout: 0
+  prefetch_factor: 2
+  persistent_workers: true
+  num_workers: 8
+precision: amp

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -15,6 +15,7 @@ def test_model_registry(model_name, request):
     model_hparams = model_registry[model_name]()
 
     requires_num_classes = set([
+        "resnet9_cifar10",
         "resnet56_cifar10",
         "efficientnetb0",
         "resnet101",


### PR DESCRIPTION
This is [the architecture](https://myrtle.ai/learn/how-to-train-your-resnet-4-architecture/) that someone got to train to 94% accuracy [in 26 seconds](https://myrtle.ai/learn/how-to-train-your-resnet-8-bag-of-tricks/). The purpose of adding this is that it should let us do CIFAR-10 runs much faster for quick prototyping--I basically threw this together while waiting for some CIFAR-10 jobs to finish.

[Wandb results](https://wandb.ai/mosaic-ml/c10/runs/ig3ra9pm?workspace=user-dblalock): 92.82% accuracy from 1 run using our resnet56 hparams. This is slightly lower than in the blog post (94%), but has zero bag-of-tricks enhancements or hparam tuning.