### PR TITLE
Fix ZeRO config

### DIFF
--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -424,7 +424,7 @@ class TrainerHparams(hp.Hparams):
             self.deepspeed["steps_per_print"] = cast(int, self.deepspeed.get("steps_per_print", 1e20))
 
             if "zero_optimization" in self.deepspeed:
-                zero_stage = cast(dict, self.deepspeed["zero_optimization"]).get("stage")
+                zero_stage = cast(dict, self.deepspeed["zero_optimization"]).get("stage", 0)
             else:
                 zero_stage = 0
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -423,11 +423,10 @@ class TrainerHparams(hp.Hparams):
         if self.deepspeed is not None:
             self.deepspeed["steps_per_print"] = cast(int, self.deepspeed.get("steps_per_print", 1e20))
 
-            zero_stage = 0
-            zero_config = cast(dict,
-                               self.deepspeed["zero_optimization"]) if "zero_optimization" in self.deepspeed else None
-            if zero_config:
-                zero_stage = cast(int, zero_config.get("stage"))
+            if "zero_optimization" in self.deepspeed:
+                zero_stage = cast(dict, self.deepspeed["zero_optimization"]).get("stage")
+            else:
+                zero_stage = 0
 
             if self.deterministic_mode and zero_stage > 0:
                 raise ValueError("Deepspeed with zero stage > 0 is not compatible with deterministic mode")

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -421,10 +421,15 @@ class TrainerHparams(hp.Hparams):
         super().validate()
 
         if self.deepspeed is not None:
-            self.deepspeed["zero_stage"] = cast(int, self.deepspeed.get("zero_stage", 0))
             self.deepspeed["steps_per_print"] = cast(int, self.deepspeed.get("steps_per_print", 1e20))
 
-            if self.deterministic_mode and self.deepspeed["zero_stage"] > 0:
+            zero_stage = 0
+            zero_config = cast(dict,
+                               self.deepspeed["zero_optimization"]) if "zero_optimization" in self.deepspeed else None
+            if zero_config:
+                zero_stage = cast(int, zero_config.get("stage"))
+
+            if self.deterministic_mode and zero_stage > 0:
                 raise ValueError("Deepspeed with zero stage > 0 is not compatible with deterministic mode")
 
             if isinstance(self.device, CPUDeviceHparams):

--- a/composer/yamls/models/gpt3_125m.yaml
+++ b/composer/yamls/models/gpt3_125m.yaml
@@ -79,7 +79,8 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 deepspeed:
-  zero_stage: 0
+  zero_optimization:
+    stage: 0
 precision: fp16
 grad_clip_norm: 1.0
 validate_every_n_batches: 1000

--- a/composer/yamls/models/gpt3_350m.yaml
+++ b/composer/yamls/models/gpt3_350m.yaml
@@ -79,7 +79,8 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 deepspeed:
-  zero_stage: 0
+  zero_optimization:
+    stage: 0
 precision: fp16
 grad_clip_norm: 1.0
 validate_every_n_batches: 1000

--- a/composer/yamls/models/gpt3_760m.yaml
+++ b/composer/yamls/models/gpt3_760m.yaml
@@ -79,7 +79,8 @@ dataloader:
   timeout: 0
   prefetch_factor: 2
 deepspeed:
-  zero_stage: 0
+  zero_optimization:
+    stage: 0
 precision: fp16
 grad_clip_norm: 1.0
 validate_every_n_batches: 1000

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -319,9 +319,9 @@ def test_checkpoint(
                 pytest.skip(
                     textwrap.dedent(f"""\
                         Skipping test since deterministic mode is required for
-                        non-trivial models, but deterministic mode isn't compatible with deepsped
+                        non-trivial models, but deterministic mode isn't compatible with deepspeed
                         zero stage {zero_stage}"""))
-        composer_trainer_hparams.deepspeed = {"zero_stage": zero_stage}
+        composer_trainer_hparams.deepspeed = {"zero_optimization": {"stage": zero_stage}}
 
     checkpoint_a_folder = "first"
     composer_trainer_hparams.save_folder = checkpoint_a_folder


### PR DESCRIPTION
This is essentially a follow-up from https://github.com/mosaicml/composer/pull/322 - where it was missed that the ZeRO stage would have to be configured differently now. Annoyingly, there was nothing on DeepSpeed's end to catch this issue - but I've at least filed a ticket now: https://github.com/microsoft/DeepSpeed/issues/1809

This is probably not related to #610.