### PR TITLE
Add C4 Streaming dataset

### DIFF
--- a/composer/datasets/__init__.py
+++ b/composer/datasets/__init__.py
@@ -21,6 +21,7 @@ A :class:`DatasetHparams` is responsible for returning a :class:`torch.utils.dat
 """
 from composer.datasets.ade20k import ADE20kDatasetHparams as ADE20kDatasetHparams
 from composer.datasets.brats import BratsDatasetHparams as BratsDatasetHparams
+from composer.datasets.c4 import C4DatasetHparams as C4DatasetHparams
 from composer.datasets.cifar10 import CIFAR10DatasetHparams as CIFAR10DatasetHparams
 from composer.datasets.dataloader import DataloaderHparams as DataloaderHparams
 from composer.datasets.dataloader import WrappedDataLoader as WrappedDataLoader

--- a/composer/datasets/c4.py
+++ b/composer/datasets/c4.py
@@ -1,0 +1,360 @@
+# Copyright 2021 MosaicML. All Rights Reserved.
+
+import logging
+from dataclasses import dataclass
+from functools import partial
+from itertools import chain
+from typing import List
+
+import yahp as hp
+from torch.utils.data import IterableDataset, get_worker_info
+
+from composer.core.types import Batch, DataSpec
+from composer.datasets.dataloader import DataloaderHparams
+from composer.datasets.hparams import DatasetHparams
+from composer.utils import dist
+
+log = logging.getLogger(__name__)
+
+__all__ = ["C4Dataset", "C4DatasetHparams"]
+
+
+def _split_dict_fn(batch: Batch, n_microbatches: int) -> List[Batch]:
+    if isinstance(batch, dict):
+        chunked = {k: v.chunk(n_microbatches) for k, v in batch.items()}
+        for k, v in chunked.items():
+            if len(v) != n_microbatches:
+                raise ValueError(
+                    f"Unable to split batch into microbatches. "
+                    f"Key '{k}' has chunked list: {v} with length {len(v)}, but expected length {n_microbatches}. ")
+        microbatches = []
+        for idx in range(n_microbatches):
+            mb = {k: v[idx] for k, v in chunked.items()}
+            microbatches.append(mb)
+        return microbatches
+    else:
+        raise ValueError(f'Expected batch to be of type Dict[str, Tensor], but got {type(batch)}')
+
+
+@dataclass
+class C4DatasetHparams(DatasetHparams):
+    """Builds a DataSpec for the C4 (Colossal Cleaned CommonCrawl) dataset.
+
+    Parameters:
+        split (str): What split of the dataset to use. Either `train` or `validation`.
+        max_samples (int): Max number of post-processed token samples, used to set epoch size of the IterableDataset.
+        tokenizer_name (str): The name of the HuggingFace tokenizer to preprocess text with.
+        max_seq_len (int): The max sequence length of each token sample.
+        group_method (str): How to group text samples into token samples. Either `truncate` or `concat`.
+        mlm (bool): Whether or not to use masked language modeling. (Default: `False`)
+        mlm_probability (float): If `mlm=True`, the probability that tokens are masked. (Default: `0.15`)
+        shuffle (bool): Whether to shuffle the samples in the dataset. Currently, shards are assigned and consumed with deterministic per-device shard order, but shuffling affects the order of samples via (per-device) shuffle buffers. (Default: `False`)
+        shuffle_buffer_size (int): If `shuffle=True`, samples are read into a buffer of this size (per-device), and randomly sampled from there to produce shuffled samples. (Default: `10000`)
+        seed (int): If `shuffle=True`, what seed to use for shuffling operations. (Default: `5`)
+        drop_last (bool): Whether to drop the last samples for the last batch. (Default: `True`)
+    Returns:
+        A :class:`~composer.core.DataSpec` object
+    """
+
+    split: str = hp.optional("What split of the dataset to use. Either `train` or `validation`.", default=None)
+    max_samples: int = hp.optional(
+        "Max number of post-processed token samples, used to set epoch size of the IterableDataset.", default=None)
+    tokenizer_name: str = hp.optional("The name of the HuggingFace tokenizer to preprocess text with.", default=None)
+    max_seq_len: int = hp.optional("The max sequence length of each token sample.", default=None)
+    group_method: str = hp.optional("How to group text samples into token samples. Either `truncate` or `concat`.",
+                                    default=None)
+    mlm: bool = hp.optional("Whether or not to use masked language modeling.", default=False)
+    mlm_probability: float = hp.optional("If `mlm=True`, the probability that tokens are masked.", default=0.15)
+    shuffle: bool = hp.optional(
+        "Whether to shuffle the samples in the dataset. Currently, shards are assigned and consumed with deterministic per-device shard order, but shuffling affects the order of samples via (per-device) shuffle buffers.",
+        default=True)
+    shuffle_buffer_size: int = hp.optional(
+        "If `shuffle=True`, samples are read into a buffer of this size (per-device), and randomly sampled from there to produce shuffled samples.",
+        default=10000)
+    seed: int = hp.optional("If `shuffle=True`, what seed to use for shuffling operations.", default=5)
+    drop_last: bool = hp.optional("Whether to drop the last samples for the last batch.", default=True)
+
+    def validate(self):
+        if self.split not in ["train", "validation"]:
+            raise ValueError(f"Unknown split: '{self.split}'")
+        if self.max_samples is None or self.max_samples <= 0:
+            raise ValueError(f"Must provide 'max_samples' > 0")
+        if self.tokenizer_name is None:
+            raise ValueError(f"Must provide 'tokenizer_name'")
+        if self.max_seq_len is None or self.max_seq_len <= 0:
+            raise ValueError(f"Must provide 'max_seq_len' > 0")
+        if self.group_method not in ["truncate", "concat"]:
+            raise ValueError(f"Unknown group_method: '{self.group_method}'. Must be 'truncate' or 'concat'")
+        if self.mlm and self.mlm_probability <= 0:
+            raise ValueError("Must provide a positive 'mlm_probability' when using masked language modeling.")
+
+    def initialize_object(self, batch_size: int, dataloader_hparams: DataloaderHparams) -> DataSpec:
+        try:
+            import transformers
+        except ImportError:
+            raise ImportError('HuggingFace transformers not installed. '
+                              'Please install with `pip install composer[nlp]`')
+
+        # Get C4 dataset
+        c4_dataset = C4Dataset(split=self.split,
+                               max_samples=self.max_samples,
+                               tokenizer_name=self.tokenizer_name,
+                               max_seq_len=self.max_seq_len,
+                               group_method=self.group_method,
+                               shuffle=self.shuffle,
+                               shuffle_buffer_size=self.shuffle_buffer_size,
+                               seed=self.seed)
+
+        # Get collate_fn
+        collate_fn = transformers.DataCollatorForLanguageModeling(tokenizer=c4_dataset.tokenizer,
+                                                                  mlm=self.mlm,
+                                                                  mlm_probability=self.mlm_probability)
+        # Return DataSpec
+        return DataSpec(dataloader=dataloader_hparams.initialize_object(
+            dataset=c4_dataset,
+            batch_size=batch_size,
+            sampler=None,
+            drop_last=self.drop_last,
+            collate_fn=collate_fn,
+        ),
+                        split_batch=_split_dict_fn)
+
+
+class C4Dataset(IterableDataset):
+    """Builds a streaming, sharded, sized IterableDataset for the C4 (Colossal Cleaned CommonCrawl) dataset. Used for
+    pretraining autoregressive or masked language models. Text samples are streamed directly from the cloud using
+    HuggingFace's C4 Dataset with streaming backend (See https://huggingface.co/datasets/c4 for more details). The text
+    samples are then shuffled, tokenized, and grouped on-the-fly.
+
+    Parameters:
+        split (str): What split of the dataset to use. Either `train` or `validation`.
+        max_samples (int): Max number of post-processed token samples, used to set epoch size of the IterableDataset.
+        tokenizer_name (str): The name of the HuggingFace tokenizer to preprocess text with.
+        max_seq_len (int): The max sequence length of each token sample.
+        group_method (str): How to group text samples into token samples. Either `truncate` or `concat`.
+        shuffle (bool): Whether to shuffle the samples in the dataset. Currently, shards are assigned and consumed with deterministic per-device shard order, but shuffling affects the order of samples via (per-device) shuffle buffers. (Default: `False`)
+        shuffle_buffer_size (int): If `shuffle=True`, samples are read into a buffer of this size (per-device), and randomly sampled from there to produce shuffled samples. (Default: `10000`)
+        seed (int): If `shuffle=True`, what seed to use for shuffling operations. (Default: `5`)
+    Returns:
+        A :class:`torch.utils.data.IterableDataset` object
+    """
+
+    def __init__(self,
+                 split,
+                 max_samples,
+                 tokenizer_name,
+                 max_seq_len,
+                 group_method,
+                 shuffle=False,
+                 shuffle_buffer_size=10000,
+                 seed=5):
+        try:
+            import datasets
+            import transformers
+        except ImportError:
+            raise ImportError('HuggingFace transformers and datasets are not installed. '
+                              'Please install with `pip install composer[nlp]`')
+
+        self.split = split
+        self.max_samples = max_samples
+        self.tokenizer_name = tokenizer_name
+        self.max_seq_len = max_seq_len
+        self.group_method = group_method
+        self.shuffle = shuffle
+        self.shuffle_buffer_size = shuffle_buffer_size
+        self.seed = seed
+
+        # Metadata
+        c4_metadata = {
+            "train": {
+                "num_shards": 1024,
+                "approx_samples_per_shard": 356317,
+            },
+            "validation": {
+                "num_shards": 8,
+                "approx_samples_per_shard": 45576,
+            }
+        }
+        if self.split in c4_metadata:
+            self.num_shards = c4_metadata[self.split]["num_shards"]
+            self.approx_samples_per_shard = c4_metadata[self.split]["approx_samples_per_shard"]
+        else:
+            raise ValueError(f"Unknown split={self.split}, expected one of {list(c4_metadata.keys())}.")
+
+        # Set dataset size
+        self.world_size = dist.get_world_size()
+        self.rank = dist.get_global_rank()
+        self.max_samples_per_device = self.max_samples // self.world_size
+        if self.max_samples % self.world_size != 0:
+            new_max_samples = self.max_samples_per_device * self.world_size
+            log.warning(
+                f"Max samples will be truncated from {max_samples}->{new_max_samples} to maintain divisibility across {self.world_size} devices."
+            )
+            self.max_samples = new_max_samples
+
+        # Try and detect if max_samples is too large
+        # TODO: For safety, repeat original dataset if max_samples is larger than original size
+        original_approx_samples = self.num_shards * self.approx_samples_per_shard
+        if self.max_samples > original_approx_samples and self.group_method == "truncate":
+            raise ValueError(
+                f"Max samples was set to {self.max_samples} with group_method 'truncate' but split '{split}' has only {original_approx_samples}.)"
+            )
+        if self.group_method == "concat":
+            log.warning(
+                f"When using group_method 'concat', sequential token samples are concatenated and chunked into fixed-length samples of size max_seq_len={self.max_seq_len}. "
+                f"In general we cannot detect ahead-of-time if your setting of max_samples={self.max_samples} is safe, "
+                f"so please be cautious to not request more tokens than the size of the original dataset.")
+
+        # Build tokenizer
+        self.tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_name)
+        if self.tokenizer.pad_token is None:
+            # Some tokenizers (e.g. GPT2 tokenizer) have no padding token which causes bugs
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        # Load and shard dataset
+        text_dataset = datasets.load_dataset(path="c4", name="en", split=split, streaming=True)
+        text_dataset = self._shard_dataset(text_dataset)
+        if not isinstance(text_dataset, datasets.IterableDataset):
+            raise ValueError("Unable to build sharded Huggingface C4 Dataset.")
+
+        # Map text samples to token samples
+        # NOTE: Mapping is executed in batched mode for better CPU utilization,
+        # but the returned dataset is still an iterable over tokenized samples
+        text_sample_batch_size = 1000
+        token_dataset = text_dataset.map(
+            self._tokenize,
+            batched=True,
+            batch_size=text_sample_batch_size,
+        )
+
+        # Map variable-length token samples to fixed-length token samples
+        # NOTE: Mapping is executed in batched mode for better CPU utilization,
+        # but the returned dataset is still an iterable over tokenized samples.
+        # NOTE: Depending on the 'group_method', this step may alter the number of
+        # token samples in the dataset, and may mix neighboring token samples together.
+        token_sample_batch_size = 1000
+        token_dataset = token_dataset.map(
+            self._group_tokens,
+            batched=True,
+            batch_size=token_sample_batch_size,
+        )
+
+        # Limit the number of post-processed token samples
+        sized_token_dataset = token_dataset.take(self.max_samples_per_device)
+
+        # Shuffle post-processed token samples
+        # Samples are read into and randomly sampled from per-device shuffle buffer
+        if self.shuffle:
+            sized_token_dataset = sized_token_dataset.shuffle(buffer_size=self.shuffle_buffer_size, seed=self.seed)
+
+        # Finish
+        self.iterable_dataset = sized_token_dataset
+
+    def __iter__(self):
+        worker_info = get_worker_info()
+        if worker_info is not None and worker_info.num_workers != 1:
+            raise ValueError("Multi-worker processing not supported for this dataset yet, please use 'num_workers=1'.")
+        return iter(self.iterable_dataset)
+
+    def __len__(self):
+        return self.max_samples_per_device
+
+    def _subsample(self, device_offset, text_batch):
+        # Only return the i-th item out of N sequential items
+        for k, v in text_batch.items():
+            text_batch[k] = v[device_offset:device_offset + 1]
+        return text_batch
+
+    # Take a HF iterable dataset with multiple shards and prepare it for data-parallel training
+    # Shards are split per-device, e.g. For 8 shards and 4 devices... device0 receives shards [0, 4], device1 receives shards [1, 5].. etc.
+    # If there are not enough shards for devices (common with small validation splits), then shards are sent to multiple devices but subsampled internally.
+    # E.g. For 2 shards and 4 devices... device0 receives shards [0] and consumes samples 0, 2, 4, ... device1 recieves shards [0] and consumes samples 1, 3, 5, ... etc.
+    # Currently, either (num_shards % num_devices == 0) or (num_devices % num_shards == 0) is enforced for efficient streaming,
+    # but this could be relaxed in the future at the cost of increased bandwidth (have many more devices read the same shards and subsample)
+    def _shard_dataset(self, dataset):
+        # Verify # of shards
+        filepaths = dataset._ex_iterable.kwargs['filepaths']
+        if self.num_shards != len(filepaths):
+            raise ValueError(f"Found {len(filepaths)} shards, expected {self.num_shards}")
+
+        # Determine how to allocate devices to shards
+        devices_per_shard = 1
+        if self.num_shards < self.world_size:
+            log.warning(
+                f"Not enough unique shards ({self.num_shards}) for world size ({self.world_size}). Splitting shards among devices."
+            )
+            if self.world_size % self.num_shards != 0:
+                raise ValueError(f"Cannot evenly split {self.num_shards} shards among {self.world_size} devices")
+            devices_per_shard = self.world_size // self.num_shards
+        elif self.num_shards % self.world_size != 0:
+            raise ValueError(f"Cannot evenly split {self.num_shards} shards among {self.world_size} devices")
+        shard_offset = self.rank // devices_per_shard
+        device_offset = self.rank % devices_per_shard
+
+        # Select a deterministic subset of shards
+        device_filepaths = filepaths[shard_offset::self.world_size]
+        dataset._ex_iterable.kwargs['filepaths'] = device_filepaths
+
+        # Subsample shard if shard is being shared among devices
+        # NOTE: Mapping is executed in batched mode for better CPU utilization,
+        # but the returned dataset is still an iterable over text samples
+        if devices_per_shard > 1:
+            dataset = dataset.map(
+                partial(self._subsample, device_offset),
+                batched=True,
+                batch_size=devices_per_shard,
+            )
+        return dataset
+
+    # Use the initialized HF tokenizer to convert a text batch to a token batch
+    def _tokenize(self, text_batch):
+        if self.group_method == "truncate":
+            truncation = True
+            padding = 'max_length'
+            max_length = self.max_seq_len
+        else:
+            truncation = False
+            padding = False
+            max_length = None
+        return self.tokenizer(text_batch["text"], truncation=truncation, padding=padding, max_length=max_length)
+
+    # Prepare a batch of token samples for pretraining, by grouping them into fixed-length token samples, with either 'truncate' or 'concat' group methods.
+    # If using 'truncate', each token sample is padded/truncated to 'self.max_seq_len', and there is no mixing between adjacent token samples.
+    # Using 'truncate' may be computationally inefficient if 'self.max_seq_len' is large, as the suffix of each token sample will consist of empty padding.
+    # Using 'truncate' may also be data inefficent as it will discard the suffix of any token sample that is larger than 'self.max_seq_len'.
+    # If using 'concat', the batch of token samples is concatenated and chunked, such that every new token sample is exactly 'self.max_seq_len' long with no padding.
+    # Using 'concat' may drop a small amount of data at the end of each batch if the total number of tokens is not divisible by 'self.max_seq_len'.
+    # Using 'concat' will alter the number of token samples in the iterable dataset, and differently per-device,
+    # so we require the user to provide a 'self.max_samples' limit to ensure epoch-boundary synchronization across devices.
+    def _group_tokens(self, token_batch):
+        if self.group_method == "truncate":
+            # No processing needed, as 'self._tokenize()' has already padded / truncated each token sample to 'self.max_seq_len'
+            return token_batch
+        elif self.group_method == "concat":
+            # Concatenate all tokens.
+            concat_tokens = {}
+            num_tokens = None
+            for k, v in token_batch.items():
+                concat_v = list(chain(*v))
+                concat_tokens[k] = concat_v
+                if num_tokens is None:
+                    num_tokens = len(concat_v)
+                elif num_tokens != len(concat_v):
+                    raise ValueError("Not all values in concat_tokens dict have same len()")
+                else:
+                    pass
+            if num_tokens is None:
+                raise ValueError("Failed to determine num_tokens.")
+
+            # We drop the small remainder of tokens at the end of the batch.
+            if num_tokens >= self.max_seq_len:
+                num_tokens = (num_tokens // self.max_seq_len) * self.max_seq_len
+
+            # Split into token samples of size max_seq_len.
+            result = {
+                k: [v[i:i + self.max_seq_len] for i in range(0, num_tokens, self.max_seq_len)
+                   ] for k, v in concat_tokens.items()
+            }
+            return result
+        else:
+            raise ValueError(f"Unknown group_method: '{self.group_method}'")

--- a/composer/datasets/dataset_registry.py
+++ b/composer/datasets/dataset_registry.py
@@ -2,6 +2,7 @@
 
 from composer.datasets.ade20k import ADE20kDatasetHparams
 from composer.datasets.brats import BratsDatasetHparams
+from composer.datasets.c4 import C4DatasetHparams
 from composer.datasets.cifar10 import CIFAR10DatasetHparams
 from composer.datasets.glue import GLUEHparams
 from composer.datasets.imagenet import ImagenetDatasetHparams
@@ -15,7 +16,8 @@ registry = {
     "cifar10": CIFAR10DatasetHparams,
     "mnist": MNISTDatasetHparams,
     "lm": LMDatasetHparams,
-    "glue": GLUEHparams
+    "glue": GLUEHparams,
+    "c4": C4DatasetHparams,
 }
 
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -420,9 +420,10 @@ class TrainerHparams(hp.Hparams):
         super().validate()
 
         if self.deepspeed is not None:
-            zero_stage = cast(int, self.deepspeed.get("zero_stage", 0))
+            self.deepspeed["zero_stage"] = cast(int, self.deepspeed.get("zero_stage", 0))
+            self.deepspeed["steps_per_print"] = cast(int, self.deepspeed.get("steps_per_print", 1e20))
 
-            if self.deterministic_mode and zero_stage > 0:
+            if self.deterministic_mode and self.deepspeed["zero_stage"] > 0:
                 raise ValueError("Deepspeed with zero stage > 0 is not compatible with deterministic mode")
 
             if isinstance(self.device, CPUDeviceHparams):

--- a/composer/yamls/models/gpt3_125m.yaml
+++ b/composer/yamls/models/gpt3_125m.yaml
@@ -1,0 +1,86 @@
+train_dataset:
+  c4:
+    split: train
+    max_samples: 3584000 # Compute-optimal 7.3e9 tok ~= 256[bs] * 14000[ba] * 2048[msl] = 3584000[sa] * 2048[msl]
+    max_seq_len: 2048
+    tokenizer_name: gpt2
+    group_method: concat
+    seed: 17
+    shuffle: true
+    drop_last: true
+val_dataset:
+  c4:
+    split: validation
+    max_samples: 102400 # Approx 100k samples
+    max_seq_len: 2048
+    tokenizer_name: gpt2
+    group_method: concat
+    seed: 17
+    shuffle: false
+    drop_last: false
+model:
+  gpt2:
+    use_pretrained: false
+    tokenizer_name: gpt2
+    model_config:
+      activation_function: gelu_new
+      architectures:
+        - GPT2LMHeadModel
+      attn_pdrop: 0.0
+      bos_token_id: 50256
+      embd_pdrop: 0.0
+      eos_token_id: 50256
+      initializer_range: 0.02
+      layer_norm_epsilon: 1.0e-05
+      model_type: gpt2
+      n_embd: 768
+      n_head: 12
+      n_inner: 3072
+      n_layer: 12
+      n_positions: 2048
+      resid_pdrop: 0.0
+      scale_attn_weights: true
+      summary_activation: null
+      summary_first_dropout: 0.0
+      summary_proj_to_labels: true
+      summary_type: cls_index
+      summary_use_proj: true
+      task_specific_params:
+        text-generation:
+          do_sample: true
+          max_length: 50
+      transformers_version: 4.16.2
+      use_cache: true
+      vocab_size: 50257
+optimizer:
+  decoupled_adamw:
+    lr: 6.0e-4
+    betas:
+      - 0.9
+      - 0.95
+    eps: 1.0e-08
+    weight_decay: 0.0
+schedulers:
+  - cosine_decay_with_warmup:
+      warmup_time: 0.01dur
+loggers:
+  - tqdm: {}
+max_duration: 1ep
+train_batch_size: 256 # 0.5e6 tok ~= 256[bs] * 2048[msl]
+grad_accum: 2 # 256[bs] / 8[devices] / 16[per_gpu_microbatch_size] = 2[ga], assuming 8xA100-80GB
+eval_batch_size: 128 # 128[bs] / 8[devices] = 16[per_gpu_microbatch_size], assuming 8xA100-80GB
+seed: 17
+device:
+  gpu: {}
+dataloader:
+  pin_memory: true
+  persistent_workers: true
+  num_workers: 1
+  timeout: 0
+  prefetch_factor: 2
+deepspeed:
+  zero_stage: 0
+precision: fp16
+grad_clip_norm: 1.0
+validate_every_n_batches: 1000
+validate_every_n_epochs: 1

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -4,8 +4,8 @@ from typing import Callable, Dict, Type
 
 import pytest
 
-from composer.datasets import (ADE20kDatasetHparams, BratsDatasetHparams, CIFAR10DatasetHparams, DataloaderHparams,
-                               DatasetHparams, GLUEHparams, ImagenetDatasetHparams, LMDatasetHparams,
+from composer.datasets import (ADE20kDatasetHparams, BratsDatasetHparams, C4DatasetHparams, CIFAR10DatasetHparams,
+                               DataloaderHparams, DatasetHparams, GLUEHparams, ImagenetDatasetHparams, LMDatasetHparams,
                                MNISTDatasetHparams, SyntheticHparamsMixin)
 from composer.trainer.trainer_hparams import dataset_registry
 
@@ -13,31 +13,46 @@ from composer.trainer.trainer_hparams import dataset_registry
 # to initialize test hparams objects
 default_required_fields: Dict[Type[DatasetHparams], Callable[[], DatasetHparams]] = {
     #  hparams with empty dicts have no required fields
-    CIFAR10DatasetHparams: lambda: CIFAR10DatasetHparams(
-        is_train=False,
-        download=False,
-    ),
-    ADE20kDatasetHparams: lambda: ADE20kDatasetHparams(is_train=False),
-    BratsDatasetHparams: lambda: BratsDatasetHparams(is_train=False,),
-    ImagenetDatasetHparams: lambda: ImagenetDatasetHparams(
-        is_train=False,
-        crop_size=224,
-        resize_size=-1,
-    ),
-    MNISTDatasetHparams: lambda: MNISTDatasetHparams(
-        is_train=False,
-        download=False,
-    ),
-    LMDatasetHparams: lambda: LMDatasetHparams(
-        datadir=["hello"],
-        split='train',
-        tokenizer_name='gpt2',
-    ),
-    GLUEHparams: lambda: GLUEHparams(
-        task="rte",
-        tokenizer_name="bert-base-uncased",
-        split="train",
-    ),
+    CIFAR10DatasetHparams:
+        lambda: CIFAR10DatasetHparams(
+            is_train=False,
+            download=False,
+        ),
+    ADE20kDatasetHparams:
+        lambda: ADE20kDatasetHparams(is_train=False),
+    BratsDatasetHparams:
+        lambda: BratsDatasetHparams(is_train=False,),
+    ImagenetDatasetHparams:
+        lambda: ImagenetDatasetHparams(
+            is_train=False,
+            crop_size=224,
+            resize_size=-1,
+        ),
+    MNISTDatasetHparams:
+        lambda: MNISTDatasetHparams(
+            is_train=False,
+            download=False,
+        ),
+    LMDatasetHparams:
+        lambda: LMDatasetHparams(
+            datadir=["hello"],
+            split='train',
+            tokenizer_name='gpt2',
+        ),
+    GLUEHparams:
+        lambda: GLUEHparams(
+            task="rte",
+            tokenizer_name="bert-base-uncased",
+            split="train",
+        ),
+    C4DatasetHparams:
+        lambda: C4DatasetHparams(
+            split="train",
+            max_samples=1000,
+            max_seq_len=100,
+            tokenizer_name="gpt2",
+            group_method="concat",
+        ),
 }
 
 


### PR DESCRIPTION
This PR adds an adapter for HF streaming datasets, so that we can train with DDP and sharding. There is also a small QoL fix for DeepSpeed.

I've also added a new GPT3-125m YAML which can be the start of our new GPT3 family of benchmarks. I think we should deprecate the GPT2 collection of YAMLs (-52m, -83m -125m) in the near future, say Composer v0.5.

Some TODOs, which can be follow-up PRs:

* Add the rest of the GPT3 family YAMLs
* Update the GPT2 model with QoL fixes
* Update the BERT-base benchmark to use C4
* Deprecate / combine the old `LMDataset` object