### PR TITLE
Symlinks for Graceful Resumption

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -347,16 +347,12 @@ class CheckpointSaver(Callback):
                                      overwrite=self.overwrite)
 
             if self.latest_filename is not None:
+                # Since object stores might not support symlinks, we emulate a symlink
+                # with ".symlink" file containing the path to the true latest checkpoint
                 symlink_name = os.path.join(
                     format_name_with_dist(self.folder, logger.run_name),
                     format_name_with_dist_and_time(self.latest_filename, logger.run_name, state.timer.get_timestamp()),
-                )
-                if state.is_model_deepspeed and not is_tar(symlink_name):
-                    # Deepspeed requires tarballs; appending `.tar`
-                    symlink_name += ".tar"
-                # Since object stores might not support symlinks, we emulate a symlink
-                # with ".symlink" file containing the path to the true latest checkpoint
-                symlink_name += ".symlink"
+                ) + ".symlink"
                 symlink_dirname = os.path.dirname(symlink_name)
                 if symlink_dirname:
                     os.makedirs(symlink_dirname, exist_ok=True)

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -242,7 +242,7 @@ def _download_checkpoint(
     rank_n_checkpoint_filepath = os.path.join(node_checkpoint_folder, f"rank{dist.get_global_rank()}_checkpoint")
     extracted_checkpoint_folder = None
     extracted_rank_n = False
-    if is_tar(path):
+    if is_tar(_follow_symlink(_format_path_with_rank_zero(path), node_checkpoint_folder, 0)):
         extracted_checkpoint_folder = os.path.join(node_checkpoint_folder, "checkpoint")
         composer_states_filepath = os.path.join(extracted_checkpoint_folder, _COMPOSER_STATES_FILENAME)
     else:

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -50,14 +50,6 @@ def _format_path_with_current_rank(path: str) -> str:
         node_rank=dist.get_node_rank(),
     )
 
-def _format_path_with_rank_zero(path: str) -> str:
-    """Formats ``path`` formatted with rank values of 0."""
-    return path.format(
-        rank=0,
-        local_rank=0,
-        node_rank=0,
-    )
-
 
 def _get_write_mode(name: str) -> str:
     """Get the write mode to use with :func:`tarfile.open`."""

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -286,9 +286,9 @@ def test_checkpoint(
         pytest.skip("DeepSpeed tests must be ran on GPU")
 
     if deepspeed_enabled:
-        if not is_tar(resume_file):
+        if not is_tar(resume_file) and not resume_file.endswith(".symlink"):
             resume_file += ".tar"
-        if not is_tar(final_checkpoint):
+        if not is_tar(final_checkpoint) and not final_checkpoint.endswith(".symlink"):
             final_checkpoint += ".tar"
 
     if model_name is not None:

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -104,6 +104,10 @@ def assert_weights_equivalent(original_trainer_hparams: TrainerHparams, new_trai
 
 def _load_checkpoint(checkpoint_dir: str, filename: str):
     filename = filename.format(rank=0)
+    if filename.endswith(".symlink"):
+        with open(filename) as f:
+            filename = f.readline()
+            filename = filename.format(rank=0)
     if not is_tar(filename):
         return torch.load(filename, map_location='cpu')
 
@@ -246,7 +250,7 @@ def test_load_weights(
 @pytest.mark.parametrize(
     "seed,save_interval,save_filename,resume_file,final_checkpoint",
     [
-        [None, "1ep", "ep{epoch}-rank{rank}", "ep1-rank{rank}", "latest-rank{rank}"
+        [None, "1ep", "ep{epoch}-rank{rank}", "ep1-rank{rank}", "latest-rank{rank}.symlink"
         ],  # test randomized seed saving and symlinking
         [42, "1ep", "ep{epoch}-rank{rank}", "ep1-rank{rank}", "ep2-rank{rank}"],  # test save at epoch end
         [42, "1ep", "ep{epoch}-rank{rank}.tgz", "ep1-rank{rank}.tgz", "ep2-rank{rank}.tgz"


### PR DESCRIPTION
Adds effective symlinks, which are necessary for object stores. Existing tests (the one edited to include `.symlink`) file extension should provide some coverage for local files, deepspeed tars, etc

What's the best way to test for the object store scenario?