### PR TITLE
Set WandB default to log rank zero only

### DIFF
--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+import coolname
 import yahp as hp
 
 from composer.core.logging import LoggerCallback, LogLevel
@@ -95,7 +96,7 @@ class WandBLoggerHparams(LoggerCallbackHparams):
     tags: str = hp.optional(doc="wandb tags comma separated", default="")
     log_artifacts: bool = hp.optional(doc="Whether to log artifacts", default=False)
     log_artifacts_every_n_batches: int = hp.optional(doc="interval, in batches, to log artifacts", default=100)
-    rank_zero_only: bool = hp.optional("Whether to log on rank zero only", default=False)
+    rank_zero_only: bool = hp.optional("Whether to log on rank zero only", default=True)
     extra_init_params: Dict[str, JSON] = hp.optional(doc="wandb parameters", default_factory=dict)
     flatten_hparams: bool = hp.optional(
         doc=
@@ -175,9 +176,17 @@ class WandBLoggerHparams(LoggerCallbackHparams):
                 )
             self.extra_init_params["config"].update(config)
 
-        name_suffix = f"Rank {dist.get_global_rank()}"
-        name = f"{self.name}_{name_suffix}" if self.name else name_suffix
-        group = self.name if (not self.group and self.rank_zero_only) else self.group
+        # If name=None, wandb.init(..) will automatically produce a unique run name
+        # But for multi-rank grouped runs, we want to provide a group name ahead of time to link the runs
+        # So let's explicitly default the run name here in a consistent way for single-rank and multi-rank
+        self.name = self.name if self.name else coolname.generate_slug(2)
+
+        if self.rank_zero_only:
+            name = self.name
+            group = self.group
+        else:
+            name = f"{self.name}_RANK_{dist.get_global_rank()}"
+            group = self.group if self.group else self.name
         init_params = {
             "project": self.project,
             "name": name,

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -34,7 +34,7 @@ class WandBLogger(LoggerCallback):
     def __init__(self,
                  log_artifacts: bool = False,
                  log_artifacts_every_n_batches: int = 100,
-                 rank_zero_only: bool = False,
+                 rank_zero_only: bool = True,
                  init_params: Optional[Dict[str, Any]] = None) -> None:
         try:
             import wandb

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ extra_deps['dev'] = [
     'docformatter>=1.4',
 ]
 
-extra_deps['logging'] = ['wandb>=0.12.2', 'apache-libcloud>=3.4.1']
+extra_deps['logging'] = ['wandb>=0.12.2', 'coolname>=1.1.0', 'apache-libcloud>=3.4.1']
 
 extra_deps['perf'] = ['torch-tb-profiler>=0.3.1', 'psutil>=5.8.0', 'tensorboard>=2.7.0']
 


### PR DESCRIPTION
This PR returns our default WandB logging to rank_zero_only. To generate unique names for groups I added the `coolname` package, see comment below. Please let me know if including this extra package is a bad idea.

In the future I'd like to consolidate some of the logger features like `rank_zero_only`, `log_interval` into a base class so that all logger backends will have them in a consistent interface, but that can be a future PR. Right now our WandB logger logs at every batch no matter what, which is kind of silly.

TODO: @abhi do some manual tests with this branch and make sure it works as expected.