### PR TITLE
Fix loss logging with DeepSpeed

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1306,7 +1306,7 @@ class Trainer:
 
                 # This is the same loss scaling and reporting we skipped earlier.
                 for loss in ensure_tuple(self.state.loss):
-                    loss.mul_(self.state.batch_num_samples / current_batch_size)
+                    loss.mul_(microbatch_num_samples / current_batch_size)
                     total_loss += loss.detach().clone()
             else:
                 for loss in ensure_tuple(self.state.loss):


### PR DESCRIPTION
Discovered that the loss being logged was `grad_accum` times larger than it should be when using DeepSpeed (any ZERO stage). I think this was due to a typo. Future `trainer.py` refactor should probably have some more explicit names like `state.microbatch`, rather than just `state.batch` which is getting set to minibatches/microbatches in different places.