### PR TITLE
Update Migrating_from_PTL.ipynb

### DIFF
--- a/notebooks/Migrating_from_PTL.ipynb
+++ b/notebooks/Migrating_from_PTL.ipynb
@@ -23,7 +23,7 @@
    "outputs": [],
    "source": [
     "!pip install mosaicml \n",
-    "!pip install pytorch-lightning\n",
+    "!pip install pytorch-lightning\n"
    ]
   },
   {


### PR DESCRIPTION
Remove a comma that yielded invalid JSON. See the notebook in production here:  https://colab.research.google.com/github/mosaicml/composer/blob/moin/ptl_notebook_fix/notebooks/Migrating_from_PTL.ipynb

Resolves #729 