### PR TITLE
Make batchnorm default for UNet

### DIFF
--- a/composer/models/unet/unet.py
+++ b/composer/models/unet/unet.py
@@ -107,7 +107,7 @@ class UNet(ComposerModel):
                           strides=strides,
                           dimension=2,
                           residual=True,
-                          normalization_layer="instance",
+                          normalization_layer="batch",
                           negative_slope=0.01)
 
         return model


### PR DESCRIPTION
Instance norm doesn't preserve memory format, i.e., if input is NHWC the output is NWHC. Therefore, instanceNorm pays the cost of NHWC => NCHW while the preceding conv pays the cost of NCHW => NHWC memory format change. 

5.5% improvement in wall_clock_train.


dice (validation): 69.99 (instance norm) 69.33 (batch norm)