### PR TITLE
Remove colons from run directory timestamps

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -60,7 +60,7 @@ def get_parser():
                         default=None,
                         help=textwrap.dedent("""\
                             Directory to store run artifcats. 
-                            Defaults to runs/{datetime.datetime.now().isoformat()}/""")),
+                            Defaults to runs/{timestamp}/""")),
     parser.add_argument("-m",
                         "--module_mode",
                         action="store_true",
@@ -110,7 +110,7 @@ def launch_processes(nproc: int, world_size: int, base_rank: int, node_rank: int
     processes = []
 
     if run_directory is None:
-        run_directory = os.path.join("runs", datetime.datetime.now().isoformat())
+        run_directory = os.path.join("runs", datetime.datetime.now().isoformat().replace(":", "-"))
     os.makedirs(run_directory, exist_ok=True)
 
     if master_port is None:

--- a/composer/utils/run_directory.py
+++ b/composer/utils/run_directory.py
@@ -50,7 +50,7 @@ log = logging.getLogger(__name__)
 
 _RUN_DIRECTORY_KEY = "COMPOSER_RUN_DIRECTORY"
 
-_start_time_str = datetime.datetime.now().isoformat()
+_start_time_str = datetime.datetime.now().isoformat().replace(":", "-")
 
 __all__ = [
     "get_node_run_directory",


### PR DESCRIPTION
> By default, the run directory contains a timestamp with ":" in its name. If the run directory is uploaded to an object store, any checkpoints within it cannot be used by CheckpointLoader because it parses the load_path as a URL: https://github.com/mosaicml/composer/blob/dev/composer/trainer/checkpoint.py#L93-L99

Closes #442