### PR TITLE
`resize_targets` set to `False` by default

### DIFF
--- a/composer/yamls/algorithms/progressive_resizing.yaml
+++ b/composer/yamls/algorithms/progressive_resizing.yaml
@@ -1,4 +1,4 @@
 mode: resize
 initial_scale: 0.5
 finetune_fraction: 0.2
-resize_targets: true
+resize_targets: false


### PR DESCRIPTION
`resize_targets` is `False` by default in the algorithm. It's used in our KS for resnet50 but not unet, so should probably be `False` in our example yamls.