### PR TITLE
[Eval-Only]: Made the `state.dataloader` optional; removed `state.ste…

### DIFF
--- a/composer/algorithms/colout/colout.py
+++ b/composer/algorithms/colout/colout.py
@@ -160,11 +160,15 @@ class ColOut(Algorithm):
         if self.batch:
             return event == Event.AFTER_DATALOADER
         else:
-            return event == Event.FIT_START and state.train_dataloader.dataset not in self._transformed_datasets
+            if event != Event.FIT_START:
+                return False
+            assert state.dataloader is not None, "dataloader should be defined on fit start"
+            return state.dataloader.dataset not in self._transformed_datasets
 
     def _apply_sample(self, state: State) -> None:
         """Add the ColOut dataset transform to the dataloader."""
-        dataset = state.train_dataloader.dataset
+        assert state.dataloader is not None, "dataloader should be defined on fit start"
+        dataset = state.dataloader.dataset
 
         transform = ColOutTransform(p_row=self.p_row, p_col=self.p_col)
 

--- a/composer/algorithms/randaugment/randaugment.py
+++ b/composer/algorithms/randaugment/randaugment.py
@@ -188,12 +188,15 @@ class RandAugment(Algorithm):
         self._transformed_datasets = weakref.WeakSet()
 
     def match(self, event: Event, state: State) -> bool:
-        return event == Event.FIT_START and state.train_dataloader.dataset not in self._transformed_datasets
+        if event != Event.FIT_START:
+            return False
+        assert state.dataloader is not None, "dataloader should be defined on fit start"
+        return state.dataloader.dataset not in self._transformed_datasets
 
     def apply(self, event: Event, state: State, logger: Logger) -> None:
         ra = RandAugmentTransform(severity=self.severity, depth=self.depth, augmentation_set=self.augmentation_set)
-        assert state.train_dataloader is not None
-        dataset = state.train_dataloader.dataset
+        assert state.dataloader is not None, "dataloader should be defined on fit start"
+        dataset = state.dataloader.dataset
         if not isinstance(dataset, VisionDataset):
             raise TypeError(
                 textwrap.dedent(f"""\

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -99,8 +99,9 @@ class ProgressBarLogger(LoggerDestination):
         if dist.get_global_rank() != 0:
             return
         assert self.is_train is not None, "self.is_train should be set by the callback"
+        assert state.dataloader is not None, "dataloader should be set when using tqdm"
         if self.is_train:
-            total_steps = state.steps_per_epoch
+            total_steps = len(state.dataloader)
         else:
             total_steps = 0
             for evaluator in state.evaluators:

--- a/composer/profiler/dataloader_profiler.py
+++ b/composer/profiler/dataloader_profiler.py
@@ -71,8 +71,9 @@ class DataLoaderProfiler(Callback):
                 textwrap.dedent("""To use the dataloader profiler, state.profiler must be set.
                 Make sure to run composer with the profiler -- i.e. with the `--profiler` CLI flag."""))
 
-        if not _ProfiledDataLoader.is_dataloader_already_wrapped(state.train_dataloader):
-            state.train_dataloader = _ProfiledDataLoader(state.profiler, state.train_dataloader, "train")
+        assert state.dataloader, "dataloader should be set on FIT_START"
+        if not _ProfiledDataLoader.is_dataloader_already_wrapped(state.dataloader):
+            state.dataloader = _ProfiledDataLoader(state.profiler, state.dataloader, "train")
 
         for evaluator in state.evaluators:
 

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -100,10 +100,6 @@ class TorchProfiler(Callback):
         assert state.profiler is not None, "composer profiler should be defined"
         composer_profiler_action = state.profiler.get_action(next_batch_in_epoch)
         next_composer_profiler_action = state.profiler.get_action(next_batch_in_epoch + 1)
-        if next_batch_in_epoch == state.steps_per_epoch:
-            if composer_profiler_action == ProfilerAction.ACTIVE:
-                # force saving at epoch boundaries
-                return TorchProfilerAction.RECORD_AND_SAVE
         if composer_profiler_action == ProfilerAction.ACTIVE and next_composer_profiler_action != ProfilerAction.ACTIVE:
             return TorchProfilerAction.RECORD_AND_SAVE
         if composer_profiler_action == ProfilerAction.ACTIVE:

--- a/tests/algorithms/test_colout.py
+++ b/tests/algorithms/test_colout.py
@@ -212,7 +212,7 @@ class TestColOutAlgorithm:
         original_image, _ = dataset[0]
         assert isinstance(original_image, Image.Image)
 
-        minimal_state.train_dataloader = dataloader
+        minimal_state.dataloader = dataloader
         colout_algorithm.apply(Event.INIT, minimal_state, empty_logger)
 
         new_image, _ = dataset[0]

--- a/tests/algorithms/test_layer_freezing.py
+++ b/tests/algorithms/test_layer_freezing.py
@@ -20,13 +20,14 @@ def _generate_state(epoch: int, max_epochs: int):
                   optimizers=torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.99),
                   precision=Precision.FP32,
                   grad_accum=1,
-                  train_dataloader=Mock(__len__=lambda x: 100),
                   evaluators=Mock(),
                   max_duration=f'{max_epochs}ep')
 
     # fast forward by epochs
     for _ in range(epoch):
         state.timer.on_epoch_complete()
+
+    state.dataloader = Mock(__len__=lambda x: 100)
 
     return state
 

--- a/tests/algorithms/test_selective_backprop.py
+++ b/tests/algorithms/test_selective_backprop.py
@@ -144,12 +144,12 @@ def conv_model(Ximage: torch.Tensor, D: int) -> ComposerClassifier:
 def state(minimal_state: State, conv_model: ComposerClassifier, loss_fun_tuple: Callable, epoch: int,
           batch: int) -> State:
     """State with required values set for Selective Backprop."""
-
+    assert minimal_state.dataloader is not None
     conv_model.loss = loss_fun_tuple
     minimal_state.model = conv_model
 
     minimal_state.timer.epoch._value = epoch
-    minimal_state.timer.batch._value = epoch * minimal_state.steps_per_epoch + batch
+    minimal_state.timer.batch._value = epoch * len(minimal_state.dataloader) + batch
     minimal_state.timer.batch_in_epoch._value = batch
 
     return minimal_state

--- a/tests/algorithms/test_stochastic_depth.py
+++ b/tests/algorithms/test_stochastic_depth.py
@@ -232,7 +232,8 @@ class TestStochasticDepthDropRate:
         self.get_drop_rate_list(state.model, drop_rates=new_drop_rates)
 
         assert state.max_duration.unit == TimeUnit.EPOCH
-        drop_warmup_iters = int(state.steps_per_epoch * int(state.max_duration.value) * algorithm.drop_warmup)
+        assert state.dataloader is not None
+        drop_warmup_iters = int(len(state.dataloader) * int(state.max_duration.value) * algorithm.drop_warmup)
         assert torch.all(torch.tensor(new_drop_rates) == ((step / drop_warmup_iters) * torch.tensor(old_drop_rates)))
 
 

--- a/tests/callbacks/test_speed_monitor.py
+++ b/tests/callbacks/test_speed_monitor.py
@@ -35,8 +35,9 @@ def test_speed_monitor(composer_trainer_hparams: TrainerHparams):
         if 'wall_clock_train' in metrics:
             wall_clock_train_calls += 1
 
-    assert isinstance(trainer.state.train_dataloader, collections.abc.Sized)
-    expected_step_calls = (trainer.state.steps_per_epoch - speed_monitor_hparams.window_size) * max_epochs
+    assert isinstance(trainer.state.dataloader, collections.abc.Sized)
+    assert trainer.train_subset_num_batches is not None
+    expected_step_calls = (trainer.train_subset_num_batches - speed_monitor_hparams.window_size) * max_epochs
     assert throughput_step_calls == expected_step_calls
     assert throughput_epoch_calls == max_epochs
     assert wall_clock_train_calls == max_epochs

--- a/tests/fixtures/dummy_fixtures.py
+++ b/tests/fixtures/dummy_fixtures.py
@@ -111,12 +111,12 @@ def dummy_state(dummy_model: SimpleBatchPairModel, dummy_train_dataloader: DataL
         precision=Precision.FP32,
         grad_accum=1,
         rank_zero_seed=rank_zero_seed,
-        train_dataloader=dummy_train_dataloader,
         evaluators=evaluators,
         optimizers=dummy_optimizer,
         max_duration="10ep",
     )
     state.schedulers = dummy_scheduler
+    state.dataloader = dummy_train_dataloader
 
     return state
 
@@ -230,9 +230,10 @@ def state_with_model(simple_conv_model: torch.nn.Module, dummy_train_dataloader:
         max_duration="100ep",
         model=simple_conv_model,
         precision=Precision.FP32,
-        train_dataloader=dummy_train_dataloader,
         evaluators=evaluators,
     )
+    state.dataloader = dummy_train_dataloader
+
     return state
 
 

--- a/tests/fixtures/new_fixtures.py
+++ b/tests/fixtures/new_fixtures.py
@@ -15,13 +15,14 @@ def minimal_state(rank_zero_seed: int):
 
     Tests should configure the state for their specific needs.
     """
-    return State(
+    state = State(
         model=SimpleModel(),
         rank_zero_seed=rank_zero_seed,
-        train_dataloader=DataLoader(RandomClassificationDataset()),
         evaluators=[],
         max_duration='100ep',
     )
+    state.dataloader = DataLoader(RandomClassificationDataset())
+    return state
 
 
 @pytest.fixture

--- a/tests/loggers/test_progress_bar_logger.py
+++ b/tests/loggers/test_progress_bar_logger.py
@@ -41,8 +41,8 @@ def test_progress_bar_logger(composer_trainer_hparams: TrainerHparams, monkeypat
     assert composer_trainer_hparams.validate_every_n_batches < 0
     assert len(is_train_to_mock_tqdms[False]) == composer_trainer_hparams.validate_every_n_epochs * max_epochs
     for mock_tqdm in is_train_to_mock_tqdms[True]:
-        assert mock_tqdm.update.call_count == trainer.state.steps_per_epoch
+        assert mock_tqdm.update.call_count == trainer.train_subset_num_batches
         mock_tqdm.close.assert_called_once()
     for mock_tqdm in is_train_to_mock_tqdms[False]:
-        assert mock_tqdm.update.call_count == trainer._eval_subset_num_batches
+        assert mock_tqdm.update.call_count == trainer.eval_subset_num_batches
         mock_tqdm.close.assert_called_once()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -29,7 +29,6 @@ def get_dummy_state(model: ComposerModel, train_dataloader: DataLoader, val_data
                   rank_zero_seed=random.randint(0, 100),
                   precision=Precision.AMP,
                   max_duration=f"{random.randint(0, 100)}ep",
-                  train_dataloader=train_dataloader,
                   evaluators=evaluators,
                   optimizers=optimizers,
                   algorithms=[ChannelsLastHparams().initialize_object()])
@@ -37,6 +36,7 @@ def get_dummy_state(model: ComposerModel, train_dataloader: DataLoader, val_data
     state.loss = random_tensor()
     state.batch = (random_tensor(), random_tensor())
     state.outputs = random_tensor()
+    state.dataloader = train_dataloader
     return state
 
 

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -385,10 +385,10 @@ def _test_checkpoint_trainer(trainer_hparams: TrainerHparams):
 
 def _validate_events_called_expected_number_of_times(trainer: Trainer):
     state = trainer.state
-
+    assert trainer.train_subset_num_batches is not None
     assert state.max_duration.unit == TimeUnit.EPOCH
     num_epochs = state.max_duration.value
-    num_total_steps = num_epochs * state.steps_per_epoch
+    num_total_steps = num_epochs * trainer.train_subset_num_batches
     num_total_microbatches = num_total_steps * state.grad_accum
     num_evals = 0
     if trainer._validate_every_n_batches > 0:
@@ -399,8 +399,8 @@ def _validate_events_called_expected_number_of_times(trainer: Trainer):
     assert state.evaluators is not None
     for evaluator in state.evaluators:
         assert evaluator.dataloader is not None
-    assert trainer._eval_subset_num_batches is not None
-    num_eval_steps = num_evals * trainer._eval_subset_num_batches * len(state.evaluators)
+    assert trainer.eval_subset_num_batches is not None
+    num_eval_steps = num_evals * trainer.eval_subset_num_batches * len(state.evaluators)
 
     event_to_num_expected_invocations = {
         Event.INIT: 1,

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -182,7 +182,6 @@ def test_ddp(device: DeviceHparams, world_size: int, composer_trainer_hparams: T
     if deepspeed:
         hparams.deepspeed = {}
     trainer = hparams.initialize_object()
-    assert isinstance(trainer.state.train_dataloader.dataset, collections.abc.Sized)
 
     for evaluator in trainer.evaluators:
         assert isinstance(evaluator.dataloader, DataSpec)

--- a/tests/trainer/test_ddp_sync_strategy.py
+++ b/tests/trainer/test_ddp_sync_strategy.py
@@ -60,9 +60,9 @@ def test_ddp_sync_strategy(ddp_sync_strategy: str, expected_grads: List[Optional
                   optimizers=optimizer,
                   grad_accum=2,
                   max_duration="1ep",
-                  train_dataloader=dummy_train_dataloader,
                   evaluators=evaluators,
                   precision='fp32')
+    state.dataloader = dummy_train_dataloader
 
     batches = [[(1, Tensor([1])), (1, Tensor([2]))], [(2, Tensor([1])), (2, Tensor([2]))]]
     state.model = _prepare_ddp_module(state.model, find_unused_parameters=True)

--- a/tests/trainer/test_scale_schedule.py
+++ b/tests/trainer/test_scale_schedule.py
@@ -9,8 +9,11 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import ExponentialLR
 
 from composer.algorithms import ScaleScheduleHparams
+from composer.core import State
+from composer.core.callback import Callback
 from composer.core.time import TimeUnit
 from composer.core.types import PyTorchScheduler
+from composer.loggers.logger import Logger
 from composer.optim import MultiStepSchedulerHparams, SGDHparams
 from composer.trainer import TrainerHparams
 from composer.trainer._scale_schedule import scale_pytorch_scheduler
@@ -27,6 +30,7 @@ def flatten(lst: list):
 
 
 @pytest.mark.parametrize('ssr', [0.5, 0.75, 1.0])
+@pytest.mark.filterwarnings(r"ignore:.*Detected call of \`lr_schedule.*:UserWarning")
 class TestScaleSchedule():
 
     @staticmethod
@@ -73,9 +77,13 @@ class TestScaleSchedule():
 
 
 @pytest.mark.parametrize('ssr', [0.5, 0.75, 1.0])
-@pytest.mark.parametrize('use_algorithm', [False, True])
+@pytest.mark.parametrize('use_algorithm', [
+    False,
+    pytest.param(True, marks=pytest.mark.filterwarnings(r"ignore:.*ScaleScheduleDeprecationWarning.*")),
+])
 class TestScaleScheduleTrainer():
 
+    @pytest.mark.filterwarnings(r"ignore:.*Detected call of \`lr_schedule.*:UserWarning")
     def test_epochs_scaled(
         self,
         ssr: float,
@@ -91,21 +99,29 @@ class TestScaleScheduleTrainer():
             composer_trainer_hparams.algorithms = [ScaleScheduleHparams(ratio=ssr)]
         else:
             composer_trainer_hparams.scale_schedule_ratio = ssr
+
+        class CheckScaleSchedule(Callback):
+
+            def fit_start(self, state: State, logger: Logger) -> None:
+                scheduler = state.schedulers[0]
+
+                test_steps = [int(20 * ssr), int(40 * ssr), int(60 * ssr)]
+                target_lrs = [1.0, 0.1, 0.01]
+                current_step = 0
+                for test_step, target_lr in zip(test_steps, target_lrs):
+
+                    while current_step < test_step:
+                        trainer.state.timer.on_batch_complete()
+                        current_step += 1
+
+                    scheduler.step()
+
+                    assert scheduler.get_last_lr()[0] == pytest.approx(target_lr)
+
         trainer = composer_trainer_hparams.initialize_object()
+        trainer.state.callbacks.append(CheckScaleSchedule())
 
         assert trainer.state.max_duration.unit == TimeUnit.EPOCH
         assert trainer.state.max_duration.value == int(10 * ssr)
-        scheduler = trainer.state.schedulers[0]
 
-        test_steps = [int(20 * ssr), int(40 * ssr), int(60 * ssr)]
-        target_lrs = [1.0, 0.1, 0.01]
-        current_step = 0
-        for test_step, target_lr in zip(test_steps, target_lrs):
-
-            while current_step < test_step:
-                trainer.state.timer.on_batch_complete()
-                current_step += 1
-
-            scheduler.step()
-
-            assert scheduler.get_last_lr()[0] == pytest.approx(target_lr)
+        trainer.fit()

--- a/tests/trainer/test_scheduler.py
+++ b/tests/trainer/test_scheduler.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Type, cast
 
 import pytest
 import torch
+import torch.utils.data
 
 from composer.core import State, Time
 from composer.core.time import TimeUnit
@@ -21,14 +22,14 @@ STEPS_PER_EPOCH = 1000
 
 
 @pytest.fixture
-def dummy_schedulers_state(dummy_model: torch.nn.Module, dummy_train_dataloader: DataLoader, rank_zero_seed: int):
-    return State(
+def dummy_schedulers_state(dummy_model: torch.nn.Module, rank_zero_seed: int):
+    state = State(
         model=dummy_model,
         rank_zero_seed=rank_zero_seed,
-        train_dataloader=dummy_train_dataloader,
         max_duration=MAX_DURATION,
-        steps_per_epoch=STEPS_PER_EPOCH,
     )
+    state.dataloader = cast(torch.utils.data.DataLoader, [None] * STEPS_PER_EPOCH)
+    return state
 
 
 @pytest.mark.parametrize("scheduler,ssr,test_times,expected_lrs", [
@@ -88,16 +89,17 @@ def test_scheduler_init(scheduler: ComposerScheduler, ssr: float, test_times: Li
                         dummy_schedulers_state: State):
 
     state = dummy_schedulers_state
-    state._max_duration = Time(value=int(state.max_duration.value * ssr), unit=state.max_duration.unit)
+    assert state.dataloader is not None
+    state.max_duration = Time(value=int(state.max_duration.value * ssr), unit=state.max_duration.unit)
     for test_time, expected_lr in zip(test_times, expected_lrs):
         parsed_time = Time.from_timestring(test_time)
         assert parsed_time.unit in [TimeUnit.EPOCH, TimeUnit.BATCH]
         if parsed_time.unit == TimeUnit.EPOCH:
             state.timer._epoch = parsed_time
-            state.timer._batch = Time(int(state.steps_per_epoch * state.timer._epoch.value), TimeUnit.BATCH)
+            state.timer._batch = Time(int(len(state.dataloader) * int(state.timer.epoch)), TimeUnit.BATCH)
         else:
             state.timer._batch = parsed_time
-            state.timer._epoch = Time(int(state.timer._batch.value / state.steps_per_epoch), TimeUnit.EPOCH)
+            state.timer._epoch = Time(int(state.timer.batch) // len(state.dataloader), TimeUnit.EPOCH)
 
         lr = scheduler(state, ssr)
         assert lr == pytest.approx(expected_lr, abs=1e-3)

--- a/tests/utils/trainer_fit.py
+++ b/tests/utils/trainer_fit.py
@@ -57,10 +57,10 @@ def train_model(composer_trainer_hparams: TrainerHparams, max_epochs: int = 2, r
     if isinstance(trainer._device, DeviceGPU):
         original_model = trainer._device.module_to_device(original_model)
 
-    if run_loss_check and trainer.state.train_dataloader:
-        initial_loss = get_total_loss(original_model, trainer.state.train_dataloader, trainer._device)
+    if run_loss_check and trainer.state.dataloader:
+        initial_loss = get_total_loss(original_model, trainer.state.dataloader, trainer._device)
 
         unwrapped_model = trainer.state.model.module
         assert isinstance(unwrapped_model, ComposerModel)
-        post_fit_loss = get_total_loss(unwrapped_model, trainer.state.train_dataloader, trainer._device)
+        post_fit_loss = get_total_loss(unwrapped_model, trainer.state.dataloader, trainer._device)
         assert post_fit_loss < initial_loss + 1e-5, f"post_fit_loss({post_fit_loss}) - initial_loss({initial_loss}) >= 1e-5"


### PR DESCRIPTION
…ps_per_epoch`.

1. Made the `state.dataloader` optional, since it will not be provided on `__init__` as part of #40.
2. Binding the active dataloader to the state on `Event.FIT_START`, and switching the dataloader to each evaluation dataloader before `Event.EVAL_START`. Restoring the previous (training) dataloader after `Event.EVAL_END`.
3. Moved `Event.EVAL_START` and `Event.EVAL_END` to run for each evaluator, instead of once for all evaluators. With #40, the eval() will take in a dataloader, which would then require `Event.EVAL_START` and `Event.EVAL_END`. This change also permits for algorithms that wish to modify (each) evalution dataloader.
4. Moved scaling of the LR schedulers to `Trainer.fit()` before `Event.FIT_START` fires. Schedulers will be passed in on `Trainer.fit()` as part of #40.
5. Removed `steps_per_epoch` as part of the state. Instead, algorithms and callbacks can read len(state.dataloader) directly. While this change will make schedulers no longer accurate when using `train_subset_num_batches`, that flag should only be used for performance measurements. As such, it is not necessarry that SSR behaves correctly for performance runs. Added a warning for the `train_subset_num_batches` field.

Implements the first part of #40.
Closes #363.