### PR TITLE
Fix random pytest timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ filterwarnings = [
     'ignore:No scheduler:UserWarning',  # testing defaults
     'ignore::DeprecationWarning:tensorboard',  # ignore tensorboard
 ]
+timeout_func_only = true  # exclude fixtures from the timeout
 
 # Coverage
 [tool.coverage.run]


### PR DESCRIPTION
1. Include a distributed barrier in test setup to ensure that no rank starts any test before other ranks are ready to start it, which could be a cause of random timeouts (e.g. rank 1 starts the next test while rank 0 is finishing up validating the previous test).
2. Exclude fixtures from timeouts. This allows that distributed barrier in 1) to take as long as needed (up to the distributed timeout).