### PR TITLE
Fix submodule type errors when doing `import composer`

### DIFF
--- a/composer/__init__.py
+++ b/composer/__init__.py
@@ -1,5 +1,15 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
+from composer import algorithms as algorithms
+from composer import callbacks as callbacks
+from composer import datasets as datasets
+from composer import functional as functional
+from composer import loggers as loggers
+from composer import models as models
+from composer import optim as optim
+from composer import profiler as profiler
+from composer import trainer as trainer
+from composer import utils as utils
 from composer.core import Algorithm as Algorithm
 from composer.core import Callback as Callback
 from composer.core import DataSpec as DataSpec


### PR DESCRIPTION
I've been using composer in a separate repo, and encountering the following pyright error when doing `import composer`, as opposed to `from composer.foo import bar`:

```python
# a minimal python file
import composer

_ = composer.optim.CosineAnnealingWithWarmupScheduler
```

```
~/code/tmp ❯ pyright tmp.py
...
Assuming Python platform Darwin
Searching for source files
Found 1 source file
/Users/davis/code/tmp/tmp.py
  /Users/davis/code/tmp/tmp.py:3:14 - error: "optim" is not a known member of module (reportGeneralTypeIssues)
1 error, 0 warnings, 0 informations 
Completed in 0.606sec
```

One-liner to reproduce:
```bash
$ echo 'import composer\n\n_ = composer.optim.CosineAnnealingWithWarmupScheduler' > tmp.py && pyright tmp.py
```

The fix is to just `from composer import optim as optim` in `composer/__init__.py`. This PR adds a line like this for each submodule except `cli` and `yamls` (I think this is the right set?)

It appears that [pytorch does the same thing](https://github.com/pytorch/pytorch/blob/f7317d3c51b8afad1d9dd48607e62ce401665acb/torch/__init__.py#L783).