### PR TITLE
Increase the timeout for test trainer equivalence

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -114,6 +114,7 @@ class TestTrainerInit():
 
 @world_size(1, 2)
 @device('cpu', 'gpu', 'gpu-amp', precision=True)
+@pytest.mark.timeout(5)
 class TestTrainerEquivalence():
 
     reference_model: Model


### PR DESCRIPTION
It occassionally fails on Jenkins with a 2 second timeout. Increasing to 5 seconds.