### PR TITLE
Let C4 Dataset overwrite `num_workers` if set incorrectly

### DIFF
--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -46,7 +46,7 @@ def set_batch_sequence_length(batch: Dict[str, Tensor], curr_seq_len: int, trunc
             where all tensors have curr_seq_len in the second dimension.
 
     Example:
-    
+
     .. code-block::
 
         import composer.functional as cf

--- a/composer/datasets/c4.py
+++ b/composer/datasets/c4.py
@@ -95,6 +95,10 @@ class C4DatasetHparams(DatasetHparams):
             raise ImportError('HuggingFace transformers not installed. '
                               'Please install with `pip install composer[nlp]`')
 
+        if dataloader_hparams.num_workers > 1:
+            log.warning("C4 Dataset not compatible with num_workers > 1. Overwriting value to num_workers=1")
+            dataloader_hparams.num_workers = 1
+
         # Get C4 dataset
         c4_dataset = C4Dataset(split=self.split,
                                max_samples=self.max_samples,


### PR DESCRIPTION
This PR is a quality-of-life improvement for training with the C4 dataset, instead of erroring out and killing the training job, it just overwrites `dataloader.num_workers` before initializing the dataloader.

I expect to relax the `num_workers=1` constraint in the future, but for now it just makes sharding simpler.