### PR TITLE
Add larger GPT models

### DIFF
--- a/composer/yamls/models/gpt2_1,3b.yaml
+++ b/composer/yamls/models/gpt2_1,3b.yaml
@@ -1,0 +1,97 @@
+train_dataset:
+  lm:
+    split: train
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 7340032000 # 7000 (batches) * 1024 (batch_size) * 1024 (seq_len)
+val_dataset:
+  lm:
+    split: validation
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+model:
+  gpt2:
+    use_pretrained: false
+    tokenizer_name: gpt2
+    model_config:
+      activation_function: gelu_new
+      architectures:
+        - GPT2LMHeadModel
+      attn_pdrop: 0.1
+      bos_token_id: 50256
+      embd_pdrop: 0.1
+      eos_token_id: 50256
+      initializer_range: 0.02
+      layer_norm_epsilon: 1.0e-05
+      model_type: gpt2
+      n_ctx: 1024
+      n_embd: 2048
+      n_head: 16
+      n_inner: 8192
+      n_layer: 24
+      n_positions: 1024
+      resid_pdrop: 0.1
+      scale_attn_weights: true
+      summary_activation: null
+      summary_first_dropout: 0.1
+      summary_proj_to_labels: true
+      summary_type: cls_index
+      summary_use_proj: true
+      task_specific_params:
+        text-generation:
+          do_sample: true
+          max_length: 50
+      transformers_version: 4.11.0.dev0
+      use_cache: true
+      vocab_size: 50257
+optimizer:
+  adamw:
+    lr: 2.0e-4
+    betas:
+      - 0.9
+      - 0.999
+    eps: 1.0e-08
+    weight_decay: 0.0
+schedulers:
+  - warmup:
+      warmup_method: linear
+      warmup_factor: 0
+      interval: step
+      warmup_iters: 140ba
+  - cosine_decay:
+      interval: step
+      eta_min: 0
+      verbose: false
+      T_max: 13860ba
+loggers:
+  - file:
+      log_level: batch
+      filename: stdout
+      buffer_size: 1
+      flush_every_n_batches: 100
+      every_n_batches: 100
+      every_n_epochs: 1
+max_epochs: 1
+train_batch_size: 1024
+eval_batch_size: 8
+seed: 17
+device:
+  gpu: {}
+dataloader:
+  pin_memory: true
+  persistent_workers: true
+  num_workers: 8
+  timeout: 0
+  prefetch_factor: 2
+precision: amp
+grad_clip_norm: 1.0
+grad_accum: 128
+validate_every_n_batches: 1000
+validate_every_n_epochs: 1

--- a/composer/yamls/models/gpt2_13b.yaml
+++ b/composer/yamls/models/gpt2_13b.yaml
@@ -1,0 +1,97 @@
+train_dataset:
+  lm:
+    split: train
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 7340032000 # 3500 (batches) * 2048 (batch_size) * 1024 (seq_len)
+val_dataset:
+  lm:
+    split: validation
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+model:
+  gpt2:
+    use_pretrained: false
+    tokenizer_name: gpt2
+    model_config:
+      activation_function: gelu_new
+      architectures:
+        - GPT2LMHeadModel
+      attn_pdrop: 0.1
+      bos_token_id: 50256
+      embd_pdrop: 0.1
+      eos_token_id: 50256
+      initializer_range: 0.02
+      layer_norm_epsilon: 1.0e-05
+      model_type: gpt2
+      n_ctx: 1024
+      n_embd: 5120
+      n_head: 40
+      n_inner: 20480
+      n_layer: 40
+      n_positions: 1024
+      resid_pdrop: 0.1
+      scale_attn_weights: true
+      summary_activation: null
+      summary_first_dropout: 0.1
+      summary_proj_to_labels: true
+      summary_type: cls_index
+      summary_use_proj: true
+      task_specific_params:
+        text-generation:
+          do_sample: true
+          max_length: 50
+      transformers_version: 4.11.0.dev0
+      use_cache: true
+      vocab_size: 50257
+optimizer:
+  adamw:
+    lr: 1.0e-4
+    betas:
+      - 0.9
+      - 0.999
+    eps: 1.0e-08
+    weight_decay: 0.0
+schedulers:
+  - warmup:
+      warmup_method: linear
+      warmup_factor: 0
+      interval: step
+      warmup_iters: 140ba
+  - cosine_decay:
+      interval: step
+      eta_min: 0
+      verbose: false
+      T_max: 13860ba
+loggers:
+  - file:
+      log_level: batch
+      filename: stdout
+      buffer_size: 1
+      flush_every_n_batches: 100
+      every_n_batches: 100
+      every_n_epochs: 1
+max_epochs: 1
+train_batch_size: 2048
+eval_batch_size: 8
+seed: 17
+device:
+  gpu: {}
+dataloader:
+  pin_memory: true
+  persistent_workers: true
+  num_workers: 8
+  timeout: 0
+  prefetch_factor: 2
+precision: amp
+grad_clip_norm: 1.0
+grad_accum: 256
+validate_every_n_batches: 1000
+validate_every_n_epochs: 1

--- a/composer/yamls/models/gpt2_2,7b.yaml
+++ b/composer/yamls/models/gpt2_2,7b.yaml
@@ -1,0 +1,97 @@
+train_dataset:
+  lm:
+    split: train
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 7340032000 # 7000 (batches) * 1024 (batch_size) * 1024 (seq_len)
+val_dataset:
+  lm:
+    split: validation
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+model:
+  gpt2:
+    use_pretrained: false
+    tokenizer_name: gpt2
+    model_config:
+      activation_function: gelu_new
+      architectures:
+        - GPT2LMHeadModel
+      attn_pdrop: 0.1
+      bos_token_id: 50256
+      embd_pdrop: 0.1
+      eos_token_id: 50256
+      initializer_range: 0.02
+      layer_norm_epsilon: 1.0e-05
+      model_type: gpt2
+      n_ctx: 1024
+      n_embd: 2560
+      n_head: 32
+      n_inner: 10240
+      n_layer: 32
+      n_positions: 1024
+      resid_pdrop: 0.1
+      scale_attn_weights: true
+      summary_activation: null
+      summary_first_dropout: 0.1
+      summary_proj_to_labels: true
+      summary_type: cls_index
+      summary_use_proj: true
+      task_specific_params:
+        text-generation:
+          do_sample: true
+          max_length: 50
+      transformers_version: 4.11.0.dev0
+      use_cache: true
+      vocab_size: 50257
+optimizer:
+  adamw:
+    lr: 1.6e-4
+    betas:
+      - 0.9
+      - 0.999
+    eps: 1.0e-08
+    weight_decay: 0.0
+schedulers:
+  - warmup:
+      warmup_method: linear
+      warmup_factor: 0
+      interval: step
+      warmup_iters: 140ba
+  - cosine_decay:
+      interval: step
+      eta_min: 0
+      verbose: false
+      T_max: 13860ba
+loggers:
+  - file:
+      log_level: batch
+      filename: stdout
+      buffer_size: 1
+      flush_every_n_batches: 100
+      every_n_batches: 100
+      every_n_epochs: 1
+max_epochs: 1
+train_batch_size: 1024
+eval_batch_size: 8
+seed: 17
+device:
+  gpu: {}
+dataloader:
+  pin_memory: true
+  persistent_workers: true
+  num_workers: 8
+  timeout: 0
+  prefetch_factor: 2
+precision: amp
+grad_clip_norm: 1.0
+grad_accum: 128
+validate_every_n_batches: 1000
+validate_every_n_epochs: 1

--- a/composer/yamls/models/gpt2_350m.yaml
+++ b/composer/yamls/models/gpt2_350m.yaml
@@ -1,0 +1,97 @@
+train_dataset:
+  lm:
+    split: train
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 5767168000 # 11000 (batches) * 512 (batch_size) * 1024 (seq_len)
+val_dataset:
+  lm:
+    split: validation
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+model:
+  gpt2:
+    use_pretrained: false
+    tokenizer_name: gpt2
+    model_config:
+      activation_function: gelu_new
+      architectures:
+        - GPT2LMHeadModel
+      attn_pdrop: 0.1
+      bos_token_id: 50256
+      embd_pdrop: 0.1
+      eos_token_id: 50256
+      initializer_range: 0.02
+      layer_norm_epsilon: 1.0e-05
+      model_type: gpt2
+      n_ctx: 1024
+      n_embd: 1024
+      n_head: 16
+      n_inner: 4096
+      n_layer: 24
+      n_positions: 1024
+      resid_pdrop: 0.1
+      scale_attn_weights: true
+      summary_activation: null
+      summary_first_dropout: 0.1
+      summary_proj_to_labels: true
+      summary_type: cls_index
+      summary_use_proj: true
+      task_specific_params:
+        text-generation:
+          do_sample: true
+          max_length: 50
+      transformers_version: 4.11.0.dev0
+      use_cache: true
+      vocab_size: 50257
+optimizer:
+  adamw:
+    lr: 3.0e-4
+    betas:
+      - 0.9
+      - 0.999
+    eps: 1.0e-08
+    weight_decay: 0.0
+schedulers:
+  - warmup:
+      warmup_method: linear
+      warmup_factor: 0
+      interval: step
+      warmup_iters: 110ba
+  - cosine_decay:
+      interval: step
+      eta_min: 0
+      verbose: false
+      T_max: 10890ba
+loggers:
+  - file:
+      log_level: batch
+      filename: stdout
+      buffer_size: 1
+      flush_every_n_batches: 100
+      every_n_batches: 100
+      every_n_epochs: 1
+max_epochs: 1
+train_batch_size: 512
+eval_batch_size: 8
+seed: 17
+device:
+  gpu: {}
+dataloader:
+  pin_memory: true
+  persistent_workers: true
+  num_workers: 8
+  timeout: 0
+  prefetch_factor: 2
+precision: amp
+grad_clip_norm: 1.0
+grad_accum: 64
+validate_every_n_batches: 1000
+validate_every_n_epochs: 1

--- a/composer/yamls/models/gpt2_6,7b.yaml
+++ b/composer/yamls/models/gpt2_6,7b.yaml
@@ -1,0 +1,97 @@
+train_dataset:
+  lm:
+    split: train
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 7340032000 # 3500 (batches) * 2048 (batch_size) * 1024 (seq_len)
+val_dataset:
+  lm:
+    split: validation
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+model:
+  gpt2:
+    use_pretrained: false
+    tokenizer_name: gpt2
+    model_config:
+      activation_function: gelu_new
+      architectures:
+        - GPT2LMHeadModel
+      attn_pdrop: 0.1
+      bos_token_id: 50256
+      embd_pdrop: 0.1
+      eos_token_id: 50256
+      initializer_range: 0.02
+      layer_norm_epsilon: 1.0e-05
+      model_type: gpt2
+      n_ctx: 1024
+      n_embd: 4096
+      n_head: 32
+      n_inner: 16384
+      n_layer: 32
+      n_positions: 1024
+      resid_pdrop: 0.1
+      scale_attn_weights: true
+      summary_activation: null
+      summary_first_dropout: 0.1
+      summary_proj_to_labels: true
+      summary_type: cls_index
+      summary_use_proj: true
+      task_specific_params:
+        text-generation:
+          do_sample: true
+          max_length: 50
+      transformers_version: 4.11.0.dev0
+      use_cache: true
+      vocab_size: 50257
+optimizer:
+  adamw:
+    lr: 1.2e-4
+    betas:
+      - 0.9
+      - 0.999
+    eps: 1.0e-08
+    weight_decay: 0.0
+schedulers:
+  - warmup:
+      warmup_method: linear
+      warmup_factor: 0
+      interval: step
+      warmup_iters: 140ba
+  - cosine_decay:
+      interval: step
+      eta_min: 0
+      verbose: false
+      T_max: 13860ba
+loggers:
+  - file:
+      log_level: batch
+      filename: stdout
+      buffer_size: 1
+      flush_every_n_batches: 100
+      every_n_batches: 100
+      every_n_epochs: 1
+max_epochs: 1
+train_batch_size: 2048
+eval_batch_size: 8
+seed: 17
+device:
+  gpu: {}
+dataloader:
+  pin_memory: true
+  persistent_workers: true
+  num_workers: 8
+  timeout: 0
+  prefetch_factor: 2
+precision: amp
+grad_clip_norm: 1.0
+grad_accum: 256
+validate_every_n_batches: 1000
+validate_every_n_epochs: 1

--- a/composer/yamls/models/gpt2_760m.yaml
+++ b/composer/yamls/models/gpt2_760m.yaml
@@ -1,0 +1,97 @@
+train_dataset:
+  lm:
+    split: train
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 7340032000 # 14000 (batches) * 512 (batch_size) * 1024 (seq_len)
+val_dataset:
+  lm:
+    split: validation
+    datadir: /datasets/openwebtext_saved
+    tokenizer_name: gpt2
+    seed: 17
+    shuffle: false
+    drop_last: false
+    num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+model:
+  gpt2:
+    use_pretrained: false
+    tokenizer_name: gpt2
+    model_config:
+      activation_function: gelu_new
+      architectures:
+        - GPT2LMHeadModel
+      attn_pdrop: 0.1
+      bos_token_id: 50256
+      embd_pdrop: 0.1
+      eos_token_id: 50256
+      initializer_range: 0.02
+      layer_norm_epsilon: 1.0e-05
+      model_type: gpt2
+      n_ctx: 1024
+      n_embd: 1536
+      n_head: 16
+      n_inner: 6144
+      n_layer: 24
+      n_positions: 1024
+      resid_pdrop: 0.1
+      scale_attn_weights: true
+      summary_activation: null
+      summary_first_dropout: 0.1
+      summary_proj_to_labels: true
+      summary_type: cls_index
+      summary_use_proj: true
+      task_specific_params:
+        text-generation:
+          do_sample: true
+          max_length: 50
+      transformers_version: 4.11.0.dev0
+      use_cache: true
+      vocab_size: 50257
+optimizer:
+  adamw:
+    lr: 2.5e-4
+    betas:
+      - 0.9
+      - 0.999
+    eps: 1.0e-08
+    weight_decay: 0.0
+schedulers:
+  - warmup:
+      warmup_method: linear
+      warmup_factor: 0
+      interval: step
+      warmup_iters: 140ba
+  - cosine_decay:
+      interval: step
+      eta_min: 0
+      verbose: false
+      T_max: 13860ba
+loggers:
+  - file:
+      log_level: batch
+      filename: stdout
+      buffer_size: 1
+      flush_every_n_batches: 100
+      every_n_batches: 100
+      every_n_epochs: 1
+max_epochs: 1
+train_batch_size: 512
+eval_batch_size: 8
+seed: 17
+device:
+  gpu: {}
+dataloader:
+  pin_memory: true
+  persistent_workers: true
+  num_workers: 8
+  timeout: 0
+  prefetch_factor: 2
+precision: amp
+grad_clip_norm: 1.0
+grad_accum: 64
+validate_every_n_batches: 1000
+validate_every_n_epochs: 1


### PR DESCRIPTION
Time to go bigger :)

Specs copied from https://arxiv.org/pdf/2005.14165.pdf. Only fields changed from the existing GPT models are:
`model.gpt2.n_embd`
`model.gpt2.n_head`
`model.gpt2.n_inner`
`model.gpt2.n_layer`
`optimizer.adamw.lr`
`train_batch_size`
`grad_accum`