### PR TITLE
Increased the timeout for `test_trainer.py`

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -25,6 +25,7 @@ from composer.utils.reproducibility import seed_all
 from tests.common import (RandomClassificationDataset, RandomImageDataset, SimpleConvModel, SimpleModel, device,
                           world_size)
 
+
 @pytest.mark.timeout(30)  # TODO lower the timeout. See https://github.com/mosaicml/composer/issues/774.
 class TestTrainerInit():
 
@@ -260,6 +261,7 @@ class AssertDataAugmented(Callback):
 
         assert not torch.allclose(original_outputs[0], state.outputs[0])
 
+
 @pytest.mark.timeout(30)  # TODO lower the timeout. See https://github.com/mosaicml/composer/issues/774.
 class TestTrainerEvents():
 
@@ -307,6 +309,7 @@ tests for each object, in situ of our trainer.
 We use the hparams_registry associated with our
 config management to retrieve the objects to test.
 """
+
 
 @pytest.mark.timeout(30)  # TODO lower the timeout. See https://github.com/mosaicml/composer/issues/774.
 class TestTrainerAssets:

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -25,7 +25,7 @@ from composer.utils.reproducibility import seed_all
 from tests.common import (RandomClassificationDataset, RandomImageDataset, SimpleConvModel, SimpleModel, device,
                           world_size)
 
-
+@pytest.mark.timeout(30)  # TODO lower the timeout. See https://github.com/mosaicml/composer/issues/774.
 class TestTrainerInit():
 
     @pytest.fixture
@@ -114,7 +114,7 @@ class TestTrainerInit():
 
 @world_size(1, 2)
 @device('cpu', 'gpu', 'gpu-amp', precision=True)
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(30)  # TODO lower the timeout. See https://github.com/mosaicml/composer/issues/774.
 class TestTrainerEquivalence():
 
     reference_model: Model
@@ -260,7 +260,7 @@ class AssertDataAugmented(Callback):
 
         assert not torch.allclose(original_outputs[0], state.outputs[0])
 
-
+@pytest.mark.timeout(30)  # TODO lower the timeout. See https://github.com/mosaicml/composer/issues/774.
 class TestTrainerEvents():
 
     @pytest.fixture
@@ -308,7 +308,7 @@ We use the hparams_registry associated with our
 config management to retrieve the objects to test.
 """
 
-
+@pytest.mark.timeout(30)  # TODO lower the timeout. See https://github.com/mosaicml/composer/issues/774.
 class TestTrainerAssets:
 
     @pytest.fixture


### PR DESCRIPTION
Increased the timeout to 30s, since some tests were failing at a 5s timeout. See #774.