### PR TITLE
Don't use Jenkins milestones on merge builds

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -129,11 +129,15 @@ def runPytest(pDockerImage, markers, extraDeps, isGpu) {
 
 stage('Prepare') {
     node (pCloud) {
-        // Automatically cancel old builds
+        // Automatically cancel old builds only on PR builds
         // From https://stackoverflow.com/questions/40760716/jenkins-abort-running-build-if-new-one-is-started
-        def buildNumber = env.BUILD_NUMBER as int
-        if (buildNumber > 1) milestone(buildNumber - 1)
-        milestone(buildNumber)
+        if (env.CHANGE_ID) {  // if it is a PR build
+            def buildNumber = env.BUILD_NUMBER as int
+            if (buildNumber > 1) {
+                milestone(buildNumber - 1)
+            }
+            milestone(buildNumber)
+        }
 
         def loadedSCM = checkout scm
 


### PR DESCRIPTION
On a PR merge into dev, build each and every commit -- not just the latest.