### PR TITLE
Removed `template_default` fields in hparams

### DIFF
--- a/composer/algorithms/cutmix/cutmix.py
+++ b/composer/algorithms/cutmix/cutmix.py
@@ -1,4 +1,5 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
+from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
@@ -196,11 +197,10 @@ def cutmix(x: Tensor,
 class CutMixHparams(AlgorithmHparams):
     """See :class:`CutMix`"""
 
-    alpha: float = hp.required('Strength of interpolation, should be >= 0. No interpolation if alpha=0.',
-                               template_default=1.0)
     num_classes: int = hp.required('Number of classes in the task labels.')
+    alpha: float = hp.optional('Strength of interpolation, should be >= 0. No interpolation if alpha=0.', default=1.0)
 
-    def initialize_object(self) -> "CutMix":
+    def initialize_object(self) -> CutMix:
         return CutMix(**asdict(self))
 
 

--- a/composer/algorithms/cutout/cutout.py
+++ b/composer/algorithms/cutout/cutout.py
@@ -1,4 +1,5 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
+from __future__ import annotations
 
 import logging
 from dataclasses import asdict, dataclass
@@ -58,10 +59,10 @@ def cutout(X: Tensor, n_holes: int, length: int) -> Tensor:
 class CutOutHparams(AlgorithmHparams):
     """See :class:`CutOut`"""
 
-    n_holes: int = hp.required('Number of holes to cut out', template_default=1)
-    length: int = hp.required('Side length of the square hole to cut out', template_default=112)
+    n_holes: int = hp.optional('Number of holes to cut out', default=1)
+    length: int = hp.optional('Side length of the square hole to cut out', default=112)
 
-    def initialize_object(self) -> "CutOut":
+    def initialize_object(self) -> CutOut:
         return CutOut(**asdict(self))
 
 

--- a/composer/algorithms/ghost_batchnorm/ghost_batchnorm.py
+++ b/composer/algorithms/ghost_batchnorm/ghost_batchnorm.py
@@ -136,10 +136,9 @@ def apply_ghost_batchnorm(model: torch.nn.Module,
 class GhostBatchNormHparams(AlgorithmHparams):
     """See :class:`GhostBatchNorm`"""
 
-    ghost_batch_size: int = hp.required(doc='Size of sub-batches to normalize over',
-                                        template_default=_DEFAULT_GHOST_BATCH_SIZE)
+    ghost_batch_size: int = hp.optional(doc='Size of sub-batches to normalize over', default=_DEFAULT_GHOST_BATCH_SIZE)
 
-    def initialize_object(self) -> "GhostBatchNorm":
+    def initialize_object(self) -> GhostBatchNorm:
         return GhostBatchNorm(**asdict(self))
 
 
@@ -152,7 +151,7 @@ class GhostBatchNorm(Algorithm):
     be the sample axis.
 
     Runs on ``Event.INIT`` and should be applied both before the model has
-    been moved to accelerators and before the model’s parameters have
+    been moved to accelerators and before the model's parameters have
     been passed to an optimizer.
 
     Args:

--- a/composer/algorithms/label_smoothing/label_smoothing.py
+++ b/composer/algorithms/label_smoothing/label_smoothing.py
@@ -1,4 +1,5 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
+from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from typing import Optional
@@ -15,9 +16,9 @@ from composer.models.loss import ensure_targets_one_hot
 class LabelSmoothingHparams(AlgorithmHparams):
     """See :class:`LabelSmoothing`"""
 
-    alpha: float = hp.required(doc='smoothing factor', template_default=0.1)
+    alpha: float = hp.optional(doc='smoothing factor', default=0.1)
 
-    def initialize_object(self) -> "LabelSmoothing":
+    def initialize_object(self) -> LabelSmoothing:
         return LabelSmoothing(**asdict(self))
 
 

--- a/composer/algorithms/mixup/mixup.py
+++ b/composer/algorithms/mixup/mixup.py
@@ -1,5 +1,7 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
+from __future__ import annotations
+
 import logging
 from dataclasses import asdict, dataclass
 from typing import Optional, Tuple
@@ -100,11 +102,10 @@ def mixup_batch(x: Tensor,
 class MixUpHparams(AlgorithmHparams):
     """See :class:`MixUp`"""
 
-    alpha: float = hp.required('Strength of interpolation, should be >= 0. No interpolation if alpha=0.',
-                               template_default=0.2)
     num_classes: int = hp.required('Number of classes in the task labels.')
+    alpha: float = hp.optional('Strength of interpolation, should be >= 0. No interpolation if alpha=0.', default=0.2)
 
-    def initialize_object(self) -> "MixUp":
+    def initialize_object(self) -> MixUp:
         return MixUp(**asdict(self))
 
 

--- a/composer/algorithms/scale_schedule/scale_schedule.py
+++ b/composer/algorithms/scale_schedule/scale_schedule.py
@@ -73,7 +73,7 @@ def scale_scheduler(scheduler: Scheduler, ssr: float, orig_max_epochs: Optional[
 class ScaleScheduleHparams(AlgorithmHparams):
     """See :class:`ScaleSchedule`"""
 
-    ratio: float = hp.required('Ratio to scale the schedule.', template_default=1.0)
+    ratio: float = hp.required('Ratio to scale the schedule.')
     method: str = hp.optional("Method to scale the schedule, one of 'epoch' or 'samples'. Default: epoch.",
                               default='epoch')
 

--- a/composer/algorithms/selective_backprop/selective_backprop.py
+++ b/composer/algorithms/selective_backprop/selective_backprop.py
@@ -12,7 +12,8 @@ import yahp as hp
 from torch.nn import functional as F
 
 from composer.algorithms.algorithm_hparams import AlgorithmHparams
-from composer.core.types import Algorithm, Event, Logger, State, Tensor
+from composer.core.types import Algorithm, Event, Logger, State, Tensor, Tensors
+from composer.models import ComposerModel
 
 
 def do_selective_backprop(
@@ -52,7 +53,7 @@ def do_selective_backprop(
 # TODO this function should probably be part of the public API
 def selective_backprop(X: torch.Tensor,
                        y: torch.Tensor,
-                       model: torch.nn.Module,
+                       model: Callable[[Tensors], Tensor],
                        loss_fun: Callable,
                        keep: float,
                        scale_factor: float = 1) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -145,14 +146,11 @@ def selective_backprop(X: torch.Tensor,
 class SelectiveBackpropHparams(AlgorithmHparams):
     """See :class:`SelectiveBackprop`"""
 
-    start: float = hp.required(doc="SB interval start, as fraction of training duration", template_default=0.5)
-    end: float = hp.required(doc="SB interval end, as fraction of training duration", template_default=0.9)
-    keep: float = hp.required(doc="fraction of minibatch to select and keep for gradient computation",
-                              template_default=0.5)
-    scale_factor: float = hp.required(doc="scale for downsampling input for selection forward pass",
-                                      template_default=0.5)
-    interrupt: int = hp.required(doc="interrupt SB with a vanilla minibatch step every 'interrupt' batches",
-                                 template_default=2)
+    start: float = hp.optional(doc="SB interval start, as fraction of training duration", default=0.5)
+    end: float = hp.optional(doc="SB interval end, as fraction of training duration", default=0.9)
+    keep: float = hp.optional(doc="fraction of minibatch to select and keep for gradient computation", default=0.5)
+    scale_factor: float = hp.optional(doc="scale for downsampling input for selection forward pass", default=0.5)
+    interrupt: int = hp.optional(doc="interrupt SB with a vanilla minibatch step every 'interrupt' batches", default=2)
 
     def initialize_object(self) -> SelectiveBackprop:
         return SelectiveBackprop(**asdict(self))
@@ -193,11 +191,17 @@ class SelectiveBackprop(Algorithm):
         self.keep = keep
         self.scale_factor = scale_factor
         self.interrupt = interrupt
+        self._loss_fn = None  # set on Event.INIT
 
     def match(self, event: Event, state: State) -> bool:
-        """Match on ``Event.AFTER_DATALOADER`` if time is between ``self.start`` and ``self.end``."""
-        is_event = (event == Event.AFTER_DATALOADER)
-        if not is_event:
+        """Matches :attr:`Event.INIT` and `Event.AFTER_DATALOADER`
+
+        * Uses `Event.INIT` to get the loss function before the model is wrapped
+        * Uses `Event.AFTER_DATALOADER`` to apply selective backprop if time is between ``self.start`` and ``self.end``.
+        """
+        if event == Event.INIT:
+            return True
+        if event != Event.AFTER_DATALOADER:
             return False
 
         is_keep = (self.keep < 1)
@@ -215,24 +219,23 @@ class SelectiveBackprop(Algorithm):
 
     def apply(self, event: Event, state: State, logger: Optional[Logger] = None) -> None:
         """Apply selective backprop to the current batch."""
+        if event == Event.INIT:
+            if self._loss_fn is None:
+                if not isinstance(state.model, ComposerModel):
+                    raise RuntimeError("Model must be of type ComposerModel")
+                self._loss_fn = state.model.loss
+            return
         input, target = state.batch_pair
         assert isinstance(input, Tensor) and isinstance(target, Tensor), \
             "Multiple tensors not supported for this method yet."
-
-        assert callable(state.model.module.loss)  # type: ignore - type not found
 
         # Model expected to only take in input, not the full batch
         model = lambda X: state.model((X, None))
 
         def loss(p, y, reduction="none"):
-            return state.model.module.loss(p, (None, y), reduction=reduction)  # type: ignore
+            assert self._loss_fn is not None, "loss_fn should be set on Event.INIT"
+            return self._loss_fn(p, (torch.Tensor(), y), reduction=reduction)
 
         with state.precision_context:
-            new_input, new_target = selective_backprop(
-                input,
-                target,
-                model,  # type: ignore - ditto because of loss
-                loss,
-                self.keep,
-                self.scale_factor)
+            new_input, new_target = selective_backprop(input, target, model, loss, self.keep, self.scale_factor)
         state.batch = (new_input, new_target)

--- a/composer/algorithms/template.py
+++ b/composer/algorithms/template.py
@@ -19,13 +19,8 @@ class MyAlgorithmHparams(AlgorithmHparams):
     """This hparams object is for use with our hparams system for specifying algorithms via YAML and argument parser
     flags."""
 
-    alpha: float = hp.optional(doc='optional hparams need a default field. This field would'
-                               'not be required for CLI flags, but still required for the YAML config.',
-                               default=0.1)
-    beta: float = hp.required(doc='required fields need a template_default, which '
-                              'is used to generate templates. '
-                              'This field is still required for CLI flags.',
-                              template_default=0.5)
+    alpha: float = hp.optional(doc='optional hparams need a default field.', default=0.1)
+    beta: float = hp.required(doc='required field')
 
     def initialize_object(self) -> MyAlgorithm:
         """

--- a/composer/datasets/dataloader.py
+++ b/composer/datasets/dataloader.py
@@ -69,14 +69,14 @@ class DataloaderHparams(hp.Hparams):
         timeout (float): Timeout, in seconds, for collecting a batch from workers. Set to 0 for no timeout.
     """
 
-    num_workers: int = hp.required("Number of CPU workers to use per device to fetch data.", template_default=8)
-    prefetch_factor: int = hp.required("Number of samples loaded in advance by each worker", template_default=2)
-    persistent_workers: bool = hp.required("Whether to shutdown workers after the dataset has been consumed once",
-                                           template_default=True)
-    pin_memory: bool = hp.required("Whether to copy Tensors into CUDA pinned memory before returning them",
-                                   template_default=True)
-    timeout: float = hp.required("Timeout, in seconds, for collecting a batch from workers. Set to 0 for no timeout",
-                                 template_default=0)
+    num_workers: int = hp.optional("Number of CPU workers to use per device to fetch data.", default=8)
+    prefetch_factor: int = hp.optional("Number of samples loaded in advance by each worker", default=2)
+    persistent_workers: bool = hp.optional("Whether to shutdown workers after the dataset has been consumed once",
+                                           default=True)
+    pin_memory: bool = hp.optional("Whether to copy Tensors into CUDA pinned memory before returning them",
+                                   default=True)
+    timeout: float = hp.optional("Timeout, in seconds, for collecting a batch from workers. Set to 0 for no timeout",
+                                 default=0)
 
     def initialize_object(
         self,

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -130,29 +130,20 @@ class TrainerHparams(hp.Hparams):
     model: ModelHparams = hp.required(doc="model")
     loggers: List[BaseLoggerBackendHparams] = hp.required(doc="loggers to use")
 
-    max_duration: str = hp.required(
-        doc="Time string for the maximum training duration (e.g., 90ep)",
-        template_default="10ep",
-    )
+    max_duration: str = hp.required(doc="Time string for the maximum training duration (e.g., 90ep)")
 
     train_batch_size: int = hp.required(
-        doc="batch size for each optimization step, across all devices and gradient accumulations.",
-        template_default=2048,
-    )
+        doc="batch size for each optimization step, across all devices and gradient accumulations.")
 
-    eval_batch_size: int = hp.required(
-        doc="batch size to use for each evaluation step",
-        template_default=2048,
-    )
+    eval_batch_size: int = hp.required(doc="batch size to use for each evaluation step")
 
     dataloader: DataloaderHparams = hp.required(doc="dataloader hparams")
 
-    grad_accum: int = hp.required(
-        template_default=1,
-        doc=
-        "Determines the number of microbatches to split a per-gpu batch into, used to compensate for low-memory-capacity devices."
-    )
-    precision: Precision = hp.required(doc="Precision to use for training", template_default=Precision.AMP)
+    grad_accum: int = hp.optional(textwrap.dedent("""\
+        Determines the number of microbatches to split a per-gpu batch into,
+        used to compensate for low-memory-capacity devices."""),
+                                  default=1)
+    precision: Precision = hp.optional(doc="Precision to use for training", default=Precision.AMP)
 
     val_dataset: Optional[datasets.DatasetHparams] = hp.optional(doc="Validation dataset hparams", default=None)
 


### PR DESCRIPTION
Replaced required hparams that have template defaults with optional fields, or just removed the template defaults. We really aren't using the templating feature, and if there's a template_default, then it should be a default for functional api users.

Also fixed typing issues in Selective Backprop