### PR TITLE
Match ADE20k crop to mmsegmentation baseline

### DIFF
--- a/composer/datasets/ade20k.py
+++ b/composer/datasets/ade20k.py
@@ -81,14 +81,16 @@ class RandomCropPair(torch.nn.Module):
                 # measure max area percentage of a single class
                 labels, counts = np.unique(np.array(target_crop), return_counts=True)
                 counts = counts[labels != 0]
-                current_max_percent = (np.max(counts) / np.sum(counts))
 
-                if len(counts) > 1 and current_max_percent < self.class_max_percent:
-                    break
+                if len(counts) > 0:
+                    current_max_percent = (np.max(counts) / np.sum(counts))
 
-                if current_max_percent < best_max_percent:
-                    best_crop = crop
-                    best_max_percent = current_max_percent
+                    if len(counts) > 1 and current_max_percent < self.class_max_percent:
+                        break
+
+                    if current_max_percent < best_max_percent:
+                        best_crop = crop
+                        best_max_percent = current_max_percent
 
                 crop = transforms.RandomCrop.get_params(
                     image, output_size=self.crop_size)  # type: ignore - transform typing excludes PIL.Image


### PR DESCRIPTION
This was one thing I neglected when setting up the ADE20k baseline. This allows the segmentation crop transform to attempt multiple crops if the class with the max area percentage is larger than some threshold. I added some functionality to maintain the crop with the lowest max area percentage if the threshold is not reached within the specified number of retries.

I need to test the "best crop" functionality, but results for the original setup are as follows:

| Model | mIoU | TTT | 
| ------ | -----  | ------ |
| [Old crop Unoptimized Deeplabv3](https://wandb.ai/mosaic-ml/landan-deeplabv3-optimized/groups/mmseg_deeplabv3_unoptimized/workspace?workspace=user-landanjs) | 44.82 +/- 0.19 | 7.8 hours | 
| [New crop Unoptimized Deeplabv3](https://wandb.ai/mosaic-ml/landan-deeplabv3-optimized/groups/mmseg_deeplabv3_unoptimized_new_crop/workspace) | 44.73 +/- 0.2 | 6.8 hours | 
| [Old crop Unoptimized DeepLabv3+](https://wandb.ai/mosaic-ml/landan-deeplabv3-optimized/groups/deeplabv3%2B_unoptimized_w_bn/workspace?workspace=user-landanjs) | 44.69 +/- 0.34 | 7.3 hours |
| [New crop Unoptimized Deeplabv3+](https://wandb.ai/mosaic-ml/landan-deeplabv3-optimized/groups/mmseg_deeplabv3%2B_unoptimized_new_crop/workspace) | 45.18 +/- 0.18 | 6.8 hours | 

Interpretations:
- Seems to help DeepLabv3+ quiet a bit
- Does not effect throughput, but the maximum dataloader throughput is likely smaller (would need to use no-op model to measure)
- Negatively impacts optimized baselines, but these should be retuned anyways