### PR TITLE
Manually calculate NLP loss

### DIFF
--- a/composer/models/bert/model.py
+++ b/composer/models/bert/model.py
@@ -99,12 +99,12 @@ class BERTModel(ComposerTransformer):
             if key not in batch.keys():
                 raise ValueError(f'Batch missing key: {key}')
 
-        labels = batch.pop('labels')
+        labels = batch.pop('labels', None)
         output = self.module(**batch)  # type: ignore (thirdparty)
         batch['labels'] = labels
         return output
 
-    def loss(self, outputs: Mapping, batch: Batch) -> Tensors:
+    def loss(self, outputs: Mapping, batch: BatchDict) -> Tensors:
         logits = outputs['logits']
         labels = batch['labels']
         loss = self.loss_func(logits.view(-1, logits.size(-1)), labels.view(-1))

--- a/composer/models/gpt2/model.py
+++ b/composer/models/gpt2/model.py
@@ -43,8 +43,33 @@ class GPT2Model(ComposerTransformer):
         #  because it'll compute the expensive softmax operation twice.
         # Instead, we should consider figuring out how to leverage self.train_loss and return the e^self.train_loss.
         # Of course, this also depends on the implementation details of algorithms.
+        self.loss_func = nn.CrossEntropyLoss()
         self.train_perplexity = Perplexity()
         self.val_perplexity = Perplexity()
+
+    def forward(self, batch: BatchDict):
+        if not isinstance(batch, dict):
+            raise ValueError(f'Model expects batch to be a dict, got {type(batch)}')
+
+        for key in self.model_inputs:
+            if key not in batch.keys():
+                raise ValueError(f'Batch missing key: {key}')
+
+        labels = batch.pop('labels')
+        output = self.module(**batch)  # type: ignore (thirdparty)
+        batch['labels'] = labels
+        return output
+
+    def loss(self, outputs: Mapping, batch: BatchDict):
+        logits = outputs['logits']
+        labels = batch['labels']
+
+        # Shift so that tokens < n predict n
+        # from https://github.com/huggingface/transformers/blob/master/src/transformers/models/gpt2/modeling_gpt2.py
+        shift_logits = logits[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+
+        loss = self.loss_func(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
 
     def loss(self, outputs: Mapping, batch: Batch) -> Tensors:
         if outputs.get('loss', None) is not None:


### PR DESCRIPTION
Currently, our transformer models automatically calculate loss during the forward pass. This can make it difficult to implement algorithms that operate in between the forward pass and the loss calculation like label smoothing, selective backprop, and other future methods. 

We can structure the transformer models to manually calculate the loss. Some downsides:
- The code feels less clean, but I think this is due to having a model be capable of performing multiple tasks.
- Can no longer provide any arbitrary model to the Composer BERT/GPT-2 models since the necessary loss function may not be specified for every model. I could add an argument to manually calculate loss, but seems hacky?


[WandB report comparing old and new loss](https://wandb.ai/mosaic-ml/landan-data-bert-base-pretrain-r1z1-r1z1-g8-a100/reports/Manual-transformer-loss--VmlldzoxNjA5MTI4/edit?firstReport&runsetFilter)