### PR TITLE
Get functional API running enough for notebook

### DIFF
--- a/composer/algorithms/colout/colout.py
+++ b/composer/algorithms/colout/colout.py
@@ -76,8 +76,8 @@ def colout_batch(X: torch.Tensor, p_row: float = 0.15, p_col: float = 0.15) -> t
     """
 
     # Get the dimensions of the image
-    row_size = X.shape[2]
-    col_size = X.shape[3]
+    row_size = X.shape[-2]
+    col_size = X.shape[-1]
 
     # Determine how many rows and columns to keep
     kept_row_size = int((1 - p_row) * row_size)
@@ -88,8 +88,8 @@ def colout_batch(X: torch.Tensor, p_row: float = 0.15, p_col: float = 0.15) -> t
     kept_col_idx = sorted(torch.randperm(col_size)[:kept_col_size].numpy())
 
     # Keep only the selected row and columns
-    X_colout = X[:, :, kept_row_idx, :]
-    X_colout = X_colout[:, :, :, kept_col_idx]
+    X_colout = X[..., kept_row_idx, :]
+    X_colout = X_colout[..., :, kept_col_idx]
     return X_colout
 
 

--- a/composer/algorithms/cutout/cutout.py
+++ b/composer/algorithms/cutout/cutout.py
@@ -27,8 +27,8 @@ def cutout_batch(X: Tensor, n_holes: int = 1, length: Union[int, float] = 0.5) -
         X_cutout: Batch of images with ``n_holes`` holes of dimension
             ``length x length`` replaced with zeros.
     """
-    h = X.size(2)
-    w = X.size(3)
+    h = X.shape[-2]
+    w = X.shape[-1]
 
     if 0 < length < 1:
         length = min(h, w) * length
@@ -83,6 +83,6 @@ def _generate_mask(mask: Tensor, width: int, height: int, x: int, y: int, cutout
     x1 = np.clip(x - cutout_length // 2, 0, width)
     x2 = np.clip(x + cutout_length // 2, 0, width)
 
-    mask[:, :, y1:y2, x1:x2] = 0.
+    mask[..., y1:y2, x1:x2] = 0.
 
     return mask


### PR DESCRIPTION
Fixing issues that stop the functional API from being used in a reasonable way. E.g., colout and cutout can't be added to a dataset's list of transforms because they *only* work when their input is a batch (not a single image, whether a PIL image or tensor). On the critical path for #326.

Update: [looks like](https://colab.research.google.com/drive/1HIxLs61pyf0ln7MlnrGYvkNHq1uVbNWu#scrollTo=oXfFDF_VUTY6) everything's working now.