### PR TITLE
Fix DatasetHparams, WebDatasetHparams docstring

### DIFF
--- a/composer/datasets/hparams.py
+++ b/composer/datasets/hparams.py
@@ -80,7 +80,7 @@ class DatasetHparams(hp.Hparams, abc.ABC, metaclass=metaclass):
 
         Returns:
             Dataloader or DataSpec: The dataloader, or if the dataloader yields batches of custom types,
-            a :class:`DataSpec`.
+                a :class:`DataSpec`.
         """
         pass
 
@@ -109,6 +109,6 @@ class WebDatasetHparams(DatasetHparams, abc.ABC, metaclass=metaclass):
 
         Returns:
             Dataloader or DataSpec: The dataloader, or if the dataloader yields batches of custom types,
-            a :class:`DataSpec`.
+                a :class:`DataSpec`.
         """
         pass


### PR DESCRIPTION
`def initialize_object()` has an improperly indented docstring line that causes rendering problems