### PR TITLE
Fix Distributed Timeouts

### DIFF
--- a/tests/fixtures/new_fixtures.py
+++ b/tests/fixtures/new_fixtures.py
@@ -1,6 +1,7 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
 """These fixtures are shared globally across the test suite."""
+import datetime
 import shutil
 
 import pytest
@@ -8,6 +9,7 @@ from torch.utils.data import DataLoader
 
 from composer.core import State
 from composer.loggers import Logger
+from composer.utils import dist
 from tests.common import RandomClassificationDataset, SimpleModel
 
 
@@ -27,14 +29,23 @@ def minimal_state(rank_zero_seed: int):
 
 
 @pytest.fixture
-def empty_logger(minimal_state: State) -> Logger:
+def empty_logger(minimal_state: State, configure_dist: None) -> Logger:
     """Logger without any output configured."""
+    # need to configure dist as the logger depends on it
+    del configure_dist  # unused
     return Logger(state=minimal_state, destinations=[])
 
 
 @pytest.fixture(autouse=True)
 def disable_wandb(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("WANDB_MODE", "disabled")
+
+
+@pytest.fixture
+def configure_dist(request: pytest.FixtureRequest):
+    backend = 'gloo' if request.node.get_closest_marker('gpu') is None else 'nccl'
+    if not dist.is_initialized():
+        dist.initialize_dist(backend, timeout=datetime.timedelta(seconds=300))
 
 
 # Class-scoped temporary directory. That deletes itself. This is useful for e.g. not

--- a/tests/loggers/test_logger.py
+++ b/tests/loggers/test_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-import datetime
 import pathlib
 
 import pytest
@@ -11,10 +10,9 @@ from composer.utils import dist, reproducibility
 
 
 @pytest.mark.world_size(2)
-def test_logger_run_name(dummy_state: State):
-    # need to manually initialize distributed if not already initialized, since this test occurs outside of the trainer
-    if not dist.is_initialized():
-        dist.initialize_dist('gloo', timeout=datetime.timedelta(seconds=5))
+def test_logger_run_name(dummy_state: State, configure_dist: None):
+    # need to configure dist as the logger depends on it
+    del configure_dist  # unused
     # seeding with the global rank to ensure that each rank has a different seed
     reproducibility.seed_all(dist.get_global_rank())
 

--- a/tests/loggers/test_logger.py
+++ b/tests/loggers/test_logger.py
@@ -10,9 +10,7 @@ from composer.utils import dist, reproducibility
 
 
 @pytest.mark.world_size(2)
-def test_logger_run_name(dummy_state: State, configure_dist: None):
-    # need to configure dist as the logger depends on it
-    del configure_dist  # unused
+def test_logger_run_name(dummy_state: State):
     # seeding with the global rank to ensure that each rank has a different seed
     reproducibility.seed_all(dist.get_global_rank())
 


### PR DESCRIPTION
A logger test that was manually initializing dist configured the timeout to be too low, resulting in timeouts in other tests.