### PR TITLE
Fix DeepSpeed checkpointing

### DIFF
--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -266,8 +266,6 @@ def test_checkpoint(
     - assert that the checkpoint from the new trainer at the end is the same as the checkpoint from the first trainer at the end.
     """
     del world_size  # unused. Read via env variable
-    if deepspeed_enabled:
-        pytest.skip("Deepspeed tests are unstable. See https://github.com/mosaicml/composer/issues/610.")
 
     if not isinstance(device_hparams, GPUDeviceHparams) and deepspeed_enabled:
         pytest.skip("DeepSpeed tests must be ran on GPU")

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -138,8 +138,6 @@ def test_ddp(device: DeviceHparams, world_size: int, composer_trainer_hparams: T
     We assert that each of these tensors are different to ensure that 1) random seeding works properly,
     and 2) each ddp process is indeed getting different data.
     """
-    if deepspeed:
-        pytest.skip("Deepspeed tests are unstable. See https://github.com/mosaicml/composer/issues/610.")
 
     hparams = composer_trainer_hparams
     model_hparams = hparams.model


### PR DESCRIPTION
This turned out to be a nasty race condition where rank 0 was able to release its temp dir, where various rank-agnostic checkpoint files were stored, before other ranks had finished using it. The fix is to add another `dist.barrier()`.

I was able to reproduce this locally, which made testing much easier. I wrapped `test_checkpoint` in a dummy fixture that just ran the whole test hundreds of time (commenting out the resnet test, which was slow), which was able to reliably produce plenty of failures. After this fix, I've seen no failures.