### PR TITLE
ffcv integration for cifar10 dataset

### DIFF
--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -8,6 +8,7 @@ import textwrap
 from typing import TYPE_CHECKING, Callable, List, Optional, Sequence
 
 import torch
+import torch.utils.data
 
 from composer.utils.iter_helpers import ensure_tuple
 
@@ -95,7 +96,9 @@ class DataSpec:
             self.num_samples = num_samples
 
         else:
-            if isinstance(dataloader.dataset, collections.abc.Sized):
+            # FFCV dataloaders don't have an associated dataset
+            if isinstance(dataloader, torch.utils.data.DataLoader) and isinstance(dataloader.dataset,
+                                                                                  collections.abc.Sized):
                 try:
                     self.num_samples = len(dataloader.dataset)
                 except (TypeError, NotImplementedError):

--- a/composer/datasets/cifar.py
+++ b/composer/datasets/cifar.py
@@ -6,9 +6,13 @@ The CIFAR datasets are a collection of labeled 32x32 colour images. Please refer
 <https://www.cs.toronto.edu/~kriz/cifar.html>`_ for more details.
 """
 
+import logging
+import os
+import textwrap
 from dataclasses import dataclass
 from typing import List
 
+import torch
 import yahp as hp
 from torchvision import transforms
 from torchvision.datasets import CIFAR10
@@ -17,12 +21,15 @@ from composer.core.types import DataLoader
 from composer.datasets.dataloader import DataLoaderHparams
 from composer.datasets.hparams import DatasetHparams, SyntheticHparamsMixin, WebDatasetHparams
 from composer.datasets.synthetic import SyntheticBatchPairDataset
+from composer.datasets.utils import create_ffcv_dataset
 from composer.utils import dist
 
 __all__ = [
     "CIFAR10DatasetHparams", "CIFARWebDatasetHparams", "CIFAR10WebDatasetHparams", "CIFAR20WebDatasetHparams",
     "CIFAR100WebDatasetHparams"
 ]
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -31,12 +38,25 @@ class CIFAR10DatasetHparams(DatasetHparams, SyntheticHparamsMixin):
 
     Args:
         download (bool): Whether to download the dataset, if needed. Default: ``True``.
+        use_ffcv (bool): Whether to use FFCV dataloaders. Default: ``False``.
+        ffcv_dir (str): A directory containing train/val <file>.ffcv files. If these files don't exist and
+            ``ffcv_write_dataset`` is ``True``, train/val <file>.ffcv files will be created in this dir. Default: ``"/tmp"``.
+        ffcv_dest_train (str): <file>.ffcv file that has training samples. Default: ``"cifar_train.ffcv"``.
+        ffcv_dest_val (str): <file>.ffcv file that has validation samples. Default: ``"cifar_val.ffcv"``.
+        ffcv_write_dataset (std): Whether to create dataset in FFCV format (<file>.ffcv) if it doesn't exist. Default:
+        ``False``.
     """
     download: bool = hp.optional("whether to download the dataset, if needed", default=True)
+    use_ffcv: bool = hp.optional("whether to use ffcv for faster dataloading", default=False)
+    ffcv_dir: str = hp.optional(
+        "A directory containing train/val <file>.ffcv files. If these files don't exist and ffcv_write_dataset is true, train/val <file>.ffcv files will be created in this dir.",
+        default="/tmp")
+    ffcv_dest_train: str = hp.optional("<file>.ffcv file that has training samples", default="cifar_train.ffcv")
+    ffcv_dest_val: str = hp.optional("<file>.ffcv file that has validation samples", default="cifar_val.ffcv")
+    ffcv_write_dataset: bool = hp.optional("Whether to create dataset in FFCV format (<file>.ffcv) if it doesn't exist",
+                                           default=False)
 
     def initialize_object(self, batch_size: int, dataloader_hparams: DataLoaderHparams) -> DataLoader:
-        cifar10_mean = 0.4914, 0.4822, 0.4465
-        cifar10_std = 0.247, 0.243, 0.261
 
         if self.use_synthetic:
             total_dataset_size = 50_000 if self.is_train else 10_000
@@ -49,9 +69,83 @@ class CIFAR10DatasetHparams(DatasetHparams, SyntheticHparamsMixin):
                 memory_format=self.synthetic_memory_format,
             )
 
+        elif self.use_ffcv:
+            try:
+                import ffcv  # type: ignore
+                from ffcv.fields.decoders import IntDecoder, SimpleRGBImageDecoder  # type: ignore
+                from ffcv.pipeline.operation import Operation  # type: ignore
+            except ImportError:
+                raise ImportError(
+                    textwrap.dedent("""\
+                    Composer was installed without ffcv support.
+                    To use ffcv with Composer, please install ffcv in your environment."""))
+
+            dataset_file = self.ffcv_dest_train if self.is_train else self.ffcv_dest_val
+            dataset_filepath = os.path.join(self.ffcv_dir, dataset_file)
+            # always create if ffcv_write_dataset is true
+            if self.ffcv_write_dataset:
+                if dist.get_local_rank() == 0:
+                    if self.datadir is None:
+                        raise ValueError(
+                            "datadir is required if use_synthetic is False and ffcv_write_dataset is True.")
+                    ds = CIFAR10(
+                        self.datadir,
+                        train=self.is_train,
+                        download=self.download,
+                    )
+
+                    create_ffcv_dataset(dataset=ds, write_path=dataset_filepath)
+
+                # Wait for the local rank 0 to be done creating the dataset in ffcv format.
+                dist.barrier()
+
+            if not os.path.exists(dataset_filepath):
+                raise ValueError(
+                    f"Dataset file containing samples not found at {dataset_filepath}. Use ffcv_dir flag to point to a dir containing {dataset_filepath}."
+                )
+
+            # Please note that this mean/std is different from the mean/std used for regular PyTorch dataloader as
+            # ToTensor does the normalization for PyTorch dataloaders.
+            cifar10_mean_ffcv = [125.307, 122.961, 113.8575]
+            cifar10_std_ffcv = [51.5865, 50.847, 51.255]
+            label_pipeline: List[Operation] = [IntDecoder(), ffcv.transforms.ToTensor(), ffcv.transforms.Squeeze()]
+            image_pipeline: List[Operation] = [SimpleRGBImageDecoder()]
+
+            if self.is_train:
+                image_pipeline.extend([
+                    ffcv.transforms.RandomHorizontalFlip(),
+                    ffcv.transforms.RandomTranslate(padding=2, fill=tuple(map(int, cifar10_mean_ffcv))),
+                    ffcv.transforms.Cutout(4, tuple(map(int, cifar10_mean_ffcv))),
+                ])
+            # Common transforms for train and test
+            image_pipeline.extend([
+                ffcv.transforms.ToTensor(),
+                ffcv.transforms.ToTorchImage(channels_last=False, convert_back_int16=False),
+                ffcv.transforms.Convert(torch.float32),
+                transforms.Normalize(cifar10_mean_ffcv, cifar10_std_ffcv),
+            ])
+
+            ordering = ffcv.loader.OrderOption.RANDOM if self.is_train else ffcv.loader.OrderOption.SEQUENTIAL
+
+            return ffcv.Loader(
+                dataset_filepath,
+                batch_size=batch_size,
+                num_workers=dataloader_hparams.num_workers,
+                order=ordering,
+                distributed=False,
+                pipelines={
+                    'image': image_pipeline,
+                    'label': label_pipeline
+                },
+                batches_ahead=dataloader_hparams.prefetch_factor,
+                drop_last=self.drop_last,
+            )
         else:
             if self.datadir is None:
                 raise ValueError("datadir is required if use_synthetic is False")
+
+            cifar10_mean = 0.4914, 0.4822, 0.4465
+            cifar10_std = 0.247, 0.243, 0.261
 
             if self.is_train:
                 transformation = transforms.Compose([

--- a/composer/datasets/utils.py
+++ b/composer/datasets/utils.py
@@ -4,21 +4,21 @@
 
 import logging
 import textwrap
-from typing import Callable, List, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-import torch.utils.data
 from PIL import Image
 from torchvision import transforms
 from torchvision.datasets import VisionDataset
 
-from composer.core.types import Batch
+from composer.core.types import Batch, Dataset
 
 __all__ = [
     "add_vision_dataset_transform",
     "NormalizationFn",
     "pil_image_collate",
+    "create_ffcv_dataset",
 ]
 
 log = logging.getLogger(__name__)
@@ -162,3 +162,45 @@ def add_vision_dataset_transform(dataset: VisionDataset, transform: Callable, is
         else:
             dataset.transform = transforms.Compose([dataset.transform, transform])
             log.warning(transform_added_logstring)
+
+
+def create_ffcv_dataset(dataset: Dataset,
+                        write_path: str,
+                        max_resolution: Optional[int] = None,
+                        num_workers: int = 16,
+                        write_mode: str = 'raw',
+                        compress_probability: float = 0.50,
+                        jpeg_quality: float = 90,
+                        chunk_size: int = 100):
+    """Iterates through ``dataset`` and converts it into FFCV format at filepath ``write_path``.
+
+    Args:
+        dataset (Iterable[Sample]): A PyTorch dataset
+        write_path (str): Write results to this file.
+        max_resolution (int): Limit resolution if provided. Default: ``None``.
+        num_workers (int): Numbers of workers to use. Default: ``16``.
+        write_mode (str): Write mode for the dataset. Default: ``'raw'``.
+        compress_probability (float): Probability with which image is JPEG-compressed. Default: ``0.5``.
+        jpeg_quality (float): Quality to use for jpeg compression. Default: ``90``.
+        chunk_size (int): Size of chunks processed by each worker during conversion. Default: ``100``.
+    """
+    try:
+        import ffcv  # type: ignore
+    except ImportError:
+        raise ImportError(
+            textwrap.dedent("""\
+            Composer was installed without ffcv support.
+            To use ffcv with Composer, please install ffcv in your environment."""))
+
+    log.info(f"Writing dataset in FFCV <file>.ffcv format to {write_path}.")
+    writer = ffcv.writer.DatasetWriter(write_path, {
+        'image':
+            ffcv.fields.RGBImageField(write_mode=write_mode,
+                                      max_resolution=max_resolution,
+                                      compress_probability=compress_probability,
+                                      jpeg_quality=jpeg_quality),
+        'label':
+            ffcv.fields.IntField()
+    },
+                                       num_workers=num_workers)
+    writer.from_indexed_dataset(dataset, chunksize=chunk_size)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -910,14 +910,18 @@ class Trainer:
         # so it does not affect any other RNG reads
         for evaluator in self.state.evaluators:
             dataloader = evaluator.dataloader.dataloader
-            if isinstance(dataloader.sampler, torch.utils.data.DistributedSampler):
+            # FFCV dataloaders use their own sampling strategy
+            if isinstance(dataloader, torch.utils.data.DataLoader) and isinstance(dataloader.sampler,
+                                                                                  torch.utils.data.DistributedSampler):
                 dataloader.sampler.set_epoch(0)
             for _ in dataloader:
                 break
 
         # spin the train dataloader's sampler to get to the state of the desired epoch
         for epoch in range(int(self.state.timer.epoch)):
-            if isinstance(self.state.train_dataloader.sampler, torch.utils.data.DistributedSampler):
+            # TODO: hasattr check will be removed while fixing https://github.com/mosaicml/composer/issues/424
+            if hasattr(self.state.train_dataloader, "sampler") and isinstance(self.state.train_dataloader.sampler,
+                                                                              torch.utils.data.DistributedSampler):
                 self.state.train_dataloader.sampler.set_epoch(epoch)
             for _ in self.state.train_dataloader:
                 break
@@ -960,7 +964,9 @@ class Trainer:
                     self.engine.run_event(Event.EPOCH_START)
                     self.logger.data_epoch({"epoch": int(self.state.timer.epoch)})
 
-                if isinstance(self.state.train_dataloader.sampler, torch.utils.data.DistributedSampler):
+                # TODO: hasattr check will be removed while fixing https://github.com/mosaicml/composer/issues/424
+                if hasattr(self.state.train_dataloader, "sampler") and isinstance(self.state.train_dataloader.sampler,
+                                                                                  torch.utils.data.DistributedSampler):
                     self.state.train_dataloader.sampler.set_epoch(int(self.state.timer.epoch))
 
                 for batch_idx, self.state.batch in enumerate(
@@ -1210,7 +1216,9 @@ class Trainer:
             for evaluator in self.state.evaluators:
                 dataloader = evaluator.dataloader.dataloader
                 metrics = self._ensure_metrics_device_and_dtype(evaluator.metrics)
-                if isinstance(dataloader.sampler, torch.utils.data.DistributedSampler):
+                # TODO: hasattr check will be removed while fixing https://github.com/mosaicml/composer/issues/424
+                if hasattr(dataloader, "sampler") and isinstance(dataloader.sampler,
+                                                                 torch.utils.data.DistributedSampler):
                     # The distributed sampler uses `set_epoch` to set the random seed
                     # Because evaluation can run on each batch, we use the batch to seed the sampler
                     # so each evaluation will get a proper shuffle.

--- a/composer/yamls/models/resnet9_cifar10.yaml
+++ b/composer/yamls/models/resnet9_cifar10.yaml
@@ -5,6 +5,7 @@ train_dataset:
     download: false
     shuffle: true
     drop_last: true
+    use_ffcv: false
 val_dataset:
   cifar10:
     datadir: /datasets/CIFAR10
@@ -12,6 +13,7 @@ val_dataset:
     download: false
     shuffle: false
     drop_last: false
+    use_ffcv: false
 optimizer:
   decoupled_sgdw:
     lr: 1.2


### PR DESCRIPTION
Plan is just add it for Cifar10 first along with taking care of dependencies and installation issues. 

ImageNet will be added in a later PR

Currently this PR is to get high level comments for integration. 

### Questions

- Should we preprocess data to ffcv format if the datafiles don't exist? 

### Instructions 

`apt update; apt install libturbojpeg-dev libopencv-dev` is needed before pip install -e .[ffcv] can work. 

If ffcv can't find opencv4, use `cp /usr/lib/x86_64-linux-gnu/pkgconfig/opencv.pc /usr/lib/x86_64-linux-gnu/pkgconfig/opencv4.pc`

Once this is installed, the following should work. 

Without ffcv: 

`composer -n 1 examples/run_composer_trainer.py -f composer/yamls/models/resnet9_cifar10.yaml --max_duration 1ep --datadir /localdisk/CIFAR10`


With ffcv:

This processes the data to ffcv format first in the /tmp (Default) dir first. 

`composer -n 1 examples/run_composer_trainer.py -f composer/yamls/models/resnet9_cifar10.yaml --train_dataset.cifar10.use_ffcv true --val_dataset.cifar10.use_ffcv true --train_dataset.cifar10.ffcv_write_dataset true --val_dataset.cifar10.ffcv_write_dataset true --datadir /localdisk/CIFAR10`