### PR TITLE
Fix failing CPU memory monitor test

### DIFF
--- a/tests/callbacks/test_memory_monitor.py
+++ b/tests/callbacks/test_memory_monitor.py
@@ -47,7 +47,7 @@ def _do_trainer_fit(composer_trainer_hparams: TrainerHparams, testing_with_gpu: 
 def test_memory_monitor_cpu(composer_trainer_hparams: TrainerHparams):
     log_destination, _ = _do_trainer_fit(composer_trainer_hparams, testing_with_gpu=False)
 
-    if torch.cuda.is_available():
+    if torch.cuda.device_count() > 0:
         pytest.skip('Skip CPU memory monitor tests if CUDA is available.')
 
     memory_monitor_called = False

--- a/tests/callbacks/test_memory_monitor.py
+++ b/tests/callbacks/test_memory_monitor.py
@@ -4,6 +4,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 from torch.cuda import device_count
 
 from composer.callbacks import MemoryMonitorHparams
@@ -45,6 +46,9 @@ def _do_trainer_fit(composer_trainer_hparams: TrainerHparams, testing_with_gpu: 
 @pytest.mark.timeout(60)
 def test_memory_monitor_cpu(composer_trainer_hparams: TrainerHparams):
     log_destination, _ = _do_trainer_fit(composer_trainer_hparams, testing_with_gpu=False)
+
+    if torch.cuda.is_available():
+        pytest.skip('Skip CPU memory monitor tests if CUDA is available.')
 
     memory_monitor_called = False
     for log_call in log_destination.log_data.mock_calls:


### PR DESCRIPTION
`make test` fails when run on a GPU machine because `test_memory_monitor_cpu` still picks up on active GPU memory from other tests / concurrent jobs and debugging sessions.

This PR skips `test_memory_monitor_cpu` if GPU devices are available. This should not affect our CI/CD since we run CPU tests in a CPU machine. 