### PR TITLE
Add back benchmarker callback

### DIFF
--- a/composer/callbacks/__init__.py
+++ b/composer/callbacks/__init__.py
@@ -41,6 +41,8 @@ Callbacks can be implemented in two ways:
                 if event == Event.EPOCH_START:
                     print(f'Epoch {state.epoch}/{state.max_epochs}')
 """
+from composer.callbacks.benchmarker import Benchmarker
+from composer.callbacks.callback_hparams import BenchmarkerHparams as BenchmarkerHparams
 from composer.callbacks.callback_hparams import CallbackHparams as CallbackHparams
 from composer.callbacks.callback_hparams import GradMonitorHparams as GradMonitorHparams
 from composer.callbacks.callback_hparams import LRMonitorHparams as LRMonitorHparams
@@ -53,6 +55,7 @@ from composer.callbacks.run_directory_uploader import RunDirectoryUploader
 from composer.callbacks.speed_monitor import SpeedMonitor
 
 __all__ = [
+    "Benchmarker",
     "GradMonitor",
     "LRMonitor",
     "RunDirectoryUploader",

--- a/composer/callbacks/benchmarker.py
+++ b/composer/callbacks/benchmarker.py
@@ -1,0 +1,177 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+from __future__ import annotations
+
+import logging
+import time
+import warnings
+from typing import Sequence
+
+from composer.core import Logger, State
+from composer.core.callback import Callback
+from composer.core.types import BreakEpochException
+
+log = logging.getLogger(__name__)
+
+
+class Benchmarker(Callback):
+    """Fast-forward the training loop to record throughput for specific epochs and/or steps.
+
+    It modifies the :attr:`~composer.core.state.State.step` and
+    :attr:`~composer.core.state.State.epoch` to fast-forward the training loop,
+    so that algorithms that activate at specific times will trigger
+    and can be profiled.
+
+    It stops the training process after the last step or epoch is profiled.
+
+    It logs:
+
+    * The throughput (averaged over the number of steps profiled in an epoch)
+      to the ``throughput/step`` key.
+    * The total elapsed training time to the ``wall_clock_train`` key.
+
+    .. warning::
+        The :class:`Benchmarker`: should NOT be used in conjunction with the
+        :class:`~composer.callbacks.speed_monitor.SpeedMonitor`, since they
+        log to the same keys.
+
+    .. warning::
+        The :class:`Benchmarker`: modifies the :class:`~compose.core.State`,
+        which is an exception to the convention that callbacks should NOT
+        modify state. This callback may break other algorithms and callbacks.
+
+    Args:
+        min_steps (int, optional):
+            Maximum number of steps to profile per epoch, regardless of the length of :attr:`step_list`.
+            Defaults to 50.
+        epoch_list (Sequence[int], optional).
+            List of epochs at which to measure throughput.
+            Defaults to [0, 1].
+        step_list (Sequence[int], optional).
+            List of steps at which to measure throughput.
+            Defaults to [0, 50].
+        all_epochs (bool, optional).
+            Whether to override epoch_list and profile at all epochs.
+
+            If False (the default), then it fast-forwards to
+            the steps and epochs being profiled (specified by ``epoch_list``
+            and ``step_list``, respectively).
+
+            Otherwise, if True, then the throughput for
+            the first ``min_steps`` batches of every epoch are recorded.
+    """
+
+    def __init__(self,
+                 min_steps: int = 50,
+                 epoch_list: Sequence[int] = (0, 1),
+                 step_list: Sequence[int] = (0, 50),
+                 all_epochs: bool = False):
+        super().__init__()
+        if not all_epochs:
+            if len(epoch_list) == 0:
+                raise ValueError("'epoch_list'  must be non-empty.")
+            if 0 not in epoch_list:
+                raise ValueError("'epoch_list' must contain 0, otherwise first K epochs have unknown speed")
+        if len(step_list) == 0:
+            raise ValueError("'step_list'  must be non-empty.")
+        if 0 not in step_list:
+            raise ValueError("'step_list' must contain 0 because `EPOCH_START` requires batch_idx of 0")
+
+        # Sort lists so that time only moves forward
+        epoch_list = list(sorted(epoch_list))
+        step_list = list(sorted(step_list))
+
+        self.current_time = None
+        self.batch_start_num_samples = None
+        self.profile_examples = 0
+        self.profile_steps = 0
+        self.profile_time = 0
+        self.wall_clock_train = 0
+
+        self.min_steps = min_steps
+
+        self.all_epochs = all_epochs
+        self.epoch_list = epoch_list
+        self.epoch_ix = 0
+        self.step_list = step_list
+        self.step_ix = 0
+
+        # initialized on the fit_start event
+        self.original_max_epochs = -1
+        self.wct_dict = {}
+
+    def _compute_elapsed_wct(self, epoch_wct_dict, steps_per_epoch: int, n_epochs: int):
+        wct = 0.0
+        wct_per_step = 0
+        assert 0 in epoch_wct_dict, "epoch_wct_dict must contain 0"
+        for step in range(steps_per_epoch):
+            if step in epoch_wct_dict:
+                wct_per_step = epoch_wct_dict[step]
+            wct += wct_per_step
+        return wct * n_epochs
+
+    def fit_start(self, state: State, logger: Logger):
+        del logger  # Unused
+        warnings.warn("The benchmarker is activated. The model will not be fully trained."
+                      "All quality metrics for this run will be incorrect.")
+        self.wall_clock_train = 0.0
+        self.original_max_epochs = state.max_epochs
+        # maybe override epoch_list
+        if self.all_epochs:
+            self.epoch_list = list(range(state.max_epochs))
+            log.info(f"all_epochs=True, overriding epoch_list to be every epoch from 0 to {state.max_epochs}")
+        self.wct_dict = {e: {s: -1.0 for s in self.step_list} for e in self.epoch_list}
+        state.max_duration = f"{len(self.epoch_list)}ep"
+
+    def epoch_end(self, state: State, logger: Logger):
+        prev_epoch = self.epoch_list[self.epoch_ix]
+        epoch_wct_dict = self.wct_dict[prev_epoch]
+        self.epoch_ix += 1
+        if self.epoch_ix < len(self.epoch_list):
+            next_epoch = self.epoch_list[self.epoch_ix]
+        else:
+            next_epoch = self.original_max_epochs
+
+        state.timer.epoch._value = next_epoch - 1
+        state.timer.batch._value = next_epoch * state.steps_per_epoch
+        n_epochs = next_epoch - prev_epoch
+
+        self.wall_clock_train += self._compute_elapsed_wct(epoch_wct_dict, state.steps_per_epoch, n_epochs)
+        logger.metric_epoch({'wall_clock_train': self.wall_clock_train})
+
+    def batch_start(self, state: State, logger: Logger):
+        del logger  # Unused
+        if self.current_time is None:
+            self.current_time = time.time()
+            self.profile_examples = 0
+            self.profile_steps = 0
+            self.profile_time = 0.0
+            self.batch_start_num_samples = state.timer.sample
+
+    def batch_end(self, state: State, logger: Logger):
+        if self.current_time is not None:
+            now = time.time()
+            elapsed = now - self.current_time
+            self.current_time = now
+            new_num_samples = state.timer.sample
+            batch_num_samples = new_num_samples - self.batch_start_num_samples
+            self.profile_examples += int(batch_num_samples)
+            self.profile_steps += 1
+            self.profile_time += elapsed
+
+            if self.profile_steps >= self.min_steps:
+                avg_throughput = self.profile_examples / self.profile_time
+                avg_time_per_step = self.profile_time / self.profile_steps
+                profile_epoch = self.epoch_list[self.epoch_ix]
+                profile_step = self.step_list[self.step_ix]
+                self.wct_dict[profile_epoch][profile_step] = avg_time_per_step
+                logger.metric_batch({'throughput/step': avg_throughput})
+
+                self.current_time = None
+                self.step_ix += 1
+                if self.step_ix == len(self.step_list):
+                    self.step_ix = 0
+                    raise BreakEpochException
+                else:
+                    state.timer.batch._value = state.epoch * state.steps_per_epoch + self.step_list[self.step_ix]
+                    state.timer.batch_in_epoch._value = self.step_list[self.step_ix]

--- a/composer/callbacks/callback_hparams.py
+++ b/composer/callbacks/callback_hparams.py
@@ -7,7 +7,7 @@ import abc
 import dataclasses
 import textwrap
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import yahp as hp
 
@@ -15,6 +15,7 @@ from composer.core.callback import Callback
 from composer.utils.object_store import ObjectStoreProviderHparams
 
 if TYPE_CHECKING:
+    from composer.callbacks.benchmarker import Benchmarker
     from composer.callbacks.grad_monitor import GradMonitor
     from composer.callbacks.lr_monitor import LRMonitor
     from composer.callbacks.memory_monitor import MemoryMonitor
@@ -39,6 +40,39 @@ class CallbackHparams(hp.Hparams, abc.ABC):
             Callback: An instance of the callback.
         """
         pass
+
+
+@dataclass
+class BenchmarkerHparams(CallbackHparams):
+    """:class:`~composer.callbacks.benchmarker.Benchmarker` hyperparameters.
+
+    See :class:`~composer.callbacks.benchmarker.Benchmarker` for documentation.
+    """
+    min_steps: int = hp.optional(
+        doc="Minimum number of steps to use for measuring throughput.",
+        default=50,
+    )
+    epoch_list: List[int] = hp.optional(
+        doc="List of epochs at which to measure throughput.",
+        default_factory=lambda: [0, 1],
+    )
+    step_list: List[int] = hp.optional(
+        doc="List of steps at which to measure throughput.",
+        default_factory=lambda: [0, 50],
+    )
+    all_epochs: bool = hp.optional(
+        doc="If true, override epoch_list and profile at all epochs.",
+        default=False,
+    )
+
+    def initialize_object(self) -> Benchmarker:
+        from composer.callbacks.benchmarker import Benchmarker
+        return Benchmarker(
+            min_steps=self.min_steps,
+            epoch_list=self.epoch_list,
+            step_list=self.step_list,
+            all_epochs=self.all_epochs,
+        )
 
 
 @dataclass

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -15,8 +15,8 @@ import yahp as hp
 import composer
 from composer import datasets
 from composer.algorithms import AlgorithmHparams, get_algorithm_registry
-from composer.callbacks import (CallbackHparams, GradMonitorHparams, LRMonitorHparams, MemoryMonitorHparams,
-                                RunDirectoryUploaderHparams, SpeedMonitorHparams)
+from composer.callbacks import (BenchmarkerHparams, CallbackHparams, GradMonitorHparams, LRMonitorHparams,
+                                MemoryMonitorHparams, RunDirectoryUploaderHparams, SpeedMonitorHparams)
 from composer.core import DataSpec
 from composer.core.types import JSON, Precision
 from composer.datasets import DataloaderHparams
@@ -84,6 +84,7 @@ algorithms_registry = get_algorithm_registry()
 
 callback_registry = {
     "speed_monitor": SpeedMonitorHparams,
+    "benchmarker": BenchmarkerHparams,
     "lr_monitor": LRMonitorHparams,
     "grad_monitor": GradMonitorHparams,
     "memory_monitor": MemoryMonitorHparams,
@@ -277,28 +278,28 @@ class TrainerHparams(hp.Hparams):
         Interval to record stats, in seconds.  Ignored if `profiler_trace_file` is not specified."""),
                                                                 default=0.5)
     torch_profiler_trace_dir: Optional[str] = hp.optional(doc=textwrap.dedent("""\
-        Directory to store trace results relative to the run directory.  Must be specified to activate the Torch profiler. 
+        Directory to store trace results relative to the run directory.  Must be specified to activate the Torch profiler.
         Ignored if ``profiler_trace_file`` is not specified."""),
                                                           default=None)
     torch_prof_use_gzip: bool = hp.optional(doc=textwrap.dedent("""\
-        Whether to use gzip for trace.  
+        Whether to use gzip for trace.
         Ignored if ``torch_profiler_trace_dir`` and `profiler_trace_file` are not specified."""),
                                             default=False)
 
     torch_prof_record_shapes: bool = hp.optional(doc=textwrap.dedent("""\
-        Whether to record tensor shapes.  
+        Whether to record tensor shapes.
         Ignored if ``torch_profiler_trace_dir`` and `profiler_trace_file` are not specified."""),
                                                  default=False)
     torch_prof_profile_memory: bool = hp.optional(doc=textwrap.dedent("""\
-        Track tensor memory allocations and frees.  
+        Track tensor memory allocations and frees.
         Ignored if ``torch_profiler_trace_dir`` and `profiler_trace_file` are not specified."""),
                                                   default=True)
     torch_prof_with_stack: bool = hp.optional(doc=textwrap.dedent("""\
-        Record stack information.  
+        Record stack information.
         Ignored if ``torch_profiler_trace_dir`` and `profiler_trace_file` are not specified."""),
                                               default=False)
     torch_prof_with_flops: bool = hp.optional(doc=textwrap.dedent("""\
-        Estimate flops for operators.  
+        Estimate flops for operators.
         Ignored if ``torch_profiler_trace_dir`` and `profiler_trace_file` are not specified."""),
                                               default=True)
 


### PR DESCRIPTION
We still use the benchmarker callback internally, so I don't think we should remove it unless it actually doesn't work anymore (or we have a proper replacement). It's been fine so far in my experience, though I haven't used it in all cases.