### PR TITLE
Use `tqdm.auto` for notebooks

### DIFF
--- a/composer/loggers/tqdm_logger.py
+++ b/composer/loggers/tqdm_logger.py
@@ -6,7 +6,7 @@ import sys
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-import tqdm
+from tqdm.auto import tqdm
 import yaml
 
 from composer.core.logging import LogLevel, TLogData, TLogDataValue, format_log_data_value
@@ -35,10 +35,10 @@ class _TQDMLoggerInstance:
 
     def __init__(self, state: _TQDMLoggerInstanceState) -> None:
         self.state = state
-        self.pbar = tqdm.tqdm(total=state.total,
-                              desc=state.description,
-                              position=state.position,
-                              bar_format="{l_bar}{bar:10}{r_bar}{bar:-10b}")
+        self.pbar = tqdm(total=state.total,
+                         desc=state.description,
+                         position=state.position,
+                         bar_format="{l_bar}{bar:10}{r_bar}{bar:-10b}")
         self.pbar.set_postfix(state.epoch_metrics)
 
     def log_metric(self, data: TLogData):

--- a/composer/loggers/tqdm_logger.py
+++ b/composer/loggers/tqdm_logger.py
@@ -6,8 +6,8 @@ import sys
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from tqdm.auto import tqdm
 import yaml
+from tqdm import auto
 
 from composer.core.logging import LogLevel, TLogData, TLogDataValue, format_log_data_value
 from composer.core.logging.base_backend import BaseLoggerBackend
@@ -35,10 +35,10 @@ class _TQDMLoggerInstance:
 
     def __init__(self, state: _TQDMLoggerInstanceState) -> None:
         self.state = state
-        self.pbar = tqdm(total=state.total,
-                         desc=state.description,
-                         position=state.position,
-                         bar_format="{l_bar}{bar:10}{r_bar}{bar:-10b}")
+        self.pbar = auto.tqdm(total=state.total,
+                              desc=state.description,
+                              position=state.position,
+                              bar_format="{l_bar}{bar:10}{r_bar}{bar:-10b}")
         self.pbar.set_postfix(state.epoch_metrics)
 
     def log_metric(self, data: TLogData):
@@ -65,12 +65,12 @@ class TQDMLoggerBackend(BaseLoggerBackend):
 
     Example output::
 
-        Epoch 1: 100%|██████████| 64/64 [00:01<00:00, 53.17it/s, loss/train=2.3023]                                                                                 
-        Epoch 1 (val): 100%|██████████| 20/20 [00:00<00:00, 100.96it/s, accuracy/val=0.0995]  
+        Epoch 1: 100%|██████████| 64/64 [00:01<00:00, 53.17it/s, loss/train=2.3023]
+        Epoch 1 (val): 100%|██████████| 20/20 [00:00<00:00, 100.96it/s, accuracy/val=0.0995]
 
     .. note::
 
-        It is currently not possible to show additional metrics. 
+        It is currently not possible to show additional metrics.
         Custom metrics for the TQDM progress bar will be supported in a future version.
 
     Args:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,8 +5,8 @@ import pathlib
 from unittest.mock import MagicMock
 
 import pytest
-import tqdm
 from _pytest.monkeypatch import MonkeyPatch
+from tqdm import auto
 
 from composer.core.event import Event
 from composer.core.logging import Logger, LogLevel
@@ -82,7 +82,8 @@ def test_tqdm_logger(mosaic_trainer_hparams: TrainerHparams, monkeypatch: Monkey
         is_train_to_mock_tqdms[is_train].append(mock_tqdm)
         return mock_tqdm
 
-    monkeypatch.setattr(tqdm, "tqdm", get_mock_tqdm)
+    monkeypatch.setattr(auto, "tqdm", get_mock_tqdm)
+
     max_epochs = 2
     mosaic_trainer_hparams.max_duration = f"{max_epochs}ep"
     mosaic_trainer_hparams.loggers = [TQDMLoggerBackendHparams()]


### PR DESCRIPTION
Will auto-select which `tqdm` to use base on whether its a console or a jupyter notebook. h/t: @moinnadeem 

Fixes #295 