### PR TITLE
Initialize distributed before dataloaders are created

### DIFF
--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
 import os
 import textwrap
@@ -473,6 +474,11 @@ class TrainerHparams(hp.Hparams):
 
         # devices and systems
         device = self.device.initialize_object()
+
+        # initialize distributed early so that it's already initialized when dataloders
+        # are created.
+        if dist.get_world_size() > 1:
+            dist.initialize_dist(device.dist_backend, datetime.timedelta(seconds=self.dist_timeout))
 
         seed = self.seed if self.seed else reproducibility.get_random_seed()
         # need to set seed before model initialization for determinism


### PR DESCRIPTION
Initialize torch distributed before Dataloaders are created. FFCV Dataloaders make some calls to some functions from dist namespace. 

Test:
`composer -n 8 examples/run_composer_trainer.py -f composer/yamls/models/resnet50.yaml --max_duration 2ep --train_batch_size 32 --datadir /localdisk/ImageNet --loggers progress_bar`