### PR TITLE
[ffcv] remove extra hyperparameter

### DIFF
--- a/composer/datasets/cifar.py
+++ b/composer/datasets/cifar.py
@@ -41,8 +41,7 @@ class CIFAR10DatasetHparams(DatasetHparams, SyntheticHparamsMixin):
         use_ffcv (bool): Whether to use FFCV dataloaders. Default: ``False``.
         ffcv_dir (str): A directory containing train/val <file>.ffcv files. If these files don't exist and
             ``ffcv_write_dataset`` is ``True``, train/val <file>.ffcv files will be created in this dir. Default: ``"/tmp"``.
-        ffcv_dest_train (str): <file>.ffcv file that has training samples. Default: ``"cifar_train.ffcv"``.
-        ffcv_dest_val (str): <file>.ffcv file that has validation samples. Default: ``"cifar_val.ffcv"``.
+        ffcv_dest (str): <file>.ffcv file that has dataset samples. Default: ``"cifar_train.ffcv"``.
         ffcv_write_dataset (std): Whether to create dataset in FFCV format (<file>.ffcv) if it doesn't exist. Default:
         ``False``.
     """
@@ -51,8 +50,7 @@ class CIFAR10DatasetHparams(DatasetHparams, SyntheticHparamsMixin):
     ffcv_dir: str = hp.optional(
         "A directory containing train/val <file>.ffcv files. If these files don't exist and ffcv_write_dataset is true, train/val <file>.ffcv files will be created in this dir.",
         default="/tmp")
-    ffcv_dest_train: str = hp.optional("<file>.ffcv file that has training samples", default="cifar_train.ffcv")
-    ffcv_dest_val: str = hp.optional("<file>.ffcv file that has validation samples", default="cifar_val.ffcv")
+    ffcv_dest: str = hp.optional("<file>.ffcv file that has dataset samples", default="cifar_train.ffcv")
     ffcv_write_dataset: bool = hp.optional("Whether to create dataset in FFCV format (<file>.ffcv) if it doesn't exist",
                                            default=False)
 
@@ -80,8 +78,7 @@ class CIFAR10DatasetHparams(DatasetHparams, SyntheticHparamsMixin):
                     Composer was installed without ffcv support.
                     To use ffcv with Composer, please install ffcv in your environment."""))
 
-            dataset_file = self.ffcv_dest_train if self.is_train else self.ffcv_dest_val
-            dataset_filepath = os.path.join(self.ffcv_dir, dataset_file)
+            dataset_filepath = os.path.join(self.ffcv_dir, self.ffcv_dest)
             # always create if ffcv_write_dataset is true
             if self.ffcv_write_dataset:
                 if dist.get_local_rank() == 0:

--- a/composer/datasets/imagenet.py
+++ b/composer/datasets/imagenet.py
@@ -45,8 +45,7 @@ class ImagenetDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
         use_ffcv (bool): Whether to use FFCV dataloaders. Default: ``False``.
         ffcv_dir (str): A directory containing train/val <file>.ffcv files. If these files don't exist and
             ``ffcv_write_dataset`` is ``True``, train/val <file>.ffcv files will be created in this dir. Default: ``"/tmp"``.
-        ffcv_dest_train (str): <file>.ffcv file that has training samples. Default: ``"train.ffcv"``.
-        ffcv_dest_val (str): <file>.ffcv file that has validation samples. Default: ``"val.ffcv"``.
+        ffcv_dest (str): <file>.ffcv file that has dataset samples. Default: ``"imagenet_train.ffcv"``.
         ffcv_write_dataset (std): Whether to create dataset in FFCV format (<file>.ffcv) if it doesn't exist. Default:
         ``False``.
     """
@@ -56,8 +55,7 @@ class ImagenetDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
     ffcv_dir: str = hp.optional(
         "A directory containing train/val <file>.ffcv files. If these files don't exist and ffcv_write_dataset is true, train/val <file>.ffcv files will be created in this dir.",
         default="/tmp")
-    ffcv_dest_train: str = hp.optional("<file>.ffcv file that has training samples", default="train.ffcv")
-    ffcv_dest_val: str = hp.optional("<file>.ffcv file that has validation samples", default="val.ffcv")
+    ffcv_dest: str = hp.optional("<file>.ffcv file that has dataset samples", default="imagenet_train.ffcv")
     ffcv_write_dataset: bool = hp.optional("Whether to create dataset in FFCV format (<file>.ffcv) if it doesn't exist",
                                            default=False)
 
@@ -88,13 +86,10 @@ class ImagenetDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
                     To use ffcv with Composer, please install ffcv in your environment."""))
 
             if self.is_train:
-                dataset_file = self.ffcv_dest_train
                 split = "train"
             else:
-                dataset_file = self.ffcv_dest_val
                 split = "val"
-            dataset_file = self.ffcv_dest_train if self.is_train else self.ffcv_dest_val
-            dataset_filepath = os.path.join(self.ffcv_dir, dataset_file)
+            dataset_filepath = os.path.join(self.ffcv_dir, self.ffcv_dest)
             # always create if ffcv_write_dataset is true
             if self.ffcv_write_dataset:
                 if dist.get_local_rank() == 0:


### PR DESCRIPTION
We only need one instead of the two hyperparamters for destination file for ffcv. 