### PR TITLE
Support for webdatasets with ffcv

### DIFF
--- a/composer/datasets/cifar.py
+++ b/composer/datasets/cifar.py
@@ -19,9 +19,9 @@ from torchvision.datasets import CIFAR10
 
 from composer.core.types import DataLoader
 from composer.datasets.dataloader import DataLoaderHparams
+from composer.datasets.ffcv_utils import write_ffcv_dataset
 from composer.datasets.hparams import DatasetHparams, SyntheticHparamsMixin, WebDatasetHparams
 from composer.datasets.synthetic import SyntheticBatchPairDataset
-from composer.datasets.utils import create_ffcv_dataset
 from composer.utils import dist
 
 __all__ = [
@@ -94,7 +94,7 @@ class CIFAR10DatasetHparams(DatasetHparams, SyntheticHparamsMixin):
                         download=self.download,
                     )
 
-                    create_ffcv_dataset(dataset=ds, write_path=dataset_filepath)
+                    write_ffcv_dataset(dataset=ds, write_path=dataset_filepath)
 
                 # Wait for the local rank 0 to be done creating the dataset in ffcv format.
                 dist.barrier()

--- a/composer/datasets/ffcv_utils.py
+++ b/composer/datasets/ffcv_utils.py
@@ -1,0 +1,75 @@
+import json
+import logging
+import subprocess
+import textwrap
+from typing import Optional
+
+from composer.core.types import Dataset
+
+log = logging.getLogger(__name__)
+
+__all__ = ["write_ffcv_dataset"]
+
+
+def write_ffcv_dataset(dataset: Optional[Dataset] = None,
+                       remote: Optional[str] = None,
+                       write_path: str = "/tmp/dataset.ffcv",
+                       max_resolution: Optional[int] = None,
+                       num_workers: int = 16,
+                       write_mode: str = 'raw',
+                       compress_probability: float = 0.50,
+                       jpeg_quality: float = 90,
+                       chunk_size: int = 100):
+    """Converts PyTorch ``dataset`` or webdataset at ``remote`` into FFCV format at filepath ``write_path``.
+
+    Args:
+        dataset (Iterable[Sample]): A PyTorch dataset. Default: ``None``.
+        remote (str): A remote path for webdataset. Default: ``None``.
+        write_path (str): Write results to this file. Default: ``"/tmp/dataset.ffcv"``.
+        max_resolution (int): Limit resolution if provided. Default: ``None``.
+        num_workers (int): Numbers of workers to use. Default: ``16``.
+        write_mode (str): Write mode for the dataset. Default: ``'raw'``.
+        compress_probability (float): Probability with which image is JPEG-compressed. Default: ``0.5``.
+        jpeg_quality (float): Quality to use for jpeg compression. Default: ``90``.
+        chunk_size (int): Size of chunks processed by each worker during conversion. Default: ``100``.
+    """
+    try:
+        import ffcv  # type: ignore
+    except ImportError:
+        raise ImportError(
+            textwrap.dedent("""\
+            Composer was installed without ffcv support.
+            To use ffcv with Composer, please install ffcv in your environment."""))
+
+    if dataset is None and remote is None:
+        raise ValueError("At least one of dataset or remote should not be None.")
+
+    log.info(f"Writing dataset in FFCV <file>.ffcv format to {write_path}.")
+    writer = ffcv.writer.DatasetWriter(write_path, {
+        'image':
+            ffcv.fields.RGBImageField(write_mode=write_mode,
+                                      max_resolution=max_resolution,
+                                      compress_probability=compress_probability,
+                                      jpeg_quality=jpeg_quality),
+        'label':
+            ffcv.fields.IntField()
+    },
+                                       num_workers=num_workers)
+    if dataset:
+        writer.from_indexed_dataset(dataset, chunksize=chunk_size)
+    else:
+        pipeline = lambda dataset: dataset.decode('pil').to_tuple('jpg', 'cls')
+
+        metadata_url = f'{remote}/meta.json'
+        cmd = 'aws', 's3', 'cp', metadata_url, '-'
+        ret = subprocess.run(cmd, capture_output=True)
+        assert not ret.stderr, 'Download failed, check your credentials?'
+        text = ret.stdout
+
+        metadata = json.loads(text)
+        num_shards = metadata['n_shards']
+        if metadata['n_leftover'] > 0:
+            num_shards = num_shards + 1
+        urls = [f'pipe: aws s3 cp {remote}/{idx:05d}.tar -' for idx in range(num_shards)]
+
+        writer.from_webdataset(urls, pipeline)

--- a/composer/datasets/imagenet.py
+++ b/composer/datasets/imagenet.py
@@ -21,9 +21,10 @@ from torchvision.datasets import ImageFolder
 from composer.core import DataSpec
 from composer.core.types import DataLoader
 from composer.datasets.dataloader import DataLoaderHparams
+from composer.datasets.ffcv_utils import write_ffcv_dataset
 from composer.datasets.hparams import DatasetHparams, SyntheticHparamsMixin, WebDatasetHparams
 from composer.datasets.synthetic import SyntheticBatchPairDataset
-from composer.datasets.utils import NormalizationFn, create_ffcv_dataset, pil_image_collate
+from composer.datasets.utils import NormalizationFn, pil_image_collate
 from composer.utils import dist
 
 # ImageNet normalization values from torchvision: https://pytorch.org/vision/stable/models.html
@@ -100,12 +101,12 @@ class ImagenetDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
                         raise ValueError(
                             "datadir is required if use_synthetic is False and ffcv_write_dataset is True.")
                     ds = ImageFolder(os.path.join(self.datadir, split))
-                    create_ffcv_dataset(dataset=ds,
-                                        write_path=dataset_filepath,
-                                        max_resolution=500,
-                                        num_workers=dataloader_hparams.num_workers,
-                                        compress_probability=0.50,
-                                        jpeg_quality=90)
+                    write_ffcv_dataset(dataset=ds,
+                                       write_path=dataset_filepath,
+                                       max_resolution=500,
+                                       num_workers=dataloader_hparams.num_workers,
+                                       compress_probability=0.50,
+                                       jpeg_quality=90)
                 # Wait for the local rank 0 to be done creating the dataset in ffcv format.
                 dist.barrier()
 

--- a/scripts/ffcv/create_ffcv_datasets.py
+++ b/scripts/ffcv/create_ffcv_datasets.py
@@ -1,0 +1,132 @@
+import json
+import logging
+import os
+import subprocess
+import sys
+import textwrap
+from argparse import ArgumentParser
+
+from torch.utils.data import Subset
+from torchvision.datasets import CIFAR10, ImageFolder
+from composer.core.types import Dataset
+from composer.datasets.ffcv_utils import write_ffcv_dataset
+
+log = logging.getLogger(__name__)
+
+def get_parser():
+    parser = ArgumentParser(description="Utility for converting datasets to ffcv format.")
+
+    parser.add_argument("--dataset",
+                        type=str,
+                        default="cifar",
+                        choices=["cifar", "imagenet"],
+                        help=textwrap.dedent("""\
+                                Dataset to use. Default: cifar"""))
+    parser.add_argument("--remote",
+                        type=str,
+                        default="s3://mosaicml-internal-dataset-cifar10",
+                        help=textwrap.dedent("""\
+                                WebDataset to use. Default: s3://mosaicml-internal-dataset-cifar10"""))
+    parser.add_argument("--split",
+                        type=str,
+                        default="train",
+                        choices=["train", "val"],
+                        help=textwrap.dedent("""\
+                                Split to use. Default: train"""))
+
+    parser.add_argument("--datadir",
+                        type=str,
+                        default=None,
+                        help=textwrap.dedent("""\
+                                Location of the dataset. Default: None"""))
+
+    parser.add_argument("--download",
+                        type=bool,
+                        default=False,
+                        help=textwrap.dedent("""\
+                                Download the dataset if possible. Default: False"""))
+
+    parser.add_argument("--write_path",
+                        type=str,
+                        default=None,
+                        help=textwrap.dedent("""\
+                                File path to use for writing the dataset. Default: /tmp/<dataset>_<split>.ffcv"""))
+
+    parser.add_argument("--write_mode",
+                        type=str,
+                        default="proportion",
+                        choices=["raw", "jpg", "smart", "proportion"],
+                        help=textwrap.dedent("""\
+                                Write mode to use. raw is uint8 values, jpg is jpeg compressed images, smart is
+                                compressing based on image size and proportion is according to the given
+                                compress_probability. Default: proportion"""))
+
+    parser.add_argument("--max_resolution", type=int, default=500, help="Max resoultion for images.")
+
+    parser.add_argument("--num_workers", type=int, default=16, help="Number of workers to use.")
+
+    parser.add_argument("--chunk_size", type=int, default=100, help="Chunk size to use.")
+
+    parser.add_argument("--jpeg_quality", type=int, default=90, help="Quality of jpeg.")
+
+    parser.add_argument("--subset", type=int, default=-1, help="Only use a subset of dataset.")
+
+    parser.add_argument("--compress_probability",
+                        type=float,
+                        required=False,
+                        default=0.50,
+                        help="Compress the given fraction of images to jpeg while writing the ffcv dataset.")
+    return parser
+
+
+def parse_args():
+    parser = get_parser()
+
+    args = parser.parse_args()
+
+    if args.datadir is not None:
+        log.info(f"Will read from local directory: {args.datadir}.")
+    else:
+        if args.remote.startswith('s3://'):
+            log.info(f"Will read from webdataset: {args.remote}.")
+        else:
+            raise ValueError(f'Unsupported webdataset location: {args.remote}.')
+
+    if args.write_path is None:
+        args.write_path = f"/tmp/{args.dataset}_{args.split}.ffcv"
+
+    return args
+
+
+def main():
+
+    args = parse_args()
+
+    ds = None
+    remote_location = None
+    if args.datadir is not None:
+        if args.dataset == 'cifar':
+            ds = CIFAR10(root=args.datadir, train=(args.split == 'train'), download=args.download)
+        elif args.dataset == 'imagenet':
+            ds = ImageFolder(os.path.join(args.datadir, args.split))
+        else:
+            raise ValueError(f'Unsupported dataset: {args.dataset}. Checkout the list of supported datasets with -h')
+
+        if args.subset > 0:
+            ds = Subset(ds, range(args.subset))
+    else:
+        remote_location = os.path.join(args.remote, args.split)
+
+    write_ffcv_dataset(dataset=ds,
+                       remote=remote_location,
+                       write_path=args.write_path,
+                       max_resolution=args.max_resolution,
+                       num_workers=args.num_workers,
+                       write_mode=args.write_mode,
+                       compress_probability=args.compress_probability,
+                       jpeg_quality=args.jpeg_quality,
+                       chunk_size=args.chunk_size)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
- A script to create datasets into ffcv format from a local dir or webdataset 

- Reorganization of ffcv_dataset function.  

Example: 
CIFAR10 from local disk: 

`python scripts/ffcv/create_ffcv_datasets.py --dataset cifar --split train --datadir /localdisk/CIFAR10 --write_path /tmp/cifar10_train.ffcv --num_workers 64`

CIFAR10 from webdataset:
`python scripts/ffcv/create_ffcv_datasets.py --dataset cifar --split train --remote s3://mosaicml-internal-dataset-cifar10 --write_path /tmp/cifar10_train.ffcv --num_workers 16`

imagenet from local disk:
`python scripts/ffcv/create_ffcv_datasets.py --dataset imagenet --split train --datadir /localdisk/ImageNet --write_path /tmp/imagenet_train.ffcv --num_workers 16`

imagenet from webdataset: 
`python scripts/ffcv/create_ffcv_datasets.py --dataset imagenet --split train --remote s3://mosaicml-internal-dataset-imagenet1k --write_path /tmp/imagenet_train.ffcv --num_workers 16`

