### PR TITLE
Fix broken tests

### DIFF
--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -2,7 +2,7 @@
 
 import logging
 from abc import ABC
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
@@ -30,45 +30,44 @@ INTERVAL_MAP = {
 }
 
 
+def _convert_time_fields(interval: str,
+                         kwargs: Dict[str, Any],
+                         max_training_duration: Optional[Union[str, Time[int]]] = None,
+                         steps_per_epoch: Optional[int] = None,
+                         samples_per_epoch: Optional[int] = None,
+                         dataset_num_tokens: Optional[int] = None) -> None:
+    """Converts all fields in ``kwargs`` that were provided as timestrings (e.g. "32ep") into
+    integers, representing either epochs or batches, depending on the
+    ``interval``. Modifies ``kwargs`` in place."""
+    interval_unit = TimeUnit(INTERVAL_MAP[interval])
+
+    for field_name, field_value in kwargs.items():
+
+        if field_name not in ('interval', 'warmup_method'):
+            if isinstance(field_value, list) and all(isinstance(x, str) for x in field_value):
+                kwargs[field_name] = [
+                    convert_time(t,
+                                 unit=interval_unit,
+                                 steps_per_epoch=steps_per_epoch,
+                                 max_training_duration=max_training_duration,
+                                 samples_per_epoch=samples_per_epoch,
+                                 dataset_num_tokens=dataset_num_tokens).value for t in field_value
+                ]
+                continue
+            if isinstance(field_value, str):
+                kwargs[field_name] = convert_time(field_value,
+                                                  unit=interval_unit,
+                                                  steps_per_epoch=steps_per_epoch,
+                                                  max_training_duration=max_training_duration,
+                                                  samples_per_epoch=samples_per_epoch,
+                                                  dataset_num_tokens=dataset_num_tokens).value
+
+
 @dataclass
 class SchedulerHparams(hp.Hparams, ABC):
 
     scheduler_object = None  # type: Optional[Callable[..., Scheduler]]
     interval = 'epochs'  # type: str
-
-    def _convert_time_fields(self,
-                             max_training_duration: Optional[Union[str, Time[int]]] = None,
-                             steps_per_epoch: Optional[int] = None,
-                             samples_per_epoch: Optional[int] = None,
-                             dataset_num_tokens: Optional[int] = None) -> None:
-        """Converts all fields that were provided as timestrings (e.g. "32ep") into
-        integers, representing either epochs or batches, depending on the
-        :attr:`interval`. Updates the fields in-place."""
-        interval_unit = TimeUnit(INTERVAL_MAP[self.interval])
-
-        for field in fields(self):
-            field_value = getattr(self, field.name)
-
-            if field.name not in ('interval', 'warmup_method') and isinstance(field_value, str):
-                time = getattr(self, field.name)
-                if isinstance(time, list):
-                    result = [
-                        convert_time(t,
-                                     unit=interval_unit,
-                                     steps_per_epoch=steps_per_epoch,
-                                     max_training_duration=max_training_duration,
-                                     samples_per_epoch=samples_per_epoch,
-                                     dataset_num_tokens=dataset_num_tokens).value for t in time
-                    ]
-                else:
-                    result = convert_time(time,
-                                          unit=interval_unit,
-                                          steps_per_epoch=steps_per_epoch,
-                                          max_training_duration=max_training_duration,
-                                          samples_per_epoch=samples_per_epoch,
-                                          dataset_num_tokens=dataset_num_tokens).value
-
-                setattr(self, field.name, result)
 
     def initialize_object(
         self,
@@ -91,14 +90,16 @@ class SchedulerHparams(hp.Hparams, ABC):
         """
 
         assert self.scheduler_object is not None, "Scheduler Hparams needs scheduler_object to initialize."
+        kwargs = {k: v for k, v in asdict(self).items() if k not in ['interval']}
 
-        self._convert_time_fields(max_training_duration=max_training_duration,
-                                  steps_per_epoch=steps_per_epoch,
-                                  samples_per_epoch=samples_per_epoch,
-                                  dataset_num_tokens=dataset_num_tokens)
+        _convert_time_fields(interval=self.interval,
+                             kwargs=kwargs,
+                             max_training_duration=max_training_duration,
+                             steps_per_epoch=steps_per_epoch,
+                             samples_per_epoch=samples_per_epoch,
+                             dataset_num_tokens=dataset_num_tokens)
 
         # we pass the interval to the trainer directly
-        kwargs = {k: v for k, v in asdict(self).items() if k not in ['interval']}
         obj = self.scheduler_object(optimizer, **kwargs)
         obj.interval = self.interval  # type: ignore
         obj.steps_per_epoch = steps_per_epoch  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ install_requires = [
     "torchvision>=0.9.0",
     "torch>=1.9",
     "yahp>=0.0.14",
+    "requests>=2.26.0",
     "numpy==1.21.5",
 ]
 extra_deps = {}

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -1,11 +1,9 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-import os
 from typing import Callable, Dict, Type
 
 import pytest
 
-from composer.core import DataSpec
 from composer.datasets import (ADE20kDatasetHparams, BratsDatasetHparams, CIFAR10DatasetHparams, DataloaderHparams,
                                DatasetHparams, GLUEHparams, ImagenetDatasetHparams, LMDatasetHparams,
                                MNISTDatasetHparams, SyntheticHparamsMixin)
@@ -55,24 +53,3 @@ def test_dataset(dataset_name: str, dummy_dataloader_hparams: DataloaderHparams)
     hparams.use_synthetic = True
 
     hparams.initialize_object(batch_size=1, dataloader_hparams=dummy_dataloader_hparams)
-
-
-@pytest.mark.parametrize("world_size", [
-    pytest.param(1),
-    pytest.param(2, marks=pytest.mark.world_size(2)),
-])
-@pytest.mark.timeout(10)
-def test_mnist_real_dataset(world_size: int, dummy_dataloader_hparams: DataloaderHparams, tmpdir: str):
-    # only test mnist since it has a small validation dataset
-    hparams_cls = dataset_registry["mnist"]
-    hparams = default_required_fields[hparams_cls]()
-    assert isinstance(hparams, MNISTDatasetHparams)
-    hparams.download = True
-    hparams.datadir = os.path.join(tmpdir, "mnist_data")
-    hparams.is_train = False
-    hparams.use_synthetic = False
-    batch_size = 10
-    device_batch_size = batch_size // world_size
-    dataloader = hparams.initialize_object(batch_size=device_batch_size, dataloader_hparams=dummy_dataloader_hparams)
-    assert not isinstance(dataloader, DataSpec)
-    assert len(dataloader) == 10_000 // batch_size  # mnist has 10_000 validation images


### PR DESCRIPTION
1. Removed `test_mnist_real_dataset` since it's slow (downloads the entire mnist) and doesn't add much value
2. Refactored `_convert_time_fields` in the scheduler so it doesn't modify the dataclass in place. The issue with in-place modification was that checkpoint saver was saving the hparams dataclass after the fields have been converted. Then, when resuming from checkpoint, the already-converted fields were no longer valid time strings, so it crashed.
3. Added `requests` to the base dependency (it is used by the checkpoint loader)