### PR TITLE
Update `C4Dataset` to repeat, handle `max_samples` safely

### DIFF
--- a/composer/datasets/c4.py
+++ b/composer/datasets/c4.py
@@ -281,6 +281,8 @@ class C4Dataset(IterableDataset):
     def __len__(self):
         return self.max_samples_per_device
 
+    # Repeat a HF iterable dataset infinitely
+    # TODO: This functionality should eventually be upstreamed to HF as `hf_iterable_dataset.repeat()`
     def _repeat(self, dataset):
         try:
             from datasets.iterable_dataset import _BaseExamplesIterable

--- a/composer/datasets/c4.py
+++ b/composer/datasets/c4.py
@@ -136,10 +136,11 @@ class C4DatasetHparams(DatasetHparams):
 
 
 class C4Dataset(IterableDataset):
-    """Builds a streaming, sharded, sized :class:`torch.utils.data.IterableDataset` for the C4 (Colossal Cleaned CommonCrawl) dataset. Used for
-    pretraining autoregressive or masked language models. Text samples are streamed directly from the cloud using
-    HuggingFace's C4 Dataset with streaming backend (See https://huggingface.co/datasets/c4 for more details). The text
-    samples are then shuffled, tokenized, and grouped on-the-fly.
+    """Builds a streaming, sharded, sized :class:`torch.utils.data.IterableDataset` for the C4 (Colossal Cleaned
+    CommonCrawl) dataset. Used for pretraining autoregressive or masked language models. Text samples are streamed
+    directly from the cloud using HuggingFace's C4 Dataset with streaming backend (See
+    https://huggingface.co/datasets/c4 for more details). The text samples are then shuffled, tokenized, and grouped on-
+    the-fly.
 
     Args:
         split (str): What split of the dataset to use. Either ``'train'`` or ``'validation'``.

--- a/composer/datasets/c4.py
+++ b/composer/datasets/c4.py
@@ -48,7 +48,7 @@ class C4DatasetHparams(DatasetHparams):
 
     Args:
         split (str): What split of the dataset to use. Either ``'train'`` or ``'validation'``. Default: ``None``.
-        max_samples (int): Max number of post-processed token samples, used to set epoch size of the
+        num_samples (int): The number of post-processed token samples, used to set epoch size of the
             :class:`torch.utils.data.IterableDataset`. Default: ``None``.
         tokenizer_name (str): The name of the HuggingFace tokenizer to preprocess text with. Default: ``None``.
         max_seq_len (int): The max sequence length of each token sample. Default: ``None``.
@@ -68,8 +68,8 @@ class C4DatasetHparams(DatasetHparams):
     """
 
     split: str = hp.optional("What split of the dataset to use. Either `train` or `validation`.", default=None)
-    max_samples: int = hp.optional(
-        "Max number of post-processed token samples, used to set epoch size of the IterableDataset.", default=None)
+    num_samples: int = hp.optional(
+        "The number of post-processed token samples, used to set epoch size of the IterableDataset.", default=None)
     tokenizer_name: str = hp.optional("The name of the HuggingFace tokenizer to preprocess text with.", default=None)
     max_seq_len: int = hp.optional("The max sequence length of each token sample.", default=None)
     group_method: str = hp.optional("How to group text samples into token samples. Either `truncate` or `concat`.",
@@ -88,8 +88,8 @@ class C4DatasetHparams(DatasetHparams):
     def validate(self):
         if self.split not in ["train", "validation"]:
             raise ValueError(f"Unknown split: '{self.split}'")
-        if self.max_samples is None or self.max_samples <= 0:
-            raise ValueError(f"Must provide 'max_samples' > 0")
+        if self.num_samples is None or self.num_samples <= 0:
+            raise ValueError(f"Must provide 'num_samples' > 0")
         if self.tokenizer_name is None:
             raise ValueError(f"Must provide 'tokenizer_name'")
         if self.max_seq_len is None or self.max_seq_len <= 0:
@@ -112,7 +112,7 @@ class C4DatasetHparams(DatasetHparams):
 
         # Get C4 dataset
         c4_dataset = C4Dataset(split=self.split,
-                               max_samples=self.max_samples,
+                               num_samples=self.num_samples,
                                tokenizer_name=self.tokenizer_name,
                                max_seq_len=self.max_seq_len,
                                group_method=self.group_method,
@@ -143,7 +143,7 @@ class C4Dataset(IterableDataset):
 
     Args:
         split (str): What split of the dataset to use. Either ``'train'`` or ``'validation'``.
-        max_samples (int): Max number of post-processed token samples, used to set epoch size of the :class:`torch.data.utils.IterableDataset`.
+        num_samples (int): The number of post-processed token samples, used to set epoch size of the :class:`torch.data.utils.IterableDataset`.
         tokenizer_name (str): The name of the HuggingFace tokenizer to preprocess text with.
         max_seq_len (int): The max sequence length of each token sample.
         group_method (str): How to group text samples into token samples. Either ``'truncate'`` or ``'concat'``.
@@ -159,7 +159,7 @@ class C4Dataset(IterableDataset):
 
     def __init__(self,
                  split,
-                 max_samples,
+                 num_samples,
                  tokenizer_name,
                  max_seq_len,
                  group_method,
@@ -174,7 +174,7 @@ class C4Dataset(IterableDataset):
                               'Please install with `pip install composer[nlp]`')
 
         self.split = split
-        self.max_samples = max_samples
+        self.num_samples = num_samples
         self.tokenizer_name = tokenizer_name
         self.max_seq_len = max_seq_len
         self.group_method = group_method
@@ -202,25 +202,25 @@ class C4Dataset(IterableDataset):
         # Set dataset size
         self.world_size = dist.get_world_size()
         self.rank = dist.get_global_rank()
-        self.max_samples_per_device = self.max_samples // self.world_size
-        if self.max_samples % self.world_size != 0:
-            new_max_samples = self.max_samples_per_device * self.world_size
+        self.num_samples_per_device = self.num_samples // self.world_size
+        if self.num_samples % self.world_size != 0:
+            new_num_samples = self.num_samples_per_device * self.world_size
             log.warning(
-                f"Max samples will be truncated from {max_samples}->{new_max_samples} to maintain divisibility across {self.world_size} devices."
+                f"Num samples will be truncated from {num_samples}->{new_num_samples} to maintain divisibility across {self.world_size} devices."
             )
-            self.max_samples = new_max_samples
+            self.num_samples = new_num_samples
 
-        # Try and detect if max_samples is larger than original dataset
+        # Try and detect if num_samples is larger than original dataset
         original_approx_samples = self.num_shards * self.approx_samples_per_shard
-        if self.max_samples > original_approx_samples and self.group_method == "truncate":
+        if self.num_samples > original_approx_samples and self.group_method == "truncate":
             log.warning(
-                f"Max samples was set to {self.max_samples} with group_method 'truncate' but split '{split}' has only {original_approx_samples}. "
-                f"The original dataset will cycle until the new nominal length of {self.max_samples}.")
+                f"Num samples was set to {self.num_samples} with group_method 'truncate' but split '{split}' has only {original_approx_samples}. "
+                f"The original dataset will cycle until the new nominal length of {self.num_samples}.")
         if self.group_method == "concat":
             log.warning(
                 f"When using group_method 'concat', sequential token samples are concatenated and chunked into fixed-length samples of size max_seq_len={self.max_seq_len}. "
-                f"In general we cannot detect ahead-of-time if your setting of max_samples={self.max_samples} will be larger than the original dataset, "
-                f"but if it is larger, the original dataset will cycle until the new nominal length of {self.max_samples}."
+                f"In general we cannot detect ahead-of-time if your setting of num_samples={self.num_samples} will be larger than the original dataset, "
+                f"but if it is larger, the original dataset will cycle until the new nominal length of {self.num_samples}."
             )
 
         # Build tokenizer
@@ -262,7 +262,7 @@ class C4Dataset(IterableDataset):
         repeat_token_dataset = self._repeat(token_dataset)
 
         # Limit the number of post-processed token samples
-        sized_token_dataset = repeat_token_dataset.take(self.max_samples_per_device)
+        sized_token_dataset = repeat_token_dataset.take(self.num_samples_per_device)
 
         # Shuffle post-processed token samples
         # Samples are read into and randomly sampled from per-device shuffle buffer
@@ -279,7 +279,7 @@ class C4Dataset(IterableDataset):
         return iter(self.iterable_dataset)
 
     def __len__(self):
-        return self.max_samples_per_device
+        return self.num_samples_per_device
 
     # Repeat a HF iterable dataset infinitely
     # TODO: This functionality should eventually be upstreamed to HF as `hf_iterable_dataset.repeat()`
@@ -378,7 +378,7 @@ class C4Dataset(IterableDataset):
     # If using 'concat', the batch of token samples is concatenated and chunked, such that every new token sample is exactly 'self.max_seq_len' long with no padding.
     # Using 'concat' may drop a small amount of data at the end of each batch if the total number of tokens is not divisible by 'self.max_seq_len'.
     # Using 'concat' will alter the number of token samples in the iterable dataset, and differently per-device,
-    # so we require the user to provide a 'self.max_samples' limit to ensure epoch-boundary synchronization across devices.
+    # so we require the user to provide a 'self.num_samples' limit to ensure epoch-boundary synchronization across devices.
     def _group_tokens(self, token_batch):
         if self.group_method == "truncate":
             # No processing needed, as 'self._tokenize()' has already padded / truncated each token sample to 'self.max_seq_len'

--- a/composer/yamls/models/gpt3_125m.yaml
+++ b/composer/yamls/models/gpt3_125m.yaml
@@ -1,7 +1,7 @@
 train_dataset:
   c4:
     split: train
-    max_samples: 5120000 # 10e9 tok ~= 256[bs] * 20000[ba] * 2048[msl] = 5120000[sa] * 2048[msl]
+    num_samples: 5120000 # 10e9 tok ~= 256[bs] * 20000[ba] * 2048[msl] = 5120000[sa] * 2048[msl]
     max_seq_len: 2048
     tokenizer_name: gpt2
     group_method: concat
@@ -11,7 +11,7 @@ train_dataset:
 val_dataset:
   c4:
     split: validation
-    max_samples: 102400 # Approx 100k samples
+    num_samples: 102400 # Approx 100k samples
     max_seq_len: 2048
     tokenizer_name: gpt2
     group_method: concat

--- a/composer/yamls/models/gpt3_350m.yaml
+++ b/composer/yamls/models/gpt3_350m.yaml
@@ -1,7 +1,7 @@
 train_dataset:
   c4:
     split: train
-    max_samples: 5120000 # 10e9 tok ~= 256[bs] * 20000[ba] * 2048[msl] = 5120000[sa] * 2048[msl]
+    num_samples: 5120000 # 10e9 tok ~= 256[bs] * 20000[ba] * 2048[msl] = 5120000[sa] * 2048[msl]
     max_seq_len: 2048
     tokenizer_name: gpt2
     group_method: concat
@@ -11,7 +11,7 @@ train_dataset:
 val_dataset:
   c4:
     split: validation
-    max_samples: 102400 # Approx 100k samples
+    num_samples: 102400 # Approx 100k samples
     max_seq_len: 2048
     tokenizer_name: gpt2
     group_method: concat

--- a/composer/yamls/models/gpt3_760m.yaml
+++ b/composer/yamls/models/gpt3_760m.yaml
@@ -1,7 +1,7 @@
 train_dataset:
   c4:
     split: train
-    max_samples: 5120000 # 10e9 tok ~= 256[bs] * 20000[ba] * 2048[msl] = 5120000[sa] * 2048[msl]
+    num_samples: 5120000 # 10e9 tok ~= 256[bs] * 20000[ba] * 2048[msl] = 5120000[sa] * 2048[msl]
     max_seq_len: 2048
     tokenizer_name: gpt2
     group_method: concat
@@ -11,7 +11,7 @@ train_dataset:
 val_dataset:
   c4:
     split: validation
-    max_samples: 102400 # Approx 100k samples
+    num_samples: 102400 # Approx 100k samples
     max_seq_len: 2048
     tokenizer_name: gpt2
     group_method: concat

--- a/tests/datasets/test_c4.py
+++ b/tests/datasets/test_c4.py
@@ -3,15 +3,14 @@ import pytest
 from composer.datasets.c4 import C4Dataset
 
 
+@pytest.mark.skip()
 @pytest.mark.timeout(30)
 @pytest.mark.parametrize("num_samples", [500, 500000])
 @pytest.mark.parametrize("group_method", ["concat", "truncate"])
 def test_c4_length(num_samples, group_method):
-    if num_samples == 500000:
-        # This is greater than the size of the validation set,
-        # and tests whether we can safely loop over the underlying dataset when `num_samples` is large.
-        # But it can take tens of minutes, depending on internet bandwidth, so we skip it in CI testing.
-        pytest.skip()
+    # For large values of `num_samples` such as 500000, this is greater than the size of the validation set
+    # and tests whether we can safely loop over the underlying dataset.
+    # But it can take tens of minutes, depending on internet bandwidth, so we skip it in CI testing.
 
     dataset = C4Dataset(split="validation",
                         num_samples=num_samples,

--- a/tests/datasets/test_c4.py
+++ b/tests/datasets/test_c4.py
@@ -1,0 +1,28 @@
+import pytest
+
+from composer.datasets.c4 import C4Dataset
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("num_samples", [500, 500000])
+@pytest.mark.parametrize("group_method", ["concat", "truncate"])
+def test_c4_length(num_samples, group_method):
+    if num_samples == 500000:
+        # This is greater than the size of the validation set,
+        # and tests whether we can safely loop over the underlying dataset when `num_samples` is large.
+        # But it can take tens of minutes, depending on internet bandwidth, so we skip it in CI testing.
+        pytest.skip()
+
+    dataset = C4Dataset(split="validation",
+                        num_samples=num_samples,
+                        tokenizer_name="gpt2",
+                        max_seq_len=1000,
+                        group_method="truncate",
+                        shuffle=False,
+                        seed=1)
+
+    count = 0
+    for _ in dataset:
+        count += 1
+
+    assert count == num_samples, f"Expected length {num_samples}, got length {c}"

--- a/tests/datasets/test_c4.py
+++ b/tests/datasets/test_c4.py
@@ -17,7 +17,7 @@ def test_c4_length(num_samples, group_method):
                         num_samples=num_samples,
                         tokenizer_name="gpt2",
                         max_seq_len=1000,
-                        group_method="truncate",
+                        group_method=group_method,
                         shuffle=False,
                         seed=1)
 
@@ -25,4 +25,4 @@ def test_c4_length(num_samples, group_method):
     for _ in dataset:
         count += 1
 
-    assert count == num_samples, f"Expected length {num_samples}, got length {c}"
+    assert count == num_samples, f"Expected length {num_samples}, got length {count}"

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -56,7 +56,7 @@ default_required_fields: Dict[Type[DatasetHparams], Callable[[], DatasetHparams]
     C4DatasetHparams:
         lambda: C4DatasetHparams(
             split="train",
-            max_samples=1000,
+            num_samples=1000,
             max_seq_len=100,
             tokenizer_name="gpt2",
             group_method="concat",


### PR DESCRIPTION
This PR modifies the C4 streaming dataset so it will repeat over its underlying data source, until reaching the epoch boundary of `max_samples` provided by the user.

Previously, if `max_samples` were too big, there was a potential bug where the dataset iterator would stop early and our Trainer's time conversions would be incorrect. Also, DDP might not be synced.

To make the repeating HF dataset, I followed the structure of this code: https://github.com/huggingface/datasets/blob/3dfdb054e3636a5784d365bcd65759e5bd697b03/src/datasets/iterable_dataset.py#L394

## Testing
I could use some guidance here... I have manually tested by creating a `C4Dataset` with a `max_samples` value that I know for sure is larger than the underlying dataset, and have seen that it works. But it takes ~5min to reach that point, and I'm not sure if we want a long test like that in our suite.

## Next steps

Two follow-ups from this PR:

1) Upstream the `RepeatExamplesIterable` to HF datasets, because it would be convenient if these objects all had a `.repeat()` operation.

2) Make Composer compatible with infinite datasets with no `len()`, this would remove the need for users to provide `max_samples` for datasets like `C4Dataset`.