### PR TITLE
Fixed loggers and callbacks

### DIFF
--- a/composer/core/callback.py
+++ b/composer/core/callback.py
@@ -8,7 +8,6 @@ import abc
 from typing import TYPE_CHECKING
 
 from composer.core.serializable import Serializable
-from composer.utils import dist
 
 try:
     from typing import final
@@ -315,24 +314,3 @@ class Callback(Serializable, abc.ABC):
         callbacks during :meth:`close`.
         """
         pass
-
-
-class RankZeroCallback(Callback, abc.ABC):
-    """Base class for callbacks that only run on the local rank zero process.
-
-    Callbacks can be implemented in two ways:
-
-    #. Override the individual methods named for each :class:`Event`. (See
-       the parent class, :class:`Callback`.)
-        
-    #. Override :meth:`_run_event` (**not** :meth:`run_event`) to run in response
-       to all events. If this method is overridden, then the individual methods
-       corresponding to each event name will not be automatically called (however,
-       the subclass implementation can invoke these methods as it wishes.)
-    """
-
-    @final
-    def run_event(self, event: Event, state: State, logger: Logger) -> None:
-        if dist.get_local_rank() != 0:
-            return
-        return self._run_event(event, state, logger)

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -9,6 +9,7 @@ from composer.core.algorithm import Algorithm
 from composer.core.callback import Callback
 from composer.core.event import Event
 from composer.core.logging import Logger
+from composer.core.logging.logger import LogLevel
 from composer.core.state import State
 
 log = logging.getLogger(__name__)
@@ -126,7 +127,15 @@ class Engine():
             trace[trace_key] = Trace(exit_code=exit_code, order=order, run=True)
 
         if self.logger is not None:
-            self.logger.metric_verbose(data={key: 1 if tr.run else 0 for key, tr in trace.items()})
+            if event in (Event.INIT, Event.TRAINING_START, Event.TRAINING_END):
+                log_level = LogLevel.FIT
+            if event in (Event.EPOCH_START, Event.EPOCH_END):
+                log_level = LogLevel.EPOCH
+            else:
+                # algs don't run on eval events, so don't have to worry about
+                # batch-frequency vs epoch-frequency evaluators
+                log_level = LogLevel.BATCH
+            self.logger.metric(log_level=log_level, data={key: 1 if tr.run else 0 for key, tr in trace.items()})
 
         return trace
 

--- a/composer/core/logging/__init__.py
+++ b/composer/core/logging/__init__.py
@@ -1,7 +1,6 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 from composer.core.logging.base_backend import BaseLoggerBackend as BaseLoggerBackend
-from composer.core.logging.base_backend import RankZeroLoggerBackend as RankZeroLoggerBackend
 from composer.core.logging.logger import Logger as Logger
 from composer.core.logging.logger import LogLevel as LogLevel
 from composer.core.logging.logger import TLogData as TLogData

--- a/composer/core/logging/base_backend.py
+++ b/composer/core/logging/base_backend.py
@@ -5,17 +5,11 @@ from __future__ import annotations
 from abc import ABC
 from typing import TYPE_CHECKING
 
-from composer.core.callback import Callback, RankZeroCallback
-from composer.utils import dist
+from composer.core.callback import Callback
 
 if TYPE_CHECKING:
     from composer.core.logging.logger import LogLevel, TLogData
     from composer.core.state import State
-
-try:
-    from typing import final
-except ImportError:
-    final = lambda x: x  # final is not available in python 3.7
 
 
 class BaseLoggerBackend(Callback, ABC):
@@ -59,73 +53,3 @@ class BaseLoggerBackend(Callback, ABC):
         """
         del epoch, step, log_level, data  # unused
         pass
-
-
-class RankZeroLoggerBackend(BaseLoggerBackend, RankZeroCallback, ABC):
-    """Base class for logging backends that run only on the rank zero process.
-
-    In a multi-process training setup (e.g. when using DistributedDataParallel),
-    some logging backends require that only the rank zero process log data.
-    For example, when logging to a file, only the main process should open the file
-    and save data.
-
-    When using this class, override
-    :func:`_will_log` and :func:`_log_metric`` instead of
-    :func:`will_log` and :func:`log_metric`, respectively.
-
-    This class ensures that :func:`_will_log` and :func:`_log_metric`
-    are invoked only on the rank zero process.
-
-    .. automethod:: _will_log
-    .. automethod:: _log_metric
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-
-    def _will_log(self, state: State, log_level: LogLevel) -> bool:
-        """Called by the :class:`~composer.core.logging.logger.Logger`
-        to determine whether the logging backend will log a metric.
-
-        By default, it always returns ``True``, but this method
-        can be overridden.
-
-        Args:
-            state (State): The global state object.
-            log_level (LogLevel): The log level.
-
-        Returns:
-            bool: Whether to log a metric call, given the
-            :class:`~composer.core.state.State` and
-            :class:`~composer.core.logging.logger.LogLevel`.
-        """
-        del state, log_level  # Unused
-        return True
-
-    @final
-    def will_log(self, state: State, log_level: LogLevel) -> bool:
-        if dist.get_local_rank() != 0:
-            return False
-        return self._will_log(state, log_level)
-
-    def _log_metric(self, epoch: int, step: int, log_level: LogLevel, data: TLogData) -> None:
-        """Called by the :class:`~composer.core.logging.logger.Logger`
-        for metrics where :func:`will_log` returned ``True``.
-
-        The logging backend should override this function to log the data
-        (e.g. write it to a file, send it to a server, etc...).
-
-        Args:
-            epoch (int): The epoch for the logged data.
-            step (int): The global step for the logged data.
-            log_level (LogLevel). The log level.
-            data (TLogData): The metric to log.
-        """
-        del epoch, step, log_level, data  # Unused
-        pass
-
-    @final
-    def log_metric(self, epoch: int, step: int, log_level: LogLevel, data: TLogData) -> None:
-        if dist.get_local_rank() != 0:
-            return
-        return self._log_metric(epoch, step, log_level, data)

--- a/composer/core/logging/logger.py
+++ b/composer/core/logging/logger.py
@@ -30,14 +30,10 @@ class LogLevel(IntEnum):
         FIT: Logged once per training run.
         EPOCH: Logged once per epoch.
         BATCH: Logged once per batch.
-        MICROBATCH: Logged once per microbatch (e.g. forward pass).
-        VERBOSE: Logged for debugging.
     """
     FIT = 1
     EPOCH = 2
     BATCH = 3
-    MICROBATCH = 4
-    VERBOSE = 5
 
 
 class Logger:
@@ -108,14 +104,6 @@ class Logger:
     def metric_batch(self, data: Union[TLogData, Callable[[], TLogData]]) -> None:
         """Helper function for ``self.metric(LogLevel.BATCH, data)``"""
         self.metric(LogLevel.BATCH, data)
-
-    def metric_microbatch(self, data: Union[TLogData, Callable[[], TLogData]]) -> None:
-        """Helper function for ``self.metric(LogLevel.MICROBATCH, data)``"""
-        self.metric(LogLevel.MICROBATCH, data)
-
-    def metric_verbose(self, data: Union[TLogData, Callable[[], TLogData]]) -> None:
-        """Helper function for ``self.metric(LogLevel.VERBOSE, data)``"""
-        self.metric(LogLevel.VERBOSE, data)
 
 
 def format_log_data_value(data: TLogDataValue) -> str:

--- a/composer/loggers/__init__.py
+++ b/composer/loggers/__init__.py
@@ -1,7 +1,6 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 from composer.core.logging.base_backend import BaseLoggerBackend as BaseLoggerBackend
-from composer.core.logging.base_backend import RankZeroLoggerBackend as RankZeroLoggerBackend
 from composer.core.logging.logger import Logger as Logger
 from composer.core.logging.logger import LogLevel as LogLevel
 from composer.core.logging.logger import TLogData as TLogData

--- a/composer/loggers/file_logger.py
+++ b/composer/loggers/file_logger.py
@@ -42,7 +42,7 @@ class FileLoggerBackend(BaseLoggerBackend):
             For example, if the ``log_level`` is :attr:`~composer.core.logging.logger.LogLevel.EPOCH`,
             then the logfile will be flushed every n epochs.
             If the ``log_level`` is :attr:`~composer.core.logging.logger.LogLevel.BATCH`, then the logfile will be flushed
-            every n batches. (default: ``1``)
+            every n batches. (default: ``100``)
     """
 
     def __init__(
@@ -52,7 +52,7 @@ class FileLoggerBackend(BaseLoggerBackend):
         buffer_size: int = 1,
         log_level: LogLevel = LogLevel.EPOCH,
         log_interval: int = 1,
-        flush_interval: int = 1,
+        flush_interval: int = 100,
         config: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()

--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -56,9 +56,9 @@ class FileLoggerBackendHparams(BaseLoggerBackendHparams):
     buffer_size: int = hp.optional("Number of bytes to buffer. Defaults to 1 for line-buffering. "
                                    "See https://docs.python.org/3/library/functions.html#open",
                                    default=1)  # line buffering. Python's default is -1.
-    flush_every_n_batches: int = hp.optional(
-        "Even if the buffer is not full, write to the file after this many steps. "
-        "Defaults to 1 (every step).",
+    flush_interval: int = hp.optional(
+        "Frequency to flush the file, relative to the ``log_interval``. "
+        "Defaults to 1 (flush every ``log_interval``)",
         default=1)
     log_interval: int = hp.optional("Frequency to record log messages. Defaults to 1 (record all messages).", default=1)
 
@@ -237,7 +237,7 @@ class MosaicMLLoggerBackendHparams(BaseLoggerBackendHparams):
         "A file containing the MosaicML api_key. If not provided "
         "will default to the environment variable MOSAIC_API_KEY.",
         default=None)
-    flush_every_n_batches: int = hp.optional("Flush the log data buffer every n batches.", default=100)
+    flush_interval: int = hp.optional("Flush the log data buffer every n batches.", default=100)
     max_logs_in_buffer: int = hp.optional(
         "The maximum number of log entries allowed in the buffer "
         "before a forced flush.", default=1000)

--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -60,14 +60,7 @@ class FileLoggerBackendHparams(BaseLoggerBackendHparams):
         "Even if the buffer is not full, write to the file after this many steps. "
         "Defaults to 1 (every step).",
         default=1)
-    every_n_epochs: int = hp.optional(
-        "Frequency of logging messages for messages of LogLevel.EPOCH and higher."
-        "Defaults to 1 (every epoch).",
-        default=1)
-    every_n_batches: int = hp.optional(
-        "Frequency of logging messages for messages of LogLevel.BATCH and higher."
-        "Defaults to 1 (every batch).",
-        default=1)
+    log_interval: int = hp.optional("Frequency to record log messages. Defaults to 1 (record all messages).", default=1)
 
     def initialize_object(self, config: Optional[Dict[str, Any]] = None) -> FileLoggerBackend:
 
@@ -98,6 +91,7 @@ class WandBLoggerBackendHparams(BaseLoggerBackendHparams):
     tags: str = hp.optional(doc="wandb tags comma separated", default="")
     log_artifacts: bool = hp.optional(doc="Whether to log artifacts", default=False)
     log_artifacts_every_n_batches: int = hp.optional(doc="interval, in batches, to log artifacts", default=100)
+    rank_zero_only: bool = hp.optional("Whether to log on rank zero only", default=False)
     extra_init_params: Dict[str, JSON] = hp.optional(doc="wandb parameters", default_factory=dict)
 
     def initialize_object(self, config: Optional[Dict[str, Any]] = None) -> WandBLoggerBackend:
@@ -202,6 +196,7 @@ class WandBLoggerBackendHparams(BaseLoggerBackendHparams):
         from composer.loggers.wandb_logger import WandBLoggerBackend
         return WandBLoggerBackend(
             log_artifacts=self.log_artifacts,
+            rank_zero_only=self.rank_zero_only,
             log_artifacts_every_n_batches=self.log_artifacts_every_n_batches,
             init_params=init_params,
         )

--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -57,10 +57,13 @@ class FileLoggerBackendHparams(BaseLoggerBackendHparams):
                                    "See https://docs.python.org/3/library/functions.html#open",
                                    default=1)  # line buffering. Python's default is -1.
     flush_interval: int = hp.optional(
-        "Frequency to flush the file, relative to the ``log_interval``. "
-        "Defaults to 1 (flush every ``log_interval``)",
+        "Frequency to flush the file, relative to the ``log_level``. "
+        "Defaults to 100 of the unit of ``log_level``.",
+        default=100)
+    log_interval: int = hp.optional(
+        "Frequency to record log messages, relative to the ``log_level``."
+        "Defaults to 1 (record all messages).",
         default=1)
-    log_interval: int = hp.optional("Frequency to record log messages. Defaults to 1 (record all messages).", default=1)
 
     def initialize_object(self, config: Optional[Dict[str, Any]] = None) -> FileLoggerBackend:
 
@@ -237,7 +240,7 @@ class MosaicMLLoggerBackendHparams(BaseLoggerBackendHparams):
         "A file containing the MosaicML api_key. If not provided "
         "will default to the environment variable MOSAIC_API_KEY.",
         default=None)
-    flush_interval: int = hp.optional("Flush the log data buffer every n batches.", default=100)
+    flush_every_n_batches: int = hp.optional("Flush the log data buffer every n batches.", default=100)
     max_logs_in_buffer: int = hp.optional(
         "The maximum number of log entries allowed in the buffer "
         "before a forced flush.", default=1000)

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import sys
+import textwrap
+import warnings
 from typing import Any, Dict, Optional
 
 from composer.core.logging import BaseLoggerBackend, LogLevel, TLogData
@@ -23,14 +25,25 @@ class WandBLoggerBackend(BaseLoggerBackend):
             was realized when logging and uploading artifacts, so it is recommended to
             do so infrequently. Only applicable when `log_artifacts` is True
             (default: ``100``)
+        rank_zero_only (bool, optional): Whether to log only on the rank-zero process (default: ``False``).
+            When logging artifacts, it is highly recommended to log on all ranks. Artifacts from ranks 1+
+            will not be stored, which may discard pertinent information. For example, when using Deepspeed
+            ZeRO, it would be impossible to restore from checkpoints without artifacts from all ranks.
         init_params (Dict[str, Any], optional): Parameters to pass into :meth:`wandb.init`.
     """
 
     def __init__(self,
                  log_artifacts: bool = False,
                  log_artifacts_every_n_batches: int = 100,
+                 rank_zero_only: bool = False,
                  init_params: Optional[Dict[str, Any]] = None) -> None:
-        super().__init__()
+        if log_artifacts and rank_zero_only:
+            warnings.warn(
+                textwrap.dedent("""When logging artifacts, `rank_zero_only` should be set to False.
+                Artifacts from other ranks will not be collected, leading to a loss of information required to
+                restore from checkpoints."""))
+        self._enabled = (not rank_zero_only) or dist.get_global_rank() == 0
+
         self._log_artifacts = log_artifacts
         self._log_artifacts_every_n_batches = log_artifacts_every_n_batches
         self._last_upload_timestamp = 0.0
@@ -40,35 +53,40 @@ class WandBLoggerBackend(BaseLoggerBackend):
 
     def log_metric(self, epoch: int, step: int, log_level: LogLevel, data: TLogData):
         del epoch, log_level  # unused
-        wandb.log(data, step=step)
+        if self._enabled:
+            wandb.log(data, step=step)
 
     def state_dict(self) -> StateDict:
         # Storing these fields in the state dict to support run resuming in the future.
-        return {
-            "name": wandb.run.name,
-            "project": wandb.run.project,
-            "entity": wandb.run.entity,
-            "id": wandb.run.id,
-            "group": wandb.run.group
-        }
+        if self._enabled:
+            return {
+                "name": wandb.run.name,
+                "project": wandb.run.project,
+                "entity": wandb.run.entity,
+                "id": wandb.run.id,
+                "group": wandb.run.group
+            }
+        else:
+            return {}
 
     def init(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
-        wandb.init(**self._init_params)
+        if self._enabled:
+            wandb.init(**self._init_params)
 
     def batch_end(self, state: State, logger: Logger) -> None:
         del logger  # unused
-        if self._log_artifacts and (state.step + 1) % self._log_artifacts_every_n_batches == 0:
+        if self._enabled and self._log_artifacts and (state.step + 1) % self._log_artifacts_every_n_batches == 0:
             self._upload_artifacts()
 
     def epoch_end(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
-        if self._log_artifacts:
+        if self._enabled and self._log_artifacts:
             self._upload_artifacts()
 
     def training_end(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
-        if self._log_artifacts:
+        if self._enabled and self._log_artifacts:
             self._upload_artifacts()
 
     def _upload_artifacts(self):
@@ -79,14 +97,10 @@ class WandBLoggerBackend(BaseLoggerBackend):
         # so uploads will not block the training loop
         # slowdown is likely from extra I/O of scanning the directory and/or
         # scheduling uploads
-        run_directory_name = run_directory.get_run_directory()
-        if run_directory_name is None:
-            return
-
         modified_files = run_directory.get_modified_files(self._last_upload_timestamp)
         for modified_file in modified_files:
             file_type = modified_file.split(".")[-1]
-            relpath = os.path.relpath(modified_file, run_directory_name)
+            relpath = os.path.relpath(modified_file, run_directory.get_run_directory())
             relpath = f"rank_{dist.get_global_rank()}-" + relpath.replace("/", "-")
             artifact = wandb.Artifact(name=relpath, type=file_type)
             artifact.add_file(os.path.abspath(modified_file))
@@ -95,6 +109,9 @@ class WandBLoggerBackend(BaseLoggerBackend):
 
     def post_close(self) -> None:
         # Cleaning up on post_close so all artifacts are uploaded
+        if not self._enabled:
+            return
+
         if self._log_artifacts:
             self._upload_artifacts()
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -639,13 +639,15 @@ class Trainer:
                     for scheduler in state.schedulers:
                         scheduler.step(interval='batch')  # type: ignore
 
-                    if self.validate_every_n_batches > 0 and (state.step + 1) % self.validate_every_n_batches == 0:
-                        self.eval(is_batch=True)
-
                     state.timer.on_batch_complete(
                         samples=int(num_samples_in_batch.item()),
                         tokens=int(num_tokens_in_batch.item()),
                     )
+
+                    if self.validate_every_n_batches > 0 and int(
+                            state.timer.batch) % self.validate_every_n_batches == 0:
+                        self.eval(is_batch=True)
+
                     if self.checkpoint_saver and self.checkpoint_saver.should_checkpoint(state=state,
                                                                                          event=Event.BATCH_END):
                         self.checkpoint_saver.save_checkpoint(state=state,
@@ -660,10 +662,10 @@ class Trainer:
 
             self.engine.run_event(Event.EPOCH_END)
 
-            if self.validate_every_n_epochs > 0 and (state.epoch + 1) % self.validate_every_n_epochs == 0:
-                self.eval(is_batch=False)
-
             state.timer.on_epoch_complete()
+
+            if self.validate_every_n_epochs > 0 and int(state.timer.epoch) % self.validate_every_n_epochs == 0:
+                self.eval(is_batch=False)
 
             if self.checkpoint_saver and self.checkpoint_saver.should_checkpoint(state=state, event=Event.EPOCH_END):
                 self.checkpoint_saver.save_checkpoint(state=state,

--- a/composer/yamls/models/bert-base.yaml
+++ b/composer/yamls/models/bert-base.yaml
@@ -54,13 +54,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 7ep  # Baseline is 256M samples, 7 epochs is ~280M samples
 train_batch_size: 4000
 eval_batch_size: 2000

--- a/composer/yamls/models/glue/cola.yaml
+++ b/composer/yamls/models/glue/cola.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 10ep
 train_batch_size: 32
 eval_batch_size: 32

--- a/composer/yamls/models/glue/mnli-m.yaml
+++ b/composer/yamls/models/glue/mnli-m.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 3ep
 train_batch_size: 48
 eval_batch_size: 48

--- a/composer/yamls/models/glue/mnli.yaml
+++ b/composer/yamls/models/glue/mnli.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 3ep
 train_batch_size: 48
 eval_batch_size: 48

--- a/composer/yamls/models/glue/mrpc.yaml
+++ b/composer/yamls/models/glue/mrpc.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 10ep
 train_batch_size: 32
 eval_batch_size: 32

--- a/composer/yamls/models/glue/qnli.yaml
+++ b/composer/yamls/models/glue/qnli.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 10ep
 train_batch_size: 16
 eval_batch_size: 16

--- a/composer/yamls/models/glue/qqp.yaml
+++ b/composer/yamls/models/glue/qqp.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 5ep
 train_batch_size: 16
 eval_batch_size: 16

--- a/composer/yamls/models/glue/rte.yaml
+++ b/composer/yamls/models/glue/rte.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 3ep
 train_batch_size: 16 
 eval_batch_size: 16 

--- a/composer/yamls/models/glue/sst-2.yaml
+++ b/composer/yamls/models/glue/sst-2.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 3ep
 train_batch_size: 16
 eval_batch_size: 16

--- a/composer/yamls/models/glue/stsb.yaml
+++ b/composer/yamls/models/glue/stsb.yaml
@@ -41,13 +41,7 @@ schedulers:
       interval: step
       verbose: false
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 10ep
 train_batch_size: 32
 eval_batch_size: 32

--- a/composer/yamls/models/gpt2_1,3b.yaml
+++ b/composer/yamls/models/gpt2_1,3b.yaml
@@ -73,13 +73,7 @@ schedulers:
       verbose: false
       T_max: 13860ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 1024
 eval_batch_size: 8

--- a/composer/yamls/models/gpt2_125m.yaml
+++ b/composer/yamls/models/gpt2_125m.yaml
@@ -75,13 +75,7 @@ schedulers:
       verbose: false
       T_max: 13860ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 8 # use micro_bs_per_gpu = 1 to accomodate 10GB limit

--- a/composer/yamls/models/gpt2_13b.yaml
+++ b/composer/yamls/models/gpt2_13b.yaml
@@ -73,13 +73,7 @@ schedulers:
       verbose: false
       T_max: 13860ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 2048
 eval_batch_size: 8

--- a/composer/yamls/models/gpt2_2,7b.yaml
+++ b/composer/yamls/models/gpt2_2,7b.yaml
@@ -73,13 +73,7 @@ schedulers:
       verbose: false
       T_max: 13860ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 1024
 eval_batch_size: 8

--- a/composer/yamls/models/gpt2_350m.yaml
+++ b/composer/yamls/models/gpt2_350m.yaml
@@ -73,13 +73,7 @@ schedulers:
       verbose: false
       T_max: 10890ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 8

--- a/composer/yamls/models/gpt2_52m.yaml
+++ b/composer/yamls/models/gpt2_52m.yaml
@@ -75,13 +75,7 @@ schedulers:
       verbose: false
       T_max: 8910ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 16 # use micro_bs_per_gpu = 2 to accomodate 10GB limit

--- a/composer/yamls/models/gpt2_6,7b.yaml
+++ b/composer/yamls/models/gpt2_6,7b.yaml
@@ -73,13 +73,7 @@ schedulers:
       verbose: false
       T_max: 13860ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 2048
 eval_batch_size: 8

--- a/composer/yamls/models/gpt2_760m.yaml
+++ b/composer/yamls/models/gpt2_760m.yaml
@@ -73,13 +73,7 @@ schedulers:
       verbose: false
       T_max: 13860ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 8

--- a/composer/yamls/models/gpt2_83m.yaml
+++ b/composer/yamls/models/gpt2_83m.yaml
@@ -75,13 +75,7 @@ schedulers:
       verbose: false
       T_max: 10890ba
 loggers:
-  - file:
-      log_level: batch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_batches: 100
-      every_n_epochs: 1
+  - tqdm: {}
 max_duration: 1ep
 train_batch_size: 512
 eval_batch_size: 16 # use micro_bs_per_gpu = 2 to accomodate 10GB limit

--- a/composer/yamls/models/resnet56_cifar10.yaml
+++ b/composer/yamls/models/resnet56_cifar10.yaml
@@ -37,13 +37,7 @@ model:
       - bn_uniform
     num_classes: 10
 loggers:
-  - file:
-      log_level: epoch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_epochs: 1
-      every_n_batches: 100
+  - tqdm: {}
 max_duration: 160ep
 train_batch_size: 1024
 eval_batch_size: 1000

--- a/composer/yamls/models/resnet56_cifar10_synthetic.yaml
+++ b/composer/yamls/models/resnet56_cifar10_synthetic.yaml
@@ -37,13 +37,7 @@ model:
       - bn_uniform
     num_classes: 10
 loggers:
-  - file:
-      log_level: epoch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_epochs: 1
-      every_n_batches: 100
+  - tqdm: {}
 max_duration: 160ep
 train_batch_size: 1024
 eval_batch_size: 1000

--- a/composer/yamls/models/resnet9_cifar10.yaml
+++ b/composer/yamls/models/resnet9_cifar10.yaml
@@ -37,13 +37,7 @@ model:
       - bn_uniform
     num_classes: 10
 loggers:
-  - file:
-      log_level: epoch
-      filename: stdout
-      buffer_size: 1
-      flush_every_n_batches: 100
-      every_n_epochs: 1
-      every_n_batches: 100
+  - tqdm: {}
 max_duration: 160ep
 train_batch_size: 1024
 eval_batch_size: 1000

--- a/docs/source/core/callback.rst
+++ b/docs/source/core/callback.rst
@@ -56,4 +56,3 @@ Callbacks can be implemented in two ways:
     :nosignatures:
 
     ~composer.Callback
-    ~composer.core.callback.RankZeroCallback

--- a/docs/source/core/logger.rst
+++ b/docs/source/core/logger.rst
@@ -30,6 +30,5 @@ For example, to define a new logging backend:
    
     ~composer.loggers.logger_hparams.BaseLoggerBackendHparams
     ~composer.core.logging.base_backend.BaseLoggerBackend
-    ~composer.core.logging.base_backend.RankZeroLoggerBackend
 
 .. autoclass:: Logger

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -28,7 +28,7 @@ def test_file_logger(dummy_state: State, log_level: LogLevel, log_file_name: str
         log_level=log_level,
         filename=log_file_name,
         buffer_size=1,
-        flush_every_n_batches=1,
+        flush_interval=1,
     ).initialize_object()
     dummy_state.timer.on_batch_complete()
     dummy_state.timer.on_batch_complete()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,14 +5,12 @@ import pathlib
 from unittest.mock import MagicMock
 
 import pytest
-import torch.distributed as dist
 import tqdm
 from _pytest.monkeypatch import MonkeyPatch
 
 from composer.core.event import Event
 from composer.core.logging import Logger, LogLevel
 from composer.core.state import State
-from composer.loggers.file_logger import FileLoggerBackend
 from composer.loggers.logger_hparams import (FileLoggerBackendHparams, TQDMLoggerBackendHparams,
                                              WandBLoggerBackendHparams)
 from composer.trainer.trainer_hparams import TrainerHparams
@@ -23,50 +21,55 @@ def log_file_name(tmpdir: pathlib.Path) -> str:
     return os.path.join(tmpdir, "output.log")
 
 
-@pytest.fixture
-def log_destination(log_file_name: str) -> FileLoggerBackend:
-    return FileLoggerBackendHparams(
-        every_n_batches=3,
-        every_n_epochs=2,
-        log_level=LogLevel.BATCH,
+@pytest.mark.parametrize("log_level", [LogLevel.EPOCH, LogLevel.BATCH])
+def test_file_logger(dummy_state: State, log_level: LogLevel, log_file_name: str):
+    log_destination = FileLoggerBackendHparams(
+        log_interval=3,
+        log_level=log_level,
         filename=log_file_name,
         buffer_size=1,
         flush_every_n_batches=1,
     ).initialize_object()
-
-
-def test_file_logger(dummy_state: State, log_destination: FileLoggerBackend, monkeypatch: MonkeyPatch,
-                     log_file_name: str):
     dummy_state.timer.on_batch_complete()
     dummy_state.timer.on_batch_complete()
-    dummy_state.timer.on_epoch_complete()
     dummy_state.timer.on_epoch_complete()
     logger = Logger(dummy_state, backends=[log_destination])
-    monkeypatch.setattr(dist, "get_rank", lambda: 0)
     log_destination.run_event(Event.INIT, dummy_state, logger)
     logger.metric_fit({"metric": "fit"})  # should print
-    logger.metric_epoch({"metric": "epoch"})  # should print
-    logger.metric_batch({"metric": "batch"})  # should print
-    logger.metric_verbose({"metric": "verbose"})  # should NOT print, since we're on the BATCH log level
+    logger.metric_epoch({"metric": "epoch"})  # should print on batch level, since epoch calls are always printed
+    logger.metric_batch({"metric": "batch"})  # should print on batch level, since we print every 3 steps
     dummy_state.timer.on_epoch_complete()
-    logger.metric_epoch({"metric": "epoch1"})  # should NOT print, since we print every 2 epochs
+    logger.metric_epoch({"metric": "epoch1"})  # should print, since we log every 3 epochs
     dummy_state.timer.on_epoch_complete()
     dummy_state.timer.on_batch_complete()
     log_destination.run_event(Event.BATCH_END, dummy_state, logger)
-    logger.metric_epoch({"metric": "epoch2"})  # should print
-    logger.metric_batch({"metric": "batch1"})  # should NOT print, since we print every 3 steps
+    logger.metric_epoch({"metric": "epoch2"})  # should print on batch level, since epoch calls are always printed
+    logger.metric_batch({"metric": "batch1"})  # should NOT print
     log_destination.run_event(Event.BATCH_END, dummy_state, logger)
     log_destination.run_event(Event.TRAINING_END, dummy_state, logger)
     with open(log_file_name, 'r') as f:
-        assert f.readlines() == [
-            '[FIT][step=2]: { "metric": "fit", }\n',
-            '[EPOCH][step=2]: { "metric": "epoch", }\n',
-            '[BATCH][step=2]: { "metric": "batch", }\n',
-            '[EPOCH][step=3]: { "metric": "epoch2", }\n',
-        ]
+        if log_level == LogLevel.EPOCH:
+            assert f.readlines() == [
+                '[FIT][step=2]: { "metric": "fit", }\n',
+                '[EPOCH][step=2]: { "metric": "epoch1", }\n',
+            ]
+        else:
+            assert log_level == LogLevel.BATCH
+            assert f.readlines() == [
+                '[FIT][step=2]: { "metric": "fit", }\n',
+                '[EPOCH][step=2]: { "metric": "epoch", }\n',
+                '[BATCH][step=2]: { "metric": "batch", }\n',
+                '[EPOCH][step=2]: { "metric": "epoch1", }\n',
+                '[EPOCH][step=3]: { "metric": "epoch2", }\n',
+            ]
 
 
-def test_tqdm_logger(mosaic_trainer_hparams: TrainerHparams, monkeypatch: MonkeyPatch):
+@pytest.mark.parametrize("world_size", [
+    pytest.param(1),
+    pytest.param(2, marks=pytest.mark.world_size(2)),
+])
+def test_tqdm_logger(mosaic_trainer_hparams: TrainerHparams, monkeypatch: MonkeyPatch, world_size: int):
+    del world_size  # unused. Set via launcher script
     is_train_to_mock_tqdms = {
         True: [],
         False: [],

--- a/tests/test_mosaicml_logger.py
+++ b/tests/test_mosaicml_logger.py
@@ -62,7 +62,7 @@ def test_mosaic_logger(tmpdir: pathlib.Path, dummy_state: State, dummy_logger: L
     expected_log_calls = 0
     for i in range(num_times_to_log):
         data_point = {f'data-{i}': 'value'}
-        logger._log_metric(epoch=1, step=i, log_level=LogLevel.BATCH, data=data_point)
+        logger.log_metric(epoch=1, step=i, log_level=LogLevel.BATCH, data=data_point)
         dummy_state.timer.on_batch_complete()
         logger.batch_end(dummy_state, dummy_logger)
 

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -215,6 +215,8 @@ def test_ddp(device: DeviceHparams, world_size: int, mosaic_trainer_hparams: Tra
     for epoch in range(max_epochs):
         for local_rank in range(dist.get_local_world_size()):
             for is_train in (True, False):
+                if not is_train:
+                    epoch += 1
                 data: Dict[str, types.Tensor] = torch.load(  # type: ignore
                     get_batch_file_path(rank=local_rank, epoch=epoch, is_train=is_train),
                     map_location='cpu',

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -215,10 +215,9 @@ def test_ddp(device: DeviceHparams, world_size: int, mosaic_trainer_hparams: Tra
     for epoch in range(max_epochs):
         for local_rank in range(dist.get_local_world_size()):
             for is_train in (True, False):
-                if not is_train:
-                    epoch += 1
+                real_epoch = epoch if is_train else epoch + 1  # validation is 1 ahead of training
                 data: Dict[str, types.Tensor] = torch.load(  # type: ignore
-                    get_batch_file_path(rank=local_rank, epoch=epoch, is_train=is_train),
+                    get_batch_file_path(rank=local_rank, epoch=real_epoch, is_train=is_train),
                     map_location='cpu',
                 )
                 for pickle in is_train_to_pickles[is_train]:


### PR DESCRIPTION
1. Removed rank zero callbacks and loggers, since these hid complexity and led to infinitely-blocking code when using distributed functions. Closes #239.
2. Incrementing `state.timer`  _before_ calling `.eval()` in the trainer. This helps ensure that the batch count is consistent for both batch-wise and epoch-wise evaluators. This batch is printed in the logs.
3. Fixed the TQDM logger so it works properly with gradient accumulation.
4. Removed `LogLevel.ALGORITHM`, `LogLevel.MICROBATCH`, and `LogLevel.VERBOSE` since these were rarely being used. Instead, the built-in python logger should probably be used for anything that is verbose (since it really wouldn't be a useful metric), MICROBATCH should use BATCH (since a MICROBATCH is like another gpu), and ALGORITHM should use batch or epoch, depending where it is being run.,
5. Updated the file logger to take a `log_interval` instead of `log_every_n_epochs` and `log_every_n_batches`, and a `flush_interval` instead of `flush_every_n_batches`.
6. Switched the default logger in all yamls to tqdm.