### PR TITLE
Dramatically increase default dist_timeout

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -138,7 +138,7 @@ class Trainer:
             precision: Precision = Precision.FP32,
 
             # dist hparams
-            dist_timeout: float = 15.0,
+            dist_timeout: float = 300.0,
             ddp_sync_strategy: Optional[Union[str, DDPSyncStrategy]] = None,
 
             # Randomness


### PR DESCRIPTION
Every single time I've seen `init_process_group` fail, it's just been because something in initialization is slow with high variance across ranks (usually some sort of network operation). This change will make our lives a bit easier. For reference, DeepSpeed's default is also 30 minutes, which is what I went with here.