### PR TITLE
Remove requirement for `validation` and `metrics`

### DIFF
--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -45,7 +45,6 @@ class ComposerModel(torch.nn.Module, abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
     def metrics(self, train: bool = False) -> Metrics:
         """Get metrics for evaluating the model.
 
@@ -64,7 +63,6 @@ class ComposerModel(torch.nn.Module, abc.ABC):
         """
         pass
 
-    @abc.abstractmethod
     def validate(self, batch: Batch) -> Tuple[Any, Any]:
         """Compute model outputs on provided data.
 

--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -61,7 +61,7 @@ class ComposerModel(torch.nn.Module, abc.ABC):
         Returns:
             Metrics: A ``Metrics`` object.
         """
-        pass
+        raise NotImplementedError('Implement metrics in your ComposerModel to run validation.')
 
     def validate(self, batch: Batch) -> Tuple[Any, Any]:
         """Compute model outputs on provided data.
@@ -78,7 +78,7 @@ class ComposerModel(torch.nn.Module, abc.ABC):
                 `update()` methods of the metrics returned by :meth:`metrics`.
                 Most often, this will be a tuple of the form (predictions, targets).
         """
-        pass
+        raise NotImplementedError('Implement validate in your ComposerModel to run validation.')
 
 
 class ComposerClassifier(ComposerModel):


### PR DESCRIPTION
Users who just want to run training, and not validate on an external dataset should not need to supply validation and metrics as part of their `ComposerModel`. Especially now that the `eval_dataloader` is an optional argument to our trainer. This PR removes the abstract marker for the two methods in question.

h/t: @A-Jacobson 