### PR TITLE
Batchwise resolution for SWA

### DIFF
--- a/composer/algorithms/hparams.py
+++ b/composer/algorithms/hparams.py
@@ -370,7 +370,7 @@ class SWAHparams(AlgorithmHparams):
         default="0.97dur")
     update_interval: str = hp.optional(doc='Time string denoting how often the averaged model is updated. For example, '
                                        '"1ep" means the averaged model will be updated once per epoch, and '
-                                       '"5ba" means the averaged model will be updated every 5 batches.',
+                                       '"10ba" means the averaged model will be updated every 10 batches.',
                                        default="1ep")
     schedule_swa_lr: bool = hp.optional(doc='Flag to determine whether to apply an SWA-specific LR schedule during the '
                                         'period in which SWA is active.',

--- a/composer/algorithms/hparams.py
+++ b/composer/algorithms/hparams.py
@@ -368,14 +368,19 @@ class SWAHparams(AlgorithmHparams):
         '(non-averaged) model is replaced with the stochastic weight averaged model. '
         'Currently only units of duration (e.g. "0.97dur") and epoch (e.g "88ep") are supported.',
         default="0.97dur")
+    update_interval: str = hp.optional(doc='Time string denoting how often the averaged model is updated. For example, '
+                                       '"1ep" means the averaged model will be updated once per epoch, and '
+                                       '"5ba" means the averaged model will be updated every 5 batches.',
+                                       default="1ep")
     schedule_swa_lr: bool = hp.optional(doc='Flag to determine whether to apply an SWA-specific LR schedule during the '
                                         'period in which SWA is active.',
                                         default=False)
     anneal_strategy: str = hp.optional(doc='SWA learning rate annealing schedule strategy. '
                                        '"linear" for linear annealing, "cos" for cosine annealing.',
                                        default='linear')
-    anneal_epochs: int = hp.optional(
-        doc='Number of epochs over which to anneal SWA learning rate.',
+    anneal_steps: int = hp.optional(
+        doc='Number of SWA model updates over which to anneal SWA learning rate. Note '
+        'that updates are determined by the ``update_interval`` argument.',
         default=10,
     )
     swa_lr: Optional[float] = hp.optional(

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -46,7 +46,7 @@ def set_batch_sequence_length(batch: Dict[str, Tensor], curr_seq_len: int, trunc
             where all tensors have curr_seq_len in the second dimension.
 
     Example:
-    
+
     .. code-block::
 
         import composer.functional as cf

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -71,7 +71,7 @@ class SWA(Algorithm):
             accuracy, so ensure ``swa_end`` < :math:`\\frac{N_{epochs}-1}{N_{epochs}}`.
             Currently only units of duration ('dur') and epoch ('ep') are supported.
             Default = ``'0.97dur'``.
-        update_interval (str, optional): Time string denoting how often the averaged 
+        update_interval (str, optional): Time string denoting how often the averaged
             model is updated. For example, ``'1ep'`` means the averaged model will be
             updated once per epoch, and ``'5ba'`` means the averaged model will be updated
             every 5 batches. Note that for single-epoch training runs (e.g. many NLP

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -71,28 +71,40 @@ class SWA(Algorithm):
             accuracy, so ensure ``swa_end`` < :math:`\\frac{N_{epochs}-1}{N_{epochs}}`.
             Currently only units of duration ('dur') and epoch ('ep') are supported.
             Default = ``'0.97dur'``.
+        update_interval (str, optional): Time string denoting how often the averaged 
+            model is updated. For example, ``'1ep'`` means the averaged model will be
+            updated once per epoch, and ``'5ba'`` means the averaged model will be updated
+            every 5 batches. Note that for single-epoch training runs (e.g. many NLP
+            training runs) ``update_interval`` must be specified in units of ``'ba'``,
+            otherwise SWA won't happen. Default = ``'1ep'``.
         schedule_swa_lr (bool, optional): Flag to determine whether to apply an
             SWA-specific LR schedule during the period in which SWA is active. Default =
             ``False``.
         anneal_strategy (str, optional): SWA learning rate annealing schedule strategy.
             "linear" for linear annealing, "cos" for cosine annealing. Default =
             ``"linear"``.
-        anneal_epochs (int, optional): Number of epochs over which to anneal SWA
-            learning rate. Default = ``10``.
-        swa_lr (float, optional): The final learning rate to anneal towards with SWA LR
-            scheduler. Set to ``None`` for no annealing.
+        anneal_steps (int, optional): Number of SWA model updates over which to
+            anneal SWA learning rate. Note that updates are determined by the
+            ``update_interval`` argument. For example, if ``anneal_steps = 10`` and
+            ``update_interval = '1ep'``, then the SWA LR will be annealed once per epoch
+            for 10 epochs; if ``anneal_steps = 20`` and ``update_interval = '8ba'``, then
+            the SWA LR will be annealed once every 8 batches over the course of 160
+            batches (20 steps * 8 batches/step). Default = ``10``.
+        swa_lr (float, optional): The final learning rate to anneal towards with the SWA
+            LR scheduler. Set to ``None`` for no annealing. Default = ``None``.
     """
 
     def __init__(self,
                  swa_start: str = "0.7dur",
                  swa_end: str = "0.97dur",
+                 update_interval: str = "1ep",
                  schedule_swa_lr: bool = False,
                  anneal_strategy: str = "linear",
-                 anneal_epochs: int = 10,
+                 anneal_steps: int = 10,
                  swa_lr: Optional[float] = None):
         self.schedule_swa_lr = schedule_swa_lr
         self.anneal_strategy = anneal_strategy
-        self.anneal_epochs = anneal_epochs
+        self.anneal_steps = anneal_steps
         self.swa_lr = swa_lr
         self.swa_model: Optional[torch.nn.Module] = None
         self.swa_completed = False
@@ -106,13 +118,21 @@ class SWA(Algorithm):
             self.swa_end = Time.from_timestring(swa_end)
         except ValueError as error:
             raise ValueError(f"Invalid time string for parameter swa_end") from error
+        try:
+            self.update_interval = Time.from_timestring(update_interval)
+        except ValueError as error:
+            raise ValueError(f"Invalid time string for parameter update_interval") from error
 
         # Check time objects have supported units
         for time_attr in ["swa_start", "swa_end"]:
             time_obj = getattr(self, time_attr)
             if time_obj.unit not in [TimeUnit.DURATION, TimeUnit.EPOCH]:
                 raise ValueError(f"Invalid unit string for parameter {time_attr}: {time_obj.unit}")
+        if self.update_interval.unit not in [TimeUnit.BATCH, TimeUnit.EPOCH]:
+            raise ValueError(f"Invalid unit string for parameter update_interval: "
+                             f"{self.update_interval.unit}")
 
+        # Check time objects have valid values
         if self.swa_start.unit == TimeUnit.DURATION:
             if self.swa_start < 0 or self.swa_start >= 1:
                 raise ValueError("If swa_start is specified in units of 'dur', it must "
@@ -124,8 +144,11 @@ class SWA(Algorithm):
                             "See the documentation for the `swa_end` parameter for details.")
             if self.swa_end > 1:
                 raise ValueError("If swa_end is specified in units of 'dur', it must be ≤1.")
-        if anneal_epochs <= 0:
-            raise ValueError("anneal_epochs must be greater than 0")
+        if self.update_interval < 1:
+            raise ValueError("update_interval must be ≥ 1.")
+
+        if anneal_steps <= 0:
+            raise ValueError("anneal_steps must be greater than 0")
 
         # Check annealing_strategy string
         if self.anneal_strategy.lower() in ["linear", "lin"]:
@@ -138,6 +161,15 @@ class SWA(Algorithm):
         self.swa_scheduler = None
         self.swa_model = None
 
+        # Keeps track of # steps so that we can know when to update averaged model
+        self.step_counter = None
+
+        # Check units for update_interval and set match event accordingly
+        if self.update_interval.unit == TimeUnit.BATCH:
+            self.match_event = Event.BATCH_END
+        elif self.update_interval.unit == TimeUnit.EPOCH:
+            self.match_event = Event.EPOCH_END
+
     def match(self, event: Event, state: State) -> bool:
         if self.swa_start.unit == TimeUnit.DURATION:
             should_start_swa = state.get_elapsed_duration() >= self.swa_start and not self.swa_completed
@@ -145,9 +177,12 @@ class SWA(Algorithm):
             should_start_swa = state.timer.get("ep") >= self.swa_start and not self.swa_completed
         else:
             should_start_swa = False
-        return event == Event.EPOCH_END and should_start_swa
+        return event == self.match_event and should_start_swa
 
     def apply(self, event: Event, state: State, logger: Logger) -> None:
+        if self.step_counter is None:
+            self.step_counter = 0
+
         if self.swa_scheduler is None and self.schedule_swa_lr:
 
             if self.swa_lr is None:
@@ -166,19 +201,22 @@ class SWA(Algorithm):
             self.swa_scheduler = SWALR(
                 state.optimizers[0],
                 swa_lr=self.swa_lr,
-                anneal_epochs=self.anneal_epochs,
+                anneal_epochs=self.anneal_steps,
                 anneal_strategy=self.anneal_strategy,
             )
 
-        if self.swa_model is None:
-            self.swa_model = AveragedModel(state.model)
+        if self.step_counter % self.update_interval.value == 0:
+            if self.swa_model is None:
+                self.swa_model = AveragedModel(state.model)
 
-        self.swa_model.update_parameters(state.model)  # type: ignore
+            self.swa_model.update_parameters(state.model)  # type: ignore
 
-        if self.schedule_swa_lr:
-            if self.swa_scheduler is None:
-                raise ValueError('SWA LR scheduler was not set.')
-            self.swa_scheduler.step()
+            if self.schedule_swa_lr:
+                if self.swa_scheduler is None:
+                    raise ValueError('SWA LR scheduler was not set.')
+                self.swa_scheduler.step()
+
+        self.step_counter += 1
 
         # Determine whether it's time to end SWA
         if self.swa_end.unit == TimeUnit.DURATION and (state.get_elapsed_duration() >= self.swa_end):

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -229,6 +229,5 @@ class SWA(Algorithm):
                             "training. This means that SWA model will not have its batch norm "
                             "statistics updated. This will negatively impact accuracy. See the "
                             "documentation for the `swa_end` parameter for details.")
-            assert type(self.swa_model.module) == type(state.model)
             state.model.load_state_dict(self.swa_model.module.state_dict())  # type: ignore
             log.info('Set model to the averaged model')

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -76,7 +76,8 @@ class SWA(Algorithm):
             updated once per epoch, and ``'5ba'`` means the averaged model will be updated
             every 5 batches. Note that for single-epoch training runs (e.g. many NLP
             training runs) ``update_interval`` must be specified in units of ``'ba'``,
-            otherwise SWA won't happen. Default = ``'1ep'``.
+            otherwise SWA won't happen. Also note that very small update intervals (e.g.
+            ``"1ba"``) can substantially slow down training. Default = ``'1ep'``.
         schedule_swa_lr (bool, optional): Flag to determine whether to apply an
             SWA-specific LR schedule during the period in which SWA is active. Default =
             ``False``.

--- a/tests/algorithms/test_algorithm_registry.py
+++ b/tests/algorithms/test_algorithm_registry.py
@@ -94,9 +94,10 @@ default_required_fields = {
     SWAHparams: {
         'swa_start': "0.7dur",
         'swa_end': "0.97dur",
+        'update_interval': "1ep",
         'schedule_swa_lr': False,
         'anneal_strategy': 'cos',
-        'anneal_epochs': 10,
+        'anneal_steps': 10,
         'swa_lr': None
     },
     AugMixHparams: {


### PR DESCRIPTION
This updates SWA to allow batch- and epoch-wise resolution for updating the averaged model. This is exposed to the user via the `update_interval`, a time string denoting how frequently the averaged model is updated (e.g. `'1ep'`, `'5ba'`). The hparam formerly known as `anneal_epochs` has been renamed to `anneal_steps` to reflect the fact that the SWA-specific LR scheduler now operates at the resolution of `update_interval` instead of single epochs.

Excited to get some NLP results, @moinnadeem!