### PR TITLE
Graceful resumption params

### DIFF
--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -179,7 +179,7 @@ class TrainerHparams(hp.Hparams):
             .. seealso:: :mod:`composer.callbacks` for the different callbacks built into Composer.
         load_path (str, optional): See :class:`.Trainer`.
         load_object_store (ObjectStore, optional): See :class:`.Trainer`.
-        load_weights_only (bool, optional): See :class:`.Trainer`.
+        load_only_weights_path (str, optional): See :class:`.Trainer`.
         load_chunk_size (int, optional): See :class:`.Trainer`.
         save_folder (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
         save_filename (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
@@ -197,7 +197,8 @@ class TrainerHparams(hp.Hparams):
             to the trainer for the ``deepspeed_config`` parameter signaling that DeepSpeed will not be used
             for training.
         prof_schedule (ProfileScheduleHparams, optional): Profile schedule hparams. Must be specified to enable the profiler.
-        prof_event_handlers (List[TraceHandlerHparams], optional): See :class:`.Trainer`. Must be specified to enable the profiler.        prof_skip_first (int, optional): See :class:`.Trainer`.        prof_wait (int, optional): See :class:`.Trainer`.
+        prof_event_handlers (List[TraceHandlerHparams], optional): See :class:`.Trainer`. Must be specified to enable the profiler.
+        prof_skip_first (int, optional): See :class:`.Trainer`.        prof_wait (int, optional): See :class:`.Trainer`.
 
         sys_prof_cpu (bool, optional): See :class:`.Trainer`.
         sys_prof_memory (bool, optional): See :class:`.Trainer`.
@@ -325,22 +326,25 @@ class TrainerHparams(hp.Hparams):
         connecting to the cloud provider object store. Otherwise, if the checkpoint is a local filepath,
         leave blank. This parameter has no effect if `load_path` is not specified."""),
                                                                   default=None)
-    load_weights_only: bool = hp.optional(doc=textwrap.dedent("""\
-        Whether to only load the weights from the model.
-        This parameter has no effect if `load_path`is not specified."""),
-                                          default=False)
+    load_only_weights_path: Optional[str] = hp.optional(doc=textwrap.dedent("""\
+        If specified, the path to an existing checkpoint file
+        (if the checkpoint is on the local disk) or the object name for the checkpoint
+        (if the checkpoint is in a cloud bucket) to load only the weights. 
+        Set to None (the default) to skip loading from a checkpoint.
+        Ignored if `load_path` is specified and exists"""),
+                                              default=None)
     load_strict_model_weights: bool = hp.optional(doc=textwrap.dedent("""\
         Ensure that the set of checkpoint weights in the checkpoint and model must exactly match.
-        This parameter has no effect if `load_path` is not specified."""),
+        This parameter has no effect if `load_path` or `load_only_weights_path` are not specified."""),
                                                   default=False)
 
     load_chunk_size: int = hp.optional(doc=textwrap.dedent("""\
         Chunk size (in bytes) to use when downloading checkpoints.
-        This parameter has no effect if `load_path` is not specified or it is a local file path."""),
+        This parameter has no effect if `load_path` or `load_only_weights_path` are not specified or are is a local file path."""),
                                        default=1_048_576)
     load_progress_bar: bool = hp.optional(doc=textwrap.dedent("""\
         Whether to show a progress bar when downloading checkpoints.
-        This parameter has no effect if `load_path` is not specified or it is a local file path."""),
+        This parameter has no effect if `load_path` or `load_only_weights_path` are not specified or are is a local file path."""),
                                           default=True)
 
     # save checkpoint
@@ -593,7 +597,7 @@ class TrainerHparams(hp.Hparams):
             # Checkpoint parameters
             load_path=self.load_path,
             load_object_store=None if self.load_object_store is None else self.load_object_store.initialize_object(),
-            load_weights_only=self.load_weights_only,
+            load_only_weights_path=self.load_only_weights_path,
             load_strict=self.load_strict_model_weights,
             load_chunk_size=self.load_chunk_size,
             load_progress_bar=self.load_progress_bar,

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -178,6 +178,7 @@ class TrainerHparams(hp.Hparams):
 
             .. seealso:: :mod:`composer.callbacks` for the different callbacks built into Composer.
         load_path (str, optional): See :class:`.Trainer`.
+        load_ignore_missing_checkpoint (str, optional): See :class:`.Trainer`.
         load_object_store (ObjectStore, optional): See :class:`.Trainer`.
         load_only_weights_path (str, optional): See :class:`.Trainer`.
         load_chunk_size (int, optional): See :class:`.Trainer`.
@@ -321,6 +322,8 @@ class TrainerHparams(hp.Hparams):
         (if the checkpoint is on the local disk) or the object name for the checkpoint
         (if the checkpoint is in a cloud bucket). Set to None (the default) to skip loading from a checkpoint."""),
                                            default=None)
+    load_ignore_missing_checkpoint: bool = hp.optional(doc="Whether to ignore missing checkpoints at load_path",
+                                                       default=False)
     load_object_store: Optional[ObjectStoreHparams] = hp.optional(doc=textwrap.dedent("""\
         If the checkpoint is in an object store (i.e. AWS S3 or Google Cloud Storage), the parameters for
         connecting to the cloud provider object store. Otherwise, if the checkpoint is a local filepath,
@@ -332,7 +335,7 @@ class TrainerHparams(hp.Hparams):
         (if the checkpoint is in a cloud bucket) to load only the weights. 
         Set to None (the default) to skip loading from a checkpoint.
         Ignored if `load_path` is specified and exists"""),
-                                              default=None)
+                                                        default=None)
     load_strict_model_weights: bool = hp.optional(doc=textwrap.dedent("""\
         Ensure that the set of checkpoint weights in the checkpoint and model must exactly match.
         This parameter has no effect if `load_path` or `load_only_weights_path` are not specified."""),
@@ -340,11 +343,13 @@ class TrainerHparams(hp.Hparams):
 
     load_chunk_size: int = hp.optional(doc=textwrap.dedent("""\
         Chunk size (in bytes) to use when downloading checkpoints.
-        This parameter has no effect if `load_path` or `load_only_weights_path` are not specified or are is a local file path."""),
+        This parameter has no effect if `load_path` or `load_only_weights_path` are not specified or are is a local file path."""
+                                                          ),
                                        default=1_048_576)
     load_progress_bar: bool = hp.optional(doc=textwrap.dedent("""\
         Whether to show a progress bar when downloading checkpoints.
-        This parameter has no effect if `load_path` or `load_only_weights_path` are not specified or are is a local file path."""),
+        This parameter has no effect if `load_path` or `load_only_weights_path` are not specified or are is a local file path."""
+                                                             ),
                                           default=True)
 
     # save checkpoint
@@ -596,6 +601,7 @@ class TrainerHparams(hp.Hparams):
 
             # Checkpoint parameters
             load_path=self.load_path,
+            load_ignore_missing_checkpoint=self.load_ignore_missing_checkpoint,
             load_object_store=None if self.load_object_store is None else self.load_object_store.initialize_object(),
             load_only_weights_path=self.load_only_weights_path,
             load_strict=self.load_strict_model_weights,

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -80,7 +80,7 @@ def load_checkpoint(
     object_store: Optional[ObjectStore] = None,
     load_weights_only: bool = False,
     strict_model_weights: bool = False,
-    error_on_failure: bool = True,
+    load_ignore_missing_checkpoint: bool = True,
     chunk_size: int = 1_048_576,
     progress_bar: bool = True,
 ):
@@ -130,8 +130,8 @@ def load_checkpoint(
             restoring the associated state. (default: ``False``)
         strict_model_weights (bool, optional): Whether or not to force that the checkpointed weights must exactly
             match the model weights. (default: ``False``)
-        error_on_failure (bool, optional): Whether or not to raise FileNotFoundExceptions to user level, or otherwise
-            catch errors and emit a warning. (default: ``True``)
+        load_ignore_missing_checkpoint (bool, optional): Whether or not to ignore missing files and emit a warning or otherwise
+            raise FileNotFoundExceptions to user level. (default: ``True``)
         chunk_size (int, optional): Chunk size (in bytes) to use when downloading checkpoints.
             Ignored if the checkpoint is a local file path. (default: ``1_048_576`` bytes (1 MB))
         progress_bar (bool, optional): Whether or not to show a progress bar when downloading checkpoints.
@@ -166,9 +166,9 @@ def load_checkpoint(
                 )
             except GetFileNotFoundException as e:
                 # GLOBAL rank zero checkpoint was not found as this is the only ``get_file``` call not wrapped in try
-                # except. In this case, abort restoring checkpoints. If error_on_failure, we reraise this error, or
+                # except. In this case, abort restoring checkpoints. If load_ignore_missing_checkpoint, we reraise this error, or
                 # otherwise emit a warning and abort restoring checkpoint but continue onward.
-                if error_on_failure:
+                if not load_ignore_missing_checkpoint:
                     raise e
                 else:
                     warnings.warn(f"Required files not found for {path}, skipping loading checkpoint")

--- a/composer/yamls/models/glue/cola.yaml
+++ b/composer/yamls/models/glue/cola.yaml
@@ -50,7 +50,6 @@ validate_every_n_batches: 250
 validate_every_n_epochs: 1
 callbacks:
   - lr_monitor: {}
-load_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
-load_weights_only: true
+load_only_weights_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
 load_strict_model_weights: false
 load_chunk_size: 8192

--- a/composer/yamls/models/glue/mnli.yaml
+++ b/composer/yamls/models/glue/mnli.yaml
@@ -69,7 +69,6 @@ validate_every_n_batches: 2300
 validate_every_n_epochs: 1
 callbacks:
   - lr_monitor: {}
-load_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
-load_weights_only: true
+load_only_weights_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
 load_strict_model_weights: false
 load_chunk_size: 8192

--- a/composer/yamls/models/glue/mrpc.yaml
+++ b/composer/yamls/models/glue/mrpc.yaml
@@ -50,7 +50,6 @@ validate_every_n_batches: 100
 validate_every_n_epochs: 1
 callbacks:
   - lr_monitor: {}
-load_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
-load_weights_only: true
+load_only_weights_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
 load_strict_model_weights: false
 load_chunk_size: 8192

--- a/composer/yamls/models/glue/qnli.yaml
+++ b/composer/yamls/models/glue/qnli.yaml
@@ -50,7 +50,6 @@ validate_every_n_batches: 1000
 validate_every_n_epochs: 1
 callbacks:
   - lr_monitor: {}
-load_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
-load_weights_only: true
+load_only_weights_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
 load_strict_model_weights: false
 load_chunk_size: 8192

--- a/composer/yamls/models/glue/qqp.yaml
+++ b/composer/yamls/models/glue/qqp.yaml
@@ -50,7 +50,6 @@ validate_every_n_batches: 2000
 validate_every_n_epochs: 1
 callbacks:
   - lr_monitor: {}
-load_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
-load_weights_only: true
+load_only_weights_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
 load_strict_model_weights: false
 load_chunk_size: 8192

--- a/composer/yamls/models/glue/rte.yaml
+++ b/composer/yamls/models/glue/rte.yaml
@@ -50,7 +50,6 @@ validate_every_n_batches: 1000
 validate_every_n_epochs: 1
 callbacks:
   - lr_monitor: {}
-load_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
-load_weights_only: true
+load_only_weights_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
 load_strict_model_weights: false
 load_chunk_size: 8192

--- a/composer/yamls/models/glue/sst-2.yaml
+++ b/composer/yamls/models/glue/sst-2.yaml
@@ -50,7 +50,6 @@ validate_every_n_batches: 500
 validate_every_n_epochs: 1
 callbacks:
   - lr_monitor: {}
-load_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
-load_weights_only: true
+load_only_weights_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
 load_strict_model_weights: false
 load_chunk_size: 8192

--- a/composer/yamls/models/glue/stsb.yaml
+++ b/composer/yamls/models/glue/stsb.yaml
@@ -50,7 +50,6 @@ validate_every_n_batches: 200
 validate_every_n_epochs: 1
 callbacks:
   - lr_monitor: {}
-load_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
-load_weights_only: true
+load_only_weights_path: https://storage.googleapis.com/llm_checkpoints/bert_checkpoint/bert_checkpoints/ep7.pt
 load_strict_model_weights: false
 load_chunk_size: 8192

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -85,9 +85,11 @@ def assert_weights_equivalent(original_trainer_hparams: TrainerHparams, new_trai
     Then assert that they are equivalent to the weights from the original model.
     """
 
-    # load_weights_only is False since the original Trainer is testing full checkpoint recovery
-    original_trainer_hparams.load_path = new_trainer_hparams.load_path
-    original_trainer_hparams.load_weights_only = False
+    print(original_trainer_hparams)
+    print(new_trainer_hparams)
+
+    # Use load_path, not load_only_weights_path since the original Trainer is testing full checkpoint recovery
+    original_trainer_hparams.load_only_weights_path = new_trainer_hparams.load_only_weights_path
     original_trainer_hparams.load_strict_model_weights = False
     original_trainer_hparams.save_overwrite = True
 
@@ -136,7 +138,6 @@ def assert_checkpoints_equivalent(
     assert hparams_b.load_path is not None
     assert hparams_b.save_folder is not None
     hparams_a.load_path = hparams_b.load_path
-    hparams_a.load_weights_only = False
     hparams_a.save_overwrite = True
     hparams_a.load_strict_model_weights = False
     hparams_a.save_folder = hparams_b.save_folder
@@ -214,8 +215,7 @@ def test_load_weights(
     dist.broadcast_object_list(checkpoint_a_file_path)
 
     # load only model weights
-    second_trainer_hparams.load_path = checkpoint_a_file_path[0]
-    second_trainer_hparams.load_weights_only = True
+    second_trainer_hparams.load_only_weights_path = checkpoint_a_file_path[0]
     second_trainer_hparams.load_strict_model_weights = True
     # setup a new optimizer
     second_trainer_hparams.optimizer = AdamWHparams()
@@ -391,7 +391,6 @@ def test_checkpoint(
 
     second_trainer_hparams.save_folder = checkpoint_b_folder
     second_trainer_hparams.load_path = checkpoint_to_resume_filepath
-    second_trainer_hparams.load_weights_only = False
     second_trainer_hparams.load_strict_model_weights = False
 
     _test_checkpoint_trainer(second_trainer_hparams)


### PR DESCRIPTION
Note: This will be rebased and merged after https://github.com/mosaicml/composer/pull/880 is merged

Reworks parameters based on graceful resumption plan. Separates out checkpoint and weights path args.

Open question on default values: how do we set path to default value of save folder? If we set load path to a default value when unspecified, it will load from the junk weights I have sitting in the folder if I try doing overwrite save folder