### PR TITLE
models cleanup - part 2, metrics and loss

### DIFF
--- a/composer/algorithms/cutmix/cutmix.py
+++ b/composer/algorithms/cutmix/cutmix.py
@@ -14,7 +14,7 @@ from torch.nn import functional as F
 
 from composer.core import Algorithm, Event, State
 from composer.loggers import Logger
-from composer.models.loss import _check_for_index_targets
+from composer.loss.loss import _check_for_index_targets
 
 log = logging.getLogger(__name__)
 

--- a/composer/algorithms/label_smoothing/label_smoothing.py
+++ b/composer/algorithms/label_smoothing/label_smoothing.py
@@ -10,7 +10,7 @@ import torch
 
 from composer.core import Algorithm, Event, State
 from composer.loggers import Logger
-from composer.models.loss import ensure_targets_one_hot
+from composer.loss.loss import ensure_targets_one_hot
 
 __all__ = ["LabelSmoothing", "smooth_labels"]
 

--- a/composer/algorithms/mixup/mixup.py
+++ b/composer/algorithms/mixup/mixup.py
@@ -13,7 +13,7 @@ from torch.nn import functional as F
 
 from composer.core import Algorithm, Event, State
 from composer.loggers import Logger
-from composer.models.loss import _check_for_index_targets
+from composer.loss.loss import _check_for_index_targets
 
 log = logging.getLogger(__name__)
 

--- a/composer/algorithms/progressive_resizing/progressive_resizing.py
+++ b/composer/algorithms/progressive_resizing/progressive_resizing.py
@@ -15,7 +15,7 @@ import torchvision.transforms.functional
 
 from composer.core import Algorithm, Event, State
 from composer.loggers import Logger
-from composer.models.loss import _check_for_index_targets
+from composer.loss.loss import _check_for_index_targets
 
 log = logging.getLogger(__name__)
 

--- a/composer/loss/__init__.py
+++ b/composer/loss/__init__.py
@@ -1,0 +1,1 @@
+from composer.loss.loss import soft_cross_entropy as soft_cross_entropy

--- a/composer/loss/loss.py
+++ b/composer/loss/loss.py
@@ -5,6 +5,8 @@ from typing import Optional
 from torch import Tensor
 from torch.nn import functional as F
 
+__all__ = ["soft_cross_entropy"]
+
 
 def _infer_target_type(input: Tensor, targets: Tensor) -> str:
     """Infers whether the target is in indices format or one_hot format.

--- a/composer/loss/loss.py
+++ b/composer/loss/loss.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from torch import Tensor
+from torch.nn import functional as F
+
+
+def _infer_target_type(input: Tensor, targets: Tensor) -> str:
+    """Infers whether the target is in indices format or one_hot format.
+
+    Example indices format: [1, 4, 7] Example one_hot format [[0, 1, 0], [1, 0, 0], ...]
+    """
+    if input.shape == targets.shape:
+        return 'one_hot'
+    elif input.ndim == targets.ndim + 1:
+        return 'indices'
+    else:
+        raise RuntimeError(f'Unable to infer indices or one_hot. Targets has shape {targets.shape}'
+                           f' and the inputs to cross entropy has shape {input.shape}. For one_hot, '
+                           'expect targets.shape == inputs.shape. For indices, expect '
+                           'inputs.ndim == targets.ndim + 1')
+
+
+def ensure_targets_one_hot(input: Tensor, targets: Tensor) -> Tensor:
+    if _infer_target_type(input, targets) == 'indices':
+        targets = F.one_hot(targets, num_classes=input.shape[1])
+    return targets
+
+
+def _check_for_index_targets(targets: Tensor) -> bool:
+    """Checks if a given set of targets are indices by looking at the type."""
+    index_types = ['torch.LongTensor', 'torch.cuda.LongTensor']
+    return targets.type() in index_types
+
+
+def soft_cross_entropy(input: Tensor,
+                       target: Tensor,
+                       weight: Optional[Tensor] = None,
+                       size_average: Optional[bool] = None,
+                       ignore_index: int = -100,
+                       reduce: Optional[bool] = None,
+                       reduction: str = 'mean'):
+    r"""Drop-in replacement for :class:`~torch.nn.CrossEntropyLoss` that can handle class indices or one-hot labels.
+
+    Args:
+        input (torch.Tensor) : :math:`(N, C)` where `C = number of classes` or :math:`(N, C, H, W)`
+            in case of 2D Loss, or :math:`(N, C, d_1, d_2, ..., d_K)` where :math:`K \geq 1`
+            in the case of K-dimensional loss. `input` is expected to contain unnormalized scores
+            (often referred to as logits).
+        target (torch.Tensor) : If containing class indices, shape :math:`(N)` where each value is
+            :math:`0 \leq \text{targets}[i] \leq C-1`, or :math:`(N, d_1, d_2, ..., d_K)` with
+            :math:`K \geq 1` in the case of K-dimensional loss. If containing class probabilities,
+            same shape as the input.
+        weight (torch.Tensor, optional): a manual rescaling weight given to each
+            class. If given, has to be a Tensor of size `C`. Default: ``None``.
+        size_average (bool, optional): Deprecated (see `reduction`). By default,
+            the losses are averaged over each loss element in the batch. Note that for
+            some losses, there multiple elements per sample. If the field ``size_average``
+            is set to ``False``, the losses are instead summed for each minibatch. Ignored
+            when reduce is ``False``. Default: ``True``
+        ignore_index (int, optional): Specifies a target value that is ignored
+            and does not contribute to the input gradient. When ``size_average`` is
+            ``True``, the loss is averaged over non-ignored targets. Note that
+            ``ignore_index`` is only applicable when the target contains class indices.
+            Default: ``-100``
+        reduce (bool, optional): Deprecated (see ``reduction``). By default, the
+            losses are averaged or summed over observations for each minibatch depending
+            on `size_average`. When ``reduce`` is ``False``, returns a loss per
+            batch element instead and ignores `size_average`. Default: ``True``
+        reduction (str, optional): Specifies the reduction to apply to the output:
+            ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
+            ``'mean'``: the sum of the output will be divided by the number of
+            elements in the output, ``'sum'``: the output will be summed. Note: ``size_average``
+            and ``reduce`` are in the process of being deprecated, and in the meantime,
+            specifying either of those two args will override ``reduction``. Default: ``'mean'``
+
+    This function will be obsolete with `this update <https://github.com/pytorch/pytorch/pull/61044>`_.
+    """
+    target_type = _infer_target_type(input, target)
+
+    if target_type == 'indices':
+        return F.cross_entropy(input, target, weight, size_average, ignore_index, reduce, reduction)
+    elif target_type == 'one_hot':
+        assert reduction in ['sum', 'mean', 'none'], f"{reduction} reduction not supported."
+        assert size_average is None, "size_average is deprecated"
+        assert reduce is None, "reduce is deprecated"
+        assert ignore_index == -100, "ignore_index not supported."
+        probs = -1 * (target * F.log_softmax(input, dim=1))
+
+        if weight is not None:
+            probs *= weight / weight.sum()  # allow broadcast along batch dim
+
+        probs = probs.sum(dim=1)
+
+        if reduction == 'sum':
+            probs = probs.sum(dim=0)
+        elif reduction == 'mean':
+            probs = probs.mean(dim=0)
+
+        return probs
+    else:
+        raise ValueError(f"Unrecognized target type {target_type}")

--- a/composer/metrics/__init__.py
+++ b/composer/metrics/__init__.py
@@ -1,9 +1,9 @@
 """A collection of common torchmetrics."""
 
 from composer.metrics.metrics import CrossEntropyLoss, Dice, LossMetric, MIoU
-from composer.metrics.nlp import BinaryF1Score, HFLanguageCrossEntropyLoss, LanguageCrossEntropyLoss, MaskedAccuracy, Perplexity
+from composer.metrics.nlp import BinaryF1Score, HFCrossEntropyLoss, LanguageCrossEntropyLoss, MaskedAccuracy, Perplexity
 
 __all__ = ["MIoU", "Dice", "CrossEntropyLoss", "LossMetric",
-           "Perplexity", "BinaryF1Score", "HFLanguageCrossEntropyLoss",
+           "Perplexity", "BinaryF1Score", "HFCrossEntropyLoss",
            "LanguageCrossEntropyLoss", "MaskedAccuracy"]
 

--- a/composer/metrics/__init__.py
+++ b/composer/metrics/__init__.py
@@ -1,0 +1,9 @@
+"""A collection of common torchmetrics."""
+
+from composer.metrics.metrics import CrossEntropyLoss, Dice, LossMetric, MIoU
+from composer.metrics.nlp import BinaryF1Score, HFLanguageCrossEntropyLoss, LanguageCrossEntropyLoss, MaskedAccuracy, Perplexity
+
+__all__ = ["MIoU", "Dice", "CrossEntropyLoss", "LossMetric",
+           "Perplexity", "BinaryF1Score", "HFLanguageCrossEntropyLoss",
+           "LanguageCrossEntropyLoss", "MaskedAccuracy"]
+

--- a/composer/metrics/metrics.py
+++ b/composer/metrics/metrics.py
@@ -3,15 +3,16 @@
 """A collection of common torchmetrics and loss functions."""
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Tuple
 
 import torch
-import torch.nn.functional as F
 from torch import Tensor
 from torchmetrics import Metric
 from torchmetrics.utilities.data import to_categorical
 
-__all__ = ["MIoU", "Dice", "CrossEntropyLoss", "soft_cross_entropy"]
+__all__ = ["MIoU", "Dice", "CrossEntropyLoss", "LossMetric"]
+
+from composer.loss.loss import soft_cross_entropy
 
 
 class MIoU(Metric):
@@ -120,103 +121,6 @@ def _stat_scores(
     return tp, fp, tn, fn, sup
 
 
-def _infer_target_type(input: Tensor, targets: Tensor) -> str:
-    """Infers whether the target is in indices format or one_hot format.
-
-    Example indices format: [1, 4, 7] Example one_hot format [[0, 1, 0], [1, 0, 0], ...]
-    """
-    if input.shape == targets.shape:
-        return 'one_hot'
-    elif input.ndim == targets.ndim + 1:
-        return 'indices'
-    else:
-        raise RuntimeError(f'Unable to infer indices or one_hot. Targets has shape {targets.shape}'
-                           f' and the inputs to cross entropy has shape {input.shape}. For one_hot, '
-                           'expect targets.shape == inputs.shape. For indices, expect '
-                           'inputs.ndim == targets.ndim + 1')
-
-
-def ensure_targets_one_hot(input: Tensor, targets: Tensor) -> Tensor:
-    if _infer_target_type(input, targets) == 'indices':
-        targets = F.one_hot(targets, num_classes=input.shape[1])
-    return targets
-
-
-def _check_for_index_targets(targets: Tensor) -> bool:
-    """Checks if a given set of targets are indices by looking at the type."""
-    index_types = ['torch.LongTensor', 'torch.cuda.LongTensor']
-    return targets.type() in index_types
-
-
-def soft_cross_entropy(input: Tensor,
-                       target: Tensor,
-                       weight: Optional[Tensor] = None,
-                       size_average: Optional[bool] = None,
-                       ignore_index: int = -100,
-                       reduce: Optional[bool] = None,
-                       reduction: str = 'mean'):
-    r"""Drop-in replacement for :class:`~torch.nn.CrossEntropyLoss` that can handle class indices or one-hot labels.
-
-    Args:
-        input (torch.Tensor) : :math:`(N, C)` where `C = number of classes` or :math:`(N, C, H, W)`
-            in case of 2D Loss, or :math:`(N, C, d_1, d_2, ..., d_K)` where :math:`K \geq 1`
-            in the case of K-dimensional loss. `input` is expected to contain unnormalized scores
-            (often referred to as logits).
-        target (torch.Tensor) : If containing class indices, shape :math:`(N)` where each value is
-            :math:`0 \leq \text{targets}[i] \leq C-1`, or :math:`(N, d_1, d_2, ..., d_K)` with
-            :math:`K \geq 1` in the case of K-dimensional loss. If containing class probabilities,
-            same shape as the input.
-        weight (torch.Tensor, optional): a manual rescaling weight given to each
-            class. If given, has to be a Tensor of size `C`. Default: ``None``.
-        size_average (bool, optional): Deprecated (see `reduction`). By default,
-            the losses are averaged over each loss element in the batch. Note that for
-            some losses, there multiple elements per sample. If the field ``size_average``
-            is set to ``False``, the losses are instead summed for each minibatch. Ignored
-            when reduce is ``False``. Default: ``True``
-        ignore_index (int, optional): Specifies a target value that is ignored
-            and does not contribute to the input gradient. When ``size_average`` is
-            ``True``, the loss is averaged over non-ignored targets. Note that
-            ``ignore_index`` is only applicable when the target contains class indices.
-            Default: ``-100``
-        reduce (bool, optional): Deprecated (see ``reduction``). By default, the
-            losses are averaged or summed over observations for each minibatch depending
-            on `size_average`. When ``reduce`` is ``False``, returns a loss per
-            batch element instead and ignores `size_average`. Default: ``True``
-        reduction (str, optional): Specifies the reduction to apply to the output:
-            ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
-            ``'mean'``: the sum of the output will be divided by the number of
-            elements in the output, ``'sum'``: the output will be summed. Note: ``size_average``
-            and ``reduce`` are in the process of being deprecated, and in the meantime,
-            specifying either of those two args will override ``reduction``. Default: ``'mean'``
-
-    This function will be obsolete with `this update <https://github.com/pytorch/pytorch/pull/61044>`_.
-    """
-    target_type = _infer_target_type(input, target)
-
-    if target_type == 'indices':
-        return F.cross_entropy(input, target, weight, size_average, ignore_index, reduce, reduction)
-    elif target_type == 'one_hot':
-        assert reduction in ['sum', 'mean', 'none'], f"{reduction} reduction not supported."
-        assert size_average is None, "size_average is deprecated"
-        assert reduce is None, "reduce is deprecated"
-        assert ignore_index == -100, "ignore_index not supported."
-        probs = -1 * (target * F.log_softmax(input, dim=1))
-
-        if weight is not None:
-            probs *= weight / weight.sum()  # allow broadcast along batch dim
-
-        probs = probs.sum(dim=1)
-
-        if reduction == 'sum':
-            probs = probs.sum(dim=0)
-        elif reduction == 'mean':
-            probs = probs.mean(dim=0)
-
-        return probs
-    else:
-        raise ValueError(f"Unrecognized target type {target_type}")
-
-
 class CrossEntropyLoss(Metric):
     """Torchmetrics cross entropy loss implementation.
 
@@ -250,3 +154,32 @@ class CrossEntropyLoss(Metric):
         assert isinstance(self.total_batches, Tensor)
         assert isinstance(self.sum_loss, Tensor)
         return self.sum_loss / self.total_batches
+
+
+class LossMetric(Metric):
+    """Turns a torch.nn Loss Module into distributed torchmetrics Metric.
+
+    Args:
+        loss_function (callable): loss function to compute and track.
+
+        dist_sync_on_step (bool, optional): sync distributed metrics every step. Default: ``False``.
+    """
+
+    def __init__(self, loss_function: callable, dist_sync_on_step=False):
+        super().__init__(dist_sync_on_step=dist_sync_on_step)
+        self.loss_function = loss_function
+        self.add_state("sum_loss", default=torch.tensor(0.), dist_reduce_fx="sum")
+        self.add_state("total_batches", default=torch.tensor(0), dist_reduce_fx="sum")
+
+    def update(self, preds: Tensor, target: Tensor) -> None:
+        """Update the state with new predictions and targets."""
+        # Loss calculated over samples/batch, accumulate loss over all batches
+        self.sum_loss += self.loss_function(preds, target)
+        self.total_batches += 1
+
+    def compute(self):
+        """Aggregate state over all processes and compute the metric.
+        """
+        # Return average loss over entire validation dataset
+        return self.sum_loss / self.total_batches
+

--- a/composer/metrics/metrics.py
+++ b/composer/metrics/metrics.py
@@ -12,7 +12,7 @@ from torchmetrics.utilities.data import to_categorical
 
 __all__ = ["MIoU", "Dice", "CrossEntropyLoss", "LossMetric"]
 
-from composer.loss.loss import soft_cross_entropy
+from composer.loss import soft_cross_entropy
 
 
 class MIoU(Metric):
@@ -117,7 +117,6 @@ def _stat_scores(
     tn = ((preds != class_index) * (target != class_index)).to(torch.long).sum()
     fn = ((preds != class_index) * (target == class_index)).to(torch.long).sum()
     sup = (target == class_index).to(torch.long).sum()
-
     return tp, fp, tn, fn, sup
 
 
@@ -178,8 +177,7 @@ class LossMetric(Metric):
         self.total_batches += 1
 
     def compute(self):
-        """Aggregate state over all processes and compute the metric.
-        """
+        """Aggregate state over all processes and compute the metric."""
         # Return average loss over entire validation dataset
         return self.sum_loss / self.total_batches
 

--- a/composer/metrics/nlp.py
+++ b/composer/metrics/nlp.py
@@ -7,9 +7,9 @@ import torch
 from torch import Tensor
 from torchmetrics import Metric
 
-from composer.loss.loss import soft_cross_entropy
+from composer.loss import soft_cross_entropy
 
-__all__ = ["Perplexity", "BinaryF1Score", "LanguageCrossEntropyLoss", "CrossEntropyLoss", "MaskedAccuracy"]
+__all__ = ["Perplexity", "BinaryF1Score", "HFLanguageCrossEntropyLoss", "LanguageCrossEntropyLoss", "MaskedAccuracy"]
 
 
 class MaskedAccuracy(Metric):
@@ -52,7 +52,7 @@ class MaskedAccuracy(Metric):
         return self.correct.float() / self.total
 
 
-class CrossEntropyLoss(Metric):
+class LanguageCrossEntropyLoss(Metric):
     """Computes cross entropy loss.
 
     Adds metric state variables:
@@ -147,12 +147,11 @@ class BinaryF1Score(Metric):
         assert isinstance(self.true_positive, Tensor)
         assert isinstance(self.false_positive, Tensor)
         assert isinstance(self.false_negative, Tensor)
-
         f1 = (self.true_positive) / (self.true_positive + (0.5 * (self.false_negative + self.false_positive)))
         return f1
 
 
-class LanguageCrossEntropyLoss(Metric):
+class HFLanguageCrossEntropyLoss(Metric):
     """Hugging Face compatible cross entropy loss.
 
     Adds metric state variables:
@@ -208,8 +207,8 @@ class LanguageCrossEntropyLoss(Metric):
         return self.sum_loss / self.total_batches  #type: ignore (third-party)
 
 
-class Perplexity(LanguageCrossEntropyLoss):
-    """Subclasses :class:`~composer.models.nlp_metrics.LanguageCrossEntropyLoss` to implement perplexity.
+class Perplexity(HFLanguageCrossEntropyLoss):
+    """Subclasses :class:`~composer.models.nlp_metrics.HFLanguageCrossEntropyLoss` to implement perplexity.
 
     If an algorithm modifies the loss function and it is no longer directly provided in the output, then this could be
     expensive because it'll compute the loss twice.

--- a/composer/metrics/nlp.py
+++ b/composer/metrics/nlp.py
@@ -9,7 +9,7 @@ from torchmetrics import Metric
 
 from composer.loss import soft_cross_entropy
 
-__all__ = ["Perplexity", "BinaryF1Score", "HFLanguageCrossEntropyLoss", "LanguageCrossEntropyLoss", "MaskedAccuracy"]
+__all__ = ["Perplexity", "BinaryF1Score", "HFCrossEntropyLoss", "LanguageCrossEntropyLoss", "MaskedAccuracy"]
 
 
 class MaskedAccuracy(Metric):
@@ -151,7 +151,7 @@ class BinaryF1Score(Metric):
         return f1
 
 
-class HFLanguageCrossEntropyLoss(Metric):
+class HFCrossEntropyLoss(Metric):
     """Hugging Face compatible cross entropy loss.
 
     Adds metric state variables:
@@ -207,7 +207,7 @@ class HFLanguageCrossEntropyLoss(Metric):
         return self.sum_loss / self.total_batches  #type: ignore (third-party)
 
 
-class Perplexity(HFLanguageCrossEntropyLoss):
+class Perplexity(HFCrossEntropyLoss):
     """Subclasses :class:`~composer.models.nlp_metrics.HFLanguageCrossEntropyLoss` to implement perplexity.
 
     If an algorithm modifies the loss function and it is no longer directly provided in the output, then this could be

--- a/composer/metrics/nlp_metrics.py
+++ b/composer/metrics/nlp_metrics.py
@@ -7,7 +7,7 @@ import torch
 from torch import Tensor
 from torchmetrics import Metric
 
-from composer.models.loss import soft_cross_entropy
+from composer.loss.loss import soft_cross_entropy
 
 __all__ = ["Perplexity", "BinaryF1Score", "LanguageCrossEntropyLoss", "CrossEntropyLoss", "MaskedAccuracy"]
 

--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -12,8 +12,8 @@ from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import Accuracy
 
 from composer.core.types import Batch, BatchPair
-from composer.metrics.metrics import CrossEntropyLoss
 from composer.loss.loss import soft_cross_entropy
+from composer.metrics.metrics import CrossEntropyLoss
 
 __all__ = ["ComposerClassifier", "ComposerModel"]
 

--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -12,7 +12,8 @@ from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import Accuracy
 
 from composer.core.types import Batch, BatchPair
-from composer.models.loss import CrossEntropyLoss, soft_cross_entropy
+from composer.metrics.metrics import CrossEntropyLoss
+from composer.loss.loss import soft_cross_entropy
 
 __all__ = ["ComposerClassifier", "ComposerModel"]
 

--- a/composer/models/bert/model.py
+++ b/composer/models/bert/model.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Mapping, Sequence, Union
 import torch
 from torchmetrics import Accuracy, MatthewsCorrcoef, MeanSquaredError, Metric, MetricCollection, SpearmanCorrcoef
 
-from composer.models.nlp_metrics import BinaryF1Score, CrossEntropyLoss, MaskedAccuracy
+from composer.metrics.nlp_metrics import BinaryF1Score, CrossEntropyLoss, MaskedAccuracy
 from composer.models.transformer_shared import ComposerTransformer
 
 if TYPE_CHECKING:

--- a/composer/models/bert/model.py
+++ b/composer/models/bert/model.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Mapping, Sequence, Union
 import torch
 from torchmetrics import Accuracy, MatthewsCorrcoef, MeanSquaredError, Metric, MetricCollection, SpearmanCorrcoef
 
-from composer.metrics.nlp_metrics import BinaryF1Score, CrossEntropyLoss, MaskedAccuracy
+from composer.metrics.nlp import BinaryF1Score, LanguageCrossEntropyLoss, MaskedAccuracy
 from composer.models.transformer_shared import ComposerTransformer
 
 if TYPE_CHECKING:
@@ -90,8 +90,8 @@ class BERTModel(ComposerTransformer):
 
         if config.num_labels == len(self.tokenizer):  # tests for MLM pre-training
             ignore_index = -100
-            self.train_loss = CrossEntropyLoss(ignore_index=ignore_index, vocab_size=config.num_labels)
-            self.val_loss = CrossEntropyLoss(ignore_index=ignore_index, vocab_size=config.num_labels)
+            self.train_loss = LanguageCrossEntropyLoss(ignore_index=ignore_index, vocab_size=config.num_labels)
+            self.val_loss = LanguageCrossEntropyLoss(ignore_index=ignore_index, vocab_size=config.num_labels)
 
             self.train_acc = MaskedAccuracy(ignore_index=ignore_index)
             self.val_acc = MaskedAccuracy(ignore_index=ignore_index)

--- a/composer/models/deeplabv3/deeplabv3.py
+++ b/composer/models/deeplabv3/deeplabv3.py
@@ -11,9 +11,9 @@ from torchmetrics import MetricCollection
 from torchvision.models import _utils, resnet
 
 from composer.core.types import BatchPair
-from composer.models.base import ComposerModel
-from composer.metrics.metrics import CrossEntropyLoss, MIoU
 from composer.loss.loss import soft_cross_entropy
+from composer.metrics.metrics import CrossEntropyLoss, MIoU
+from composer.models.base import ComposerModel
 from composer.models.model_hparams import Initializer
 
 __all__ = ["deeplabv3_builder", "ComposerDeepLabV3"]

--- a/composer/models/deeplabv3/deeplabv3.py
+++ b/composer/models/deeplabv3/deeplabv3.py
@@ -12,7 +12,8 @@ from torchvision.models import _utils, resnet
 
 from composer.core.types import BatchPair
 from composer.models.base import ComposerModel
-from composer.models.loss import CrossEntropyLoss, MIoU, soft_cross_entropy
+from composer.metrics.metrics import CrossEntropyLoss, MIoU
+from composer.loss.loss import soft_cross_entropy
 from composer.models.model_hparams import Initializer
 
 __all__ = ["deeplabv3_builder", "ComposerDeepLabV3"]

--- a/composer/models/gpt2/model.py
+++ b/composer/models/gpt2/model.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Mapping, Sequence, Union
 from torch import Tensor
 from torchmetrics import Metric, MetricCollection
 
-from composer.metrics.nlp_metrics import Perplexity
+from composer.metrics.nlp import Perplexity
 from composer.models.transformer_shared import ComposerTransformer
 
 if TYPE_CHECKING:

--- a/composer/models/gpt2/model.py
+++ b/composer/models/gpt2/model.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Mapping, Sequence, Union
 from torch import Tensor
 from torchmetrics import Metric, MetricCollection
 
-from composer.models.nlp_metrics import Perplexity
+from composer.metrics.nlp_metrics import Perplexity
 from composer.models.transformer_shared import ComposerTransformer
 
 if TYPE_CHECKING:

--- a/composer/models/transformer_shared.py
+++ b/composer/models/transformer_shared.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING, Mapping, Sequence, Tuple, Union
 
 from torch import Tensor
 
+from composer.metrics.nlp import HFLanguageCrossEntropyLoss
 from composer.models.base import ComposerModel
-from composer.metrics.nlp_metrics import LanguageCrossEntropyLoss
 
 if TYPE_CHECKING:
     import transformers
@@ -57,8 +57,8 @@ class ComposerTransformer(ComposerModel):
         self.model_inputs.update(set({"labels"}))
 
         # define metrics for measurements
-        self.train_loss = LanguageCrossEntropyLoss()
-        self.val_loss = LanguageCrossEntropyLoss()
+        self.train_loss = HFLanguageCrossEntropyLoss()
+        self.val_loss = HFLanguageCrossEntropyLoss()
 
         if gradient_checkpointing:
             self.module.gradient_checkpointing_enable()  # type: ignore

--- a/composer/models/transformer_shared.py
+++ b/composer/models/transformer_shared.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Mapping, Sequence, Tuple, Union
 
 from torch import Tensor
 
-from composer.metrics.nlp import HFLanguageCrossEntropyLoss
+from composer.metrics.nlp import HFCrossEntropyLoss
 from composer.models.base import ComposerModel
 
 if TYPE_CHECKING:
@@ -57,8 +57,8 @@ class ComposerTransformer(ComposerModel):
         self.model_inputs.update(set({"labels"}))
 
         # define metrics for measurements
-        self.train_loss = HFLanguageCrossEntropyLoss()
-        self.val_loss = HFLanguageCrossEntropyLoss()
+        self.train_loss = HFCrossEntropyLoss()
+        self.val_loss = HFCrossEntropyLoss()
 
         if gradient_checkpointing:
             self.module.gradient_checkpointing_enable()  # type: ignore

--- a/composer/models/transformer_shared.py
+++ b/composer/models/transformer_shared.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Mapping, Sequence, Tuple, Union
 from torch import Tensor
 
 from composer.models.base import ComposerModel
-from composer.models.nlp_metrics import LanguageCrossEntropyLoss
+from composer.metrics.nlp_metrics import LanguageCrossEntropyLoss
 
 if TYPE_CHECKING:
     import transformers

--- a/composer/models/unet/unet.py
+++ b/composer/models/unet/unet.py
@@ -12,7 +12,7 @@ from torchmetrics import Metric, MetricCollection
 
 from composer.core.types import BatchPair
 from composer.models.base import ComposerModel
-from composer.models.loss import Dice
+from composer.metrics.metrics import Dice
 from composer.models.unet.model import UNet as UNetModel
 
 log = logging.getLogger(__name__)

--- a/composer/models/unet/unet.py
+++ b/composer/models/unet/unet.py
@@ -11,8 +11,8 @@ import torch.nn as nn
 from torchmetrics import Metric, MetricCollection
 
 from composer.core.types import BatchPair
-from composer.models.base import ComposerModel
 from composer.metrics.metrics import Dice
+from composer.models.base import ComposerModel
 from composer.models.unet.model import UNet as UNetModel
 
 log = logging.getLogger(__name__)

--- a/tests/algorithms/test_label_smoothing.py
+++ b/tests/algorithms/test_label_smoothing.py
@@ -6,9 +6,10 @@ import pytest
 import torch
 import torch.nn.functional as F
 
+import composer.loss.loss
 from composer.algorithms import LabelSmoothingHparams, label_smoothing
 from composer.core import Event
-from composer.models import loss
+from composer.metrics import metrics
 
 
 def _generate_tensors_classification(batch_size: int, num_classes: int):
@@ -57,8 +58,8 @@ class TestSoftCrossEntropy:
 
     def test_infer_target_type(self, tensors):
         (input, target_indices, target_onehot) = tensors
-        assert loss._infer_target_type(input, target_indices) == 'indices'
-        assert loss._infer_target_type(input, target_onehot) == 'one_hot'
+        assert composer.loss.loss._infer_target_type(input, target_indices) == 'indices'
+        assert composer.loss.loss._infer_target_type(input, target_onehot) == 'one_hot'
 
     @pytest.mark.parametrize('reduction', ['mean', 'sum'])
     @pytest.mark.parametrize('use_weights', [xfail(True), False])
@@ -72,8 +73,8 @@ class TestSoftCrossEntropy:
 
         loss_args = dict(weight=weights, reduction=reduction)
 
-        loss_indices = loss.soft_cross_entropy(input, target_indices, **loss_args)
-        loss_onehot = loss.soft_cross_entropy(input, target_onehot, **loss_args)
+        loss_indices = composer.loss.loss.soft_cross_entropy(input, target_indices, **loss_args)
+        loss_onehot = composer.loss.loss.soft_cross_entropy(input, target_onehot, **loss_args)
         loss_reference = F.cross_entropy(input, target_indices, **loss_args)
 
         torch.testing.assert_allclose(loss_indices, loss_onehot)

--- a/tests/models/test_loss.py
+++ b/tests/models/test_loss.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 
-from composer.models.loss import MIoU
+from composer.metrics.metrics import MIoU
 
 
 @pytest.fixture

--- a/tests/test_nlp_metrics.py
+++ b/tests/test_nlp_metrics.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from torch.nn.functional import cross_entropy
 
-from composer.metrics.nlp_metrics import BinaryF1Score, CrossEntropyLoss, MaskedAccuracy
+from composer.metrics.nlp import BinaryF1Score, LanguageCrossEntropyLoss, MaskedAccuracy
 
 
 @pytest.mark.parametrize("ignore_index", [-100])
@@ -67,7 +67,7 @@ def test_cross_entropy(batch_size: float, ignore_index: int, sequence_length: in
     generated_preds = torch.randn((batch_size, sequence_length, num_classes))
     generated_true = torch.randint(low=0, high=num_classes, size=(batch_size, sequence_length))
 
-    torchmetrics_xent = CrossEntropyLoss(vocab_size=num_classes, dist_sync_on_step=False, ignore_index=ignore_index)
+    torchmetrics_xent = LanguageCrossEntropyLoss(vocab_size=num_classes, dist_sync_on_step=False, ignore_index=ignore_index)
 
     if ignore_index is not None:
         labels_mask = torch.rand((batch_size, sequence_length))

--- a/tests/test_nlp_metrics.py
+++ b/tests/test_nlp_metrics.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from torch.nn.functional import cross_entropy
 
-from composer.models.nlp_metrics import BinaryF1Score, CrossEntropyLoss, MaskedAccuracy
+from composer.metrics.nlp_metrics import BinaryF1Score, CrossEntropyLoss, MaskedAccuracy
 
 
 @pytest.mark.parametrize("ignore_index", [-100])


### PR DESCRIPTION
moved metrics and loss functions out of models to their own modules. 

@moinnadeem do you think it makes sense to move the logic from `LanguageCrossEntropyLoss.update` and `HFCrossEntropyLoss.update` into their respective `ComposerModels.validate` and use a standard `CrossEntropyLoss` instead? 

@coryMosaicML do we still need `soft_cross_entropy`? It's merged into pytorch (1.10) + I think we can convert labels when we need now?