### PR TITLE
DeepSpeed precision fixes for CV

### DIFF
--- a/composer/trainer/deepspeed.py
+++ b/composer/trainer/deepspeed.py
@@ -62,6 +62,11 @@ class DeepSpeedHparams(hp.Hparams):
                 "reduce_bucket_size": self.zero2_bucket_size,
                 "overlap_comm": self.overlap_comm,
             },
+
+            # Without this, DeepSpeed throws errors when ZeRO is used in combination with
+            # non-standard optimizers. Most likely, this will trigger when one of the decoupled
+            # weight decay optimizers is used, but it has been verified that those optimizers work
+            # in combination with DeepSpeed.
             "zero_allow_untested_optimizer": True,
         }
 

--- a/composer/trainer/deepspeed.py
+++ b/composer/trainer/deepspeed.py
@@ -7,10 +7,9 @@ from typing import Any, Optional
 import torch
 import yahp as hp
 
-from composer.composer.core.precision import Precision
-from composer.composer.utils.iter_helpers import map_collection
 from composer.core import State
 from composer.core.types import Batch, Precision, Tensor
+from composer.utils.iter_helpers import map_collection
 
 
 @dataclass

--- a/composer/trainer/deepspeed.py
+++ b/composer/trainer/deepspeed.py
@@ -100,6 +100,7 @@ def _convert_fp32_tensor_to_fp16(tensor: Tensor):
         return tensor.half()
     return tensor
 
+
 def fix_batch_precision_for_deepspeed(batch: Batch, precision: Precision) -> Batch:
     """Ensures that a batch is properly formatted for DeepSpeed FP16, if active.
 

--- a/composer/trainer/deepspeed.py
+++ b/composer/trainer/deepspeed.py
@@ -62,6 +62,7 @@ class DeepSpeedHparams(hp.Hparams):
                 "reduce_bucket_size": self.zero2_bucket_size,
                 "overlap_comm": self.overlap_comm,
             },
+            "zero_allow_untested_optimizer": True,
         }
 
         if self.optimizer_offload:
@@ -99,7 +100,6 @@ def fix_batch_precision_for_deepspeed(batch: Batch, precision: Precision) -> Bat
     """
 
     def convert_tensor(tensor: Tensor):
-        print(tensor.dtype)
         if precision == Precision.FP16 and tensor.dtype == torch.float32:
             return tensor.half()
         return tensor

--- a/composer/trainer/deepspeed.py
+++ b/composer/trainer/deepspeed.py
@@ -113,4 +113,4 @@ def fix_batch_precision_for_deepspeed(batch: Batch, precision: Precision) -> Bat
     if precision != Precision.FP16:
         return batch
 
-    return map_collection(batch, _convert_fp32_tensor_to_fp16)
+    return map_collection(batch, _convert_fp32_tensor_to_fp16)  # type: ignore

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -614,7 +614,6 @@ class Trainer:
 
                     if self.deepspeed_enabled:
                         state.batch = fix_batch_precision_for_deepspeed(state.batch, state.precision)
-                    print('foo')
 
                     if self.compute_training_metrics:
                         # compute metrics on the training set
@@ -760,20 +759,6 @@ class Trainer:
 
                 # forward pass
                 self.engine.run_event(Event.BEFORE_FORWARD)
-
-                # state.batch = (state.batch[0].half(), state.batch[1])
-                def print_batch_dtypes(b, prefix='root'):
-                    if isinstance(b, torch.Tensor):
-                        print(prefix, b.dtype)
-                    else:
-                        if isinstance(b, dict):
-                            for k, bb in b.items():
-                                print_batch_dtypes(bb, f'{prefix}.{k}')
-                        else:
-                            for i, bb in enumerate(b):
-                                print_batch_dtypes(bb, f'{prefix}[{i}]')
-
-                print_batch_dtypes(state.batch)
 
                 with state.precision_context:
                     state.outputs = state.model.forward(state.batch)


### PR DESCRIPTION
Fixes the precision issues that were causing DeepSpeed to crash when used to train CV models. Namely, in FP16 mode we just have to cast batches to FP16 manually in some scenarios.

https://wandb.ai/mosaic-ml/deepspeed-cv-3?workspace=user-jbloxham