### PR TITLE
Deprecate scale scheduler algorithm and move to trainer

### DIFF
--- a/composer/algorithms/scale_schedule/__init__.py
+++ b/composer/algorithms/scale_schedule/__init__.py
@@ -2,7 +2,6 @@
 
 from composer.algorithms.scale_schedule.scale_schedule import ScaleSchedule as ScaleSchedule
 from composer.algorithms.scale_schedule.scale_schedule import ScaleScheduleHparams as ScaleScheduleHparams
-from composer.algorithms.scale_schedule.scale_schedule import scale_scheduler as scale_scheduler
 
 _name = 'Scale Schedule'
 _class_name = 'ScaleScheduler'

--- a/composer/algorithms/scale_schedule/scale_schedule.py
+++ b/composer/algorithms/scale_schedule/scale_schedule.py
@@ -42,6 +42,10 @@ class ScaleSchedule(Algorithm):
 
     def __init__(self, ratio: float):
         self.ratio = ratio
+        warnings.warn(
+            "ScaleScheduleDeprecationWarning: The scale schedule algorithm is deprecated. "
+            "Please instead use the scale_schedule_ratio parameter of the Composer Trainer.",
+            category=DeprecationWarning)
 
     def match(self, event: Event, state: State) -> bool:
         """Run on Event.INIT.
@@ -50,13 +54,9 @@ class ScaleSchedule(Algorithm):
             event (:class:`Event`): The current event.
             state (:class:`State`): The current state.
         Returns:
-            bool: True if this algorithm should run no
+            bool: True if this algorithm should run.
         """
         return event == Event.INIT
 
     def apply(self, event: Event, state: State, logger: Logger) -> Optional[int]:
         """No-op."""
-        warnings.warn(
-            "ScaleScheduleDeprecationWarning: The scale schedule algorithm is deprecated. "
-            "Please instead use the scale_schedule_ratio parameter of the Composer Trainer.",
-            category=DeprecationWarning)

--- a/composer/algorithms/scale_schedule/scale_schedule.py
+++ b/composer/algorithms/scale_schedule/scale_schedule.py
@@ -1,74 +1,16 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 import logging
-from collections import Counter
+import warnings
 from dataclasses import asdict, dataclass
-from typing import Optional, cast
+from typing import Optional
 
 import yahp as hp
-from torch.optim.lr_scheduler import CosineAnnealingLR, CosineAnnealingWarmRestarts, ExponentialLR, MultiStepLR, StepLR
 
 from composer.algorithms import AlgorithmHparams
 from composer.core import Algorithm, Event, Logger, State
-from composer.core.time import Time
-from composer.core.types import Scheduler
-from composer.optim.scheduler import ConstantLR
 
 log = logging.getLogger(__name__)
-
-
-def scale_scheduler(scheduler: Scheduler, ssr: float, orig_max_epochs: Optional[int] = None):
-    """Makes a learning rate schedule take a different number of epochs.
-
-    See :class:`ScaleSchedule` for more information.
-
-    Args:
-        scheduler: A learning rate schedule object. Must be one of:
-
-            * ``torch.optim.lr_scheduler.CosineAnnealingLR``
-            * ``torch.optim.lr_scheduler.CosineAnnealingWarmRestarts``
-            * ``torch.optim.lr_scheduler.ExponentialLR``
-            * ``torch.optim.lr_scheduler.MultiStepLR``
-            * ``torch.optim.lr_scheduler.StepLR``
-
-        ssr: the factor by which to scale the duration of the schedule. E.g., 0.5
-            makes the schedule take half as many epochs and 2.0 makes it
-            take twice as many epochs.
-        orig_max_epochs: the current number of epochs spanned by ``scheduler``.
-            Used along with ``ssr`` to determine the new number of epochs
-            ``scheduler`` should span.
-
-    Raises:
-        ValueError: If ``scheduler`` is not an instance of one of the above types.
-    """
-    if isinstance(scheduler, StepLR):
-        scheduler.step_size = int(scheduler.step_size * ssr)  # type: ignore  -- unknown attribute
-    elif isinstance(scheduler, MultiStepLR):
-        milestones = scheduler.milestones  # type: ignore  -- unknown attribute
-        milestones = Counter([int(ms * ssr) for ms in milestones])
-        scheduler.milestones = milestones  # type: ignore  -- unknown attribute
-    elif isinstance(scheduler, CosineAnnealingLR):
-        assert orig_max_epochs is not None, "To scale Cosine decay, max_epochs must be provided."
-
-        if hasattr(scheduler, 'interval') and scheduler.interval == "step":  # type: ignore  -- unknown attribute
-            orig_max_epochs *= scheduler.steps_per_epoch  # type: ignore  -- unknown attribute
-
-        warmup = orig_max_epochs - scheduler.T_max  # type: ignore  -- unknown attribute
-        scheduler.T_max = int(orig_max_epochs * ssr - warmup)  # type: ignore  -- unknown attribute
-    elif isinstance(scheduler, CosineAnnealingWarmRestarts):
-        # TODO: account for warmups
-        scheduler.T_0 = int(scheduler.T_0 * ssr)  # type: ignore  -- unknown attribute
-    elif isinstance(scheduler, ExponentialLR):
-        factor = 1 / ssr
-        scheduler.gamma = scheduler.gamma**factor  # type: ignore  -- unknown attribute
-    elif isinstance(scheduler, ConstantLR):
-        return
-    elif hasattr(scheduler, 'scale_schedule') and callable(
-            scheduler.scale_schedule):  # type: ignore  -- unknown attribute
-        scheduler.scale_schedule(ssr)  # type: ignore  -- unknown attribute
-    else:
-        raise ValueError(f'Scale schedule being applied to unrecognized Scheduler {scheduler}. '
-                         'Please implement scale_schedule(ssr: float) method in your scheduler.')
 
 
 @dataclass
@@ -82,35 +24,20 @@ class ScaleScheduleHparams(AlgorithmHparams):
 
 
 class ScaleSchedule(Algorithm):
-    """Makes the learning rate schedule take a different number of epochs.
+    """Deprecated - do not use.
 
-    Training for less time is a strong baseline approach to speeding up
-    training, provided that the training still gets through the entire
-    learning rate schedule. E.g., training for half as long often yields
-    little accuracy degredation, provided that the learning rate schedule
-    is rescaled to take half as long as well. In contrast, if the schedule
-    is not rescaled, training for half as long would mean simply stopping
-    halfway through the training curve, which does reach nearly as
-    high an accuracy.
-
-    To see the difference, consider training for half as long using a cosine
-    annealing learning rate schedule. If the schedule is not rescaled,
-    training ends while the learning rate is still ~0.5. If the schedule is
-    rescaled, training ends after passing through the full cosine
-    curve, at a learning rate orders of .01 or smaller.
+    This algorithm is deprecated, and is being replaced by the scale_schedule_ratio param
+    supported directly by the Composer Trainer. For backwards compatibility, the Composer
+    Trainer detects when this algorithm has been initialized, and pulls the `ratio` param
+    accordingly.
 
     Args:
         ratio: The factor by which to scale the duration of the schedule. E.g., 0.5
             makes the schedule take half as long and 2.0 makes it
             take twice as long.
 
-    Raises:
-        ValueError: Raised during ``apply`` if ``scheduler`` is not supported by :func:`scale_scheduler`.
-        ValueError: Raised during ``apply`` if the resulting number of epochs after scaling the
-            learning rate schedule is zero.
-
     See also:
-        :func:`scale_scheduler`
+        :func:`composer.trainer.scale_schedule.scale_scheduler`
     """
 
     def __init__(self, ratio: float):
@@ -128,28 +55,8 @@ class ScaleSchedule(Algorithm):
         return event == Event.INIT
 
     def apply(self, event: Event, state: State, logger: Logger) -> Optional[int]:
-        """Rescales the number of epochs spanned by `state`'s learning rate schedule.
-
-        Raises:
-            ValueError: If ``scheduler`` is not supported by :func:`scale_scheduler`.
-            ValueError: If the resulting number of epochs after scaling the
-                learning rate schedule is zero.
-            NotImplementedError: If ``self.method == 'samples'``.
-        """
-
-        orig_max_duration = state.max_duration
-        orig_max_epochs = state.max_epochs
-        state.max_duration = cast(Time[int], orig_max_duration * self.ratio)
-        log.info(f'max_duration changed from {orig_max_duration} to {state.max_duration}')
-        if int(state.max_duration) == 0:
-            raise ValueError('Scale schedule has reduced the max_duration to 0. Set a higher ratio or more epochs.')
-
-        schedulers = []
-        for scheduler in state.schedulers:
-            if hasattr(scheduler, 'schedulers'):
-                schedulers.extend(getattr(scheduler, "schedulers"))
-            else:
-                schedulers.append(scheduler)
-
-        for scheduler in schedulers:
-            scale_scheduler(scheduler, self.ratio, orig_max_epochs)
+        """No-op."""
+        warnings.warn(
+            "ScaleScheduleDeprecationWarning: The scale schedule algorithm is deprecated. "
+            "Please instead use the scale_schedule_ratio parameter of the Composer Trainer.",
+            category=DeprecationWarning)

--- a/composer/functional/__init__.py
+++ b/composer/functional/__init__.py
@@ -30,7 +30,6 @@ from composer.algorithms.mixup import gen_mixup_interpolation_lambda as gen_mixu
 from composer.algorithms.mixup import mixup_batch as mixup_batch
 from composer.algorithms.progressive_resizing import resize_batch as resize_batch
 from composer.algorithms.randaugment import randaugment_image as randaugment_image
-from composer.algorithms.scale_schedule import scale_scheduler as scale_scheduler
 from composer.algorithms.selective_backprop import selective_backprop as selective_backprop
 from composer.algorithms.selective_backprop import should_selective_backprop as should_selective_backprop
 from composer.algorithms.seq_length_warmup import set_batch_sequence_length as set_batch_sequence_length
@@ -55,7 +54,6 @@ __all__ = [
     "mixup_batch",
     "resize_batch",
     "randaugment_image",
-    "scale_scheduler",
     "should_selective_backprop",
     "selective_backprop",
     "set_batch_sequence_length",

--- a/composer/trainer/scale_schedule.py
+++ b/composer/trainer/scale_schedule.py
@@ -1,0 +1,76 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+from collections import Counter
+from typing import Optional
+
+from torch.optim.lr_scheduler import CosineAnnealingLR, CosineAnnealingWarmRestarts, ExponentialLR, MultiStepLR, StepLR
+
+from composer.core.types import Scheduler
+from composer.optim.scheduler import ConstantLR
+
+
+def scale_scheduler(scheduler: Scheduler, ssr: float, orig_max_epochs: Optional[int] = None):
+    """Makes a learning rate schedule take a different number of epochs.
+
+    Training for less time is a strong baseline approach to speeding up
+    training, provided that the training still gets through the entire
+    learning rate schedule. E.g., training for half as long often yields
+    little accuracy degredation, provided that the learning rate schedule
+    is rescaled to take half as long as well. In contrast, if the schedule
+    is not rescaled, training for half as long would mean simply stopping
+    halfway through the training curve, which does reach nearly as
+    high an accuracy.
+
+    To see the difference, consider training for half as long using a cosine
+    annealing learning rate schedule. If the schedule is not rescaled,
+    training ends while the learning rate is still ~0.5. If the schedule is
+    rescaled, training ends after passing through the full cosine
+    curve, at a learning rate near 0.
+
+    Args:
+        scheduler: A learning rate schedule object. Must be one of:
+
+            * ``torch.optim.lr_scheduler.CosineAnnealingLR``
+            * ``torch.optim.lr_scheduler.CosineAnnealingWarmRestarts``
+            * ``torch.optim.lr_scheduler.ExponentialLR``
+            * ``torch.optim.lr_scheduler.MultiStepLR``
+            * ``torch.optim.lr_scheduler.StepLR``
+
+        ssr: the factor by which to scale the duration of the schedule. E.g., 0.5
+            makes the schedule take half as many epochs and 2.0 makes it
+            take twice as many epochs.
+        orig_max_epochs: the current number of epochs spanned by ``scheduler``.
+            Used along with ``ssr`` to determine the new number of epochs
+            ``scheduler`` should span.
+
+    Raises:
+        ValueError: If ``scheduler`` is not an instance of one of the above types.
+    """
+    if isinstance(scheduler, StepLR):
+        scheduler.step_size = int(scheduler.step_size * ssr)  # type: ignore  -- unknown attribute
+    elif isinstance(scheduler, MultiStepLR):
+        milestones = scheduler.milestones  # type: ignore  -- unknown attribute
+        milestones = Counter([int(ms * ssr) for ms in milestones])
+        scheduler.milestones = milestones  # type: ignore  -- unknown attribute
+    elif isinstance(scheduler, CosineAnnealingLR):
+        assert orig_max_epochs is not None, "To scale Cosine decay, max_epochs must be provided."
+
+        if hasattr(scheduler, 'interval') and scheduler.interval == "step":  # type: ignore  -- unknown attribute
+            orig_max_epochs *= scheduler.steps_per_epoch  # type: ignore  -- unknown attribute
+
+        warmup = orig_max_epochs - scheduler.T_max  # type: ignore  -- unknown attribute
+        scheduler.T_max = int(orig_max_epochs * ssr - warmup)  # type: ignore  -- unknown attribute
+    elif isinstance(scheduler, CosineAnnealingWarmRestarts):
+        # TODO: account for warmups
+        scheduler.T_0 = int(scheduler.T_0 * ssr)  # type: ignore  -- unknown attribute
+    elif isinstance(scheduler, ExponentialLR):
+        factor = 1 / ssr
+        scheduler.gamma = scheduler.gamma**factor  # type: ignore  -- unknown attribute
+    elif isinstance(scheduler, ConstantLR):
+        return
+    elif hasattr(scheduler, 'scale_schedule') and callable(
+            scheduler.scale_schedule):  # type: ignore  -- unknown attribute
+        scheduler.scale_schedule(ssr)  # type: ignore  -- unknown attribute
+    else:
+        raise ValueError(f'Scale schedule being applied to unrecognized Scheduler {scheduler}. '
+                         'Please implement scale_schedule(ssr: float) method in your scheduler.')

--- a/composer/trainer/scale_schedule.py
+++ b/composer/trainer/scale_schedule.py
@@ -46,6 +46,9 @@ def scale_scheduler(scheduler: Scheduler, ssr: float, orig_max_epochs: Optional[
     Raises:
         ValueError: If ``scheduler`` is not an instance of one of the above types.
     """
+    if ssr <= 0:
+        raise ValueError("Scale schedule ratio must be a positive value.")
+
     if isinstance(scheduler, StepLR):
         scheduler.step_size = int(scheduler.step_size * ssr)  # type: ignore  -- unknown attribute
     elif isinstance(scheduler, MultiStepLR):

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -82,7 +82,9 @@ class Trainer:
         compute_training_metrics (bool, optional): True to compute metrics on training data and False to not.
             (default: ``False``)
         precision (str or Precision, optional): Numerical precision to use for training, one of 'fp32', 'fp16'
-            for 'amp' (recommended). (default: ``Precision.FP32``).
+            or 'amp' (recommended). (default: ``Precision.FP32``).
+        scale_schedule_ratio (float, optional): Ratio by which to scale the training duration and learning rate
+            schedules. (default: ``0``),
         dist_timeout (float, optional): Timeout, in seconds, for initializing the distributed process group.
             (default: ``15.0``)
         ddp_sync_strategy (str or DDPSyncStrategy, optional): The strategy to use for synchronizing gradients.

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -84,7 +84,7 @@ class Trainer:
         precision (str or Precision, optional): Numerical precision to use for training, one of 'fp32', 'fp16'
             or 'amp' (recommended). (default: ``Precision.FP32``).
         scale_schedule_ratio (float, optional): Ratio by which to scale the training duration and learning rate
-            schedules. (default: ``0``),
+            schedules. See :func:`scale_schedule` for details. (default: ``1.0``)
         dist_timeout (float, optional): Timeout, in seconds, for initializing the distributed process group.
             (default: ``15.0``)
         ddp_sync_strategy (str or DDPSyncStrategy, optional): The strategy to use for synchronizing gradients.

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -19,8 +19,7 @@ from torch.optim.lr_scheduler import CosineAnnealingLR
 from torchmetrics.collections import MetricCollection
 from torchmetrics.metric import Metric
 
-from composer.composer.algorithms.scale_schedule.scale_schedule import ScaleSchedule
-from composer.composer.trainer.scale_schedule import scale_scheduler
+from composer.algorithms import ScaleSchedule
 from composer.core import Callback, DataSpec, Engine, Event, Logger, State, Time, surgery
 from composer.core.algorithm import Algorithm
 from composer.core.evaluator import Evaluator
@@ -38,6 +37,7 @@ from composer.trainer.checkpoint import CheckpointLoader, CheckpointSaver
 from composer.trainer.ddp import DDPSyncStrategy, ddp_sync_context, prepare_ddp_module
 from composer.trainer.deepspeed import fix_batch_precision_for_deepspeed, parse_deepspeed_config
 from composer.trainer.devices import Device, DeviceCPU, DeviceGPU
+from composer.trainer.scale_schedule import scale_scheduler
 from composer.trainer.scaler import ClosureGradScaler
 from composer.utils import dist, ensure_tuple, map_collection, reproducibility
 from composer.utils.object_store import ObjectStoreProvider
@@ -318,7 +318,8 @@ class Trainer:
 
         if scale_schedule_ratio != 1.0:
             if orig_max_duration.unit != TimeUnit.EPOCH:
-                raise NotImplementedError("Max duration must be specified in epochs. Other units are not yet supported.")
+                raise NotImplementedError(
+                    "Max duration must be specified in epochs. Other units are not yet supported.")
 
             for scheduler in ensure_tuple(schedulers):
                 scale_scheduler(scheduler, scale_schedule_ratio, orig_max_duration.value)

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -170,9 +170,9 @@ class TrainerHparams(hp.Hparams):
     validate_every_n_batches: int = hp.optional(
         doc="Validate every N batches. Set to -1 to never validate on a batchwise frequency. Defaults to -1.",
         default=-1)
+    scale_schedule_ratio: float = hp.optional(
+        doc="Ratio by which to scale the training duration and learning rate schedules.", default=1.0)
     callbacks: List[CallbackHparams] = hp.optional(doc="Callback hparams", default_factory=list)
-
-    scale_schedule_ratio: float = hp.optional(doc="", default=1.0)
 
     load_path: Optional[str] = hp.optional(doc=textwrap.dedent("""\
         If specified, the path to an existing checkpoint file

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -172,6 +172,8 @@ class TrainerHparams(hp.Hparams):
         default=-1)
     callbacks: List[CallbackHparams] = hp.optional(doc="Callback hparams", default_factory=list)
 
+    scale_schedule_ratio: float = hp.optional(doc="", default=1.0)
+
     load_path: Optional[str] = hp.optional(doc=textwrap.dedent("""\
         If specified, the path to an existing checkpoint file
         (if the checkpoint is on the local disk) or the object name for the checkpoint
@@ -265,6 +267,9 @@ class TrainerHparams(hp.Hparams):
         if self.evaluators is not None and len(self.evaluators) > 0 and self.val_dataset is not None:
             raise ValueError(
                 "val_dataset and evaluators shouldn't both be specified. Only one can be passed in to the trainer.")
+
+        if self.scale_schedule_ratio <= 0:
+            raise ValueError("scale_schedule_ratio must be a positive value.")
 
     def initialize_object(self) -> Trainer:
         self.validate()
@@ -381,6 +386,7 @@ class TrainerHparams(hp.Hparams):
             validate_every_n_epochs=self.validate_every_n_epochs,
             compute_training_metrics=self.compute_training_metrics,
             precision=self.precision,
+            scale_schedule_ratio=self.scale_schedule_ratio,
 
             # dist hparams
             dist_timeout=self.dist_timeout,


### PR DESCRIPTION
The upcoming schedulers refactor is easier to do if the trainer treats SSR as a first-class feature. Thus, this PR adds a new `scale_schedule_ratio` param to the trainer. The existing algorithm is still supported, but should eventually be removed.