### PR TITLE
Readme code fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ from torchvision import models
 my_model = models.resnet18()
 
 # add blurpool and squeeze excite layers
-model = cf.apply_blurpool(my_model)
-model = cf.apply_squeeze_excite(my_model)
+my_model = cf.apply_blurpool(my_model)
+my_model = cf.apply_squeeze_excite(my_model)
 
 # your own training code starts here
 ```


### PR DESCRIPTION
`model` variable was overwritten, not added to, in our code example.