### PR TITLE
Add eval dataloader to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,15 @@ from composer.algorithms import BlurPool, ChannelsLast, CutMix, LabelSmoothing
 from composer.models import MNIST_Classifier
 
 transform = transforms.Compose([transforms.ToTensor()])
-dataset = datasets.MNIST("data", download=True, transform=transform)
-train_dataloader = DataLoader(dataset, batch_size=128)
+train_dataset = datasets.MNIST("data", download=True, train=True, transform=transform)
+eval_dataset = datasets.MNIST("data", download=True, train=False, transform=transform)
+train_dataloader = DataLoader(train_dataset, batch_size=128)
+eval_dataloader = DataLoader(eval_dataset, batch_size=128)
 
 trainer = Trainer(
     model=MNIST_Classifier(num_classes=10),
     train_dataloader=train_dataloader,
+    eval_dataloader=eval_dataloader,
     max_duration="2ep",
     algorithms=[
         BlurPool(replace_convs=True, replace_maxpools=True, blur_first=True),


### PR DESCRIPTION
Add the eval dataloader to the readme to show decreasing loss.

PLEASE TEST THIS PR MANUALLY before approving, as it is not covered by Jenkins.