### PR TITLE
Example of flattening composer.core.logging for docs

### DIFF
--- a/composer/callbacks/run_directory_uploader.py
+++ b/composer/callbacks/run_directory_uploader.py
@@ -22,7 +22,7 @@ from urllib3.exceptions import ProtocolError
 
 from composer.core.callback import Callback
 from composer.core.logging import Logger
-from composer.core.logging.logger import LogLevel
+from composer.core.logging import LogLevel
 from composer.core.state import State
 from composer.utils import dist, run_directory
 from composer.utils.object_store import ObjectStoreProviderHparams

--- a/composer/callbacks/run_directory_uploader.py
+++ b/composer/callbacks/run_directory_uploader.py
@@ -21,8 +21,7 @@ from requests.exceptions import ConnectionError
 from urllib3.exceptions import ProtocolError
 
 from composer.core.callback import Callback
-from composer.core.logging import Logger
-from composer.core.logging import LogLevel
+from composer.core.logging import Logger, LogLevel
 from composer.core.state import State
 from composer.utils import dist, run_directory
 from composer.utils.object_store import ObjectStoreProviderHparams

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -53,8 +53,7 @@ from typing import ContextManager, Dict, Optional, Sequence, Union, cast
 from composer.core.algorithm import Algorithm
 from composer.core.callback import Callback
 from composer.core.event import Event
-from composer.core.logging import Logger
-from composer.core.logging import LogLevel
+from composer.core.logging import Logger, LogLevel
 from composer.core.state import State
 from composer.profiler import ProfilerAction
 

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -54,7 +54,7 @@ from composer.core.algorithm import Algorithm
 from composer.core.callback import Callback
 from composer.core.event import Event
 from composer.core.logging import Logger
-from composer.core.logging.logger import LogLevel
+from composer.core.logging import LogLevel
 from composer.core.state import State
 from composer.profiler import ProfilerAction
 

--- a/composer/core/logging/__init__.py
+++ b/composer/core/logging/__init__.py
@@ -1,8 +1,24 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-from composer.core.logging.base_backend import LoggerCallback as LoggerCallback
-from composer.core.logging.logger import Logger as Logger
-from composer.core.logging.logger import LogLevel as LogLevel
-from composer.core.logging.logger import TLogData as TLogData
-from composer.core.logging.logger import TLogDataValue as TLogDataValue
-from composer.core.logging.logger import format_log_data_value as format_log_data_value
+"""Super Badass Docstring about composer.core.logging
+
+Attributes:
+    TLogData: Logging attribute that does stuff
+    TLogDataValue: Another attribute that probably does stuff
+"""
+
+from composer.core.logging._base_backend import LoggerCallback as LoggerCallback
+from composer.core.logging._logger import Logger as Logger
+from composer.core.logging._logger import LogLevel as LogLevel
+from composer.core.logging._logger import TLogData as TLogData
+from composer.core.logging._logger import TLogDataValue as TLogDataValue
+from composer.core.logging._logger import format_log_data_value as format_log_data_value
+
+__all__ = ["LoggerCallback", "Logger", "LogLevel", "TLogData", "TLogDataValue", "format_log_data_value"]
+
+LoggerCallback.__module__ = __name__
+Logger.__module__ = __name__
+LogLevel.__module__ = __name__
+TLogData.__module__ = __name__
+TLogDataValue.__module__ = __name__
+format_log_data_value.__module__ = __name__

--- a/composer/core/logging/__init__.py
+++ b/composer/core/logging/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-"""Super Badass Docstring about composer.core.logging
+"""Super Badass Docstring about composer.core.logging.
 
 Attributes:
     TLogData: Logging attribute that does stuff

--- a/composer/core/logging/_base_backend.py
+++ b/composer/core/logging/_base_backend.py
@@ -9,7 +9,7 @@ from composer.core.callback import Callback
 from composer.core.time import Timestamp
 
 if TYPE_CHECKING:
-    from composer.core.logging.logger import LogLevel, TLogData
+    from composer.core.logging import LogLevel, TLogData
     from composer.core.state import State
 
 

--- a/composer/core/logging/_logger.py
+++ b/composer/core/logging/_logger.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Callable, Generator, Mapping, Sequence, Union
 import torch
 
 if TYPE_CHECKING:
-    from composer.core.logging.base_backend import LoggerCallback
+    from composer.core.logging import LoggerCallback
     from composer.core.state import State
     from composer.core.types import JSON
 

--- a/composer/loggers/in_memory_logger.py
+++ b/composer/loggers/in_memory_logger.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Tuple, Union
 
-from composer.core.logging import LoggerCallback, LogLevel, TLogData
-from composer.core.logging import TLogDataValue
+from composer.core.logging import LoggerCallback, LogLevel, TLogData, TLogDataValue
 from composer.core.time import Timestamp
 
 

--- a/composer/loggers/in_memory_logger.py
+++ b/composer/loggers/in_memory_logger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, List, Tuple, Union
 
 from composer.core.logging import LoggerCallback, LogLevel, TLogData
-from composer.core.logging.logger import TLogDataValue
+from composer.core.logging import TLogDataValue
 from composer.core.time import Timestamp
 
 

--- a/composer/loggers/tqdm_logger.py
+++ b/composer/loggers/tqdm_logger.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import yaml
 from tqdm import auto
 
-from composer.core.logging import LogLevel, TLogData, TLogDataValue, format_log_data_value
-from composer.core.logging import LoggerCallback
+from composer.core.logging import LoggerCallback, LogLevel, TLogData, TLogDataValue, format_log_data_value
 from composer.core.state import State
 from composer.core.time import Timestamp
 from composer.core.types import StateDict

--- a/composer/loggers/tqdm_logger.py
+++ b/composer/loggers/tqdm_logger.py
@@ -11,7 +11,7 @@ import yaml
 from tqdm import auto
 
 from composer.core.logging import LogLevel, TLogData, TLogDataValue, format_log_data_value
-from composer.core.logging.base_backend import LoggerCallback
+from composer.core.logging import LoggerCallback
 from composer.core.state import State
 from composer.core.time import Timestamp
 from composer.core.types import StateDict


### PR DESCRIPTION
@growlix example of how to flatten the `composer.core.logging` docs.