### PR TITLE
Fix Lint

### DIFF
--- a/composer/callbacks/run_directory_uploader.py
+++ b/composer/callbacks/run_directory_uploader.py
@@ -40,7 +40,7 @@ class RunDirectoryUploader(Callback):
     timestamp. Only files that have a newer last modified timestamp since the last upload will be  uploaded.
 
     Example
-        .. testsetup::
+        .. testsetup:: composer.callbacks.RunDirectoryUploader.__init__
 
            import os
            import functools
@@ -63,7 +63,7 @@ class RunDirectoryUploader(Callback):
                num_concurrent_uploads=1,
            )
 
-        .. doctest::
+        .. doctest:: composer.callbacks.RunDirectoryUploader.__init__
 
            >>> osphparams = ObjectStoreProviderHparams(
            ...     provider="s3",
@@ -86,7 +86,7 @@ class RunDirectoryUploader(Callback):
            >>> # is triggered, like this:
            >>> _ = trainer.engine.run_event(Event.EPOCH_END)
         
-        .. testcleanup::
+        .. testcleanup:: composer.callbacks.RunDirectoryUploader.__init__
 
            # Shut down the uploader
            run_directory_uploader._finished.set()

--- a/composer/callbacks/run_directory_uploader.py
+++ b/composer/callbacks/run_directory_uploader.py
@@ -40,7 +40,11 @@ class RunDirectoryUploader(Callback):
     timestamp. Only files that have a newer last modified timestamp since the last upload will be  uploaded.
 
     Example
-        .. testsetup:: *
+        .. testsetup::
+
+           import os
+           import functools
+           from composer.callbacks import RunDirectoryUploader, run_directory_uploader
 
            # For this example, we do not validate credentials
            def do_not_validate(
@@ -48,7 +52,16 @@ class RunDirectoryUploader(Callback):
                object_name_prefix: str,
            ) -> None:
                pass
-           callbacks.run_directory_uploader._validate_credentials = do_not_validate
+
+           run_directory_uploader._validate_credentials = do_not_validate
+           
+           os.environ['OBJECT_STORE_KEY'] = 'KEY'
+           os.environ['OBJECT_STORE_SECRET'] = 'SECRET'
+           RunDirectoryUploader = functools.partial(
+               RunDirectoryUploader,
+               use_procs=False,
+               num_concurrent_uploads=1,
+           )
 
         .. doctest::
 
@@ -60,17 +73,23 @@ class RunDirectoryUploader(Callback):
            ...     region="us-west-2",
            ...     )
            >>> # construct trainer object with this callback
+           >>> run_directory_uploader = RunDirectoryUploader(osphparams)
            >>> trainer = Trainer(
            ...     model=model,
            ...     train_dataloader=train_dataloader,
            ...     eval_dataloader=eval_dataloader,
            ...     optimizers=optimizer,
            ...     max_duration="1ep",
-           ...     callbacks=[callbacks.RunDirectoryUploader(osphparams)],
+           ...     callbacks=[run_directory_uploader],
            ... )
            >>> # trainer will run this callback whenever the EPOCH_END
            >>> # is triggered, like this:
            >>> _ = trainer.engine.run_event(Event.EPOCH_END)
+        
+        .. testcleanup::
+
+           # Shut down the uploader
+           run_directory_uploader._finished.set()
 
     .. note::
         This callback blocks the training loop to copy files from the :mod:`~composer.utils.run_directory` to the

--- a/composer/profiler/json_trace.py
+++ b/composer/profiler/json_trace.py
@@ -22,8 +22,8 @@ __all__ = ["JSONTraceHandler"]
 
 
 class JSONTraceHandler(ProfilerEventHandler):
-    """Records trace events in `JSON trace format
-    <https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview>`_.
+    """Records trace events in `JSON trace format <https://\\
+    docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview>`_.
 
     Traces are output to ``output_directory``.  Traces can be visualized using the Chrome Trace Viewer.
     To view in a Google Chrome browser, navigate to ``chrome://tracing`` and load the JSON trace file.

--- a/composer/utils/object_store.py
+++ b/composer/utils/object_store.py
@@ -56,21 +56,29 @@ class ObjectStoreProviderHparams(hp.Hparams):
             For example, if your key is an environment variable called ``OBJECT_STORE_KEY`` that is set to ``MY_KEY``,
             then you should set this parameter equal to ``OBJECT_STORE_KEY``. Composer will read the key like this:
             
-            .. testsetup::
+            .. testsetup:: object_store_hparams_key
 
                 import os
                 import functools
 
+                original_key = os.environ.get("OBJECT_STORE_KEY")
                 os.environ["OBJECT_STORE_KEY"] = "MY_KEY"
                 ObjectStoreProviderHparams = functools.partial(ObjectStoreProviderHparams, provider="s3", container="container")
             
-            .. doctest::
+            .. doctest:: object_store_hparams_key
 
                 >>> import os
                 >>> params = ObjectStoreProviderHparams(key_environ="OBJECT_STORE_KEY")
                 >>> key = os.environ[params.key_environ]
                 >>> key
                 'MY_KEY'
+
+            .. testcleanup:: object_store_hparams_key
+
+                if original_key is None:
+                    del os.environ['OBJECT_STORE_KEY']
+                else:
+                    os.environ['OBJECT_STORE_KEY'] = original_key
 
         secret_environ (str, optional): The name of an environment variable containing the API secret  or password
             to use for the provider. If no secret is required, then set this field to ``None``. (default: ``None``)
@@ -79,21 +87,29 @@ class ObjectStoreProviderHparams(hp.Hparams):
             For example, if your secret is an environment variable called ``OBJECT_STORE_SECRET`` that is set to ``MY_SECRET``,
             then you should set this parameter equal to ``OBJECT_STORE_SECRET``. Composer will read the secret like this:
                 
-            .. testsetup::
+            .. testsetup:: object_store_hparams_secret
 
                 import os
                 import functools
+                original_secret = os.environ.get("OBJECT_STORE_SECRET")
                 os.environ["OBJECT_STORE_SECRET"] = "MY_SECRET"
                 ObjectStoreProviderHparams = functools.partial(ObjectStoreProviderHparams, provider="s3", container="container")
 
 
-            .. doctest::
+            .. doctest:: object_store_hparams_secret
 
                 >>> import os
                 >>> params = ObjectStoreProviderHparams(secret_environ="OBJECT_STORE_SECRET")
                 >>> secret = os.environ[params.secret_environ]
                 >>> secret
                 'MY_SECRET'
+
+            .. testcleanup:: object_store_hparams_secret
+
+                if original_secret is None:
+                    del os.environ['OBJECT_STORE_SECRET']
+                else:
+                    os.environ['OBJECT_STORE_SECRET'] = original_secret
 
         region (str, optional): Cloud region to use for the cloud provider.
             Most providers do not require the region to be specified. (default: ``None``)

--- a/composer/utils/object_store.py
+++ b/composer/utils/object_store.py
@@ -25,13 +25,14 @@ class ObjectStoreProviderHparams(hp.Hparams):
     * The AWS Access Key ID is stored in an environment variable named ``AWS_ACCESS_KEY_ID``.
     * The Secret Access Key is in an environmental variable named ``AWS_SECRET_ACCESS_KEY``.
 
-    .. testsetup::
+    .. testsetup:: composer.utils.object_store.ObjectStoreProviderHparams.__init__.s3
 
         import os
+
         os.environ["AWS_ACCESS_KEY_ID"] = "key"
         os.environ["AWS_SECRET_ACCESS_KEY"] = "secret"
 
-    .. doctest::
+    .. doctest:: composer.utils.object_store.ObjectStoreProviderHparams.__init__.s3
 
         >>> provider_hparams = ObjectStoreProviderHparams(
         ...     provider="s3",
@@ -56,29 +57,21 @@ class ObjectStoreProviderHparams(hp.Hparams):
             For example, if your key is an environment variable called ``OBJECT_STORE_KEY`` that is set to ``MY_KEY``,
             then you should set this parameter equal to ``OBJECT_STORE_KEY``. Composer will read the key like this:
             
-            .. testsetup:: object_store_hparams_key
+            .. testsetup::  composer.utils.object_store.ObjectStoreProviderHparams.__init__.key
 
                 import os
                 import functools
 
-                original_key = os.environ.get("OBJECT_STORE_KEY")
                 os.environ["OBJECT_STORE_KEY"] = "MY_KEY"
                 ObjectStoreProviderHparams = functools.partial(ObjectStoreProviderHparams, provider="s3", container="container")
             
-            .. doctest:: object_store_hparams_key
+            .. doctest:: composer.utils.object_store.ObjectStoreProviderHparams.__init__.key
 
                 >>> import os
                 >>> params = ObjectStoreProviderHparams(key_environ="OBJECT_STORE_KEY")
                 >>> key = os.environ[params.key_environ]
                 >>> key
                 'MY_KEY'
-
-            .. testcleanup:: object_store_hparams_key
-
-                if original_key is None:
-                    del os.environ['OBJECT_STORE_KEY']
-                else:
-                    os.environ['OBJECT_STORE_KEY'] = original_key
 
         secret_environ (str, optional): The name of an environment variable containing the API secret  or password
             to use for the provider. If no secret is required, then set this field to ``None``. (default: ``None``)
@@ -87,7 +80,7 @@ class ObjectStoreProviderHparams(hp.Hparams):
             For example, if your secret is an environment variable called ``OBJECT_STORE_SECRET`` that is set to ``MY_SECRET``,
             then you should set this parameter equal to ``OBJECT_STORE_SECRET``. Composer will read the secret like this:
                 
-            .. testsetup:: object_store_hparams_secret
+            .. testsetup:: composer.utils.object_store.ObjectStoreProviderHparams.__init__.secret
 
                 import os
                 import functools
@@ -96,20 +89,13 @@ class ObjectStoreProviderHparams(hp.Hparams):
                 ObjectStoreProviderHparams = functools.partial(ObjectStoreProviderHparams, provider="s3", container="container")
 
 
-            .. doctest:: object_store_hparams_secret
+            .. doctest:: composer.utils.object_store.ObjectStoreProviderHparams.__init__.secret
 
                 >>> import os
                 >>> params = ObjectStoreProviderHparams(secret_environ="OBJECT_STORE_SECRET")
                 >>> secret = os.environ[params.secret_environ]
                 >>> secret
                 'MY_SECRET'
-
-            .. testcleanup:: object_store_hparams_secret
-
-                if original_secret is None:
-                    del os.environ['OBJECT_STORE_SECRET']
-                else:
-                    os.environ['OBJECT_STORE_SECRET'] = original_secret
 
         region (str, optional): Cloud region to use for the cloud provider.
             Most providers do not require the region to be specified. (default: ``None``)

--- a/composer/utils/run_directory.py
+++ b/composer/utils/run_directory.py
@@ -32,11 +32,13 @@ relative to the current working directory (CWD).
 
 This folder is partitioned into subfolders by each rank. For example:
 
->>> import os
->>> os.environ['COMPOSER_RUN_DIRECTORY'] = "./path/to/my_run_directory"
->>> from composer.utils import run_directory
->>> os.path.relpath(run_directory.get_run_directory())
-'path/to/my_run_directory/rank_0'
+.. doctest:: composer.utils.run_directory
+
+    >>> import os
+    >>> os.environ['COMPOSER_RUN_DIRECTORY'] = "./path/to/my_run_directory"
+    >>> from composer.utils import run_directory
+    >>> os.path.relpath(run_directory.get_run_directory())
+    'path/to/my_run_directory/rank_0'
 """
 import datetime
 import logging

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -86,9 +86,12 @@ engine = Engine(state, logger)
 
 image = Image.fromarray(np.random.randint(0, 256, size=(32, 32, 3), dtype=np.uint8))
 
-X_example = torch.randn(batch_size, num_channels, 32, 32)
-logits = torch.randn(batch_size, num_classes)
-y_example = torch.randint(num_classes, (batch_size,))
+# error: "randn" is not a known member of module (reportGeneralTypeIssues)
+X_example = torch.randn(batch_size, num_channels, 32, 32)  # type: ignore
+# error: "randn" is not a known member of module (reportGeneralTypeIssues)
+logits = torch.randn(batch_size, num_classes)  # type: ignore
+# error: "randint" is not a known member of module (reportGeneralTypeIssues)
+y_example = torch.randint(num_classes, (batch_size,))  # type: ignore
 
 # bind the required arguments to the Trainer so it can be used without arguments in the doctests
 Trainer = functools.partial(

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ extra_deps['dev'] = [
     'jupyter>=1.0.0',
     'yamllint>=1.26.2',
     'pytest-timeout>=1.4.2',
-    'pyright>=0.0.13',
+    'pyright==1.1.224.post1',
     'recommonmark>=0.7.1',
     'sphinx>=4.2.0',
     'sphinx_copybutton>=0.4.0',


### PR DESCRIPTION
1. Fix the run directory uploader doctest. This doctest example was never actually running, but because it was launching subprocesses, it somehow did not trigger a failure exit code. Instead, it would occasionally hang the linting process, triggering a timeout.
2. Fixed pyright issues. Pinned version to 1.1.224.post1.
3. Added doctest groups to all doctests that patch env variables. Groups are needed to ensure that the environments don't conflict.