### PR TITLE
Added In Memory Logger, Timestamp Object

### DIFF
--- a/composer/core/__init__.py
+++ b/composer/core/__init__.py
@@ -11,4 +11,5 @@ from composer.core.logging import Logger as Logger
 from composer.core.state import State as State
 from composer.core.time import Time as Time
 from composer.core.time import Timer as Timer
+from composer.core.time import Timestamp as Timestamp
 from composer.core.time import TimeUnit as TimeUnit

--- a/composer/core/logging/base_backend.py
+++ b/composer/core/logging/base_backend.py
@@ -6,6 +6,7 @@ from abc import ABC
 from typing import TYPE_CHECKING
 
 from composer.core.callback import Callback
+from composer.core.time import Timestamp
 
 if TYPE_CHECKING:
     from composer.core.logging.logger import LogLevel, TLogData
@@ -36,7 +37,7 @@ class BaseLoggerBackend(Callback, ABC):
         del state, log_level  # unused
         return True
 
-    def log_metric(self, epoch: int, step: int, log_level: LogLevel, data: TLogData):
+    def log_metric(self, timestamp: Timestamp, log_level: LogLevel, data: TLogData):
         """Called by the :class:`~composer.core.logging.logger.Logger` for metrics where :func:`will_log` returned
         ``True``.
 
@@ -49,5 +50,5 @@ class BaseLoggerBackend(Callback, ABC):
             log_level (LogLevel): The log level.
             data (TLogData): The metric to log.
         """
-        del epoch, step, log_level, data  # unused
+        del timestamp, log_level, data  # unused
         pass

--- a/composer/core/logging/logger.py
+++ b/composer/core/logging/logger.py
@@ -91,7 +91,7 @@ class Logger:
             # this way, the flushed data will be the same as at the time of the logger call
             copied_data = deepcopy(data)
             assert isinstance(copied_data, collections.abc.Mapping)
-            destination.log_metric(self._state.epoch, self._state.step, log_level, copied_data)
+            destination.log_metric(self._state.timer.get_timestamp(), log_level, copied_data)
 
     def metric_fit(self, data: Union[TLogData, Callable[[], TLogData]]) -> None:
         """Helper function for ``metric(LogLevel.FIT, data)``"""

--- a/composer/core/time.py
+++ b/composer/core/time.py
@@ -478,9 +478,10 @@ class Timer(Serializable):
 
         Unlike the :class:`Timer`, the values in a :class:`Timestamp` are NOT incremented as training
         progresses.
-        
+
         Returns:
-            Timestamp: Tuple of (epoch, batch, sample, token) for the current time."""
+            Timestamp: Tuple of (epoch, batch, sample, token) for the current time.
+        """
         return Timestamp(
             epoch=self.epoch,
             batch=self.batch,

--- a/composer/core/time.py
+++ b/composer/core/time.py
@@ -474,13 +474,13 @@ class Timer(Serializable):
         return self_counter >= other
 
     def get_timestamp(self):
-        """Returns a Timestamp tuple for the current time.
+        """Returns a snapshot of the current time.
 
-        Unlike the :class:`Timer`, the values in a :class:`Timestamp` are NOT incremented as training
-        progresses.
+        Unlike the :class:`Timer`, the values in a :class:`Timestamp` are a snapshot and are NOT incremented as
+        training progresses.
 
         Returns:
-            Timestamp: Tuple of (epoch, batch, sample, token) for the current time.
+            Timestamp: A snapshot of the current training time.
         """
         return Timestamp(
             epoch=self.epoch,
@@ -494,10 +494,12 @@ class Timer(Serializable):
 
 
 class Timestamp(NamedTuple):
-    """Timestamp contains the values of all time counters from a call to :meth:`Timer.get_timestamp`.
+    """Timestamp represents a snapshot of :class:`Timer`.
 
-    Unlike the :class:`Timer`, the values in a :class:`Timestamp` are NOT incremented as training
-    progresses.
+    It is returned from a call to :meth:`Timer.get_timestamp`.
+
+    Unlike the :class:`Timer`, the values in a :class:`Timestamp` are a snapshot and are NOT incremented as
+    training progresses.
 
     .. note::
 

--- a/composer/core/time.py
+++ b/composer/core/time.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import textwrap
 import warnings
-from typing import TYPE_CHECKING, Generic, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Generic, NamedTuple, TypeVar, Union, cast
 
 from composer.core.serializable import Serializable
 from composer.utils.string_enum import StringEnum
@@ -472,3 +472,40 @@ class Timer(Serializable):
         other = self._parse(other)
         self_counter = self.get(other.unit)
         return self_counter >= other
+
+    def get_timestamp(self):
+        """Returns a Timestamp tuple for the current time.
+
+        Unlike the :class:`Timer`, the values in a :class:`Timestamp` are NOT incremented as training
+        progresses.
+        
+        Returns:
+            Timestamp: Tuple of (epoch, batch, sample, token) for the current time."""
+        return Timestamp(
+            epoch=self.epoch,
+            batch=self.batch,
+            batch_in_epoch=self.batch_in_epoch,
+            sample=self.sample,
+            sample_in_epoch=self.sample_in_epoch,
+            token=self.token,
+            token_in_epoch=self.token_in_epoch,
+        )
+
+
+class Timestamp(NamedTuple):
+    """Timestamp contains the values of all time counters from a call to :meth:`Timer.get_timestamp`.
+
+    Unlike the :class:`Timer`, the values in a :class:`Timestamp` are NOT incremented as training
+    progresses.
+
+    .. note::
+
+        :class:`Timestamp` should not be instantiated directly; instead use :meth:`Timer.get_timestamp`.
+    """
+    epoch: Time[int]
+    batch: Time[int]
+    batch_in_epoch: Time[int]
+    sample: Time[int]
+    sample_in_epoch: Time[int]
+    token: Time[int]
+    token_in_epoch: Time[int]

--- a/composer/loggers/__init__.py
+++ b/composer/loggers/__init__.py
@@ -5,8 +5,14 @@ from composer.core.logging.logger import Logger as Logger
 from composer.core.logging.logger import LogLevel as LogLevel
 from composer.core.logging.logger import TLogData as TLogData
 from composer.core.logging.logger import TLogDataValue as TLogDataValue
+from composer.loggers.file_logger import FileLoggerBackend as FileLoggerBackend
+from composer.loggers.in_memory_logger import InMemoryLogger as InMemoryLogger
 from composer.loggers.logger_hparams import BaseLoggerBackendHparams as BaseLoggerBackendHparams
 from composer.loggers.logger_hparams import FileLoggerBackendHparams as FileLoggerBackendHparams
+from composer.loggers.logger_hparams import InMemoryLoggerHaparms as InMemoryLoggerHaparms
 from composer.loggers.logger_hparams import MosaicMLLoggerBackendHparams as MosaicMLLoggerBackendHparams
 from composer.loggers.logger_hparams import TQDMLoggerBackendHparams as TQDMLoggerBackendHparams
 from composer.loggers.logger_hparams import WandBLoggerBackendHparams as WandBLoggerBackendHparams
+from composer.loggers.mosaicml_logger import MosaicMLLoggerBackend as MosaicMLLoggerBackend
+from composer.loggers.tqdm_logger import TQDMLoggerBackend as TQDMLoggerBackend
+from composer.loggers.wandb_logger import WandBLoggerBackend as WandBLoggerBackend

--- a/composer/loggers/file_logger.py
+++ b/composer/loggers/file_logger.py
@@ -10,6 +10,7 @@ import yaml
 
 from composer.core.logging import BaseLoggerBackend, Logger, LogLevel, TLogData, format_log_data_value
 from composer.core.state import State
+from composer.core.time import Timestamp
 from composer.utils import run_directory
 
 
@@ -89,11 +90,11 @@ class FileLoggerBackend(BaseLoggerBackend):
             return self.is_batch_interval
         raise ValueError(f"Unknown log level: {log_level}")
 
-    def log_metric(self, epoch: int, step: int, log_level: LogLevel, data: TLogData):
+    def log_metric(self, timestamp: Timestamp, log_level: LogLevel, data: TLogData):
         data_str = format_log_data_value(data)
         if self.file is None:
             raise RuntimeError("Attempted to log before self.init() or after self.close()")
-        print(f"[{log_level.name}][step={step}]: {data_str}", file=self.file, flush=False)
+        print(f"[{log_level.name}][step={timestamp.batch}]: {data_str}", file=self.file, flush=False)
 
     def init(self, state: State, logger: Logger) -> None:
         del state, logger  # unused

--- a/composer/loggers/file_logger.py
+++ b/composer/loggers/file_logger.py
@@ -94,7 +94,7 @@ class FileLoggerBackend(BaseLoggerBackend):
         data_str = format_log_data_value(data)
         if self.file is None:
             raise RuntimeError("Attempted to log before self.init() or after self.close()")
-        print(f"[{log_level.name}][step={timestamp.batch}]: {data_str}", file=self.file, flush=False)
+        print(f"[{log_level.name}][step={int(timestamp.batch)}]: {data_str}", file=self.file, flush=False)
 
     def init(self, state: State, logger: Logger) -> None:
         del state, logger  # unused

--- a/composer/loggers/in_memory_logger.py
+++ b/composer/loggers/in_memory_logger.py
@@ -1,0 +1,43 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple, Union
+
+from composer.core.logging import BaseLoggerBackend, LogLevel, TLogData
+from composer.core.logging.logger import TLogDataValue
+from composer.core.time import Timestamp
+
+
+class InMemoryLogger(BaseLoggerBackend):
+    """Stores all logging calls in memory.
+
+    Args:
+        log_level (str or LogLevel, optional): Minimum LogLevel to record. Defaults to
+            :attr:`LogLevel.BATCH`, which records everything.
+
+    Attributes:
+        data (dict): Mapping of a logged key to a
+            (:class:`Timestamp`, :class:`LogLevel`, :class`~composer.core.logging.TLogDataValue`) tuple.
+            This dictionary contains all logged data.
+        most_recent_values (Dict[str, TLogData]): Mapping of a key to the most recent value for that key.
+        most_recent_timestamps (Dict[str, Timestamp]): Mapping of a key to the :class:`Timestamp` of
+            the last logging call for that key.
+    """
+
+    def __init__(self, log_level: Union[str, LogLevel] = LogLevel.BATCH) -> None:
+        self.log_level = LogLevel(log_level)
+        self.data: Dict[str, List[Tuple[Timestamp, LogLevel, TLogDataValue]]] = {}
+        self.most_recent_values: Dict[str, TLogDataValue] = {}
+        self.most_recent_timestamps: Dict[str, Timestamp] = {}
+
+    def log_metric(self, timestamp: Timestamp, log_level: LogLevel, data: TLogData):
+        if log_level > self.log_level:
+            # the logged metric is more verbose than what we want to record.
+            return
+        for k, v in data.items():
+            if k not in self.data:
+                self.data[k] = []
+            self.data[k].append((timestamp, log_level, v))
+        self.most_recent_values.update(data)
+        self.most_recent_timestamps.update({k: timestamp for k in data})

--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -12,6 +12,7 @@ import yahp as hp
 
 from composer.core.logging import BaseLoggerBackend, LogLevel
 from composer.core.types import JSON
+from composer.loggers.in_memory_logger import InMemoryLogger
 from composer.loggers.mosaicml_logger import RunType
 from composer.utils import dist
 
@@ -241,3 +242,17 @@ class MosaicMLLoggerBackendHparams(BaseLoggerBackendHparams):
     def initialize_object(self, config: Optional[Dict[str, Any]] = None) -> MosaicMLLoggerBackend:
         from composer.loggers.mosaicml_logger import MosaicMLLoggerBackend
         return MosaicMLLoggerBackend(**asdict(self), config=config)
+
+
+@dataclass
+class InMemoryLoggerHaparms(BaseLoggerBackendHparams):
+    """:class:`~composer.loggers.in_memory_logger.InMemoryLogger`
+    hyperparameters.
+
+    See :class:`~composer.loggers.in_memory_logger.InMemoryLogger`
+    for documentation.
+    """
+    log_level: LogLevel = hp.optional("The maximum verbosity to log. Default: BATCH", default=LogLevel.BATCH)
+
+    def initialize_object(self, config: Optional[Dict[str, Any]] = None) -> BaseLoggerBackend:
+        return InMemoryLogger(log_level=self.log_level)

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -16,6 +16,7 @@ import requests
 from composer.core.logging import LogLevel, TLogData
 from composer.core.logging.base_backend import BaseLoggerBackend
 from composer.core.logging.logger import format_log_data_as_json
+from composer.core.time import Timestamp
 from composer.core.types import JSON, Logger, State, StateDict
 from composer.utils import dist
 from composer.utils.string_enum import StringEnum
@@ -159,7 +160,7 @@ class MosaicMLLoggerBackend(BaseLoggerBackend):
         del state  # unused
         return log_level <= self.log_level
 
-    def log_metric(self, epoch: int, step: int, log_level: LogLevel, data: TLogData):
+    def log_metric(self, timestamp: Timestamp, log_level: LogLevel, data: TLogData):
         del log_level  # unused
 
         if self.skip_logging:
@@ -167,8 +168,8 @@ class MosaicMLLoggerBackend(BaseLoggerBackend):
 
         formatted_data = format_log_data_as_json(data)
         log_data = {
-            "epoch": epoch,
-            "step": step,
+            "epoch": int(timestamp.epoch),
+            "step": int(timestamp.batch),
         }
         log_data.update(formatted_data)  # type: ignore
         self.buffered_data.append(log_data)

--- a/composer/loggers/tqdm_logger.py
+++ b/composer/loggers/tqdm_logger.py
@@ -13,6 +13,7 @@ from tqdm import auto
 from composer.core.logging import LogLevel, TLogData, TLogDataValue, format_log_data_value
 from composer.core.logging.base_backend import BaseLoggerBackend
 from composer.core.state import State
+from composer.core.time import Timestamp
 from composer.core.types import StateDict
 from composer.utils import dist
 
@@ -89,8 +90,8 @@ class TQDMLoggerBackend(BaseLoggerBackend):
         del state  # Unused
         return dist.get_global_rank() == 0 and log_level <= LogLevel.BATCH
 
-    def log_metric(self, epoch: int, step: int, log_level: LogLevel, data: TLogData) -> None:
-        del epoch, step, log_level  # Unused
+    def log_metric(self, timestamp: Timestamp, log_level: LogLevel, data: TLogData) -> None:
+        del timestamp, log_level  # Unused
         if self.is_train in self.pbars:
             # Logging outside an epoch
             assert self.is_train is not None

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -64,6 +64,7 @@ class WandBLoggerBackend(BaseLoggerBackend):
 
     def state_dict(self) -> StateDict:
         import wandb
+
         # Storing these fields in the state dict to support run resuming in the future.
         if self._enabled:
             return {
@@ -100,6 +101,7 @@ class WandBLoggerBackend(BaseLoggerBackend):
 
     def _upload_artifacts(self):
         import wandb
+
         # Scan the run directory and upload artifacts to wandb
         # On resnet50, _log_artifacts() caused a 22% throughput degradation
         # wandb.log_artifact() is async according to the docs
@@ -119,6 +121,7 @@ class WandBLoggerBackend(BaseLoggerBackend):
 
     def post_close(self) -> None:
         import wandb
+
         # Cleaning up on post_close so all artifacts are uploaded
         if not self._enabled:
             return

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -60,7 +60,7 @@ class WandBLoggerBackend(BaseLoggerBackend):
         import wandb
         del log_level  # unused
         if self._enabled:
-            wandb.log(data, step=timestamp.batch)
+            wandb.log(data, step=int(timestamp.batch))
 
     def state_dict(self) -> StateDict:
         import wandb

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -9,6 +9,7 @@ import warnings
 from typing import Any, Dict, Optional
 
 from composer.core.logging import BaseLoggerBackend, LogLevel, TLogData
+from composer.core.time import Timestamp
 from composer.core.types import Logger, State, StateDict
 from composer.utils import dist, run_directory
 
@@ -52,10 +53,10 @@ class WandBLoggerBackend(BaseLoggerBackend):
             init_params = {}
         self._init_params = init_params
 
-    def log_metric(self, epoch: int, step: int, log_level: LogLevel, data: TLogData):
-        del epoch, log_level  # unused
+    def log_metric(self, timestamp: Timestamp, log_level: LogLevel, data: TLogData):
+        del log_level  # unused
         if self._enabled:
-            wandb.log(data, step=step)
+            wandb.log(data, step=timestamp.batch)
 
     def state_dict(self) -> StateDict:
         # Storing these fields in the state dict to support run resuming in the future.

--- a/docs/source/core/time.rst
+++ b/docs/source/core/time.rst
@@ -24,3 +24,4 @@ supports comparisons, arithmetic, and conversions.
     ~composer.core.TimeUnit
     ~composer.core.Time
     ~composer.core.Timer
+    ~composer.core.Timestamp

--- a/docs/source/loggers.rst
+++ b/docs/source/loggers.rst
@@ -21,9 +21,10 @@ Backends
     :nosignatures:
     :recursive:
 
-    ~composer.loggers.file_logger.FileLoggerBackend
-    ~composer.loggers.tqdm_logger.TQDMLoggerBackend
-    ~composer.loggers.wandb_logger.WandBLoggerBackend
+    ~composer.loggers.FileLoggerBackend
+    ~composer.loggers.TQDMLoggerBackend
+    ~composer.loggers.WandBLoggerBackend
+    ~composer.loggers.InMemoryLogger
 
 
 Backend Hyperparameters
@@ -34,6 +35,7 @@ Backend Hyperparameters
     :nosignatures:
     :recursive:
 
-    ~composer.loggers.logger_hparams.FileLoggerBackendHparams
-    ~composer.loggers.logger_hparams.TQDMLoggerBackendHparams
-    ~composer.loggers.logger_hparams.WandBLoggerBackendHparams
+    ~composer.loggers.FileLoggerBackendHparams
+    ~composer.loggers.TQDMLoggerBackendHparams
+    ~composer.loggers.WandBLoggerBackendHparams
+    ~composer.loggers.InMemoryLoggerHparams

--- a/tests/callbacks/test_grad_monitor.py
+++ b/tests/callbacks/test_grad_monitor.py
@@ -27,7 +27,7 @@ def test_grad_monitor_no_layers(composer_trainer_hparams: TrainerHparams):
     log_destination, num_train_steps = _do_trainer_fit(composer_trainer_hparams, log_layers=False)
     grad_norm_calls = 0
     for log_call in log_destination.log_metric.mock_calls:
-        metrics = log_call[1][3]
+        metrics = log_call[1][2]
         if "grad_l2_norm/step" in metrics:
             grad_norm_calls += 1
 
@@ -39,7 +39,7 @@ def test_grad_monitor_per_layer(composer_trainer_hparams: TrainerHparams):
     log_destination, num_train_steps = _do_trainer_fit(composer_trainer_hparams, log_layers=True)
     layer_norm_calls = 0
     for log_call in log_destination.log_metric.mock_calls:
-        metrics = log_call[1][3]
+        metrics = log_call[1][2]
         if not isinstance(metrics, dict):
             continue
         if any(map(lambda x: "layer_grad_l2_norm" in x, metrics.keys())):

--- a/tests/callbacks/test_memory_monitor.py
+++ b/tests/callbacks/test_memory_monitor.py
@@ -63,7 +63,7 @@ def test_memory_monitor_gpu(composer_trainer_hparams: TrainerHparams):
 
         num_memory_monitor_calls = 0
         for log_call in log_destination.log_metric.mock_calls:
-            metrics = log_call[1][3]
+            metrics = log_call[1][2]
             if "memory/alloc_requests" in metrics:
                 if metrics["memory/alloc_requests"] > 0:
                     num_memory_monitor_calls += 1

--- a/tests/callbacks/test_memory_monitor.py
+++ b/tests/callbacks/test_memory_monitor.py
@@ -45,7 +45,7 @@ def test_memory_monitor_cpu(composer_trainer_hparams: TrainerHparams):
 
     memory_monitor_called = False
     for log_call in log_destination.log_metric.mock_calls:
-        metrics = log_call[1][3]
+        metrics = log_call[1][2]
         if "memory/alloc_requests" in metrics:
             if metrics["memory/alloc_requests"] > 0:
                 memory_monitor_called = True

--- a/tests/callbacks/test_speed_monitor.py
+++ b/tests/callbacks/test_speed_monitor.py
@@ -24,7 +24,7 @@ def test_speed_monitor(composer_trainer_hparams: TrainerHparams):
     wall_clock_train_calls = 0
     throughput_step_calls = 0
     for call_ in log_destination.log_metric.mock_calls:
-        metrics = call_[1][3]
+        metrics = call_[1][2]
         if "throughput/step" in metrics:
             throughput_step_calls += 1
         if "throughput/epoch" in metrics:

--- a/tests/test_mosaicml_logger.py
+++ b/tests/test_mosaicml_logger.py
@@ -60,9 +60,10 @@ def test_mosaic_logger(tmpdir: pathlib.Path, dummy_state: State, dummy_logger: L
     expected_data = []
     buffer_length = 0
     expected_log_calls = 0
+    dummy_state.timer.on_epoch_complete()
     for i in range(num_times_to_log):
         data_point = {f'data-{i}': 'value'}
-        logger.log_metric(epoch=1, step=i, log_level=LogLevel.BATCH, data=data_point)
+        logger.log_metric(timestamp=dummy_state.timer.get_timestamp(), log_level=LogLevel.BATCH, data=data_point)
         dummy_state.timer.on_batch_complete()
         logger.batch_end(dummy_state, dummy_logger)
 


### PR DESCRIPTION
1. Added a Timestamp object to `composer.core.time`. The Timestamp object is Tuple that represents a snapshot of state.timer
2. Updated the logging API to pass the Timestamp object rather than (epoch, step).
3. Added an In memory logger that records all logging calls, with easy helpers to the most recent values for each key. This new feature required `Timestamp` objects so it is possible, say, to create a plot of samples or tokens vs a logged value. It also cleans up the API compared to storing (epoch, batch, sample, token) as a non-named tuple.

Closes #294