### PR TITLE
Clean up Transformer models __init__ function

### DIFF
--- a/composer/models/bert/bert_hparams.py
+++ b/composer/models/bert/bert_hparams.py
@@ -9,7 +9,7 @@ import yahp as hp
 from composer.models.transformer_hparams import TransformerHparams
 
 if TYPE_CHECKING:
-    from composer.models.transformer_shared import ComposerTransformer
+    from composer.models.bert import BERTModel
 
 
 @dataclass

--- a/composer/models/bert/bert_hparams.py
+++ b/composer/models/bert/bert_hparams.py
@@ -20,7 +20,7 @@ class BERTForClassificationHparams(TransformerHparams):
         if self.num_labels < 1:
             raise ValueError("The number of target labels must be at least one.")
 
-    def initialize_object(self) -> "ComposerTransformer":
+    def initialize_object(self) -> "BERTModel":
         try:
             import transformers
         except ImportError as e:
@@ -42,6 +42,9 @@ class BERTForClassificationHparams(TransformerHparams):
             raise ValueError('One of pretrained_model_name or model_config needed.')
         config.num_labels = self.num_labels
 
+        # setup the tokenizer in the hparams interface
+        tokenizer = transformers.BertTokenizer.from_pretrained(self.tokenizer_name)
+
         if self.use_pretrained:
             # TODO (Moin): handle the warnings on not using the seq_relationship head
             model = transformers.AutoModelForSequenceClassification.from_pretrained(self.pretrained_model_name,
@@ -53,14 +56,14 @@ class BERTForClassificationHparams(TransformerHparams):
         return BERTModel(
             module=model,
             config=config,  #type: ignore (thirdparty)
-            tokenizer_name=self.tokenizer_name,
+            tokenizer=tokenizer,
         )
 
 
 @dataclass
 class BERTHparams(TransformerHparams):
 
-    def initialize_object(self) -> "ComposerTransformer":
+    def initialize_object(self) -> "BERTModel":
         try:
             import transformers
         except ImportError as e:
@@ -82,6 +85,9 @@ class BERTHparams(TransformerHparams):
         # set the number of labels ot the vocab size, used for measuring MLM accuracy
         config.num_labels = config.vocab_size
 
+        # setup the tokenizer in the hparams interface
+        tokenizer = transformers.BertTokenizer.from_pretrained(self.tokenizer_name)
+
         if self.use_pretrained:
             # TODO (Moin): handle the warnings on not using the seq_relationship head
             model = transformers.AutoModelForMaskedLM.from_pretrained(self.pretrained_model_name)
@@ -91,5 +97,5 @@ class BERTHparams(TransformerHparams):
         return BERTModel(
             module=model,
             config=config,  #type: ignore (thirdparty)
-            tokenizer_name=self.tokenizer_name,
+            tokenizer=tokenizer,
         )

--- a/composer/models/bert/model.py
+++ b/composer/models/bert/model.py
@@ -19,13 +19,24 @@ __all__ = ["BERTModel"]
 
 
 class BERTModel(ComposerTransformer):
-    """Implements a BERT wrapper around a ComposerTransformer."""
+    """Implements a BERT wrapper around a ComposerTransformer.
 
-    def __init__(self, module: transformers.BertModel, config: transformers.BertConfig, tokenizer_name: str) -> None:
+    See this `paper <https://arxiv.org/abs/1810.04805>`_
+    for details on the BERT architecutre.
+
+    Args:
+        module (transformers.BertModel): The model to wrap with this module.
+        config (transformers.BertConfig): The config for the model.
+        tokenizer (transformers.BertTokenizer): The tokenizer used for this model,
+            necessary to assert required model inputs.
+    """
+
+    def __init__(self, module: transformers.BertModel, config: transformers.BertConfig,
+                 tokenizer: transformers.BertTokenizer) -> None:
         super().__init__(
             module=module,  #type: ignore (thirdparty)
             config=config,
-            tokenizer_name=tokenizer_name)
+            tokenizer=tokenizer)
 
         # we're going to remove the label from the expected inputs
         # since we will handle metric calculation with TorchMetrics instead of HuggingFace.

--- a/composer/models/gpt2/gpt2_hparams.py
+++ b/composer/models/gpt2/gpt2_hparams.py
@@ -32,6 +32,9 @@ class GPT2Hparams(TransformerHparams):
         else:
             raise ValueError('One of pretrained_model_name or model_config needed.')
 
+        # setup the tokenizer in the hparams interface
+        tokenizer = transformers.GPT2Tokenizer.from_pretrained(self.tokenizer_name)
+
         if self.use_pretrained:
             model = transformers.AutoModelForCausalLM.from_pretrained(self.pretrained_model_name)
         else:
@@ -40,6 +43,6 @@ class GPT2Hparams(TransformerHparams):
         return GPT2Model(
             module=model,
             config=config,  #type: ignore (thirdparty)
-            tokenizer_name=self.tokenizer_name,
+            tokenizer=tokenizer,
             gradient_checkpointing=self.gradient_checkpointing,
         )

--- a/composer/models/gpt2/model.py
+++ b/composer/models/gpt2/model.py
@@ -24,19 +24,19 @@ class GPT2Model(ComposerTransformer):
     Args:
         module (transformers.GPT2Model): The model to wrap with this module.
         config (transformers.GPT2Config): The config for the model.
-        tokenizer_name (str): The name of the tokenizer used for tihs model,
+        tokenizer (transformers.GPT2Tokenizer): The tokenizer used for this model,
             necessary to assert required model inputs.
     """
 
     def __init__(self,
                  module: transformers.GPT2Model,
                  config: transformers.GPT2Config,
-                 tokenizer_name: str,
+                 tokenizer: transformers.GPT2Tokenizer,
                  gradient_checkpointing: bool = False) -> None:
         super().__init__(
             module=module,  #type: ignore (thirdparty)
             config=config,
-            tokenizer_name=tokenizer_name,
+            tokenizer=tokenizer,
             gradient_checkpointing=gradient_checkpointing)
 
         # If we ever have algorithms that modify the loss function, then this might be a bit inefficient
@@ -47,7 +47,6 @@ class GPT2Model(ComposerTransformer):
         self.val_perplexity = Perplexity()
 
     def loss(self, outputs: Mapping, batch: Batch) -> Tensors:
-
         if outputs.get('loss', None) is not None:
             return outputs['loss']
         else:

--- a/composer/models/transformer_hparams.py
+++ b/composer/models/transformer_hparams.py
@@ -14,7 +14,7 @@ from composer.models.model_hparams import ModelHparams
 class TransformerHparams(ModelHparams, ABC):
     """Defines the necessary hyparameters for a Transformer base module."""
 
-    tokenizer_name: str = hp.optional("Model name to pull from Huggingface Model Hub.", default=None)
+    tokenizer_name: str = hp.optional("Tokenizer name to pull from Huggingface Model Hub.", default=None)
     pretrained_model_name: Optional[str] = hp.optional(
         doc="Pretrained model name to pull from Huggingface Model Hub.",
         default=None,

--- a/composer/models/transformer_shared.py
+++ b/composer/models/transformer_shared.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import textwrap
 from typing import TYPE_CHECKING, Mapping, Tuple
 
 from composer.models.base import ComposerModel

--- a/composer/models/transformer_shared.py
+++ b/composer/models/transformer_shared.py
@@ -34,17 +34,9 @@ class ComposerTransformer(ComposerModel):
     def __init__(self,
                  module: transformers.PreTrainedModel,
                  config: transformers.PretrainedConfig,
-                 tokenizer: transformers.PreTrainedTokenizer = None,
+                 tokenizer: transformers.PreTrainedTokenizer,
                  gradient_checkpointing: bool = False) -> None:
         super().__init__()
-        try:
-            import transformers
-        except ImportError as e:
-            raise ImportError(
-                textwrap.dedent("""\
-                Composer was installed without NLP support. To use NLP with Composer, run `pip install mosaicml[nlp]`
-                if using pip or `conda install -c conda-forge transformers` if using Anaconda.""")) from e
-
         self.module = module
         self.config = config
         self.tokenizer = tokenizer

--- a/composer/models/transformer_shared.py
+++ b/composer/models/transformer_shared.py
@@ -27,14 +27,14 @@ class ComposerTransformer(ComposerModel):
             contains the forward pass function.
         config (transformers.PretrainedConfig): The PretrainedConfig object that
             stores information about the model hyperparameters.
-        tokenizer_name (str): The name of the tokenizer used for this model,
+        tokenizer (transformers.PreTrainedTokenizer): The tokenizer used for this model,
             necessary to assert required model inputs.
     """
 
     def __init__(self,
                  module: transformers.PreTrainedModel,
                  config: transformers.PretrainedConfig,
-                 tokenizer_name: str,
+                 tokenizer: transformers.PreTrainedTokenizer = None,
                  gradient_checkpointing: bool = False) -> None:
         super().__init__()
         try:
@@ -47,7 +47,7 @@ class ComposerTransformer(ComposerModel):
 
         self.module = module
         self.config = config
-        self.tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_name)
+        self.tokenizer = tokenizer
         log.info("Number of parameters in the model: " \
                  f"{sum(p.numel() for p in module.parameters()):,}")  # type: ignore (thirdparty)
         log.info("Number of trainable parameters in the model: "


### PR DESCRIPTION
It doesn't really make sense for a ComposerTransformer to accept a `transformers.PreTrainedModel`, but a `tokenizer_name: str`. This interface was just too tightly coupled to YAHP.

This remedies the problem by the `__init__` function taking in a `transformers.PreTrainedTokenizer` instead of a `str`.

I also welcome any other suggestions for quality-of-life fixes!