### PR TITLE
fix autocast for pytorch < 1.10

### DIFF
--- a/composer/trainer/devices/device_gpu.py
+++ b/composer/trainer/devices/device_gpu.py
@@ -51,7 +51,7 @@ class DeviceGPU(Device):
         elif precision == Precision.BF16:
             if version.parse(torch.__version__) < version.parse("1.10"):
                 raise ValueError(f"BF16 precision requires torch > 1.10, got version {torch.__version__}")
-            with torch.cuda.amp.autocast(True, torch.bfloat16):
+            with torch.cuda.amp.autocast(True, torch.bfloat16): # type: ignore
                 yield
         # Retain compatibility with PyTorch < 1.10
         if precision != Precision.BF16:

--- a/composer/trainer/devices/device_gpu.py
+++ b/composer/trainer/devices/device_gpu.py
@@ -51,11 +51,11 @@ class DeviceGPU(Device):
         elif precision == Precision.BF16:
             if version.parse(torch.__version__) < version.parse("1.10"):
                 raise ValueError(f"BF16 precision requires torch > 1.10, got version {torch.__version__}")
-            with torch.cuda.amp.autocast(True, torch.bfloat16): # type: ignore
+            with torch.cuda.amp.autocast(True, torch.bfloat16):  # type: ignore
                 yield
         # Retain compatibility with PyTorch < 1.10
         if precision != Precision.BF16:
-            with torch.cuda.amp.autocast(enabled): # type: ignore
+            with torch.cuda.amp.autocast(enabled):  # type: ignore
                 yield
 
     def state_dict(self) -> StateDict:

--- a/composer/trainer/devices/device_gpu.py
+++ b/composer/trainer/devices/device_gpu.py
@@ -44,7 +44,6 @@ class DeviceGPU(Device):
     def precision_context(self, precision: Union[str, Precision]) -> Generator[None, None, None]:
         precision = Precision(precision)
         enabled = False
-        dtype = torch.float16
         if precision == Precision.FP32:
             enabled = False
         elif precision == Precision.AMP:
@@ -52,10 +51,12 @@ class DeviceGPU(Device):
         elif precision == Precision.BF16:
             if version.parse(torch.__version__) < version.parse("1.10"):
                 raise ValueError(f"BF16 precision requires torch > 1.10, got version {torch.__version__}")
-            enabled = True
-            dtype = torch.bfloat16
-        with torch.cuda.amp.autocast(enabled, dtype):
-            yield
+            with torch.cuda.amp.autocast(True, torch.bfloat16):
+                yield
+        # Retain compatibility with PyTorch < 1.10
+        if precision != Precision.BF16:
+            with torch.cuda.amp.autocast(enabled):
+                yield
 
     def state_dict(self) -> StateDict:
         return {

--- a/composer/trainer/devices/device_gpu.py
+++ b/composer/trainer/devices/device_gpu.py
@@ -55,7 +55,7 @@ class DeviceGPU(Device):
                 yield
         # Retain compatibility with PyTorch < 1.10
         if precision != Precision.BF16:
-            with torch.cuda.amp.autocast(enabled):
+            with torch.cuda.amp.autocast(enabled): # type: ignore
                 yield
 
     def state_dict(self) -> StateDict:


### PR DESCRIPTION
PyTorch versions < 1.10 do not have a second argument for autocast: https://pytorch.org/docs/1.9.1/amp.html. This PR fixes a bug introduced by the bfloat PR (#433) where we called torch.cuda.amp.autocast with a second argument (dtype) regardless of the PyTorch version.