### PR TITLE
Add test for grad_accum > 2 to the asset tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ filterwarnings = [
     'ignore:SubsetNumBatchesWarning',  # different subsets OK for testing
     'ignore:No optimizer:UserWarning',  # testing defaults
     'ignore:No scheduler:UserWarning',  # testing defaults
+    'ignore::DeprecationWarning:tensorboard',  # ignore tensorboard
 ]
 
 # Coverage

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -311,8 +311,10 @@ config management to retrieve the objects to test.
 @pytest.mark.timeout(15)
 class TestTrainerAssets:
 
-    @pytest.fixture
-    def config(self, rank_zero_seed: int):
+    @pytest.fixture(params=[1, 2], ids=['ga-1', 'ga-2'])
+    def config(self, rank_zero_seed: int, request):
+        grad_accum = request.param
+
         return {
             'model': SimpleConvModel(),
             'train_dataloader': DataLoader(
@@ -326,6 +328,7 @@ class TestTrainerAssets:
             'max_duration': '2ep',
             'loggers': [],  # no progress bar
             'seed': rank_zero_seed,
+            'grad_accum': grad_accum,
         }
 
     # Note: Not all algorithms, callbacks, and loggers are compatible


### PR DESCRIPTION
As an addendum to #875 (fix mixup and grad accum error):
* adds a test for `grad_accum=2` to the tests of each algorithm x trainer combination, which would catch the error being fixed in 875 earlier.
* silences the third-party (tensorboard) deprecation warnings.

This PR's tests should fail until #875 is merged:
```
=================== short test summary info ====================
FAILED trainer/test_trainer.py::TestTrainerAssets::test_algorithms[ga-2-mixup]
FAILED trainer/test_trainer.py::TestTrainerAssets::test_algorithms_multiple_calls[ga-2-mixup]
```