### PR TITLE
Lazy imports for `pycocotools`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,4 @@ python:
    version: "3.8"
    install:
       - method: pip
-        path: .[base]
-      - method: pip
         path: .[all]

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -46,7 +46,7 @@ def set_batch_sequence_length(batch: Dict[str, Tensor], curr_seq_len: int, trunc
             where all tensors have curr_seq_len in the second dimension.
 
     Example:
-    
+
     .. code-block::
 
         import composer.functional as cf

--- a/composer/models/ssd/ssd.py
+++ b/composer/models/ssd/ssd.py
@@ -2,8 +2,6 @@ import os
 from typing import Any, Tuple
 
 import numpy as np
-from pycocotools.coco import COCO
-from pycocotools.cocoeval import COCOeval
 from torchmetrics import Metric
 
 from composer.core.types import BatchPair, Metrics, Tensor, Tensors
@@ -101,6 +99,11 @@ class coco_map(Metric):
 
     def __init__(self, data):
         super().__init__()
+        try:
+            from pycocotools.coco import COCO
+        except ImportError:
+            raise ImportError('Module pycocotools not installed. '
+                              'Please install with `pip install composer[coco]`')
         self.add_state("predictions", default=[])
         val_annotate = os.path.join(data, "annotations/instances_val2017.json")
         self.cocogt = COCO(annotation_file=val_annotate)
@@ -110,6 +113,11 @@ class coco_map(Metric):
         np.squeeze(self.predictions)  #type: ignore
 
     def compute(self):
+        try:
+            from pycocotools.cocoeval import COCOeval
+        except ImportError:
+            raise ImportError('Module pycocotools not installed. '
+                              'Please install with `pip install composer[coco]`')
         cocoDt = self.cocogt.loadRes(np.array(self.predictions))
         E = COCOeval(self.cocogt, cocoDt, iouType='bbox')
         E.evaluate()

--- a/meta.yaml
+++ b/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - python >=3.7
     - pyyaml >=5.4.1
     - pytorch >=1.9
-    - pycocotools ==2.0.1
     - torch-optimizer ==0.1.0
     - torchmetrics >=0.6.0
     - torchvision >=0.9.0
@@ -45,6 +44,7 @@ requirements:
     # - timm >=0.5.4 # This timm version is not available on conda
     - transformers >=4.11
     - datasets >=1.14
+    - pycocotools >=2.0.4
 
 test:
   requires:
@@ -64,6 +64,7 @@ test:
     # - timm >=0.5.4 # This timm version is not available on conda; installing via pip
     - transformers >=4.11
     - datasets >=1.14
+    - pycocotools >=2.0.4
   files:
     - "**/composer/**"
     - "**/tests/**"

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ install_requires = [
     "numpy==1.21.5",
     "apache-libcloud>=3.3.1",
     "psutil>=5.8.0",
-    "wget==3.2",
 ]
 extra_deps = {}
 
@@ -114,7 +113,7 @@ extra_deps["timm"] = [
 ]
 
 extra_deps["coco"] = [
-    'pycocotools@git+https://github.com/cocodataset/cocoapi#egg=pycocotools&subdirectory=PythonAPI',
+    'pycocotools>=2.0.4',
 ]
 
 extra_deps["nlp"] = [

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ extra_deps['dev'] = [
     'pylint>=2.12.2',
     'docformatter>=1.4',
     'sphinx_panels==0.6.0',
-    'pycocotools@git+https://github.com/cocodataset/cocoapi#egg=pycocotools&subdirectory=PythonAPI',
 ]
 
 extra_deps["deepspeed"] = [
@@ -112,6 +111,10 @@ extra_deps["unet"] = [
 
 extra_deps["timm"] = [
     'timm==0.5.4',
+]
+
+extra_deps["coco"] = [
+    'pycocotools@git+https://github.com/cocodataset/cocoapi#egg=pycocotools&subdirectory=PythonAPI',
 ]
 
 extra_deps["nlp"] = [


### PR DESCRIPTION
1. This PR adds try..catch for the `pycocotools` imports, so that it's possible to use Composer locally without installing all the requirements. Right now with MCLI this was causing some issues.
2. Remove the hack in the readthedocs build
3. Fix the pycocotools in the meta.yaml to not install by default.
5. Remove wget (this library hasn't been updated since 2015) as a dependency; replace with requests