### PR TITLE
Add missing ffcv dependency in pytorch_vision docker image

### DIFF
--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -179,6 +179,7 @@ ARG PYTHON_VERSION
 RUN sudo pip${PYTHON_VERSION} install --no-cache-dir \
     ffcv==0.0.3 \
     'opencv-python>=4.5.5.64,<4.6' \
-    'numba>=0.55.0,<0.56' && \
+    'numba>=0.55.0,<0.56' \
+    cupy-`echo ${CUDA_VERSION_TAG} | sed "s/cu/cuda/g"`>=10.2.0 && \
     sudo pip${PYTHON_VERSION} install --no-cache-dir mmcv-full==1.4.4 -f https://download.openmmlab.com/mmcv/dist/${CUDA_VERSION_TAG}/${MMCV_TORCH_VERSION}/index.html && \
     sudo pip${PYTHON_VERSION} install --no-cache-dir 'mmsegmentation>=0.22.0,<0.23'


### PR DESCRIPTION
cupy was missing. Adding it in the PyTorch_vision image. 