### PR TITLE
W&B excludes final eval metrics when plotted as a fxn of epoch or trainer/global_step

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1147,6 +1147,11 @@ class Trainer:
 
                     self.engine.run_event(Event.EVAL_BATCH_END)
 
+                self.logger.metric_epoch({"epoch": self.state.epoch})
+                self.logger.metric_batch({
+                    "trainer/global_step": self.state.step,
+                    "trainer/batch_idx": self.state.timer.batch_in_epoch.value,
+                })
                 self._compute_and_log_metrics(metrics, is_train=False, is_batch=is_batch, logging_label=evaluator.label)
 
             self.engine.run_event(Event.EVAL_END)


### PR DESCRIPTION
The metrics logged during the final call to `trainer.eval()` do not have an associated `epoch` or `trainer/global_step` when logging to W&B. This causes W&B not to plot metrics computed during the final call to `trainer.eval()`. For example, computing `accuracy/val` vs. `epoch` or `accuracy/val` vs. `trainer/global_step` [truncates the final value (interestingly this is not the case when plotting `accuracy/val` vs. `Step`)](https://wandb.ai/mosaic-ml/logger_test?workspace=user-mleavitt).

My naive solution was to insert
```
self.logger.metric_epoch({"epoch": self.state.epoch})
self.logger.metric_batch({
    "trainer/global_step": self.state.step,
    "trainer/batch_idx": self.state.timer.batch_in_epoch.value,
})
```
into `trainer.eval()`