### PR TITLE
Adding use_masked attr to new GPT-2 YAMLs

### DIFF
--- a/composer/yamls/models/gpt2_1,3b.yaml
+++ b/composer/yamls/models/gpt2_1,3b.yaml
@@ -7,6 +7,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 7340032000 # 7000 (batches) * 1024 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -16,6 +17,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false

--- a/composer/yamls/models/gpt2_125m.yaml
+++ b/composer/yamls/models/gpt2_125m.yaml
@@ -9,6 +9,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 7340032000 # 14000 (batches) * 512 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -18,6 +19,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false

--- a/composer/yamls/models/gpt2_13b.yaml
+++ b/composer/yamls/models/gpt2_13b.yaml
@@ -7,6 +7,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 7340032000 # 3500 (batches) * 2048 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -16,6 +17,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false

--- a/composer/yamls/models/gpt2_2,7b.yaml
+++ b/composer/yamls/models/gpt2_2,7b.yaml
@@ -7,6 +7,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 7340032000 # 7000 (batches) * 1024 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -16,6 +17,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false

--- a/composer/yamls/models/gpt2_350m.yaml
+++ b/composer/yamls/models/gpt2_350m.yaml
@@ -7,6 +7,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 5767168000 # 11000 (batches) * 512 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -16,6 +17,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false

--- a/composer/yamls/models/gpt2_52m.yaml
+++ b/composer/yamls/models/gpt2_52m.yaml
@@ -9,6 +9,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 4718592000 # 9000 (batches) * 512 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -18,6 +19,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false

--- a/composer/yamls/models/gpt2_6,7b.yaml
+++ b/composer/yamls/models/gpt2_6,7b.yaml
@@ -7,6 +7,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 7340032000 # 3500 (batches) * 2048 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -16,6 +17,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false

--- a/composer/yamls/models/gpt2_760m.yaml
+++ b/composer/yamls/models/gpt2_760m.yaml
@@ -7,6 +7,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 7340032000 # 14000 (batches) * 512 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -16,6 +17,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false

--- a/composer/yamls/models/gpt2_83m.yaml
+++ b/composer/yamls/models/gpt2_83m.yaml
@@ -9,6 +9,7 @@ train_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 5767168000 # 11000 (batches) * 512 (batch_size) * 1024 (seq_len)
+    use_masked_lm: false
 val_dataset:
   lm:
     split: validation
@@ -18,6 +19,7 @@ val_dataset:
     shuffle: false
     drop_last: false
     num_tokens: 102400000 # 100000 (seq) * 1024 (seq_len)
+    use_masked_lm: false
 model:
   gpt2:
     use_pretrained: false


### PR DESCRIPTION
We just merged in some new GPT-2 YAMLs, but they lack the `use_masked_lm` property. This serves to add this to the YAMLs, so BERT can get merged in.