### PR TITLE
CLI Launcher supports environment variables and tells fewer lies

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -21,25 +21,23 @@ log = logging.getLogger(__name__)
 def get_parser():
     parser = ArgumentParser(description="Utility for launching distributed machine learning jobs.")
 
-    parser.add_argument("-n",
-                        "--nproc",
-                        type=int,
-                        required=True,
-                        help="The number of processes to launch on this node. Required.")
-    parser.add_argument("--world_size",
-                        type=int,
-                        default=-1,
-                        help="The total number of processes to launch on all "
-                        "nodes. Set to -1 to default to nproc (single-node operation). "
-                        "Defaults to -1.")
+    required_args = parser.add_argument_group("required arguments")
+
+    required_args.add_argument("-n",
+                               "--nproc",
+                               type=int,
+                               default=None,
+                               help="The number of processes to launch on this node. Overrides env var "
+                               "LOCAL_WORLD_SIZE.")
+
     parser.add_argument(
         "--stdout",
         type=str,
         default=None,
-        help=("Format string for a filename to dump the STDOUT from the non-local-rank-zero processes."
+        help=("Format string for a filename to dump the STDOUT from the non-local-rank-zero processes. "
               "The local rank zero process will be piped through to STDOUT. The available format variables are: "
               "'{rank}', '{local_rank}', '{world_size}', '{node_rank}', and '{local_world_size}'. If specified, "
-              "it is recommended to include '{rank}' or '{local_rank}' in the filename so each rank will write to its"
+              "it is recommended to include '{rank}' or '{local_rank}' in the filename so each rank will write to its "
               "own file. By default, the STDOUT of the non-local-rank-zero processes is discarded; instead, use the "
               "FileLogger within Composer. This logger captures and saves the STDOUT of each process."),
     )
@@ -47,49 +45,70 @@ def get_parser():
         "--stderr",
         type=str,
         default=None,
-        help=("Format string for a filename to dump the STDERR from the non-local-rank-zero processes."
+        help=("Format string for a filename to dump the STDERR from the non-local-rank-zero processes. "
               "The local rank zero process will be piped through to STDERR. The available format variables are: "
               "'{rank}', '{local_rank}', '{world_size}', '{node_rank}', and '{local_world_size}'. If specified, "
-              "it is recommended to include '{rank}' or '{local_rank}' in the filename so each rank will write to its"
+              "it is recommended to include '{rank}' or '{local_rank}' in the filename so each rank will write to its "
               "own file. By default, the STDERR of the non-local-rank-zero processes is discarded; instead, use the "
               "FileLogger within Composer. This logger captures and saves the STDERR of each process."),
     )
-    parser.add_argument("--base_rank",
-                        type=int,
-                        default=0,
-                        help="The rank of the lowest ranked process to launch on this node. "
-                        "Specifying a base_rank B and an nproc N will spawn processes "
-                        "with global ranks [B, B+1, ... B+N-1]. Defaults to 0 (single-node "
-                        "operation).")
-    parser.add_argument("--node_rank",
-                        type=int,
-                        default=-1,
-                        help="The rank of this node. Set to -1 to assume that all nodes have "
-                        "the same number of processes, and calculate accordingly. Defaults to -1.")
-    parser.add_argument("--master_addr",
-                        type=str,
-                        default="127.0.0.1",
-                        help="The FQDN of the node running the rank 0 worker. Defaults to "
-                        "127.0.0.1 (single-node operation).")
-    parser.add_argument("--master_port",
-                        type=int,
-                        default=None,
-                        help="The port on the master hosting the C10d TCP store. If you are running "
-                        "multiple trainers on a single node, this generally needs to be unique for "
-                        "each one. Defaults to a random free port.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="If set, print verbose messages")
     parser.add_argument("-m",
                         "--module_mode",
                         action="store_true",
                         help="If set, run the training script as a module instead of as a script.")
-    parser.add_argument("-v", "--verbose", action="store_true", help="If set, print verbose messages")
-    parser.add_argument("training_script",
-                        type=str,
-                        help="The path to the training script used to initialize a single training "
-                        "process. Should be followed by any command-line arguments the script "
-                        "should be launched with.")
-    parser.add_argument("training_script_args",
-                        nargs="...",
-                        help="Any arguments for the training script, given in the expected order.")
+
+    multinode_args = parser.add_argument_group(
+        "multi-node arguments",
+        description="These arguments generally only need to be set when training in a multi-node "
+        "environment, i.e. when the world_size is bigger than nproc.")
+    multinode_args.add_argument("--world_size",
+                                type=int,
+                                default=None,
+                                help="The total number of processes to launch across all nodes. "
+                                "Setting this to a value greater than nproc indicates a multi-node "
+                                "environment. Overrides env var WORLD_SIZE. Defaults to nproc.")
+    multinode_args.add_argument("--base_rank",
+                                type=int,
+                                default=None,
+                                help="The rank of the lowest ranked process to launch on this node. "
+                                "Specifying a base_rank B and an nproc N will spawn processes with "
+                                "global ranks [B, B+1, ... B+N-1]. In a multi-node environment, "
+                                "at least one of base_rank and node_rank must be specified. "
+                                "If only one of base_rank and node_rank are provided, it is assumed "
+                                "that all nodes have the same amount of processes, and that the two "
+                                "values are related as node_rank * nproc = base_rank. If this is "
+                                "not the case, both base_rank and node_rank must be provided. "
+                                "Overrides env var BASE_RANK. Defaults to 0 in a single-node "
+                                "environment.")
+    multinode_args.add_argument("--node_rank",
+                                type=int,
+                                default=None,
+                                help="The rank of this node. See base_rank for information on when "
+                                "this must be provided. Overrides env var NODE_RANK. Defaults to 0 "
+                                "in a single-node environment.")
+    multinode_args.add_argument("--master_addr",
+                                type=str,
+                                default=None,
+                                help="The FQDN of the node hosting the C10d TCP store. For single-node "
+                                "operation, this can generally be left as 127.0.0.1. Overrides env var "
+                                "MASTER_ADDR. Defaults to 127.0.0.1 in a single-node environment.")
+    multinode_args.add_argument("--master_port",
+                                type=int,
+                                default=None,
+                                help="The port on the master hosting the C10d TCP store. If you are "
+                                "running multiple trainers on a single node, this generally needs "
+                                "to be unique for each one. Overrides env var MASTER_PORT. Defaults "
+                                "to a random free port in a single-node environment.")
+
+    required_args.add_argument("training_script",
+                               type=str,
+                               help="The path to the training script used to initialize a single training "
+                               "process. Should be followed by any command-line arguments the script "
+                               "should be launched with.")
+    required_args.add_argument("training_script_args",
+                               nargs="...",
+                               help="Any arguments for the training script, given in the expected order.")
 
     return parser
 
@@ -107,30 +126,87 @@ def parse_args():
     parser = get_parser()
 
     args = parser.parse_args()
-    if args.world_size == -1:
+
+    env_var_mapping = {
+        "nproc": "LOCAL_WORLD_SiZE",
+        "world_size": "WORLD_SIZE",
+        "base_rank": "BASE_RANK",
+        "node_rank": "NODE_RANK",
+        "master_addr": "MASTER_ADDR",
+        "master_port": "MASTER_PORT",
+    }
+
+    for arg_name, env_var_name in env_var_mapping.items():
+        if getattr(args, arg_name) is None:
+            if env_var_name in os.environ:
+                env_var_value = os.environ[env_var_name]
+                if env_var_name != "master_addr":
+                    env_var_value = int(env_var_value)
+                setattr(args, arg_name, env_var_value)
+
+    if args.world_size is None:
         args.world_size = args.nproc
 
-    if args.node_rank == -1:
-        if args.base_rank % args.nproc != 0:
-            raise ValueError("node_rank not specified, but unable to infer since nodes appear to "
-                             "have different amounts of processes.")
-        args.node_rank = args.base_rank // args.nproc
+    if args.world_size < args.nproc:
+        raise ValueError(f"world_size({args.world_size}) cannot be less than nproc({args.nproc})")
+
+    is_multinode = args.world_size > args.nproc
+
+    if is_multinode:
+        if args.base_rank is None and args.node_rank is None:
+            raise ValueError(f"In a multi-node environment, at least one of node_rank and base_rank must be provided.")
+
+        if args.node_rank is None:
+            if args.world_size % args.nproc != 0 or args.base_rank % args.nproc != 0:
+                raise ValueError("node_rank not provided, but unable to infer from base_rank since nodes appear to "
+                                 "have different amounts of processes. Please also specify node_rank.")
+            args.node_rank = args.base_rank // args.nproc
+
+        if args.base_rank is None:
+            if args.world_size % args.nproc != 0:
+                raise ValueError("base_rank not provided, but unable to infer from node_rank since nodes appear to "
+                                 "have different amounts of processes. Please also provide base_rank.")
+            args.base_rank = args.node_rank * args.nproc
+
+        if args.base_rank + args.nproc >= args.world_size:
+            raise ValueError(f"Cannot initialize processes for node with base_rank({args.base_rank}) and "
+                             f"nproc({args.nproc}) because this would mean creating a process with "
+                             f"rank({args.base_rank + args.nproc}), and all processes must have smaller rank than the "
+                             f"world_size({args.world_size}).")
+
+        if args.master_addr is None:
+            raise ValueError("In a multi-node environment, master_addr is required.")
+
+        if args.master_port is None:
+            raise ValueError("In a multi-node environment, master_port is required.")
+
+    else:
+        if args.base_rank is not None and args.base_rank != 0:
+            raise ValueError(f"base_rank({args.base_rank}) != 0 is not valid in a single-node environment.")
+        args.base_rank = 0
+
+        if args.node_rank is not None and args.node_rank != 0:
+            raise ValueError(f"node_rank({args.node_rank}) != 0 is not valid in a single-node environment.")
+        args.node_rank = 0
+
+        if args.master_addr is None:
+            args.master_addr = "127.0.0.1"
+
+        if args.master_port is None:
+            warnings.warn("AutoSelectPortWarning: The distributed key-value port was auto-selected. "
+                          "This may lead to race conditions when launching multiple training processes simultaneously. "
+                          "To eliminate this race condition, explicitly specify a port with --master_port PORT_NUMBER")
+            args.master_port = get_free_tcp_port()
 
     return args
 
 
-def launch_processes(nproc: int, world_size: int, base_rank: int, node_rank: int, master_addr: str,
-                     master_port: Optional[int], module_mode: bool, training_script: str,
-                     stdout_file_format: Optional[str], stderr_file_format: Optional[str],
-                     training_script_args: List[Any], processes: Set[subprocess.Popen]):
-    log.info("Starting DDP on local node for global_rank(%s-%s)", base_rank, base_rank + nproc - 1)
-
-    if master_port is None:
-        warnings.warn("AutoSelectPortWarning: The DDP port was auto-selected. "
-                      "This may lead to race conditions when launching multiple training processes simultaneously. "
-                      "To eliminate this race condition, explicitely specify a port with --master_port PORT_NUMBER")
-        master_port = get_free_tcp_port()
-    log.info("DDP Store: tcp://%s:%s", master_addr, master_port)
+def launch_processes(nproc: int, world_size: int, base_rank: int, node_rank: int, master_addr: str, master_port: int,
+                     module_mode: bool, training_script: str, stdout_file_format: Optional[str],
+                     stderr_file_format: Optional[str], training_script_args: List[Any],
+                     processes: Set[subprocess.Popen]):
+    log.info("Starting distributed environment on local node for global_rank(%s-%s)", base_rank, base_rank + nproc - 1)
+    log.info("Distributed KV store: tcp://%s:%s", master_addr, master_port)
 
     for local_rank in range(nproc):
         global_rank = base_rank + local_rank

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -198,9 +198,9 @@ def _parse_args():
 
 
 def _launch_processes(nproc: int, world_size: int, base_rank: int, node_rank: int, master_addr: str, master_port: int,
-                     module_mode: bool, training_script: str, stdout_file_format: Optional[str],
-                     stderr_file_format: Optional[str], training_script_args: List[Any],
-                     processes: Set[subprocess.Popen]):
+                      module_mode: bool, training_script: str, stdout_file_format: Optional[str],
+                      stderr_file_format: Optional[str], training_script_args: List[Any],
+                      processes: Set[subprocess.Popen]):
     log.info("Starting distributed environment on local node for global_rank(%s-%s)", base_rank, base_rank + nproc - 1)
     log.info("Distributed KV store: tcp://%s:%s", master_addr, master_port)
 
@@ -366,17 +366,17 @@ def main():
 
     try:
         _launch_processes(nproc=args.nproc,
-                         world_size=args.world_size,
-                         base_rank=args.base_rank,
-                         node_rank=args.node_rank,
-                         master_addr=args.master_addr,
-                         master_port=args.master_port,
-                         module_mode=args.module_mode,
-                         stdout_file_format=args.stdout,
-                         stderr_file_format=args.stderr,
-                         training_script=args.training_script,
-                         training_script_args=args.training_script_args,
-                         processes=processes)
+                          world_size=args.world_size,
+                          base_rank=args.base_rank,
+                          node_rank=args.node_rank,
+                          master_addr=args.master_addr,
+                          master_port=args.master_port,
+                          module_mode=args.module_mode,
+                          stdout_file_format=args.stdout,
+                          stderr_file_format=args.stderr,
+                          training_script=args.training_script,
+                          training_script_args=args.training_script_args,
+                          processes=processes)
         _monitor_processes(processes)
     except:
         # Print the exception first, then kill the training processes, since killing

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -26,7 +26,6 @@ def get_parser():
     required_args.add_argument("-n",
                                "--nproc",
                                type=int,
-                               default=None,
                                help="The number of processes to launch on this node. Overrides env var "
                                "LOCAL_WORLD_SIZE.")
 
@@ -64,13 +63,11 @@ def get_parser():
         "environment, i.e. when the world_size is bigger than nproc.")
     multinode_args.add_argument("--world_size",
                                 type=int,
-                                default=None,
                                 help="The total number of processes to launch across all nodes. "
                                 "Setting this to a value greater than nproc indicates a multi-node "
                                 "environment. Overrides env var WORLD_SIZE. Defaults to nproc.")
     multinode_args.add_argument("--base_rank",
                                 type=int,
-                                default=None,
                                 help="The rank of the lowest ranked process to launch on this node. "
                                 "Specifying a base_rank B and an nproc N will spawn processes with "
                                 "global ranks [B, B+1, ... B+N-1]. In a multi-node environment, "
@@ -83,19 +80,16 @@ def get_parser():
                                 "environment.")
     multinode_args.add_argument("--node_rank",
                                 type=int,
-                                default=None,
                                 help="The rank of this node. See base_rank for information on when "
                                 "this must be provided. Overrides env var NODE_RANK. Defaults to 0 "
                                 "in a single-node environment.")
     multinode_args.add_argument("--master_addr",
                                 type=str,
-                                default=None,
                                 help="The FQDN of the node hosting the C10d TCP store. For single-node "
                                 "operation, this can generally be left as 127.0.0.1. Overrides env var "
                                 "MASTER_ADDR. Defaults to 127.0.0.1 in a single-node environment.")
     multinode_args.add_argument("--master_port",
                                 type=int,
-                                default=None,
                                 help="The port on the master hosting the C10d TCP store. If you are "
                                 "running multiple trainers on a single node, this generally needs "
                                 "to be unique for each one. Overrides env var MASTER_PORT. Defaults "

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -134,7 +134,7 @@ def parse_args():
         if getattr(args, arg_name) is None:
             if env_var_name in os.environ:
                 env_var_value = os.environ[env_var_name]
-                if env_var_name != "master_addr":
+                if env_var_name != "MASTER_ADDR":
                     env_var_value = int(env_var_value)
                 setattr(args, arg_name, env_var_value)
 


### PR DESCRIPTION
1. Multi-node values for the CLI launcher can be specified via environment variables, akin to other common distributed launching tools.
2. A lot more validation to make sure that invalid multi-node configurations cannot be provided.
3. Only one of `node_rank` and `base_rank` needs to be provided when there's a constant amount of processes per node.
4. Another pass on the (internal) documentation for the launcher. In particular, the documentation is simplified for most users by distinguishing the multi-node options from everything else, and not documenting the "actual" placeholder defaults.

`composer -h` now returns:

```
% composer -h
usage: composer [-h] [-n NPROC] [--stdout STDOUT] [--stderr STDERR] [-v] [-m]
                [--world_size WORLD_SIZE] [--base_rank BASE_RANK] [--node_rank NODE_RANK]
                [--master_addr MASTER_ADDR] [--master_port MASTER_PORT]
                training_script ...

Utility for launching distributed machine learning jobs.

optional arguments:
  -h, --help            show this help message and exit
  --stdout STDOUT       Format string for a filename to dump the STDOUT from the non-local-rank-
                        zero processes. The local rank zero process will be piped through to
                        STDOUT. The available format variables are: '{rank}', '{local_rank}',
                        '{world_size}', '{node_rank}', and '{local_world_size}'. If specified, it
                        is recommended to include '{rank}' or '{local_rank}' in the filename so
                        each rank will write to its own file. By default, the STDOUT of the non-
                        local-rank-zero processes is discarded; instead, use the FileLogger within
                        Composer. This logger captures and saves the STDOUT of each process.
  --stderr STDERR       Format string for a filename to dump the STDERR from the non-local-rank-
                        zero processes. The local rank zero process will be piped through to
                        STDERR. The available format variables are: '{rank}', '{local_rank}',
                        '{world_size}', '{node_rank}', and '{local_world_size}'. If specified, it
                        is recommended to include '{rank}' or '{local_rank}' in the filename so
                        each rank will write to its own file. By default, the STDERR of the non-
                        local-rank-zero processes is discarded; instead, use the FileLogger within
                        Composer. This logger captures and saves the STDERR of each process.
  -v, --verbose         If set, print verbose messages
  -m, --module_mode     If set, run the training script as a module instead of as a script.

required arguments:
  -n NPROC, --nproc NPROC
                        The number of processes to launch on this node. Overrides env var
                        LOCAL_WORLD_SIZE.
  training_script       The path to the training script used to initialize a single training
                        process. Should be followed by any command-line arguments the script
                        should be launched with.
  training_script_args  Any arguments for the training script, given in the expected order.

multi-node arguments:
  These arguments generally only need to be set when training in a multi-node environment, i.e.
  when the world_size is bigger than nproc.

  --world_size WORLD_SIZE
                        The total number of processes to launch across all nodes. Setting this to
                        a value greater than nproc indicates a multi-node environment. Overrides
                        env var WORLD_SIZE. Defaults to nproc.
  --base_rank BASE_RANK
                        The rank of the lowest ranked process to launch on this node. Specifying a
                        base_rank B and an nproc N will spawn processes with global ranks [B, B+1,
                        ... B+N-1]. In a multi-node environment, at least one of base_rank and
                        node_rank must be specified. If only one of base_rank and node_rank are
                        provided, it is assumed that all nodes have the same amount of processes,
                        and that the two values are related as node_rank * nproc = base_rank. If
                        this is not the case, both base_rank and node_rank must be provided.
                        Overrides env var BASE_RANK. Defaults to 0 in a single-node environment.
  --node_rank NODE_RANK
                        The rank of this node. See base_rank for information on when this must be
                        provided. Overrides env var NODE_RANK. Defaults to 0 in a single-node
                        environment.
  --master_addr MASTER_ADDR
                        The FQDN of the node hosting the C10d TCP store. For single-node
                        operation, this can generally be left as 127.0.0.1. Overrides env var
                        MASTER_ADDR. Defaults to 127.0.0.1 in a single-node environment.
  --master_port MASTER_PORT
                        The port on the master hosting the C10d TCP store. If you are running
                        multiple trainers on a single node, this generally needs to be unique for
                        each one. Overrides env var MASTER_PORT. Defaults to a random free port in
                        a single-node environment.
```