### PR TITLE
WandB multi-rank logging

### DIFF
--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -129,16 +129,10 @@ class WandBLoggerHparams(LoggerDestinationHparams):
         if self.flatten_config:
             config_dict = self._flatten_dict(config_dict)
 
-        if self.rank_zero_only:
-            name = self.name
-            group = self.group
-        else:
-            name = f"{self.name} [RANK_{dist.get_global_rank()}]"
-            group = self.group if self.group else self.name
         init_params = {
             "project": self.project,
-            "name": name,
-            "group": group,
+            "name": self.name,
+            "group": self.group,
             "entity": self.entity,
             "tags": tags,
             "config": config_dict,

--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -16,7 +16,7 @@ from composer.loggers.logger_destination import LoggerDestination
 from composer.loggers.object_store_logger import ObjectStoreLogger
 from composer.loggers.progress_bar_logger import ProgressBarLogger
 from composer.loggers.wandb_logger import WandBLogger
-from composer.utils import ObjectStoreHparams, dist, import_object
+from composer.utils import ObjectStoreHparams, import_object
 
 __all__ = [
     "FileLoggerHparams",

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -131,7 +131,7 @@ class WandBLogger(LoggerDestination):
 
             if self._enabled and self._log_artifacts:
                 import wandb
-                extension = file_path.name.split(".")[-1]
+                extension = new_artifact_name.split(".")[-1]
                 artifact = wandb.Artifact(name=new_artifact_name, type=extension)
                 artifact.add_file(os.path.abspath(file_path))
                 wandb.log_artifact(artifact, aliases=aliases)

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -7,9 +7,7 @@ from __future__ import annotations
 import os
 import pathlib
 import re
-import shutil
 import sys
-import tempfile
 import textwrap
 import warnings
 from typing import Any, Dict, Optional
@@ -65,10 +63,6 @@ class WandBLogger(LoggerDestination):
         if init_params is None:
             init_params = {}
         self._init_params = init_params
-
-        # Temporary directory for staging artifact upload
-        tempdir = tempfile.TemporaryDirectory()
-        self._upload_staging_folder = tempdir.name
 
     def log_data(self, state: State, log_level: LogLevel, data: Dict[str, Any]):
         import wandb

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -47,7 +47,7 @@ def main() -> None:
     with tempfile.NamedTemporaryFile(mode="x+") as f:
         f.write(hparams.to_yaml())
         trainer.logger.file_artifact(LogLevel.FIT,
-                                     artifact_name="{run_name}/hparams.yaml",
+                                     artifact_name=f"{trainer.logger.run_name}/hparams.yaml",
                                      file_path=f.name,
                                      overwrite=True)
 

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -43,20 +43,21 @@ def main() -> None:
 
     trainer = hparams.initialize_object()
 
+    # Log the config to an artifact store if global rank 0
+    if dist.get_global_rank() == 0:
+        with tempfile.NamedTemporaryFile(mode="x+") as f:
+            f.write(hparams.to_yaml())
+            trainer.logger.file_artifact(LogLevel.FIT,
+                                         artifact_name=f"{trainer.logger.run_name}/hparams.yaml",
+                                         file_path=f.name,
+                                         overwrite=True)
+
     # Print the config to the terminal and log to artifact store if on each local rank 0
     if dist.get_local_rank() == 0:
         print("*" * 30)
         print("Config:")
         print(hparams.to_yaml())
         print("*" * 30)
-
-        with tempfile.NamedTemporaryFile(mode="x+") as f:
-            f.write(hparams.to_yaml())
-            trainer.logger.file_artifact(
-                LogLevel.FIT,
-                artifact_name=f"{trainer.logger.run_name}/hparams-rank{dist.get_global_rank()}.yaml",
-                file_path=f.name,
-                overwrite=True)
 
     trainer.fit()
 

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -43,7 +43,7 @@ def main() -> None:
 
     trainer = hparams.initialize_object()
 
-    # Log the config to an artifact store if global rank 0
+    # Only log the config once, since it should be the same on all ranks.
     if dist.get_global_rank() == 0:
         with tempfile.NamedTemporaryFile(mode="x+") as f:
             f.write(hparams.to_yaml())

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -43,20 +43,20 @@ def main() -> None:
 
     trainer = hparams.initialize_object()
 
-    # Log the config to an artifact store
-    with tempfile.NamedTemporaryFile(mode="x+") as f:
-        f.write(hparams.to_yaml())
-        trainer.logger.file_artifact(LogLevel.FIT,
-                                     artifact_name=f"{trainer.logger.run_name}/hparams.yaml",
-                                     file_path=f.name,
-                                     overwrite=True)
-
-    # Print the config to the terminal on each local rank 0
+    # Print the config to the terminal and log to artifact store if on each local rank 0
     if dist.get_local_rank() == 0:
         print("*" * 30)
         print("Config:")
         print(hparams.to_yaml())
         print("*" * 30)
+
+        with tempfile.NamedTemporaryFile(mode="x+") as f:
+            f.write(hparams.to_yaml())
+            trainer.logger.file_artifact(
+                LogLevel.FIT,
+                artifact_name=f"{trainer.logger.run_name}/hparams-rank{dist.get_global_rank()}.yaml",
+                file_path=f.name,
+                overwrite=True)
 
     trainer.fit()
 

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -43,13 +43,13 @@ def main() -> None:
 
     trainer = hparams.initialize_object()
 
-    # Log the config to an artifact store
-    with tempfile.NamedTemporaryFile(mode="x+") as f:
-        f.write(hparams.to_yaml())
-        trainer.logger.file_artifact(LogLevel.FIT,
-                                     artifact_name=f"{trainer.logger.run_name}/hparams.yaml",
-                                     file_path=f.name,
-                                     overwrite=True)
+    # # Log the config to an artifact store
+    # with tempfile.NamedTemporaryFile(mode="x+") as f:
+    #     f.write(hparams.to_yaml())
+    #     trainer.logger.file_artifact(LogLevel.FIT,
+    #                                  artifact_name="{run_name}/hparams.yaml",
+    #                                  file_path=f.name,
+    #                                  overwrite=True)
 
     # Print the config to the terminal on each local rank 0
     if dist.get_local_rank() == 0:

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -43,13 +43,13 @@ def main() -> None:
 
     trainer = hparams.initialize_object()
 
-    # # Log the config to an artifact store
-    # with tempfile.NamedTemporaryFile(mode="x+") as f:
-    #     f.write(hparams.to_yaml())
-    #     trainer.logger.file_artifact(LogLevel.FIT,
-    #                                  artifact_name="{run_name}/hparams.yaml",
-    #                                  file_path=f.name,
-    #                                  overwrite=True)
+    # Log the config to an artifact store
+    with tempfile.NamedTemporaryFile(mode="x+") as f:
+        f.write(hparams.to_yaml())
+        trainer.logger.file_artifact(LogLevel.FIT,
+                                     artifact_name="{run_name}/hparams.yaml",
+                                     file_path=f.name,
+                                     overwrite=True)
 
     # Print the config to the terminal on each local rank 0
     if dist.get_local_rank() == 0:


### PR DESCRIPTION
This PR changes a few things to improve WandB arifact logging and make multinode logging more user-friendly. Note that the multi-rank features are only really necesary when using DeepSpeed ZERO.

Changes:
* Move the `rank_zero_only` naming behavior to `WandBLogger`, rather than `WandBLoggerHparams`
  * previously, `traner.run_name` was not making its way into the logger
* Stick with WandB Artifacts rather than WandB `.save()`, because the latter doesn't have safe tmpdir+upload+delete_on_finish, which is required for our `LoggerDestination`
* WandB artifact extension is detected based on destination artifact name, not source filename (caused an issue with our temporary YAML file)

Right now, the way I would recommend a user to use the WandB logger with multi-rank is something like this:
```bash
composer -n 8 examples/run_composer_trainer.py -f composer/yamls/models/gpt3_125m.yaml \
  --run_name myrun \
  --save_folder "/tmp/{run_name}" \
  --save_artifact_name "{run_name}/checkpoints/rank{rank}" \
  --save_interval 5ba \
  --save_num_checkpoints_to_keep 1 \
  ...
  --loggers wandb \
  --loggers.wandb.project abhi-multinode-checkpointing \
  --loggers.wandb.rank_zero_only false \
  --loggers.wandb.log_artifacts true
```

This creates `WORLD_SIZE` artifacts that are each linked to one of the `WORLD_SIZE` runs, and within each artifact, there are user-readable tagged versions of the checkpoint, like `entity/runname/runname.checkpoints.rank0.tar:ep0-ba10`. When you download this artifact, you get a `.tar` file with the original `save_filename`.

I tried consolidating the multiple ranks into a single artifact, but had a lot of difficulty doing so. I found a [potentially useful api call here](https://docs.wandb.ai/guides/artifacts/artifact-creation-modes#collaborative-mode), but would like to get this PR merged first as it is useable enough.

TODO @abhi-mosaic : launch an E2E multi-node test and sanity check the WandB UI. Also run with frequent checkpointing to make sure we are never running out of local disk space.