### PR TITLE
Functional API renaming part 1

### DIFF
--- a/composer/algorithms/augmix/__init__.py
+++ b/composer/algorithms/augmix/__init__.py
@@ -3,11 +3,11 @@
 from composer.algorithms.augmix.augmix import AugmentAndMixTransform as AugmentAndMixTransform
 from composer.algorithms.augmix.augmix import AugMix as AugMix
 from composer.algorithms.augmix.augmix import AugMixHparams as AugMixHparams
-from composer.algorithms.augmix.augmix import augment_and_mix as augment_and_mix
+from composer.algorithms.augmix.augmix import augmix_image as augmix_image
 
 _name = 'AugMix'
 _class_name = 'AugMix'
-_functional = 'augment_and_mix'
+_functional = 'augmix_image'
 _tldr = 'Image-perserving data augmentations'
 _attribution = '(Hendrycks et al, 2020)'
 _link = 'http://arxiv.org/abs/1912.02781'

--- a/composer/algorithms/augmix/augmix.py
+++ b/composer/algorithms/augmix/augmix.py
@@ -33,12 +33,12 @@ class AugMixHparams(AlgorithmHparams):
         return AugMix(**asdict(self))
 
 
-def augment_and_mix(img: Optional[ImageType] = None,
-                    severity: int = 3,
-                    depth: int = -1,
-                    width: int = 3,
-                    alpha: float = 1.0,
-                    augmentation_set: List = augmentation_sets["all"]) -> ImageType:
+def augmix_image(img: Optional[ImageType] = None,
+                 severity: int = 3,
+                 depth: int = -1,
+                 width: int = 3,
+                 alpha: float = 1.0,
+                 augmentation_set: List = augmentation_sets["all"]) -> ImageType:
     """Applies AugMix (`Hendrycks et al.
 
     <http://arxiv.org/abs/1912.02781>`_) data augmentation to an image. See :class:`AugMix` for details.
@@ -68,7 +68,7 @@ def augment_and_mix(img: Optional[ImageType] = None,
 
 
 class AugmentAndMixTransform(torch.nn.Module):
-    """Wrapper module for :func:`augment_and_mix` that can be passed to :class:`torchvision.transforms.Compose`"""
+    """Wrapper module for :func:`augmix_image` that can be passed to :class:`torchvision.transforms.Compose`"""
 
     def __init__(self,
                  severity: int = 3,
@@ -91,12 +91,12 @@ class AugmentAndMixTransform(torch.nn.Module):
 
     def forward(self, img: ImageType) -> ImageType:
 
-        return augment_and_mix(img=img,
-                               severity=self.severity,
-                               depth=self.depth,
-                               width=self.width,
-                               alpha=self.alpha,
-                               augmentation_set=self.augmentation_set)
+        return augmix_image(img=img,
+                            severity=self.severity,
+                            depth=self.depth,
+                            width=self.width,
+                            alpha=self.alpha,
+                            augmentation_set=self.augmentation_set)
 
 
 class AugMix(Algorithm):

--- a/composer/algorithms/colout/__init__.py
+++ b/composer/algorithms/colout/__init__.py
@@ -2,11 +2,12 @@
 
 from composer.algorithms.colout.colout import ColOut as ColOut
 from composer.algorithms.colout.colout import ColOutHparams as ColOutHparams
-from composer.algorithms.colout.colout import colout as colout
+from composer.algorithms.colout.colout import colout_batch as colout_batch
+from composer.algorithms.colout.colout import colout_image as colout_image
 
 _name = 'ColumnOut'
 _class_name = 'ColOut'
-_functional = 'colout'
+_functional = 'colout_batch'
 _tldr = 'Removes columns and rows from the image for augmentation and efficiency.'
 _attribution = 'MosaicML'
 _link = ''

--- a/composer/algorithms/colout/colout.py
+++ b/composer/algorithms/colout/colout.py
@@ -19,7 +19,7 @@ from composer.utils.data import add_dataset_transform
 log = logging.getLogger(__name__)
 
 
-def colout(img: Union[torch.Tensor, Image], p_row: float, p_col: float) -> Union[torch.Tensor, Image]:
+def colout_image(img: Union[torch.Tensor, Image], p_row: float, p_col: float) -> Union[torch.Tensor, Image]:
     """Drops random rows and columns from a single image.
 
     Args:
@@ -86,10 +86,10 @@ class ColOutTransform:
         Returns:
             torch.Tensor or PIL Image: A smaller image with rows and columns dropped
         """
-        return colout(img, self.p_row, self.p_col)
+        return colout_image(img, self.p_row, self.p_col)
 
 
-def batch_colout(X: torch.Tensor, p_row: float, p_col: float) -> torch.Tensor:
+def colout_batch(X: torch.Tensor, p_row: float, p_col: float) -> torch.Tensor:
     """Applies ColOut augmentation to a batch of images, dropping the same random rows and columns from all images in a
     batch.
 
@@ -177,7 +177,7 @@ class ColOut(Algorithm):
         """Transform a batch of images using the ColOut augmentation."""
         inputs, labels = state.batch_pair
         assert isinstance(inputs, Tensor), "Multiple Tensors not supported yet for ColOut"
-        new_inputs = batch_colout(inputs, p_row=self.p_row, p_col=self.p_col)
+        new_inputs = colout_batch(inputs, p_row=self.p_row, p_col=self.p_col)
 
         state.batch = (new_inputs, labels)
 

--- a/composer/algorithms/cutmix/__init__.py
+++ b/composer/algorithms/cutmix/__init__.py
@@ -2,11 +2,11 @@
 
 from composer.algorithms.cutmix.cutmix import CutMix as CutMix
 from composer.algorithms.cutmix.cutmix import CutMixHparams as CutMixHparams
-from composer.algorithms.cutmix.cutmix import cutmix as cutmix
+from composer.algorithms.cutmix.cutmix import cutmix_batch as cutmix_batch
 
 _name = 'CutMix'
 _class_name = 'CutMix'
-_functional = 'cutmix'
+_functional = 'cutmix_batch'
 _tldr = 'Combines pairs of examples in non-overlapping regions and mixes labels'
 _attribution = '(Yun et al, 2019)'
 _link = 'https://arxiv.org/abs/1905.04899'

--- a/composer/algorithms/cutmix/cutmix.py
+++ b/composer/algorithms/cutmix/cutmix.py
@@ -109,13 +109,13 @@ def adjust_lambda(cutmix_lambda: float, x: Tensor, bbox: Tuple) -> float:
     return adjusted_lambda
 
 
-def cutmix(x: Tensor,
-           y: Tensor,
-           alpha: float,
-           n_classes: int,
-           cutmix_lambda: Optional[float] = None,
-           bbox: Optional[Tuple] = None,
-           indices: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+def cutmix_batch(x: Tensor,
+                 y: Tensor,
+                 alpha: float,
+                 n_classes: int,
+                 cutmix_lambda: Optional[float] = None,
+                 bbox: Optional[Tuple] = None,
+                 indices: Optional[torch.Tensor] = None) -> Tuple[torch.Tensor, torch.Tensor]:
     """Create new samples using combinations of pairs of samples.
 
     This is done by masking a region of x, and filling the masked region with a
@@ -284,7 +284,7 @@ class CutMix(Algorithm):
         self.bbox = rand_bbox(input.shape[2], input.shape[3], self.cutmix_lambda)
         self.cutmix_lambda = adjust_lambda(self.cutmix_lambda, input, self.bbox)
 
-        new_input, new_target = cutmix(
+        new_input, new_target = cutmix_batch(
             x=input,
             y=target,
             alpha=alpha,

--- a/composer/algorithms/cutout/__init__.py
+++ b/composer/algorithms/cutout/__init__.py
@@ -2,11 +2,11 @@
 
 from composer.algorithms.cutout.cutout import CutOut as CutOut
 from composer.algorithms.cutout.cutout import CutOutHparams as CutOutHparams
-from composer.algorithms.cutout.cutout import cutout as cutout
+from composer.algorithms.cutout.cutout import cutout_batch as cutout_batch
 
 _name = 'CutOut'
 _class_name = 'CutOut'
-_functional = 'cutout'
+_functional = 'cutout_batch'
 _tldr = 'Randomly erases rectangular blocks from the image.'
 _attribution = '(DeVries et al, 2017)'
 _link = 'https://arxiv.org/abs/1708.04552'

--- a/composer/algorithms/cutout/cutout.py
+++ b/composer/algorithms/cutout/cutout.py
@@ -30,7 +30,7 @@ def apply_cutout(X: Tensor, mask: Tensor):
     return X * mask
 
 
-def cutout(X: Tensor, n_holes: int, length: int) -> Tensor:
+def cutout_batch(X: Tensor, n_holes: int, length: int) -> Tensor:
     """See :class:`CutOut`.
 
     Args:
@@ -91,5 +91,5 @@ class CutOut(Algorithm):
         x, y = state.batch_pair
         assert isinstance(x, Tensor), "Multiple tensors not supported for Cutout."
 
-        new_x = cutout(X=x, n_holes=self.n_holes, length=self.length)
+        new_x = cutout_batch(X=x, n_holes=self.n_holes, length=self.length)
         state.batch = (new_x, y)

--- a/composer/algorithms/randaugment/__init__.py
+++ b/composer/algorithms/randaugment/__init__.py
@@ -3,11 +3,11 @@
 from composer.algorithms.randaugment.randaugment import RandAugment as RandAugment
 from composer.algorithms.randaugment.randaugment import RandAugmentHparams as RandAugmentHparams
 from composer.algorithms.randaugment.randaugment import RandAugmentTransform as RandAugmentTransform
-from composer.algorithms.randaugment.randaugment import randaugment as randaugment
+from composer.algorithms.randaugment.randaugment import randaugment_image as randaugment_image
 
 _name = 'RandAugment'
 _class_name = 'RandAugment'
-_functional = 'randaugment'
+_functional = 'randaugment_image'
 _tldr = 'Applies a series of random augmentations'
 _attribution = '(Cubuk et al, 2020)'
 _link = 'https://openaccess.thecvf.com/content_CVPRW_2020/html/w40/Cubuk_Randaugment_Practical_Automated_Data_Augmentation_With_a_Reduced_Search_Space_CVPRW_2020_paper.html'

--- a/composer/algorithms/randaugment/randaugment.py
+++ b/composer/algorithms/randaugment/randaugment.py
@@ -29,10 +29,10 @@ class RandAugmentHparams(AlgorithmHparams):
         return RandAugment(**asdict(self))
 
 
-def randaugment(img: Optional[ImageType] = None,
-                severity: int = 9,
-                depth: int = 2,
-                augmentation_set: List = augmentation_sets["all"]) -> ImageType:
+def randaugment_image(img: Optional[ImageType] = None,
+                      severity: int = 9,
+                      depth: int = 2,
+                      augmentation_set: List = augmentation_sets["all"]) -> ImageType:
     """Randomly applies a sequence of image data augmentations (`Cubuk et al.
 
     2019 <https://openaccess.thecvf.com/content_CVPRW_2020/papers/w40/Cubuk_Randaugment_Practical_Automated_Data_Augmentation_With_a_Reduced_Search_Space_CVPRW_2020_paper.pdf>`_).
@@ -64,7 +64,10 @@ class RandAugmentTransform(torch.nn.Module):
 
     def forward(self, img: ImageType) -> ImageType:
 
-        return randaugment(img=img, severity=self.severity, depth=self.depth, augmentation_set=self.augmentation_set)
+        return randaugment_image(img=img,
+                                 severity=self.severity,
+                                 depth=self.depth,
+                                 augmentation_set=self.augmentation_set)
 
 
 class RandAugment(Algorithm):

--- a/composer/functional/__init__.py
+++ b/composer/functional/__init__.py
@@ -14,7 +14,7 @@ from composer.algorithms.channels_last.channels_last import apply_channels_last 
 from composer.algorithms.colout.colout import colout_batch as colout_batch
 from composer.algorithms.colout.colout import colout_image as colout_image
 from composer.algorithms.cutmix.cutmix import cutmix_batch as cutmix_batch
-from composer.algorithms.cutout.cutout import cutout as cutout
+from composer.algorithms.cutout.cutout import cutout_batch as cutout_batch
 from composer.algorithms.ghost_batchnorm.ghost_batchnorm import apply_ghost_batchnorm as apply_ghost_batchnorm
 from composer.algorithms.label_smoothing import smooth_labels as smooth_labels
 from composer.algorithms.layer_freezing import freeze_layers as freeze_layers

--- a/composer/functional/__init__.py
+++ b/composer/functional/__init__.py
@@ -13,7 +13,7 @@ from composer.algorithms.blurpool import apply_blurpool as apply_blurpool
 from composer.algorithms.channels_last.channels_last import apply_channels_last as apply_channels_last
 from composer.algorithms.colout.colout import colout_batch as colout_batch
 from composer.algorithms.colout.colout import colout_image as colout_image
-from composer.algorithms.cutmix.cutmix import cutmix as cutmix
+from composer.algorithms.cutmix.cutmix import cutmix_batch as cutmix_batch
 from composer.algorithms.cutout.cutout import cutout as cutout
 from composer.algorithms.ghost_batchnorm.ghost_batchnorm import apply_ghost_batchnorm as apply_ghost_batchnorm
 from composer.algorithms.label_smoothing import smooth_labels as smooth_labels

--- a/composer/functional/__init__.py
+++ b/composer/functional/__init__.py
@@ -11,7 +11,8 @@ from composer.algorithms.alibi.alibi import apply_alibi as apply_alibi
 from composer.algorithms.augmix import augmix_image as augmix_image
 from composer.algorithms.blurpool import apply_blurpool as apply_blurpool
 from composer.algorithms.channels_last.channels_last import apply_channels_last as apply_channels_last
-from composer.algorithms.colout.colout import colout as colout
+from composer.algorithms.colout.colout import colout_batch as colout_batch
+from composer.algorithms.colout.colout import colout_image as colout_image
 from composer.algorithms.cutmix.cutmix import cutmix as cutmix
 from composer.algorithms.cutout.cutout import cutout as cutout
 from composer.algorithms.ghost_batchnorm.ghost_batchnorm import apply_ghost_batchnorm as apply_ghost_batchnorm

--- a/composer/functional/__init__.py
+++ b/composer/functional/__init__.py
@@ -21,7 +21,7 @@ from composer.algorithms.layer_freezing import freeze_layers as freeze_layers
 from composer.algorithms.mixup import mixup_batch as mixup_batch
 from composer.algorithms.mixup.mixup import gen_interpolation_lambda as gen_interpolation_lambda
 from composer.algorithms.progressive_resizing import resize_inputs as resize_inputs
-from composer.algorithms.randaugment import randaugment as randaugment
+from composer.algorithms.randaugment import randaugment_image as randaugment_image
 from composer.algorithms.scale_schedule.scale_schedule import scale_scheduler as scale_scheduler
 from composer.algorithms.selective_backprop.selective_backprop import do_selective_backprop as do_selective_backprop
 from composer.algorithms.selective_backprop.selective_backprop import selective_backprop as selective_backprop

--- a/composer/functional/__init__.py
+++ b/composer/functional/__init__.py
@@ -4,11 +4,11 @@
 
 Functional forms of methods are available here via::
 
-    from composer import functional as CF
-    my_model = CF.apply_blurpool(my_model)
+    from composer import functional as cf
+    my_model = cf.apply_blurpool(my_model)
 """
 from composer.algorithms.alibi.alibi import apply_alibi as apply_alibi
-from composer.algorithms.augmix import augment_and_mix as augment_and_mix
+from composer.algorithms.augmix import augmix_image as augmix_image
 from composer.algorithms.blurpool import apply_blurpool as apply_blurpool
 from composer.algorithms.channels_last.channels_last import apply_channels_last as apply_channels_last
 from composer.algorithms.colout.colout import colout as colout

--- a/docs/source/algorithms.rst
+++ b/docs/source/algorithms.rst
@@ -138,6 +138,21 @@ Standalone
 .. autofunction:: composer.algorithms.cutout.cutout
 
 
+CutMix
+---------------
+
+Algorithm
+^^^^^^^^^
+
+.. autoclass:: composer.algorithms.cutmix.CutMix
+.. autoclass:: composer.algorithms.cutmix.CutMixHparams
+
+Standalone
+^^^^^^^^^^
+
+.. autofunction:: composer.algorithms.cutmix.cutmix_batch
+
+
 Ghost Batch Normalization
 -------------------------
 

--- a/docs/source/algorithms.rst
+++ b/docs/source/algorithms.rst
@@ -119,7 +119,8 @@ Algorithm
 Standalone
 ^^^^^^^^^^
 
-.. autofunction:: composer.algorithms.colout.colout
+.. autofunction:: composer.algorithms.colout.colout_image
+.. autofunction:: composer.algorithms.colout.colout_batch
 
 
 CutOut

--- a/docs/source/algorithms.rst
+++ b/docs/source/algorithms.rst
@@ -123,6 +123,16 @@ Standalone
 .. autofunction:: composer.algorithms.colout.colout_batch
 
 
+CutMix
+---------------
+
+Algorithm
+^^^^^^^^^
+
+.. autoclass:: composer.algorithms.cutmix.CutMix
+.. autoclass:: composer.algorithms.cutmix.CutMixHparams
+
+
 CutOut
 ---------------
 
@@ -135,17 +145,8 @@ Algorithm
 Standalone
 ^^^^^^^^^^
 
-.. autofunction:: composer.algorithms.cutout.cutout
+.. autofunction:: composer.algorithms.cutout.cutout_batch
 
-
-CutMix
----------------
-
-Algorithm
-^^^^^^^^^
-
-.. autoclass:: composer.algorithms.cutmix.CutMix
-.. autoclass:: composer.algorithms.cutmix.CutMixHparams
 
 Standalone
 ^^^^^^^^^^

--- a/docs/source/algorithms.rst
+++ b/docs/source/algorithms.rst
@@ -268,7 +268,7 @@ Algorithm
 Standalone
 ^^^^^^^^^^
 
-.. autofunction:: composer.algorithms.randaugment.randaugment
+.. autofunction:: composer.algorithms.randaugment.randaugment_image
 
 Sequence Length Warmup
 ----------------------

--- a/docs/source/algorithms.rst
+++ b/docs/source/algorithms.rst
@@ -69,7 +69,7 @@ Algorithm
 Standalone
 ^^^^^^^^^^
 
-.. autofunction:: composer.algorithms.augmix.augment_and_mix
+.. autofunction:: composer.algorithms.augmix.augmix_image
 
 
 BlurPool

--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -22,7 +22,7 @@ Algorithms can be used directly through our functions-based API.
     :toctree: generated
     :nosignatures:
 
-    functional.augment_and_mix
+    functional.augmix_image
     functional.apply_blurpool
     functional.apply_alibi
     functional.colout

--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -32,7 +32,7 @@ Algorithms can be used directly through our functions-based API.
     functional.apply_ghost_batchnorm
     functional.mixup_batch
     functional.resize_inputs
-    functional.randaugment
+    functional.randaugment_image
     functional.scale_scheduler
     functional.selective_backprop
     functional.apply_se

--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -5,15 +5,15 @@ Algorithms can be used directly through our functions-based API.
 
 .. code-block:: python
 
-    from composer import functional as CF
+    from composer import functional as cf
     from torchvision import models
 
     model = models.resnet(model_name='resnet50')
 
     # replace some layers with blurpool
-    CF.apply_blurpool(model)
+    cf.apply_blurpool(model)
     # replace some layers with squeeze-excite
-    CF.apply_se(model, latent_channels=64, min_channels=128)
+    cf.apply_squeeze_excite(model, latent_channels=64, min_channels=128)
 
 
 .. currentmodule:: composer.algorithms

--- a/docs/source/functional.rst
+++ b/docs/source/functional.rst
@@ -16,7 +16,7 @@ Algorithms can be used directly through our functions-based API.
     cf.apply_squeeze_excite(model, latent_channels=64, min_channels=128)
 
 
-.. currentmodule:: composer.algorithms
+.. currentmodule:: composer
 
 .. autosummary::
     :toctree: generated
@@ -25,8 +25,9 @@ Algorithms can be used directly through our functions-based API.
     functional.augmix_image
     functional.apply_blurpool
     functional.apply_alibi
-    functional.colout
-    functional.cutout
+    functional.colout_batch
+    functional.colout_image
+    functional.cutout_batch
     functional.smooth_labels
     functional.freeze_layers
     functional.apply_ghost_batchnorm

--- a/docs/source/method_cards/col_out.md
+++ b/docs/source/method_cards/col_out.md
@@ -16,7 +16,7 @@ Cory Stephenson at MosaicML.
 
 ## Applicable Settings
 
-ColOut is applicable to computer vision tasks where the network architecture is capable of handling different input image sizes. 
+ColOut is applicable to computer vision tasks where the network architecture is capable of handling different input image sizes.
 
 ## Hyperparameters
 
@@ -34,7 +34,7 @@ ColOut currently has two implementations, one which acts as an additional data a
 
 ## Suggested Hyperparameters
 
-`p_row = 0.15` and `p_col = 0.15` strike a good balance between improving training throughput and limiting the negative impact on model accuracy. Setting `batch = True` also yields slightly lower accuracy, but for larger images this is offset by a large increase in throughput (~11% for ResNet-50 on ImageNet) because ColOut is only called once per batch and its operations are offloaded onto the GPU. 
+`p_row = 0.15` and `p_col = 0.15` strike a good balance between improving training throughput and limiting the negative impact on model accuracy. Setting `batch = True` also yields slightly lower accuracy, but for larger images this is offset by a large increase in throughput (~11% for ResNet-50 on ImageNet) because ColOut is only called once per batch and its operations are offloaded onto the GPU.
 
 ## Considerations
 
@@ -51,7 +51,9 @@ ColOut will show diminishing returns with other methods that change the size of 
     :members: match, apply
     :noindex:
 
-.. autofunction:: composer.algorithms.colout.colout
+.. autofunction:: composer.algorithms.colout.colout_image
+    :noindex:
+.. autofunction:: composer.algorithms.colout.colout_batch
     :noindex:
 ```
 

--- a/docs/source/method_cards/cut_out.md
+++ b/docs/source/method_cards/cut_out.md
@@ -40,7 +40,7 @@ Our implementation is based on that of Terrance DeVries as [posted on GitHub](ht
 
 ## Considerations
 
-As Cutout runs on GPU by default and uses some extra memory to construct the mask, out of memory errors may occur if GPU memory is severely limited. 
+As Cutout runs on GPU by default and uses some extra memory to construct the mask, out of memory errors may occur if GPU memory is severely limited.
 
 Also, since Cutout masks a portion of the input, this can alter the inherent shape/texture bias. For an example, see [The Origins and Prevalence of Texture Bias in Convolutional Neural Networks](https://arxiv.org/abs/1911.09071).
 
@@ -55,6 +55,6 @@ As general rule, combining regularization-based methods yields sublinear improve
     :members: match, apply
     :noindex:
 
-.. autofunction:: composer.algorithms.cutout.cutout
+.. autofunction:: composer.algorithms.cutout.cutout_batch
     :noindex:
 ```

--- a/docs/source/method_cards/cutmix.md
+++ b/docs/source/method_cards/cutmix.md
@@ -64,7 +64,7 @@ This method interacts with other methods (such as CutOut) that alter the inputs 
 .. autofunction:: composer.algorithms.cutmix.cutmix.adjust_lambda
   :noindex:
 
-.. autofunction:: composer.algorithms.cutmix.cutmix
+.. autofunction:: composer.algorithms.cutmix.cutmix_batch
   :noindex:
 
 ```

--- a/docs/source/method_cards/rand_augment.md
+++ b/docs/source/method_cards/rand_augment.md
@@ -72,7 +72,7 @@ RandAugment is also more suitable for larger models because large model workload
 
 As general rule, combining regularization-based methods yields sublinear improvements to accuracy. This holds true for RandAugment. For example, adding RandAugment on top of BlurPool, MixUp, and label smoothing yields no significant additional accuracy improvement.
 
---- 
+---
 
 ## Code
 
@@ -81,7 +81,7 @@ As general rule, combining regularization-based methods yields sublinear improve
     :members: match, apply
     :noindex:
 
-.. autofunction:: composer.algorithms.randaugment.randaugment
+.. autofunction:: composer.algorithms.randaugment.randaugment_image
     :noindex:
 
 .. autofunction:: composer.algorithms.randaugment.RandAugmentTransform

--- a/tests/algorithms/test_colout.py
+++ b/tests/algorithms/test_colout.py
@@ -8,7 +8,7 @@ import torch
 from PIL import Image
 
 from composer.algorithms import ColOut, ColOutHparams
-from composer.algorithms.colout.colout import ColOutTransform, batch_colout
+from composer.algorithms.colout.colout import ColOutTransform, colout_batch
 from composer.core import Event
 from composer.trainer import TrainerHparams
 from tests.utils.trainer_fit import train_model
@@ -154,8 +154,8 @@ def test_reproducibility_image(fake_image_tensor, p_row, p_col):
 
 def test_reproducibility_batch(fake_image_batch, p_row, p_col):
     """Test that batch augmentation is reproducible given the same seed."""
-    transform_1 = functools.partial(batch_colout, p_row=p_row, p_col=p_col)
-    transform_2 = functools.partial(batch_colout, p_row=p_row, p_col=p_col)
+    transform_1 = functools.partial(colout_batch, p_row=p_row, p_col=p_col)
+    transform_2 = functools.partial(colout_batch, p_row=p_row, p_col=p_col)
 
     torch.manual_seed(42)
     new_batch_1 = transform_1(fake_image_batch)
@@ -167,7 +167,7 @@ def test_reproducibility_batch(fake_image_batch, p_row, p_col):
 
 def test_batch_drop_size(fake_image_batch, p_row, p_col):
     """Test application to a batch of images."""
-    colout = functools.partial(batch_colout, p_row=p_row, p_col=p_col)
+    colout = functools.partial(colout_batch, p_row=p_row, p_col=p_col)
     new_batch = colout(fake_image_batch)
     verify_shape_batch(fake_image_batch, new_batch, p_row, p_col)
 
@@ -175,7 +175,7 @@ def test_batch_drop_size(fake_image_batch, p_row, p_col):
 @pytest.mark.parametrize("p_col", [0.05, 0.25])
 def test_rectangle_batch_drop_size(fake_image_batch, p_row, p_col):
     """Test that unequal values of p_row and p_col work properly."""
-    colout = functools.partial(batch_colout, p_row=p_row, p_col=p_col)
+    colout = functools.partial(colout_batch, p_row=p_row, p_col=p_col)
     new_batch = colout(fake_image_batch)
     verify_shape_batch(fake_image_batch, new_batch, p_row, p_col)
 

--- a/tests/algorithms/test_cutmix.py
+++ b/tests/algorithms/test_cutmix.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 
 from composer.algorithms import CutMixHparams
-from composer.algorithms.cutmix.cutmix import cutmix, rand_bbox
+from composer.algorithms.cutmix.cutmix import cutmix_batch, rand_bbox
 from composer.core.types import Event
 from composer.models.base import ComposerClassifier
 from composer.trainer.trainer_hparams import TrainerHparams
@@ -69,13 +69,13 @@ class TestCutMix:
         cutmix_lambda = 1 - ((bbx2 - bbx1) * (bby2 - bby1) / (x_fake.size()[-1] * x_fake.size()[-2]))
 
         # Apply cutmix
-        x_cutmix, y_cutmix = cutmix(x=x_fake,
-                                    y=y_fake,
-                                    alpha=1.0,
-                                    n_classes=n_classes,
-                                    cutmix_lambda=cutmix_lambda,
-                                    bbox=bbox,
-                                    indices=indices)
+        x_cutmix, y_cutmix = cutmix_batch(x=x_fake,
+                                          y=y_fake,
+                                          alpha=1.0,
+                                          n_classes=n_classes,
+                                          cutmix_lambda=cutmix_lambda,
+                                          bbox=bbox,
+                                          indices=indices)
 
         # Validate results
         validate_cutmix(x=x_fake,


### PR DESCRIPTION
Addresses #364. Just renames primary data augmentation algorithm functional API functions. Helper functions out of scope since we should probably make most of these private.

Changed names:
`augment_and_mix -> augmix_image`
`colout -> colout_image`, `batch_colout -> colout_batch`
`cutmix -> cutmix_batch`
`cutout() -> cutout_batch()`
`randaugment() -> randaugment_image()`

Splitting this into 2 PRs to keep each one nice and lightweight, since renames for different algorithms are independent.