### PR TITLE
Modify ResNet9 benchmark to enable channels_last and progressive_resizing

### DIFF
--- a/composer/models/resnet_cifar/resnets.py
+++ b/composer/models/resnet_cifar/resnets.py
@@ -157,13 +157,14 @@ class ResNet9(nn.Module):
             nn.ReLU(inplace=True),
             nn.MaxPool2d(kernel_size=2, stride=2),
             BasicBlock(inplanes=256, planes=256, stride=1),
-            nn.MaxPool2d(kernel_size=2, stride=2),
+            #nn.MaxPool2d(kernel_size=2, stride=2),
         )
 
-        self.fc = nn.Linear(in_features=1024, out_features=num_classes, bias=True)
+        self.fc = nn.Linear(in_features=256, out_features=num_classes, bias=True)
 
     def forward(self, x):
         out = self.body(x)
-        out = out.view(-1, out.shape[1] * out.shape[2] * out.shape[3])
+        out = F.avg_pool2d(out, out.size()[3])
+        out = out.view(out.size(0), -1)
         out = self.fc(out)
         return out

--- a/composer/models/resnet_cifar/resnets.py
+++ b/composer/models/resnet_cifar/resnets.py
@@ -157,7 +157,6 @@ class ResNet9(nn.Module):
             nn.ReLU(inplace=True),
             nn.MaxPool2d(kernel_size=2, stride=2),
             BasicBlock(inplanes=256, planes=256, stride=1),
-            #nn.MaxPool2d(kernel_size=2, stride=2),
         )
 
         self.fc = nn.Linear(in_features=256, out_features=num_classes, bias=True)


### PR DESCRIPTION
This PR switches ResNet9 to use average pooling rather than max pooling, which has two effects:
1) The model can handle different input sizes, which enables `progressive_resizing`.
2) The reshape before the fully connected layer now plays nicely with `channels_last`, which didn't run before.

These changes also seem to slightly improve accuracy with current hparams.

Runs (5 seeds):
[Current dev: Accuracy 92.93% +/- 0.30 
After change: Accuracy 93.68% +/- 0.22](https://wandb.ai/mosaic-ml/cory-resnet9-speedtest?workspace=user-corymosaicml)