### PR TITLE
Switch mixup events to avoid grad accum issues

### DIFF
--- a/composer/algorithms/mixup/mixup.py
+++ b/composer/algorithms/mixup/mixup.py
@@ -126,14 +126,14 @@ class MixUp(Algorithm):
 
     def match(self, event: Event, state: State) -> bool:
         if self.interpolate_loss:
-            return event in [Event.AFTER_DATALOADER, Event.AFTER_LOSS]
+            return event in [Event.BEFORE_FORWARD, Event.BEFORE_BACKWARD]
         else:
-            return event in [Event.AFTER_DATALOADER, Event.BEFORE_LOSS]
+            return event in [Event.BEFORE_FORWARD, Event.BEFORE_LOSS]
 
     def apply(self, event: Event, state: State, logger: Logger) -> None:
         input, target = state.batch_pair
 
-        if event == Event.AFTER_DATALOADER:
+        if event == Event.BEFORE_FORWARD:
             if not isinstance(input, torch.Tensor):
                 raise NotImplementedError("Multiple tensors for inputs not supported yet.")
             if not isinstance(target, torch.Tensor):
@@ -165,7 +165,7 @@ class MixUp(Algorithm):
             # Create the new batch
             state.batch = (input, mixed_up_target)
 
-        if self.interpolate_loss and event == Event.AFTER_LOSS:
+        if self.interpolate_loss and event == Event.BEFORE_BACKWARD:
             # Grab the loss function
             if hasattr(state.model, "loss"):
                 loss_fn = state.model.loss

--- a/tests/algorithms/test_mixup.py
+++ b/tests/algorithms/test_mixup.py
@@ -60,7 +60,7 @@ class TestMixUp:
         state.batch = (x_fake, y_fake)
 
         # Apply algo, use test hooks to specify indices and override internally generated interpolation lambda for testability
-        algorithm.apply(Event.AFTER_DATALOADER, state, empty_logger)
+        algorithm.apply(Event.BEFORE_FORWARD, state, empty_logger)
 
         x, _ = state.batch
         # Use algorithm generated indices and mixing_coef for validation


### PR DESCRIPTION
This PR fixes the issue with mixup + grad_accum > 1 by switching it to operate on the batch after it has been split. This should be math equivalent to the previous behavior.

Test runs currently gated due to lack of GPUs
[ResNet50-I1k with grad_accum=2 and interpolate_loss=True Accuracy 77.27%](https://wandb.ai/mosaic-ml/cory-mixup-changes/runs/nanpf6er)