### PR TITLE
Set the random seed before each test.

### DIFF
--- a/tests/algorithms/test_colout.py
+++ b/tests/algorithms/test_colout.py
@@ -88,21 +88,18 @@ def W(H) -> int:
 @pytest.fixture
 def fake_image(H: int, W: int, C: int) -> Image.Image:
     """Fake PIL Image."""
-    rng = np.random.RandomState(0)
-    return Image.fromarray((255 * rng.uniform(size=(H, W, C)).squeeze()).astype(np.uint8))
+    return Image.fromarray((255 * np.random.uniform(size=(H, W, C)).squeeze()).astype(np.uint8))
 
 
 @pytest.fixture
 def fake_image_tensor(H: int, W: int, C: int) -> torch.Tensor:
     """Fake image tensor."""
-    torch.manual_seed(0)
     return torch.rand(C, H, W)
 
 
 @pytest.fixture
 def fake_image_batch(H: int, W: int, C: int) -> torch.Tensor:
     """Fake batch of images."""
-    torch.manual_seed(0)
     return torch.rand(16, C, H, W)
 
 

--- a/tests/algorithms/test_cutmix.py
+++ b/tests/algorithms/test_cutmix.py
@@ -17,7 +17,6 @@ from tests.common import SimpleConvModel
 def fake_data(request):
     # Generate some fake data
     N, C, d1, d2, num_classes = request.param
-    torch.manual_seed(0)
     x_fake = torch.randn(N, C, d1, d2)
     y_fake = torch.randint(num_classes, size=(N,))
     indices = torch.randperm(N)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from pytest import MonkeyPatch
 
 import composer
-from composer.utils import run_directory
+from composer.utils import dist, reproducibility, run_directory
 
 # Allowed options for pytest.mark.world_size()
 # Important: when updating this list, make sure to also up ./.ci/test.sh
@@ -42,6 +42,12 @@ if _include_deprecated_fixtures:
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption("--seed",
+                     default=0,
+                     type=int,
+                     help="""\
+        Rank zero seed to use. `reproducibility.seed_all(seed + dist.get_global_rank())` will be invoked
+        before each test.""")
     parser.addoption("--duration",
                      default="all",
                      choices=["short", "long", "all"],
@@ -123,6 +129,21 @@ def set_loglevels():
     """Ensures all log levels are set to DEBUG."""
     logging.basicConfig()
     logging.getLogger(composer.__name__).setLevel(logging.DEBUG)
+
+
+@pytest.fixture
+def rank_zero_seed(request: pytest.FixtureRequest) -> int:
+    """Read the rank_zero_seed from the CLI option."""
+    seed = request.config.getoption("seed")
+    assert isinstance(seed, int)
+    return seed
+
+
+@pytest.fixture(autouse=True)
+def seed_all(rank_zero_seed: int):
+    """Set the random seed before each test to ensure consistent test results, which and limit flakiness due to random
+    initializations."""
+    reproducibility.seed_all(rank_zero_seed + dist.get_global_rank())
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/dummy_fixtures.py
+++ b/tests/fixtures/dummy_fixtures.py
@@ -1,7 +1,7 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 from typing import Tuple, Type, Union
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -101,9 +101,8 @@ def dummy_scheduler(dummy_optimizer: Optimizer):
 
 
 @pytest.fixture()
-def dummy_state_without_rank(dummy_model: SimpleBatchPairModel, dummy_train_dataloader: DataLoader,
-                             dummy_optimizer: Optimizer, dummy_scheduler: PyTorchScheduler,
-                             dummy_val_dataloader: DataLoader) -> State:
+def dummy_state(dummy_model: SimpleBatchPairModel, dummy_train_dataloader: DataLoader, dummy_optimizer: Optimizer,
+                dummy_scheduler: PyTorchScheduler, dummy_val_dataloader: DataLoader, rank_zero_seed: int) -> State:
     evaluators = [
         Evaluator(label="dummy_label", dataloader=dummy_val_dataloader, metrics=dummy_model.metrics(train=False))
     ]
@@ -111,7 +110,7 @@ def dummy_state_without_rank(dummy_model: SimpleBatchPairModel, dummy_train_data
         model=dummy_model,
         precision=Precision.FP32,
         grad_accum=1,
-        rank_zero_seed=0,
+        rank_zero_seed=rank_zero_seed,
         train_dataloader=dummy_train_dataloader,
         evaluators=evaluators,
         optimizers=dummy_optimizer,
@@ -152,18 +151,8 @@ def dummy_val_dataloader(dummy_train_dataset_hparams: DatasetHparams, dummy_val_
 
 
 @pytest.fixture()
-def dummy_state(dummy_state_without_rank: State) -> State:
-    return dummy_state_without_rank
-
-
-@pytest.fixture()
 def dummy_logger(dummy_state: State):
     return Logger(dummy_state)
-
-
-@pytest.fixture
-def logger_mock():
-    return MagicMock()
 
 
 """
@@ -195,6 +184,7 @@ def composer_trainer_hparams(
     dummy_val_dataset_hparams: DatasetHparams,
     dummy_train_batch_size: int,
     dummy_val_batch_size: int,
+    rank_zero_seed: int,
 ) -> TrainerHparams:
     return TrainerHparams(
         algorithms=[],
@@ -204,6 +194,7 @@ def composer_trainer_hparams(
         precision=Precision.FP32,
         train_batch_size=dummy_train_batch_size,
         eval_batch_size=dummy_val_batch_size,
+        seed=rank_zero_seed,
         dataloader=DataLoaderHparams(
             num_workers=0,
             prefetch_factor=2,
@@ -230,12 +221,12 @@ def simple_conv_model_input():
 
 @pytest.fixture()
 def state_with_model(simple_conv_model: torch.nn.Module, dummy_train_dataloader: DataLoader,
-                     dummy_val_dataloader: DataLoader):
+                     dummy_val_dataloader: DataLoader, rank_zero_seed: int):
     metric_coll = MetricCollection([Accuracy()])
     evaluators = [Evaluator(label="dummy_label", dataloader=dummy_val_dataloader, metrics=metric_coll)]
     state = State(
         grad_accum=1,
-        rank_zero_seed=0,
+        rank_zero_seed=rank_zero_seed,
         max_duration="100ep",
         model=simple_conv_model,
         precision=Precision.FP32,

--- a/tests/fixtures/new_fixtures.py
+++ b/tests/fixtures/new_fixtures.py
@@ -10,14 +10,14 @@ from tests.common import RandomClassificationDataset, SimpleModel
 
 
 @pytest.fixture
-def minimal_state():
+def minimal_state(rank_zero_seed: int):
     """Most minimally defined state possible.
 
     Tests should configure the state for their specific needs.
     """
     return State(
         model=SimpleModel(),
-        rank_zero_seed=0,
+        rank_zero_seed=rank_zero_seed,
         train_dataloader=DataLoader(RandomClassificationDataset()),
         evaluators=[],
         max_duration='100ep',

--- a/tests/loggers/test_object_store_logger.py
+++ b/tests/loggers/test_object_store_logger.py
@@ -93,6 +93,7 @@ def test_object_store_logger_use_procs(tmpdir: pathlib.Path, dummy_state: State,
 
 
 @pytest.mark.timeout(5)
+@pytest.mark.filterwarnings(r"ignore:((.|\n)*)FileExistsError((.|\n)*):pytest.PytestUnhandledThreadExceptionWarning")
 def test_object_store_logger_no_overwrite(tmpdir: pathlib.Path, dummy_state: State, monkeypatch: pytest.MonkeyPatch):
     object_store_test_helper(tmpdir=tmpdir, dummy_state=dummy_state, monkeypatch=monkeypatch, overwrite=False)
 

--- a/tests/test_nlp_metrics.py
+++ b/tests/test_nlp_metrics.py
@@ -11,7 +11,6 @@ from composer.models.nlp_metrics import BinaryF1Score, CrossEntropyLoss, MaskedA
 
 @pytest.mark.parametrize("ignore_index", [-100])
 @pytest.mark.parametrize("num_classes", [2, 3, 4, 5])
-@pytest.mark.xfail(reason="Test is flaky. See https://github.com/mosaicml/composer/issues/767.")
 def test_masked_accuracy(ignore_index, num_classes):
     """Sanity check to make sure that masked accuracy has reasonable performance.
 

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1,10 +1,10 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 import os
-import random
 import tarfile
 import tempfile
 import textwrap
+import time
 from typing import Any, Dict, Optional
 
 import pytest
@@ -35,7 +35,7 @@ class DummyStatefulCallback(Callback):
 
     def __init__(self) -> None:
         super().__init__()
-        self.random_value = random.random()
+        self.random_value = time.time_ns()
 
     def state_dict(self) -> Dict[str, Any]:
         return {

--- a/tests/trainer/test_ddp_sync_strategy.py
+++ b/tests/trainer/test_ddp_sync_strategy.py
@@ -49,14 +49,14 @@ class MinimalConditionalModel(nn.Module):
 ])
 @pytest.mark.world_size(2)
 def test_ddp_sync_strategy(ddp_sync_strategy: str, expected_grads: List[Optional[float]],
-                           dummy_train_dataloader: DataLoader, dummy_val_dataloader: DataLoader):
+                           dummy_train_dataloader: DataLoader, dummy_val_dataloader: DataLoader, rank_zero_seed: int):
     original_model = MinimalConditionalModel()
     # ddp = DDP(backend="gloo", find_unused_parameters=True, sync_strategy=ddp_sync_strategy, timeout=5.)
     optimizer = torch.optim.SGD(original_model.parameters(), 0.1)
     metric_coll = MetricCollection([Accuracy()])
     evaluators = [Evaluator(label="dummy_label", dataloader=dummy_val_dataloader, metrics=metric_coll)]
     state = State(model=original_model,
-                  rank_zero_seed=0,
+                  rank_zero_seed=rank_zero_seed,
                   optimizers=optimizer,
                   grad_accum=2,
                   max_duration="1ep",

--- a/tests/trainer/test_scheduler.py
+++ b/tests/trainer/test_scheduler.py
@@ -21,10 +21,10 @@ STEPS_PER_EPOCH = 1000
 
 
 @pytest.fixture
-def dummy_schedulers_state(dummy_model: torch.nn.Module, dummy_train_dataloader: DataLoader):
+def dummy_schedulers_state(dummy_model: torch.nn.Module, dummy_train_dataloader: DataLoader, rank_zero_seed: int):
     return State(
         model=dummy_model,
-        rank_zero_seed=0,
+        rank_zero_seed=rank_zero_seed,
         train_dataloader=dummy_train_dataloader,
         max_duration=MAX_DURATION,
         steps_per_epoch=STEPS_PER_EPOCH,
@@ -113,7 +113,7 @@ def test_scheduler_init(scheduler: ComposerScheduler, ssr: float, test_times: Li
         (lambda state: 0.01, 1.5,
          ValueError),  # this should error since the ssr != 1.0 and the lambda doesn't support ssr
     ])
-def test_scheduler_trains(scheduler: ComposerScheduler, ssr: float, dummy_model: ComposerModel,
+def test_scheduler_trains(scheduler: ComposerScheduler, ssr: float, dummy_model: ComposerModel, rank_zero_seed: int,
                           dummy_train_dataloader: DataLoader, should_raise: Optional[Type[Exception]]):
     with pytest.raises(should_raise) if should_raise is not None else contextlib.nullcontext():
         trainer = Trainer(
@@ -123,5 +123,6 @@ def test_scheduler_trains(scheduler: ComposerScheduler, ssr: float, dummy_model:
             train_subset_num_batches=5,
             scale_schedule_ratio=ssr,
             schedulers=scheduler,
+            seed=rank_zero_seed,
         )
         trainer.fit()

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -20,7 +20,7 @@ from composer.core.precision import Precision
 from composer.loggers import FileLogger, ProgressBarLogger, WandBLogger
 from composer.trainer.devices.device import Device
 from composer.trainer.trainer_hparams import algorithms_registry, callback_registry, logger_registry
-from composer.utils import dist, reproducibility
+from composer.utils import dist
 from tests.common import (RandomClassificationDataset, RandomImageDataset, SimpleConvModel, SimpleModel, device,
                           world_size)
 

--- a/tests/utils/classifer.py
+++ b/tests/utils/classifer.py
@@ -14,14 +14,17 @@ from composer.loggers import Logger
 from tests.utils.model import SimpleModel
 
 
-def _get_state(train_dataloader: DataLoader, eval_dataloader: DataLoader, steps_per_epoch: int = 1):
+def _get_state(train_dataloader: DataLoader,
+               eval_dataloader: DataLoader,
+               rank_zero_seed: int,
+               steps_per_epoch: int = 1):
     model = SimpleModel()
     steps_per_epoch = steps_per_epoch
     metric_coll = MetricCollection([Accuracy()])
     evaluators = [Evaluator(label="dummy_label", dataloader=eval_dataloader, metrics=metric_coll)]
     return State(
         model=model,
-        rank_zero_seed=0,
+        rank_zero_seed=rank_zero_seed,
         optimizers=SGD(model.parameters(), lr=.001, momentum=0.0),
         max_duration="1ep",
         train_dataloader=train_dataloader,
@@ -34,6 +37,7 @@ def _get_state(train_dataloader: DataLoader, eval_dataloader: DataLoader, steps_
 def test_classifier_trains(
     train_dataloader: DataLoader,
     eval_dataloader: DataLoader,
+    rank_zero_seed: int,
     algorithms: Sequence[Algorithm],
     n_steps: int = 1,
     check_steps: Optional[Sequence[int]] = None,
@@ -41,7 +45,10 @@ def test_classifier_trains(
     if check_steps is None:
         check_steps = list(range(n_steps))
 
-    state = _get_state(train_dataloader=train_dataloader, eval_dataloader=eval_dataloader, steps_per_epoch=n_steps)
+    state = _get_state(train_dataloader=train_dataloader,
+                       eval_dataloader=eval_dataloader,
+                       steps_per_epoch=n_steps,
+                       rank_zero_seed=rank_zero_seed)
     model = state.model
 
     logger = Logger(state=state, destinations=[])


### PR DESCRIPTION
Motivation behind using a deterministic seed for each test is to avoid test flakiness and ensure that PRs do not fail due to unrelated test failures. Instead, we should configure Jenkins to run nightly regressions across multiple seeds to identify tests that depend on the random initialization, and triage nightly regression errors as appropriate.

1. Added a pytest CLI option `--seed`. If not set, defaults to 0.
2. Added an `autouse` fixture to set the seed automatically before each test.
3. For tests that create instances of the trainer, manually specified the `rank_zero_seed`, as otherwise the trainer would re-seed the rng with `os.random`.
4. Removed the xfail on `test_masked_accuracy`, as the seed is now deterministic.
5. Unrelated cleanup: Removed unused fixtures from `conftest`; filtering warnings that should be ignored.

Closes #767