### PR TITLE
Fix broken "best practices" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Everyone has their own priorities: best accuracy, cheapest cost, and somewhere i
 
 Composer features:
 - 20+ efficient training methods for training a better language and vision models! Don't waste hours trying to reproduce research papers when Composer has done the work for you.
-- Easy-to-use (optional) Trainer interface written to be as performant as possible, and [integrated best practices](https://www.mosaicml.com/blog/best-practices-dec-2021).
+- Easy-to-use (optional) Trainer interface written to be as performant as possible, and [integrated best practices](https://www.mosaicml.com/blog/5-best-practices-for-efficient-model-training).
 - Easy-to-use Functional forms that allow you to integrate efficient training methods into your training loop!
 - Strong, _reproducible_ baselines to get you started as 💨 fast 💨 as possible
 


### PR DESCRIPTION
The link to the best practices blog post was broken