### PR TITLE
Checkpointing & DeepSpeed

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import warnings
 from typing import TYPE_CHECKING, Callable, ContextManager, Optional, Sequence, Union
-from deepspeed.runtime.engine import DeepSpeedEngine
 
 import torch
 import torch.nn.modules.utils

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -229,6 +229,8 @@ class State(Serializable):
                 continue
             elif state_field_name == "model" and state["_is_model_deepspeed"]:
                 continue
+            elif state_field_name == "_optimizers" and state["_is_model_deepspeed"]:
+                continue
             elif state_field_name in DIRECT_SERIALIZATION_FIELDS:
                 setattr(self, state_field_name, state[state_field_name])
             elif state_field_name in STATE_DICT_SERIALIZATION_FIELDS:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -217,7 +217,8 @@ class State(Serializable):
                     serialized_value = {
                         obj.__class__.__qualname__: obj.state_dict()
                         for obj in ensure_tuple(state_field_value)
-                        if obj is not None                    }
+                        if obj is not None
+                    }
                 state_dict[state_field_name] = serialized_value
 
             else:

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -3,6 +3,9 @@
 import logging
 import os
 import random
+import shutil
+import tarfile
+import tempfile
 import warnings
 from typing import Any, Dict, Optional
 
@@ -16,22 +19,6 @@ from composer.trainer.devices.device import Device
 from composer.utils import ddp, seed_all
 
 log = logging.getLogger(__name__)
-
-
-def parse_checkpoint_filepath(checkpoint_filepath: str):
-    """Parse a checkpoint filepath to obtain the root checkpoints folder and the checkpoint tag.
-    
-    The checkpoint tag, in this case, is just the name of a subdirectory within the root checkpoints
-    folder.
-
-    If a checkpoint file is provided, we assume the encompassing directory should be parsed instead.
-    """
-
-    folder, tag = os.path.split(checkpoint_filepath)
-    if tag.endswith(".pt"):
-        folder, tag = os.path.split(folder)
-
-    return folder, tag
 
 
 def get_mosaic_checkpoint_filepath(checkpoint_folder: str, checkpoint_tag: str):
@@ -51,11 +38,6 @@ class CheckpointLoader:
         self.checkpoint_filepath = checkpoint_filepath
         self.load_weights_only = load_weights_only
         self.strict_model_weights = strict_model_weights
-
-        self.checkpoint_folder, self.checkpoint_tag = parse_checkpoint_filepath(checkpoint_filepath)
-        mosaic_checkpoint_filepath = get_mosaic_checkpoint_filepath(self.checkpoint_folder, self.checkpoint_tag)
-
-        self.state_dict = torch.load(mosaic_checkpoint_filepath, map_location='cpu')
         self.checkpoint_rng_state = None
 
     def load_checkpoint(self, state: State):
@@ -67,29 +49,41 @@ class CheckpointLoader:
         Returns:
             The seed that was loaded from the checkpoint if it exists otherwise `None`.
         """
-
         seed_to_restore = None
 
-        if self.load_weights_only:
-            state.load_model_state(self.state_dict['state'], strict=self.strict_model_weights)
-        else:
-            state.load_state_dict(self.state_dict["state"])
-            self.checkpoint_rng_state = self._get_checkpoint_rng_state(self.state_dict["rng"])
+        with tempfile.TemporaryDirectory() as checkpoint_folder:
+            with tarfile.open(self.checkpoint_filepath) as tarball:
+                tarball.extractall(checkpoint_folder)
 
-            if "seed" in self.state_dict:
-                world_size = ddp.get_world_size()
-                checkpointed_world_size = len(self.state_dict["seed"])
-                if world_size != checkpointed_world_size:
-                    warnings.warn(f"Current world size {world_size} does not match the checkpointed world size "
-                                  f"{checkpointed_world_size}. The seed will not be restored.")
-                else:
-                    seed_to_restore = self.state_dict["seed"][ddp.get_global_rank()]
-                    seed_all(seed_to_restore)
+            checkpoint_tag = os.listdir(checkpoint_folder)[0]
+            mosaic_checkpoint_filepath = get_mosaic_checkpoint_filepath(checkpoint_folder, checkpoint_tag)
 
-        if state.model.__class__.__qualname__ == 'DeepSpeedEngine':
-            load_path, _ = state.model.load_checkpoint(self.checkpoint_folder, self.checkpoint_tag)  # type: ignore
-            if load_path is None:
-                raise RuntimeError(f"Failed to load DeepSpeed checkpoint from {self.checkpoint_filepath}")
+            self.state_dict = torch.load(mosaic_checkpoint_filepath, map_location='cpu')
+
+            if self.load_weights_only:
+                state.load_model_state(self.state_dict['state'], strict=self.strict_model_weights)
+            else:
+                state.load_state_dict(self.state_dict["state"])
+                self.checkpoint_rng_state = self._get_checkpoint_rng_state(self.state_dict["rng"])
+
+                if "seed" in self.state_dict:
+                    world_size = ddp.get_world_size()
+                    checkpointed_world_size = len(self.state_dict["seed"])
+                    if world_size != checkpointed_world_size:
+                        warnings.warn(f"Current world size {world_size} does not match the checkpointed world size "
+                                      f"{checkpointed_world_size}. The seed will not be restored.")
+                    else:
+                        seed_to_restore = self.state_dict["seed"][ddp.get_global_rank()]
+                        seed_all(seed_to_restore)
+
+            try:
+                import deepspeed
+                if isinstance(state.model, deepspeed.DeepSpeedEngine):
+                    load_path, _ = state.model.load_checkpoint(checkpoint_folder, checkpoint_tag)
+                    if load_path is None:
+                        raise RuntimeError(f"Failed to load DeepSpeed checkpoint from {self.checkpoint_filepath}")
+            except ImportError:
+                pass
 
         return seed_to_restore
 
@@ -180,44 +174,51 @@ class CheckpointSaver:
         else:
             raise ValueError(f"Invalid checkpoint event: {self.save_event}")
 
-        if state.model.__class__.__qualname__ == 'DeepSpeedEngine':
-            state.model.save_checkpoint(self.checkpoint_folder, tag)  # type: ignore
+        try:
+            import deepspeed
+            if isinstance(state.model, deepspeed.DeepSpeedEngine):
+                state.model.save_checkpoint(self.checkpoint_folder, tag)
+        except ImportError:
+            pass
 
-        if ddp.get_global_rank() != 0:
+        if ddp.get_global_rank() == 0:
             # only rank 0 saves checkpoints
-            # Need the check down here so all the DDP syncs will work for generating the checkpoint
 
-            # Sync before exiting so that even the non rank 0 processes cannot exit before the
-            # checkpoint has been saved.
-            ddp.barrier()
-            return
+            # we add the state only on rank 0 since other processes don't have loggers to serialize
+            state_dict['state'] = state.state_dict()  # should be the same across all ranks. per-rank state not stored
 
-        # we add the state only on rank 0 since other processes don't have loggers to serialize
-        state_dict['state'] = state.state_dict()  # should be the same across all ranks. per-rank state not stored
+            if config:
+                hparams_path = os.path.join(self.checkpoint_folder, "hparams.yaml")
+                os.makedirs(self.checkpoint_folder, mode=0o775, exist_ok=True)
+                config_yaml_str = yaml.dump(config)
+                try:
+                    with open(hparams_path, "x") as f:
+                        # Storing the config (ex. hparams) in a separate file so they can be modified before resuming
+                        f.write(config_yaml_str)
+                except FileExistsError as e:
+                    with open(hparams_path, "r") as f:
+                        # comparing the parsed hparams to ignore whitespace and formatting differences
+                        if yaml.safe_load(config_yaml_str) != yaml.safe_load(f):
+                            raise RuntimeError(
+                                f"The hparams in the existing checkpoint folder {self.checkpoint_folder} "
+                                "differ from those being used in the current training run. "
+                                "Please specify a new checkpoint folder.") from e
+            checkpoint_filepath = os.path.join(self.checkpoint_folder, tag)
+            mosaic_states_filepath = get_mosaic_checkpoint_filepath(self.checkpoint_folder, tag)
+            if not os.path.exists(checkpoint_filepath):
+                os.makedirs(checkpoint_filepath)
+            with open(mosaic_states_filepath, 'xb') as f:
+                torch.save(state_dict, f)
 
-        if config:
-            hparams_path = os.path.join(self.checkpoint_folder, "hparams.yaml")
-            os.makedirs(self.checkpoint_folder, mode=0o775, exist_ok=True)
-            config_yaml_str = yaml.dump(config)
-            try:
-                with open(hparams_path, "x") as f:
-                    # Storing the config (ex. hparams) in a separate file so they can be modified before resuming
-                    f.write(config_yaml_str)
-            except FileExistsError as e:
-                with open(hparams_path, "r") as f:
-                    # comparing the parsed hparams to ignore whitespace and formatting differences
-                    if yaml.safe_load(config_yaml_str) != yaml.safe_load(f):
-                        raise RuntimeError(f"The hparams in the existing checkpoint folder {self.checkpoint_folder} "
-                                           "differ from those being used in the current training run. "
-                                           "Please specify a new checkpoint folder.") from e
-        checkpoint_filepath = get_mosaic_checkpoint_filepath(self.checkpoint_folder, tag)
-        if not os.path.exists(os.path.join(self.checkpoint_folder, tag)):
-            os.makedirs(os.path.join(self.checkpoint_folder, tag))
-        with open(checkpoint_filepath, 'xb') as f:
-            torch.save(state_dict, f)
-        log.info(f'Trainer checkpoint saved to {checkpoint_filepath}')
+            checkpoint_archive_filepath = os.path.join(self.checkpoint_folder, f'{tag}.tgz')
+            with tarfile.open(checkpoint_archive_filepath, "w:gz") as tarball:
+                tarball.add(checkpoint_filepath, arcname=tag)
 
-        # Sync with the non rank 0 processes, which are still waiting to return
+            shutil.rmtree(checkpoint_filepath)
+
+            log.info(f'Trainer checkpoint saved to {checkpoint_archive_filepath}')
+
+        # Ensure that the non-rank 0 processes don't exit before the checkpoint is saved.
         ddp.barrier()
 
     def _get_rng_state(self, device: Device) -> StateDict:

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -202,6 +202,8 @@ class Checkpointer:
                                            "differ from those being used in the current training run. "
                                            "Please specify a new checkpoint folder.") from e
         checkpoint_filepath = get_mosaic_checkpoint_filepath(self.checkpoint_folder, tag)
+        if not os.path.exists(os.path.join(self.checkpoint_folder, tag)):
+            os.makedirs(os.path.join(self.checkpoint_folder, tag))
         with open(checkpoint_filepath, 'xb') as f:
             torch.save(state_dict, f)
         log.info(f'Trainer checkpoint saved to {checkpoint_filepath}')

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -32,7 +32,7 @@ def parse_checkpoint_filepath(checkpoint_filepath: str):
         folder, tag = os.path.split(folder)
 
     return folder, tag
-    
+
 
 def get_mosaic_checkpoint_filepath(checkpoint_folder: str, checkpoint_tag: str):
     return os.path.join(checkpoint_folder, checkpoint_tag, "mosaic_states.pt")
@@ -81,7 +81,7 @@ class CheckpointLoader:
                 checkpointed_world_size = len(self.state_dict["seed"])
                 if world_size != checkpointed_world_size:
                     warnings.warn(f"Current world size {world_size} does not match the checkpointed world size "
-                                f"{checkpointed_world_size}. The seed will not be restored.")
+                                  f"{checkpointed_world_size}. The seed will not be restored.")
                 else:
                     seed_to_restore = self.state_dict["seed"][ddp.get_global_rank()]
                     seed_all(seed_to_restore)

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -5,12 +5,10 @@ import os
 import random
 import warnings
 from typing import Any, Dict, Optional
-import re
 
 import numpy as np
 import torch
 import yaml
-from deepspeed.runtime.engine import DeepSpeedEngine
 
 from composer.core import Event, State
 from composer.core.types import StateDict
@@ -182,7 +180,7 @@ class CheckpointSaver:
         else:
             raise ValueError(f"Invalid checkpoint event: {self.save_event}")
 
-        if isinstance(state.model, DeepSpeedEngine):
+        if state.model.__class__.__qualname__ == 'DeepSpeedEngine':
             state.model.save_checkpoint(self.checkpoint_folder, tag)
 
         if ddp.get_global_rank() != 0:

--- a/composer/trainer/checkpoint.py
+++ b/composer/trainer/checkpoint.py
@@ -87,7 +87,7 @@ class CheckpointLoader:
                     seed_all(seed_to_restore)
 
         if state.model.__class__.__qualname__ == 'DeepSpeedEngine':
-            load_path, _ = state.model.load_checkpoint(self.checkpoint_folder, self.checkpoint_tag)
+            load_path, _ = state.model.load_checkpoint(self.checkpoint_folder, self.checkpoint_tag)  # type: ignore
             if load_path is None:
                 raise RuntimeError(f"Failed to load DeepSpeed checkpoint from {self.checkpoint_filepath}")
 
@@ -181,7 +181,7 @@ class CheckpointSaver:
             raise ValueError(f"Invalid checkpoint event: {self.save_event}")
 
         if state.model.__class__.__qualname__ == 'DeepSpeedEngine':
-            state.model.save_checkpoint(self.checkpoint_folder, tag)
+            state.model.save_checkpoint(self.checkpoint_folder, tag)  # type: ignore
 
         if ddp.get_global_rank() != 0:
             # only rank 0 saves checkpoints

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -306,8 +306,8 @@ class Trainer:
         self.checkpoint_saver = None
         if checkpoint_folder and checkpoint_interval and checkpoint_interval_unit:
             self.checkpoint_saver = CheckpointSaver(checkpoint_folder=get_relative_to_run_directory(checkpoint_folder),
-                                             checkpoint_interval=checkpoint_interval,
-                                             checkpoint_interval_unit=checkpoint_interval_unit)
+                                                    checkpoint_interval=checkpoint_interval,
+                                                    checkpoint_interval_unit=checkpoint_interval_unit)
 
         self.checkpoint_loader = None
         if checkpoint_filepath:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -328,16 +328,15 @@ class Trainer:
                 optimizer=optimizer,
             )
 
-            if self.checkpoint_loader:
-                restored_seed = self.checkpoint_loader.load_checkpoint(state=self.state)
-                if restored_seed is not None:
-                    self.seed = restored_seed
-        else:
-            if self.checkpoint_loader:
-                restored_seed = self.checkpoint_loader.load_checkpoint(state=self.state)
-                if restored_seed is not None:
-                    self.seed = restored_seed
+        # If using DeepSpeed, the model must be loaded from checkpoint after the engine has been
+        # initialized, but if using PyTorch DDP, the model must be loaded before it is wrapped with
+        # DDP.
+        if self.checkpoint_loader:
+            restored_seed = self.checkpoint_loader.load_checkpoint(state=self.state)
+            if restored_seed is not None:
+                self.seed = restored_seed
 
+        if not self.deepspeed_enabled:
             self.state.model = self.device.module_to_device(self.state.model)
             self.state.optimizers = map_collection(self.state.optimizers, self.device.optimizer_to_device)
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -94,7 +94,7 @@ class Trainer:
             (default ``[TQDMLoggerBackend()]``).
         callbacks (Sequence[Callback], optional): The callbacks to run during training. (default: ``[]``)
         checkpoint_filepath (str, optional): The path to a trainer checkpoint file. If provided
-            the trainer will load the state (along with it's associated attributes) during initialization.
+            the trainer will load the state (along with its associated attributes) during initialization.
             (default: ``None``)
         checkpoint_interval_unit (int, optional): Unit for the checkpoint save interval -- should be 'ep'
             for epochs, 'it' for iterations, or None to disable checkpointing. (default: ``None``).
@@ -296,19 +296,13 @@ class Trainer:
         self.state.schedulers = ComposedScheduler(schedulers=schedulers)
 
         self.checkpointer = None
-        # TODO(#121): get checkpointing working with DeepSpeed.
         if checkpoint_folder and checkpoint_interval and checkpoint_interval_unit:
-            if self.deepspeed_enabled:
-                raise NotImplementedError("Checkpointing is not yet supported with DeepSpeed.")
             self.checkpointer = Checkpointer(checkpoint_folder=get_relative_to_run_directory(checkpoint_folder),
                                              checkpoint_interval=checkpoint_interval,
                                              checkpoint_interval_unit=checkpoint_interval_unit)
 
         self.checkpoint_loader = None
-        # TODO(#121): get checkpointing working with DeepSpeed.
         if checkpoint_filepath:
-            if self.deepspeed_enabled:
-                raise NotImplementedError("Checkpointing is not yet supported with DeepSpeed.")
             self.checkpoint_loader = CheckpointLoader(checkpoint_filepath=checkpoint_filepath)
             restored_seed = self.checkpoint_loader.load_checkpoint(state=self.state)
             # Set the restored seed so that the correct seed will be saved in future checkpoints

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -195,8 +195,6 @@ class TrainerHparams(hp.Hparams):
                                          default=None)
 
     def validate(self):
-
-        print(self.deepspeed)
         super().validate()
 
         deepspeed_enabled = self.deepspeed and self.deepspeed.enabled

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -202,6 +202,8 @@ class TrainerHparams(hp.Hparams):
                                          default=None)
 
     def validate(self):
+
+        print(self.deepspeed)
         super().validate()
 
         deepspeed_enabled = self.deepspeed and self.deepspeed.enabled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ reportUnusedCoroutine = "error"
 
 # Pytest
 [tool.pytest.ini_options]
-addopts = "--strict-markers -m 'not daily_regression and not weekly_regression and not gpu'"
+addopts = "--strict-markers -m 'not daily_regression and not weekly_regression and not gpu and not deepspeed'"
 
 # by default, tests should be fast.
 # for slower tests, use @pytest.mark.timeout with a higher timeout (specified in seconds)
@@ -63,6 +63,8 @@ markers = [
     # Specify -m daily_regression to run daily_regression tests
     "weekly_regression",
     # Specify -m weekly_regression to run weekly_regression tests.
+    "deepspeed",
+    # Whether the test needs to initialize the DeepSpeed engine.
 ]
 filterwarnings = [
     # "error",  # warnings should be treated like errors, but still need to fix some warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def configure_ddp(request: pytest.FixtureRequest):
             backend = "gloo"
         if deepspeed_marker is not None:
             use_deepspeed = True
-    """if use_deepspeed:
+    if use_deepspeed:
         if not "RANK" in os.environ:
             os.environ["RANK"] = str(0)
             os.environ["LOCAL_RANK"] = str(0)
@@ -142,8 +142,8 @@ def configure_ddp(request: pytest.FixtureRequest):
             os.environ["MASTER_ADDR"] = "127.0.0.1"
             os.environ["MASTER_PORT"] = str(29500)
         import deepspeed
-        deepspeed.init_distributed(timeout=DDP_TIMEOUT)"""
-    if not torch.distributed.is_initialized():
+        deepspeed.init_distributed(timeout=DDP_TIMEOUT)
+    elif not torch.distributed.is_initialized():
         if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
             torch.distributed.init_process_group(backend, timeout=DDP_TIMEOUT)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,7 +140,7 @@ def configure_ddp(request: pytest.FixtureRequest):
             os.environ["LOCAL_RANK"] = str(0)
             os.environ["WORLD_SIZE"] = str(1)
             os.environ["MASTER_ADDR"] = "127.0.0.1"
-            os.environ["MASTER_PORT"] = str(29500)
+            os.environ["MASTER_PORT"] = str(26000)
         import deepspeed
         deepspeed.init_distributed(timeout=DDP_TIMEOUT)
     elif not torch.distributed.is_initialized():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,8 @@ def configure_ddp(request: pytest.FixtureRequest):
     for item in request.session.items:
         gpu_marker = item.get_closest_marker('gpu')
         deepspeed_marker = item.get_closest_marker('deepspeed')
+        if deepspeed_marker and not gpu_marker:
+            pytest.fail('Tests that use DeepSpeed must also use GPUs.')
         if gpu_marker is not None:
             backend = "nccl"
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,13 +124,25 @@ def subfolder_run_directory(tmpdir: pathlib.Path, monkeypatch: MonkeyPatch) -> N
 @pytest.fixture(autouse=True)
 def configure_ddp(request: pytest.FixtureRequest):
     backend = None
+    use_deepspeed = False
     for item in request.session.items:
-        marker = item.get_closest_marker('gpu')
-        if marker is not None:
+        gpu_marker = item.get_closest_marker('gpu')
+        deepspeed_marker = item.get_closest_marker('deepspeed')
+        if gpu_marker is not None:
             backend = "nccl"
         else:
             backend = "gloo"
-        break
+        if deepspeed_marker is not None:
+            use_deepspeed = True
+    """if use_deepspeed:
+        if not "RANK" in os.environ:
+            os.environ["RANK"] = str(0)
+            os.environ["LOCAL_RANK"] = str(0)
+            os.environ["WORLD_SIZE"] = str(1)
+            os.environ["MASTER_ADDR"] = "127.0.0.1"
+            os.environ["MASTER_PORT"] = str(29500)
+        import deepspeed
+        deepspeed.init_distributed(timeout=DDP_TIMEOUT)"""
     if not torch.distributed.is_initialized():
         if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
             torch.distributed.init_process_group(backend, timeout=DDP_TIMEOUT)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -14,6 +14,7 @@ from composer.datasets.dataloader import DataloaderHparams
 from composer.datasets.hparams import DataloaderSpec, DatasetHparams
 from composer.models.base import BaseMosaicModel
 from tests.fixtures.models import SimpleBatchPairModel
+from deepspeed.runtime.engine import DeepSpeedEngine
 
 
 def random_tensor(size=(4, 10)):
@@ -66,6 +67,8 @@ def assert_state_equivalent(state1: State, state2: State):
         var2 = getattr(state2, field_name)
 
         if field_name == "model":
+            if isinstance(state1.model, DeepSpeedEngine):
+                assert isinstance(state2.model, DeepSpeedEngine)
             for p, q in zip(state1.model.parameters(), state2.model.parameters()):
                 torch.testing.assert_allclose(p, q, atol=1e-2, rtol=1e-2)
         elif isinstance(var1, types.Tensor):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,6 +5,7 @@ import random
 
 import torch
 import torch.nn.functional as F
+from deepspeed.runtime.engine import DeepSpeedEngine
 from torch.functional import Tensor
 
 from composer.algorithms.dummy import DummyHparams
@@ -14,7 +15,6 @@ from composer.datasets.dataloader import DataloaderHparams
 from composer.datasets.hparams import DataloaderSpec, DatasetHparams
 from composer.models.base import BaseMosaicModel
 from tests.fixtures.models import SimpleBatchPairModel
-from deepspeed.runtime.engine import DeepSpeedEngine
 
 
 def random_tensor(size=(4, 10)):

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -17,6 +17,7 @@ from composer.core.precision import Precision
 from composer.core.state import State
 from composer.core.types import Logger, StateDict
 from composer.datasets import SyntheticHparamsMixin
+from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.trainer.trainer import Trainer
 from composer.trainer.trainer_hparams import TrainerHparams, callback_registry
@@ -267,6 +268,7 @@ def validate_events_called_expected_number_of_times(trainer: Trainer):
     pytest.param(2, marks=pytest.mark.world_size(2)),
 ])
 @pytest.mark.gpu
+@pytest.mark.deepspeed
 @pytest.mark.parametrize("checkpoint_filename", ["ep1", "it4", "it1", "it6"])
 @pytest.mark.parametrize("seed", [None, 42])
 @pytest.mark.parametrize("validate_every_n_batches,validate_every_n_epochs", [
@@ -305,10 +307,10 @@ def test_checkpoint_deepspeed(
     mosaic_trainer_hparams.train_subset_num_batches = 5
     mosaic_trainer_hparams.device = GPUDeviceHparams()
 
-    mosaic_trainer_hparams.deepspeed = {
-        "enabled": True,
-        "zero_stage": zero_stage,
-    }
+    mosaic_trainer_hparams.deepspeed = DeepSpeedHparams(
+        enabled=True,
+        zero_stage=zero_stage,
+    )
 
     checkpoint_a_folder = "first"
     mosaic_trainer_hparams.checkpoint_folder = checkpoint_a_folder

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -318,9 +318,9 @@ def test_checkpoint_deepspeed(
     mosaic_trainer_hparams.seed = seed
     mosaic_trainer_hparams.validate_every_n_batches = validate_every_n_batches
     mosaic_trainer_hparams.validate_every_n_epochs = validate_every_n_epochs
-    final_checkpoint = "ep2.pt" if checkpoint_filename.startswith("ep") else "it8.pt"
+    final_checkpoint = ("ep2" if checkpoint_filename.startswith("ep") else "it8") + "/mosaic_states.pt"
     _test_checkpoint_trainer(mosaic_trainer_hparams)
-    checkpoint_a_file_path = os.path.join(checkpoint_a_folder, f"{checkpoint_filename}.pt")
+    checkpoint_a_file_path = os.path.join(checkpoint_a_folder, checkpoint_filename)
     checkpoint_b_file_path = run_directory.get_relative_to_run_directory(checkpoint_a_folder, final_checkpoint)
     trainer_1_hparams_filepath = run_directory.get_relative_to_run_directory(checkpoint_a_folder, "hparams.yaml")
 
@@ -333,13 +333,11 @@ def test_checkpoint_deepspeed(
     checkpoint_c_file_path = run_directory.get_relative_to_run_directory(checkpoint_b_folder, final_checkpoint)
     trainer_2_hparams_filepath = run_directory.get_relative_to_run_directory(checkpoint_b_folder, "hparams.yaml")
 
-    if ddp.get_global_rank() == 0:
-
-        assert_checkpoints_equivalent(
-            hparams_file_a=trainer_1_hparams_filepath,
-            checkpoint_file_a=checkpoint_b_file_path,
-            hparams_file_b=trainer_2_hparams_filepath,
-            checkpoint_file_b=checkpoint_c_file_path,
-        )
+    assert_checkpoints_equivalent(
+        hparams_file_a=trainer_1_hparams_filepath,
+        checkpoint_file_a=checkpoint_b_file_path,
+        hparams_file_b=trainer_2_hparams_filepath,
+        checkpoint_file_b=checkpoint_c_file_path,
+    )
 
 

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -179,9 +179,9 @@ def test_checkpoint(
     mosaic_trainer_hparams.seed = seed
     mosaic_trainer_hparams.validate_every_n_batches = validate_every_n_batches
     mosaic_trainer_hparams.validate_every_n_epochs = validate_every_n_epochs
-    final_checkpoint = "ep2.pt" if checkpoint_filename.startswith("ep") else "it8.pt"
+    final_checkpoint = ("ep2" if checkpoint_filename.startswith("ep") else "it8") + "/mosaic_states.pt"
     _test_checkpoint_trainer(mosaic_trainer_hparams)
-    checkpoint_a_file_path = os.path.join(checkpoint_a_folder, f"{checkpoint_filename}.pt")
+    checkpoint_a_file_path = os.path.join(checkpoint_a_folder, checkpoint_filename)
     checkpoint_b_file_path = run_directory.get_relative_to_run_directory(checkpoint_a_folder, final_checkpoint)
     trainer_1_hparams_filepath = run_directory.get_relative_to_run_directory(checkpoint_a_folder, "hparams.yaml")
 
@@ -194,14 +194,12 @@ def test_checkpoint(
     checkpoint_c_file_path = run_directory.get_relative_to_run_directory(checkpoint_b_folder, final_checkpoint)
     trainer_2_hparams_filepath = run_directory.get_relative_to_run_directory(checkpoint_b_folder, "hparams.yaml")
 
-    if ddp.get_global_rank() == 0:
-
-        assert_checkpoints_equivalent(
-            hparams_file_a=trainer_1_hparams_filepath,
-            checkpoint_file_a=checkpoint_b_file_path,
-            hparams_file_b=trainer_2_hparams_filepath,
-            checkpoint_file_b=checkpoint_c_file_path,
-        )
+    assert_checkpoints_equivalent(
+        hparams_file_a=trainer_1_hparams_filepath,
+        checkpoint_file_a=checkpoint_b_file_path,
+        hparams_file_b=trainer_2_hparams_filepath,
+        checkpoint_file_b=checkpoint_c_file_path,
+    )
 
 
 def _test_checkpoint_trainer(trainer_hparams: TrainerHparams):

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -24,7 +24,7 @@ from composer.trainer.checkpoint_hparams import CheckpointLoaderHparams, Checkpo
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.trainer.trainer import Trainer
 from composer.trainer.trainer_hparams import TrainerHparams, callback_registry
-from composer.utils import ddp, run_directory
+from composer.utils import run_directory
 from tests.test_state import assert_state_equivalent
 from tests.utils.deep_compare import deep_compare
 

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -17,10 +17,10 @@ from composer.core.precision import Precision
 from composer.core.state import State
 from composer.core.types import Logger, StateDict
 from composer.datasets import SyntheticHparamsMixin
-from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.optim import AdamWHparams
 from composer.optim.scheduler import ConstantLRHparams, CosineAnnealingLRHparams
 from composer.trainer.checkpoint_hparams import CheckpointLoaderHparams, CheckpointSaverHparams
+from composer.trainer.deepspeed import DeepSpeedHparams
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.trainer.trainer import Trainer
 from composer.trainer.trainer_hparams import TrainerHparams, callback_registry

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -252,11 +252,13 @@ def test_load_weights(
     (0, 1),
     (1, 0),
 ])
-@pytest.mark.parametrize("model_name", [
-    None, 
-    # "resnet50_synthetic", 
-    # "gpt2_52m",
-])
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        None,
+        # "resnet50_synthetic",
+        # "gpt2_52m",
+    ])
 def test_checkpoint(
     device_hparams: DeviceHparams,
     world_size: int,

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -260,3 +260,84 @@ def validate_events_called_expected_number_of_times(trainer: Trainer):
                 assert expected == actual, f"Event {event} expected to be called {expected} times, but instead it was called {actual} times"
             return
     assert False, "EventCounterCallback not found in callbacks"
+
+@pytest.mark.timeout(90)
+@pytest.mark.parametrize("world_size", [
+    pytest.param(1),
+    pytest.param(2, marks=pytest.mark.world_size(2)),
+])
+@pytest.mark.gpu
+@pytest.mark.parametrize("checkpoint_filename", ["ep1", "it4", "it1", "it6"])
+@pytest.mark.parametrize("seed", [None, 42])
+@pytest.mark.parametrize("validate_every_n_batches,validate_every_n_epochs", [
+    (0, 1),
+    (1, 0),
+])
+@pytest.mark.parametrize("zero_stage", [0, 1, 2])
+def test_checkpoint_deepspeed(
+    mosaic_trainer_hparams: TrainerHparams,
+    world_size: int,
+    checkpoint_filename: str,
+    seed: Optional[int],
+    validate_every_n_batches: int,
+    validate_every_n_epochs: int,
+    zero_stage: int,
+):
+    """strategy:
+    - train two epochs. capture checkpoints after `checkpoint_interval` and ep2.
+    - create a new trainer from the `checkpoint_interval` checkpoint, and train until end. checkpoint again.
+    - assert that the checkpoint from the new trainer at the end is the same as the checkpoint from the first trainer at the end.
+    """
+    del world_size  # unused. Read via env variable
+
+    mosaic_trainer_hparams.train_dataset.use_synthetic = True
+    mosaic_trainer_hparams.train_dataset.shuffle = False
+    mosaic_trainer_hparams.val_dataset.use_synthetic = True
+    mosaic_trainer_hparams.val_dataset.shuffle = False
+    mosaic_trainer_hparams.grad_accum = 2
+    mosaic_trainer_hparams.loggers = []
+    mosaic_trainer_hparams.checkpoint_interval = 1
+    mosaic_trainer_hparams.train_batch_size = 8
+    mosaic_trainer_hparams.eval_batch_size = 16
+    mosaic_trainer_hparams.max_epochs = 2
+    mosaic_trainer_hparams.precision = Precision.FP32
+    mosaic_trainer_hparams.callbacks = [DummyStatefulCallbackHparams(), EventCounterCallbackHparams()]
+    mosaic_trainer_hparams.train_subset_num_batches = 5
+    mosaic_trainer_hparams.device = GPUDeviceHparams()
+
+    mosaic_trainer_hparams.deepspeed = {
+        "enabled": True,
+        "zero_stage": zero_stage,
+    }
+
+    checkpoint_a_folder = "first"
+    mosaic_trainer_hparams.checkpoint_folder = checkpoint_a_folder
+    mosaic_trainer_hparams.checkpoint_interval_unit = "ep" if checkpoint_filename.startswith("ep") else "it"
+    mosaic_trainer_hparams.seed = seed
+    mosaic_trainer_hparams.validate_every_n_batches = validate_every_n_batches
+    mosaic_trainer_hparams.validate_every_n_epochs = validate_every_n_epochs
+    final_checkpoint = "ep2.pt" if checkpoint_filename.startswith("ep") else "it8.pt"
+    _test_checkpoint_trainer(mosaic_trainer_hparams)
+    checkpoint_a_file_path = os.path.join(checkpoint_a_folder, f"{checkpoint_filename}.pt")
+    checkpoint_b_file_path = run_directory.get_relative_to_run_directory(checkpoint_a_folder, final_checkpoint)
+    trainer_1_hparams_filepath = run_directory.get_relative_to_run_directory(checkpoint_a_folder, "hparams.yaml")
+
+    second_trainer_hparams = TrainerHparams.create(trainer_1_hparams_filepath, cli_args=False)
+    checkpoint_b_folder = "second"
+    second_trainer_hparams.checkpoint_folder = checkpoint_b_folder
+    second_trainer_hparams.checkpoint_filepath = run_directory.get_relative_to_run_directory(checkpoint_a_file_path)
+    _test_checkpoint_trainer(second_trainer_hparams)
+
+    checkpoint_c_file_path = run_directory.get_relative_to_run_directory(checkpoint_b_folder, final_checkpoint)
+    trainer_2_hparams_filepath = run_directory.get_relative_to_run_directory(checkpoint_b_folder, "hparams.yaml")
+
+    if ddp.get_global_rank() == 0:
+
+        assert_checkpoints_equivalent(
+            hparams_file_a=trainer_1_hparams_filepath,
+            checkpoint_file_a=checkpoint_b_file_path,
+            hparams_file_b=trainer_2_hparams_filepath,
+            checkpoint_file_b=checkpoint_c_file_path,
+        )
+
+


### PR DESCRIPTION
Support for model checkpointing while using DeepSpeed. We're lucky in that DeepSpeed provides a pretty good API for creating checkpoints. With this design, we entrust DeepSpeed to serialize the model and optimizer states, and we handle everything else as before.

One of the biggest changes in this PR is that a "checkpoint" is no longer a file, but a folder. This is necessary because it's how DeepSpeed does it - its checkpoints often comprise several files.

In practice, whereas before our structure was something like:
```
checkpoints_folder/
  hparams.yaml
  ep1.pt
  ep2.pt
  ep3.pt
```
We now have:
```
checkpoints_folder/
  hparams.yaml
  ep1/
    mosaic_states.pt
    <any DeepSpeed files>
  ep2/
    ...
  ep3/
    ...
  ...
```

DDP (and DeepSpeed) initialization has been moved into `Trainer.__init__` - this was necessary because DeepSpeed cannot load a checkpoint until DeepSpeed itself has initialized. This seemed reasonable to me - I think the trainer initialization functions should contain all the initialization code that only runs once. This does, however, have the notable consequence that `Trainer.__init__` will block if called from less than `WORLD_SIZE` different processes. This is why I had to remove the `is_rank_zero` check from some of the tests.

The eagle-eyed might note that DeepSpeed's checkpointing API supports a `client_state` param for any non-DeepSpeed state that might want to be checkpointed. I opted not to use this functionality, because I wasn't sure how it would interact with tensors (since it didn't seem to be using `torch.load`). We also just didn't need it - we already have code for checkpointing our own state.

There's a few additional features (like run directory sanitation) that will likely be necessary for this to be useful in practice - owing to the very large size of DeepSpeed checkpoints. I'll tackle those in a subsequent PR.