### PR TITLE
Fixing version number

### DIFF
--- a/composer/__init__.py
+++ b/composer/__init__.py
@@ -24,4 +24,4 @@ from composer.core import types as types
 from composer.models import ComposerModel as ComposerModel
 from composer.trainer import Trainer as Trainer
 
-__version__ = "0.4.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
Version number was never bumped to 0.5.0 upon release. Just updating it now for the next release to avoid that in the future :) 