### PR TITLE
Installing pyright via npm

### DIFF
--- a/.ci/lint_doctests.sh
+++ b/.ci/lint_doctests.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 # Doctests are executed on the linting worker, so they are
 # executed only once on an install with all dependencies
 
-sudo npm install -g pyright@1.1.224.post1
+sudo npm install -g pyright@1.1.224
 
 pip install .[all]
 make lint

--- a/.ci/lint_doctests.sh
+++ b/.ci/lint_doctests.sh
@@ -5,6 +5,8 @@ set -euxo pipefail
 # Doctests are executed on the linting worker, so they are
 # executed only once on an install with all dependencies
 
+sudo npm install -g pyright@1.1.224.post1
+
 pip install .[all]
 make lint
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 DURATION ?= all  # pytest duration, one of short, long or all
 WORLD_SIZE ?= 1  # world size for launcher tests
 MASTER_PORT ?= 26000 # port for distributed tests
-PYTHON ?= python
-PYTEST ?= pytest
+PYTHON ?= python  # Python command
+PYTEST ?= pytest  # Pytest command
+PYRIGHT ?= pyright  # Pyright command. Pyright must be installed seperately -- e.g. `node install -g pyright`
 EXTRA_ARGS ?=  # extra arguments for pytest
-PYRIGHT_PYTHON_FORCE_VERSION ?= 1.1.224
 
 # Force append the duration flag to extra args
 override EXTRA_ARGS += --duration $(DURATION)
@@ -23,7 +23,7 @@ lint:
 	$(PYTHON) -m isort -c --diff $(dirs)
 	$(PYTHON) -m yapf -dr $(dirs)
 	$(PYTHON) -m docformatter -r --wrap-summaries 120 --wrap-descriptions 120 $(dirs)
-	PYRIGHT_PYTHON_FORCE_VERSION=$(PYRIGHT_PYTHON_FORCE_VERSION) pyright $(dirs)
+	$(PYRIGHT) $(dirs)
 
 test:
 	$(PYTHON) -m $(PYTEST) $(EXTRA_ARGS)

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -49,6 +49,16 @@ RUN if [ -n "$CUDA_VERSION" ] ; then \
 ENV USE_SYSTEM_NCCL=${CUDA_VERSION:+1}
 ENV LD_PRELOAD=${CUDA_VERSION:+/usr/lib/x86_64-linux-gnu/libnccl.so.2.9.6}
 
+##############################
+# Install NodeJS (for Pyright)
+##############################
+RUN \
+    curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    apt-get autoclean && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 ################
 # Install Python
 ################

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -10,7 +10,7 @@ The output of this setup script does not show up in the documentation.
 import functools
 import os
 import sys
-from typing import Callable
+from typing import Callable as Callable
 
 import numpy as np
 import torch.optim
@@ -21,10 +21,10 @@ from torch.optim.lr_scheduler import CosineAnnealingLR
 import composer
 from composer import Trainer as OriginalTrainer
 from composer import *  # Make all composer imports available in doctests
-from composer.core.logging import LogLevel
-from composer.core.time import Time, Timestamp
+from composer.core.logging import LogLevel as LogLevel
+from composer.core.time import Time as Time, Timestamp as Timestamp
 from composer.datasets.synthetic import SyntheticBatchPairDataset
-from composer.loggers import InMemoryLogger
+from composer.loggers import InMemoryLogger as InMemoryLogger
 from composer.utils import *  # Make all composer.utils imports available in doctests
 
 # Need to insert the repo root at the beginning of the path, since there may be other modules named `tests`
@@ -105,7 +105,9 @@ def Trainer(fake_ellipses='...', *args, **kwargs):
 
 
 # bind the required arguments to the Trainer so it can be used without arguments in the doctests
-Trainer = functools.partial(
+
+# Declaration "Trainer" is obscured by a declaration of the same name (reportGeneralTypeIssues)
+Trainer = functools.partial(  # type: ignore
     Trainer,
     model=model,
     max_duration="1ep",

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ extra_deps['dev'] = [
     'jupyter>=1.0.0',
     'yamllint>=1.26.2',
     'pytest-timeout>=1.4.2',
-    'pyright==1.1.224.post1',
     'recommonmark==0.7.1',
     'sphinx>=4.4.0',
     'docutils>=0.15',

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -330,7 +330,7 @@ class TestTrainerAssets:
     #       with the above configuration. The fixtures below filter and
     #       create the objects to test.
 
-    @pytest.fixture(params=algorithms_registry.items(), ids=algorithms_registry.keys())
+    @pytest.fixture(params=algorithms_registry.items(), ids=tuple(algorithms_registry.keys()))
     def algorithm(self, request):
 
         name, hparams = request.param
@@ -359,7 +359,7 @@ class TestTrainerAssets:
 
         return algorithm
 
-    @pytest.fixture(params=callback_registry.items(), ids=callback_registry.keys())
+    @pytest.fixture(params=callback_registry.items(), ids=tuple(callback_registry.keys()))
     def callback(self, request, tmpdir, monkeypatch):
         name, hparams = request.param
 
@@ -377,7 +377,7 @@ class TestTrainerAssets:
 
         return callback
 
-    @pytest.fixture(params=logger_registry.items(), ids=logger_registry.keys())
+    @pytest.fixture(params=logger_registry.items(), ids=tuple(logger_registry.keys()))
     def logger(self, request):
 
         name, hparams = request.param


### PR DESCRIPTION
Installing pyright via npm, as the pip pyright does not appear to pin versions properly.

Closes #733