### PR TITLE
Don't init dist when world_size is 1

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -39,6 +39,11 @@ def get_parser():
                         "Specifying a base_rank B and an nproc N will spawn processes "
                         "with global ranks [B, B+1, ... B+N-1]. Defaults to 0 (single-node "
                         "operation).")
+    parser.add_argument("--node_rank",
+                        type=int,
+                        default=-1,
+                        help="The rank of this node. Set to -1 to assume that all nodes have "
+                        "the same number of processes, and calculate accordingly. Defaults to -1.")
     parser.add_argument("--master_addr",
                         type=str,
                         default="127.0.0.1",
@@ -88,11 +93,17 @@ def parse_args():
     if args.world_size == -1:
         args.world_size = args.nproc
 
+    if args.node_rank == -1:
+        if args.base_rank % args.nproc != 0:
+            raise ValueError("node_rank not specified, but unable to infer since nodes appear to "
+                             "have different amounts of processes.")
+        args.node_rank = args.base_rank // args.nproc
+
     return args
 
 
-def launch_processes(nproc: int, world_size: int, base_rank: int, master_addr: str, master_port: Optional[int],
-                     module_mode: bool, run_directory: Optional[str], training_script: str,
+def launch_processes(nproc: int, world_size: int, base_rank: int, node_rank: int, master_addr: str,
+                     master_port: Optional[int], module_mode: bool, run_directory: Optional[str], training_script: str,
                      training_script_args: List[Any]) -> Set[subprocess.Popen]:
     log.info("Starting DDP on local node for global_rank(%s-%s)", base_rank, base_rank + nproc - 1)
     processes = []
@@ -120,6 +131,7 @@ def launch_processes(nproc: int, world_size: int, base_rank: int, master_addr: s
         current_env["WORLD_SIZE"] = str(world_size)
         current_env["LOCAL_RANK"] = str(local_rank)
         current_env["LOCAL_WORLD_SIZE"] = str(nproc)
+        current_env["NODE_RANK"] = str(node_rank)
         current_env["MASTER_ADDR"] = master_addr
         current_env["MASTER_PORT"] = str(master_port)
         current_env["COMPOSER_RUN_DIRECTORY"] = run_directory
@@ -255,6 +267,7 @@ def main():
     processes = launch_processes(nproc=args.nproc,
                                  world_size=args.world_size,
                                  base_rank=args.base_rank,
+                                 node_rank=args.node_rank,
                                  master_addr=args.master_addr,
                                  master_port=args.master_port,
                                  module_mode=args.module_mode,

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -191,8 +191,6 @@ class Engine():
         algorithms = sorted(algorithms_to_run,
                             key=lambda x: not isinstance(x, SelectiveBackprop) and not isinstance(x, StochasticDepth))
 
-        print(event, algorithms)
-
         if event.is_after_event:
             """Establish a FILO queue of algorithms before_ and after_ an event.
 

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -236,9 +236,9 @@ def initialize_dist(backend: str, timeout: datetime.timedelta):
 
     if dist.is_initialized():
         if dist.get_backend() != backend.lower() and get_world_size() > 1:
-            warnings.warn(f"The requested backend ({backend}) differs from the backend "
-                          f"of the current process group ({dist.get_backend()})."
-                          "If you wish to change backends, please restart the python process.")
+            raise RuntimeError(f"The requested backend ({backend}) differs from the backend "
+                               f"of the current process group ({dist.get_backend()}). If you "
+                               "wish to change backends, please restart the python process.")
         return
 
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -24,7 +24,7 @@ def _get_distributed_config_var(env_var: str,
         return default
 
     if dist.is_initialized() and fetch_fn_name is not None:
-        dist_value = int(getattr(dist, fetch_fn_name))
+        dist_value = int(getattr(dist, fetch_fn_name)())
         if env_var in os.environ:
             env_value = int(os.environ[env_var])
             if dist_value != env_value:

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -31,6 +31,7 @@ def _get_distributed_config_var(env_var: str,
                 raise RuntimeError("Torch distributed has been initialized with a value of "
                                    f"{dist_value} for {human_name}, but environment variable "
                                    f"{env_var} has value {env_value}.")
+        return dist_value
 
     if env_var in os.environ:
         return int(os.environ[env_var])

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -236,7 +236,7 @@ def initialize_dist(backend: str, timeout: datetime.timedelta):
         return
 
     if dist.is_initialized():
-        if dist.get_backend() != backend.lower() and get_world_size() > 1:
+        if dist.get_backend() != backend.lower():
             raise RuntimeError(f"The requested backend ({backend}) differs from the backend "
                                f"of the current process group ({dist.get_backend()}). If you "
                                "wish to change backends, please restart the python process.")


### PR DESCRIPTION
The distributed process group doesn't necessarily need to be initialized when we're doing single-process training, and this can help avoid crashes in certain environments. Note that the DDP initialization code already is a no-op when the distributed process group is not initialized.

Tested by running models with various world sizes (and no explicit world size), and using a print statement to verify whether the model was the original model class or a DDP wrapper.