### PR TITLE
Require `pip install -e` be `pip install --user -e` when running as root

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,19 @@ import textwrap
 import setuptools
 from setuptools import setup
 
+_IS_EDITABLE = "-e" in sys.argv[1:] or "--editable" in sys.argv[1:]
+_IS_ROOT = os.getuid() == 0
+_IS_USER = "--user" in sys.argv[1:]
+_IS_VIRTUALENV = "VIRTUAL_ENV" in os.environ
+
+if _IS_EDITABLE and _IS_ROOT and (not _IS_VIRTUALENV) and (not _IS_USER):
+    raise RuntimeError(
+        textwrap.dedent("""When installing in editable mode as root outside of a virtual environment,
+        please specify `--user`. Editable installs as the root user outside of a virtual environment
+        do not work without the `--user` flag. Please instead run something like: `pip install --user -e .`"""))
+
 # From https://github.com/pypa/pip/issues/7953#issuecomment-645133255
-site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+site.ENABLE_USER_SITE = _IS_USER
 
 
 def package_files(directory: str):

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,21 @@ import textwrap
 
 import setuptools
 from setuptools import setup
+from setuptools.command.develop import develop as develop_orig
 
-_IS_EDITABLE = "-e" in sys.argv[1:] or "--editable" in sys.argv[1:]
 _IS_ROOT = os.getuid() == 0
 _IS_USER = "--user" in sys.argv[1:]
 _IS_VIRTUALENV = "VIRTUAL_ENV" in os.environ
 
-if _IS_EDITABLE and _IS_ROOT and (not _IS_VIRTUALENV) and (not _IS_USER):
-    raise RuntimeError(
-        textwrap.dedent("""When installing in editable mode as root outside of a virtual environment,
-        please specify `--user`. Editable installs as the root user outside of a virtual environment
-        do not work without the `--user` flag. Please instead run something like: `pip install --user -e .`"""))
+class develop(develop_orig):
+
+    def run(self):
+        if _IS_ROOT and (not _IS_VIRTUALENV) and (not _IS_USER):
+            raise RuntimeError(
+                textwrap.dedent("""When installing in editable mode as root outside of a virtual environment,
+                please specify `--user`. Editable installs as the root user outside of a virtual environment
+                do not work without the `--user` flag. Please instead run something like: `pip install --user -e .`"""))
+        super().run()
 
 # From https://github.com/pypa/pip/issues/7953#issuecomment-645133255
 site.ENABLE_USER_SITE = _IS_USER
@@ -118,6 +122,7 @@ setup(
     dependency_links=['https://developer.download.nvidia.com/compute/redist'],
     python_requires='>=3.7',
     ext_package="composer",
+    cmdclass={'develop': develop}
 )
 
 # only visible if user installs with verbose -v flag

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ _IS_ROOT = os.getuid() == 0
 _IS_USER = "--user" in sys.argv[1:]
 _IS_VIRTUALENV = "VIRTUAL_ENV" in os.environ
 
+
+# From https://stackoverflow.com/questions/51292333/how-to-tell-from-setup-py-if-the-module-is-being-installed-in-editable-mode
 class develop(develop_orig):
 
     def run(self):
@@ -22,6 +24,7 @@ class develop(develop_orig):
                 please specify `--user`. Editable installs as the root user outside of a virtual environment
                 do not work without the `--user` flag. Please instead run something like: `pip install --user -e .`"""))
         super().run()
+
 
 # From https://github.com/pypa/pip/issues/7953#issuecomment-645133255
 site.ENABLE_USER_SITE = _IS_USER
@@ -96,34 +99,32 @@ extra_deps['deepspeed'] = [
 
 extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
 
-setup(
-    name="mosaicml",
-    version="0.3.1",
-    author="MosaicML",
-    author_email="team@mosaicml.com",
-    description="composing methods for ML training efficiency",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/mosaicml/composer",
-    include_package_data=True,
-    package_data={
-        "composer": ['py.typed'],
-        "": package_files('composer/yamls'),
-    },
-    packages=setuptools.find_packages(exclude=["tests*"]),
-    classifiers=[
-        "Programming Language :: Python :: 3",
-    ],
-    install_requires=install_requires,
-    entry_points={
-        'console_scripts': ['composer = composer.cli.launcher:main',],
-    },
-    extras_require=extra_deps,
-    dependency_links=['https://developer.download.nvidia.com/compute/redist'],
-    python_requires='>=3.7',
-    ext_package="composer",
-    cmdclass={'develop': develop}
-)
+setup(name="mosaicml",
+      version="0.3.1",
+      author="MosaicML",
+      author_email="team@mosaicml.com",
+      description="composing methods for ML training efficiency",
+      long_description=long_description,
+      long_description_content_type="text/markdown",
+      url="https://github.com/mosaicml/composer",
+      include_package_data=True,
+      package_data={
+          "composer": ['py.typed'],
+          "": package_files('composer/yamls'),
+      },
+      packages=setuptools.find_packages(exclude=["tests*"]),
+      classifiers=[
+          "Programming Language :: Python :: 3",
+      ],
+      install_requires=install_requires,
+      entry_points={
+          'console_scripts': ['composer = composer.cli.launcher:main',],
+      },
+      extras_require=extra_deps,
+      dependency_links=['https://developer.download.nvidia.com/compute/redist'],
+      python_requires='>=3.7',
+      ext_package="composer",
+      cmdclass={'develop': develop})
 
 # only visible if user installs with verbose -v flag
 # Printing to stdout as not to interfere with setup.py CLI flags (e.g. --version)


### PR DESCRIPTION
`pip install -e` doesn't work as root. `pip install --user -e` does.