### PR TITLE
Cleaned Up State

### DIFF
--- a/.github/actions/pyright/action.yaml
+++ b/.github/actions/pyright/action.yaml
@@ -12,7 +12,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       run: |
         set -ex
-        sudo npm install -g pyright@1.1.206
+        sudo npm install -g pyright@1.1.203
 
     - name: Run Pyright
       shell: bash

--- a/.github/actions/pyright/action.yaml
+++ b/.github/actions/pyright/action.yaml
@@ -12,7 +12,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       run: |
         set -ex
-        sudo npm install -g pyright@1.1.203
+        sudo npm install -g pyright@1.1.206
 
     - name: Run Pyright
       shell: bash

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -179,9 +179,12 @@ class SeqLengthWarmup(Algorithm):
             # all of the parameters
             device = next(state.model.parameters()).device
 
-            per_gpu_batch = state.train_dataloader.batch_size
-            if per_gpu_batch is None:
+            per_gpu_macrobatch = state.train_dataloader.batch_size
+            if per_gpu_macrobatch is None:
                 raise RuntimeError("seq_length_warmup requires constant batch sizing")
+            assert per_gpu_macrobatch % state.grad_accum == 0, "grad accum should evenly divide the batch"
+            per_gpu_batch = per_gpu_macrobatch // state.grad_accum
+
             input_ids = torch.randint(low=0,
                                       high=vocab_size - 1,
                                       size=(per_gpu_batch, self.hparams.max_seq_length),

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -6,11 +6,14 @@ import time
 from collections import deque
 from typing import Deque, Optional
 
+import torch
+
 from composer.callbacks.callback_hparams import SpeedMonitorHparams
 from composer.core import Logger, State
 from composer.core.callback import RankZeroCallback
 from composer.core.types import StateDict
 from composer.utils import dist
+from composer.utils.data import get_device_of_batch
 
 
 class SpeedMonitor(RankZeroCallback):
@@ -39,6 +42,7 @@ class SpeedMonitor(RankZeroCallback):
         self.batch_num_samples: Deque[int] = deque(maxlen=window_size)  # rolling list of num samples in batch.
         self.hparams = SpeedMonitorHparams(window_size=window_size)
         self.loaded_state: Optional[StateDict] = None
+        self.current_batch_num_samples = torch.tensor(0)
 
     def state_dict(self) -> StateDict:
         current_time = time.time()
@@ -78,14 +82,9 @@ class SpeedMonitor(RankZeroCallback):
 
     def batch_end(self, state: State, logger: Logger):
         self.batch_end_times.append(time.time())
-        batch_num_samples = 0
-        batch_num_samples += state.last_batch_size
-        # TODO this is a hack around not having proper syncing / reduction available in callbacks
-        # Ideally, callbacks would have a way of reducing tensors.
-        # It assumes that each process has equal batch sizing
-        # For the speed monitor, we might be able to use the static step converter with num_samples
-        batch_num_samples *= dist.get_world_size()
-        self.batch_num_samples.append(batch_num_samples)
+        batch_num_samples = torch.tensor([int(state.batch_num_samples)], device=get_device_of_batch(state.batch))
+        dist.all_reduce(batch_num_samples, reduce_operation="SUM")
+        self.batch_num_samples.append(int(batch_num_samples.item()))
         self.train_examples_per_epoch += batch_num_samples
         if len(self.batch_end_times) == self.hparams.window_size + 1:
             throughput = sum(self.batch_num_samples) / (self.batch_end_times[-1] - self.batch_end_times[0])

--- a/composer/trainer/deepspeed.py
+++ b/composer/trainer/deepspeed.py
@@ -50,9 +50,11 @@ class DeepSpeedHparams(hp.Hparams):
             warnings.warn("ZeRO stage 3 is largely untested with composer. Certain algorithms may break.")
 
     def initialize_object(self, state: State, grad_clip_norm: Optional[float]):
+        if state.train_dataloader.batch_size is None:
+            raise RuntimeError("Deepspeed requires a dataloader with a known batch size")
 
         deepspeed_config: dict[str, Any] = {
-            "train_batch_size": state.train_batch_size,
+            "train_micro_batch_size_per_gpu": state.train_dataloader.batch_size // state.grad_accum,
             "gradient_accumulation_steps": state.grad_accum,
             "zero_optimization": {
                 "stage": self.zero_stage,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -807,9 +807,9 @@ class Trainer:
 
             for state.batch in itertools.islice(state.eval_dataloader, self._eval_subset_num_batches):
                 state.batch = self.device.batch_to_device(state.batch)
-                state.batch = self._eval_data_spoc.device_transforms(state.batch)
-                state.batch_num_samples = self._eval_data_spoc.get_num_samples_in_batch(state.batch)
-                state.batch_num_tokens = self._eval_data_spoc.get_num_tokens_in_batch(state.batch)
+                state.batch = self._eval_data_spec.device_transforms(state.batch)
+                state.batch_num_samples = self._eval_data_spec.get_num_samples_in_batch(state.batch)
+                state.batch_num_tokens = self._eval_data_spec.get_num_tokens_in_batch(state.batch)
 
                 if self.deepspeed_enabled:
                     state.batch = fix_batch_precision_for_deepspeed(state.batch, state.precision)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -8,7 +8,7 @@ import itertools
 import logging
 import textwrap
 import warnings
-from typing import Any, Callable, ContextManager, Dict, List, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, ContextManager, Dict, List, Optional, Sequence, Union, cast
 
 import torch
 import torch.distributed
@@ -21,7 +21,7 @@ from torchmetrics.metric import Metric
 from composer.core import Callback, DataSpec, Engine, Event, Logger, State, Time
 from composer.core.algorithm import Algorithm
 from composer.core.logging import BaseLoggerBackend, LogLevel
-from composer.core.types import Batch, BreakEpochException, DataLoader, Metrics, Precision, Tensor
+from composer.core.types import BreakEpochException, DataLoader, Metrics, Precision
 from composer.datasets.dataloader import DDPDataLoader
 from composer.loggers.tqdm_logger import TQDMLoggerBackend
 from composer.models.base import BaseMosaicModel
@@ -37,6 +37,9 @@ from composer.trainer.devices.device_gpu import DeviceGPU
 from composer.trainer.scaler import ClosureGradScaler
 from composer.trainer.trainer_hparams import TrainerHparams
 from composer.utils import dist, ensure_tuple, map_collection, reproducibility
+
+if TYPE_CHECKING:
+    import deepspeed
 
 log = logging.getLogger(__name__)
 
@@ -214,6 +217,9 @@ class Trainer:
             eval_dataloader = DataSpec(eval_dataloader)
         eval_dataloader.dataloader = DDPDataLoader(eval_dataloader.dataloader)
 
+        self._train_data_spec = train_dataloader
+        self._eval_data_spoc = eval_dataloader
+
         self.state = State(
             max_duration=max_duration,
             algorithms=algorithms,
@@ -222,8 +228,8 @@ class Trainer:
             grad_accum=grad_accum,
             precision=precision,
             precision_context=precision_context,
-            train_dataloader=train_dataloader,
-            eval_dataloader=eval_dataloader,
+            train_dataloader=train_dataloader.dataloader,
+            eval_dataloader=eval_dataloader.dataloader,
         )
 
         # Steps per epoch
@@ -272,17 +278,18 @@ class Trainer:
         if not isinstance(schedulers_hparams, list):
             schedulers_hparams = [schedulers_hparams]
         optimizer = optimizer_hparams.initialize_object(param_group=self.state.model.parameters())
-        if self.state.train_data.num_samples is None:
+        if self._train_data_spec.num_samples is None or self.state.train_dataloader.batch_size is None:
             samples_per_epoch = None
         else:
-            samples_per_epoch = min(self.state.steps_per_epoch * self.state.train_batch_size,
-                                    self.state.train_data.num_samples)
+            batch_size = self.state.train_dataloader.batch_size * dist.get_world_size()
+
+            samples_per_epoch = min(self.state.steps_per_epoch * batch_size, self._train_data_spec.num_samples)
         schedulers = [
             x.initialize_object(optimizer=optimizer,
                                 max_training_duration=self.state.max_duration,
                                 steps_per_epoch=self.state.steps_per_epoch,
                                 samples_per_epoch=samples_per_epoch,
-                                dataset_num_tokens=self.state.train_data.num_tokens)
+                                dataset_num_tokens=self._train_data_spec.num_tokens)
             for x in ensure_warmup_last(schedulers_hparams)
         ]
         self.state.optimizers = optimizer
@@ -557,9 +564,11 @@ class Trainer:
                             self.checkpoint_loader.restore_checkpoint_rng_state(self.device)
                         continue
 
-                    state.last_batch_size = state.train_data.get_num_samples_in_batch(state.batch)
                     state.batch = self.device.batch_to_device(state.batch)
-                    state.batch = state.train_data.device_transforms(state.batch)
+                    state.batch = self._train_data_spec.device_transforms(state.batch)
+                    state.batch_num_samples = self._train_data_spec.get_num_samples_in_batch(state.batch)
+                    state.batch_num_tokens = self._train_data_spec.get_num_tokens_in_batch(state.batch)
+                    state.microbatches = self._train_data_spec.split_batch(state.batch, state.grad_accum)
 
                     if self.deepspeed_enabled:
                         state.batch = fix_batch_precision_for_deepspeed(state.batch, state.precision)
@@ -569,8 +578,7 @@ class Trainer:
                         assert train_metrics is not None
                         state.model.eval()
                         with torch.no_grad():
-                            eval_microbatches = state.train_data.split_batch(state.batch, state.grad_accum)
-                            for eval_microbatch in eval_microbatches:
+                            for eval_microbatch in state.microbatches:
                                 # TODO: Detect if self.run_event(Event.AFTER_DATALOADER) changes the training
                                 # data and if so print a warning that metrics may return unexpected results
                                 outputs, targets = self.original_model.validate(eval_microbatch)
@@ -580,7 +588,12 @@ class Trainer:
 
                     self.engine.run_event(Event.AFTER_DATALOADER)
 
-                    microbatches = state.train_data.split_batch(state.batch, state.grad_accum)
+                    num_samples_in_batch = self.device.tensor_to_device(
+                        torch.tensor([state.batch_num_samples], dtype=torch.int))
+                    num_tokens_in_batch = self.device.tensor_to_device(
+                        torch.tensor([state.batch_num_tokens], dtype=torch.int))
+                    dist.all_reduce(num_samples_in_batch, reduce_operation="SUM")
+                    dist.all_reduce(num_tokens_in_batch, reduce_operation="SUM")
 
                     self.engine.run_event(Event.BATCH_START)
                     self.logger.metric_batch({
@@ -589,18 +602,15 @@ class Trainer:
                     })
                     total_loss = None
                     if self.deepspeed_enabled:
-                        total_loss = self._train_batch(microbatches)
+                        total_loss = self._train_batch()
                     elif self._use_closures():
-                        closure = lambda **kwargs: self._train_batch(microbatches, **kwargs)
                         for optimizer in state.optimizers:
                             if use_grad_scaling:
-                                total_loss = state.scaler.step(optimizer, closure=closure)
+                                total_loss = state.scaler.step(optimizer, closure=self._train_batch)
                             else:
-                                # Torch optimizers technically expect closures to return a float, not a Tensor.
-                                # In practice, this doesn't seem to actually matter.
-                                total_loss = optimizer.step(closure=closure)  # type: ignore
+                                total_loss = optimizer.step(closure=lambda: self._train_batch().item())
                     else:
-                        total_loss = self._train_batch(microbatches)
+                        total_loss = self._train_batch()
                         for optimizer in state.optimizers:
                             if use_grad_scaling:
                                 state.scaler.step(optimizer)
@@ -611,7 +621,7 @@ class Trainer:
                         state.scaler.update()
 
                     if total_loss is not None:
-                        assert isinstance(total_loss, Tensor)
+                        total_loss = self.device.tensor_to_device(torch.tensor([total_loss]))
 
                         # total_loss can be None if gradient scaling failed
                         dist.all_reduce(total_loss, reduce_operation="SUM")
@@ -632,8 +642,8 @@ class Trainer:
                         self.eval(is_batch=True)
 
                     state.timer.on_batch_complete(
-                        samples=state.train_data.get_num_samples_in_batch(state.batch),
-                        tokens=state.train_data.get_num_tokens_in_batch(state.batch),
+                        samples=int(num_samples_in_batch.item()),
+                        tokens=int(num_tokens_in_batch.item()),
                     )
                     if self.checkpoint_saver and self.checkpoint_saver.should_checkpoint(state=state,
                                                                                          event=Event.BATCH_END):
@@ -662,7 +672,7 @@ class Trainer:
 
         self.engine.run_event(Event.TRAINING_END)
 
-    def _train_batch(self, microbatches: Sequence[Batch], ddp_sync: bool = True):
+    def _train_batch(self, ddp_sync: bool = True):
         """Run training on a full batch of data.
 
         Args:
@@ -677,14 +687,11 @@ class Trainer:
             context = self.state.model.no_sync
 
         with context():  # type: ignore - Pyright apparently doesn't recognize no_sync
-            return self._train_batch_inner(microbatches)
+            return self._train_batch_inner()
 
-    def _train_batch_inner(self, microbatches: Sequence[Batch]):
+    def _train_batch_inner(self):
         """Iterate over microbatches and compute the loss that will be used to step
         the optimizer.
-
-        Args:
-            microbatches (Sequence[Batch]): The microbatches which make up the batch.
         """
         self.engine.run_event(Event.BEFORE_TRAIN_BATCH)
 
@@ -700,15 +707,16 @@ class Trainer:
 
         # tracker for gradient accumulation
         total_loss = self.device.tensor_to_device(torch.zeros(size=(1,)))
-        current_batch_size = sum([state.train_data.get_num_samples_in_batch(batch) for batch in microbatches])
+        current_batch_size = sum(
+            [self._train_data_spec.get_num_samples_in_batch(batch) for batch in state.microbatches])
 
-        for microbatch_idx, state.batch in enumerate(microbatches):
-            is_final_microbatch = microbatch_idx + 1 == len(microbatches)
+        for state.microbatch_idx, state.batch in enumerate(state.microbatches):
+            state.batch_num_tokens = self._train_data_spec.get_num_tokens_in_batch(state.batch)
+            state.batch_num_samples = self._train_data_spec.get_num_samples_in_batch(state.batch)
+            is_final_microbatch = state.microbatch_idx + 1 == len(state.microbatches)
             sync_context = contextlib.nullcontext() if self.deepspeed_enabled else ddp_sync_context(
                 state, is_final_microbatch, self.ddp_sync_strategy)
             with sync_context:
-                last_microbatch_size = state.train_data.get_num_samples_in_batch(state.batch)
-
                 # forward pass
                 self.engine.run_event(Event.BEFORE_FORWARD)
 
@@ -732,7 +740,7 @@ class Trainer:
                 # Likely need to look into the performance impact
                 if not self.deepspeed_enabled:
                     for loss in ensure_tuple(state.loss):
-                        loss.mul_(last_microbatch_size / current_batch_size)
+                        loss.mul_(state.batch_num_samples / current_batch_size)
                         total_loss += loss.detach().clone()
 
                 assert state.loss is not None
@@ -745,11 +753,11 @@ class Trainer:
                     state.loss = state.scaler.scale(state.loss)
 
                 if self.deepspeed_enabled:
-                    state.model.backward(state.loss)  # type: ignore
+                    cast("deepspeed.DeepSpeedEngine", state.model).backward(state.loss)
 
                     # This is the same loss scaling and reporting we skipped earlier.
                     for loss in ensure_tuple(state.loss):
-                        loss.mul_(last_microbatch_size / current_batch_size)
+                        loss.mul_(state.batch_num_samples / current_batch_size)
                         total_loss += loss.detach().clone()
                 else:
                     for loss in ensure_tuple(state.loss):
@@ -758,7 +766,7 @@ class Trainer:
                 self.engine.run_event(Event.AFTER_BACKWARD)
 
             if self.deepspeed_enabled:
-                state.model.step()  # type: ignore
+                cast("deepspeed.DeepSpeedEngine", state.model).step()
 
         # Unscale gradients before `Event.AFTER_TRAIN_BATCH`
         if use_grad_scaling:
@@ -798,7 +806,9 @@ class Trainer:
 
             for state.batch in itertools.islice(state.eval_dataloader, self._eval_subset_num_batches):
                 state.batch = self.device.batch_to_device(state.batch)
-                state.batch = state.eval_data.device_transforms(state.batch)
+                state.batch = self._eval_data_spoc.device_transforms(state.batch)
+                state.batch_num_samples = self._eval_data_spoc.get_num_samples_in_batch(state.batch)
+                state.batch_num_tokens = self._eval_data_spoc.get_num_tokens_in_batch(state.batch)
 
                 if self.deepspeed_enabled:
                     state.batch = fix_batch_precision_for_deepspeed(state.batch, state.precision)

--- a/composer/utils/data.py
+++ b/composer/utils/data.py
@@ -65,10 +65,11 @@ def get_device_of_batch(batch: Batch) -> torch.device:
     if isinstance(batch, Tensor):
         return batch.device
     if isinstance(batch, (tuple, list)):  # BatchPair
-        if isinstance(batch, Tensor):
-            return batch.device
-        for x in ensure_tuple(batch):
-            return get_device_of_batch(x)
+        for sample in ensure_tuple(batch):
+            for x in ensure_tuple(sample):
+                for tensor in ensure_tuple(x):
+                    return tensor.device
+
     if isinstance(batch, dict):  # BatchDict
         for x in batch.values():
             return x.device

--- a/composer/utils/iter_helpers.py
+++ b/composer/utils/iter_helpers.py
@@ -29,6 +29,8 @@ def map_collection(collection, map_fn):
 
 
 def ensure_tuple(x):
+    if x is None:
+        return tuple()
     if isinstance(x, tuple):
         return x
     if isinstance(x, list):

--- a/composer/utils/iter_helpers.pyi
+++ b/composer/utils/iter_helpers.pyi
@@ -28,7 +28,24 @@ def map_collection(dict_of_elements: Dict[KT, T], map_fn: Callable[[T], V], /) -
 def map_collection(singleton: T, map_fn: Callable[[T], V], /) -> V:
     ...
 
-def ensure_tuple(x: Union[T, Tuple[T, ...], List[T], Dict[Any, T]]) -> Tuple[T, ...]:
+@overload
+def ensure_tuple(x: None) -> Tuple:
+    ...
+
+@overload
+def ensure_tuple(x: Tuple[T, ...]) -> Tuple[T, ...]:
+    ...
+
+@overload
+def ensure_tuple(x: List[T]) -> Tuple[T, ...]:
+    ...
+
+@overload
+def ensure_tuple(x: Dict[Any, T]) -> Tuple[T, ...]:
+    ...
+
+@overload
+def ensure_tuple(x: Union[T, None, Tuple[T, ...], List[T], Dict[Any, T]]) -> Tuple[T, ...]:
     ...
 
 


### PR DESCRIPTION
1. Remove the dataspec from state! Instead, the trainer sets `batch_num_samples`, `batch_num_tokens`, `microbatches`, and `microbatch_idx` so these fields are accessible to algorithms that need to know the pertinent information that the data spec provided.
2. Removed last_batch_size from state. Replaced it with `dist.all_reduce(state.batch_num_samples)` where it was used.
3. Removed `train_batch_size` and `eval_batch_size` from state, as algorithms should not depend on constant batch sizing. Replaced it with `state.train_dataloader.batch_size * dist.get_world_size()` in the few places where it was used
4. Added a helper function to `get_device_of_batch`, which is required for part 3 (since `dist.all_reduce` requires tensors to be placed on the device it torch.dist was initialized with)
5. Fixed the type annotations for `ensure_tuple` to support `get_device_of_batch`