### PR TITLE
Generalize progressive resizing

### DIFF
--- a/composer/algorithms/hparams.py
+++ b/composer/algorithms/hparams.py
@@ -237,6 +237,8 @@ class ProgressiveResizingHparams(AlgorithmHparams):
     initial_scale: float = hp.optional(doc="Initial scale factor", default=0.5)
     finetune_fraction: float = hp.optional(doc="Fraction of training to reserve for finetuning on full-sized inputs",
                                            default=0.2)
+    delay_fraction: float = hp.optional(doc="Fraction of training before resizing ramp begins", default=0.0)
+    size_increment: int = hp.optional(doc="Align sizes to a multiple of this number.", default=1)
     resize_targets: bool = hp.optional(doc="Also resize targets", default=False)
 
     def initialize_object(self) -> ProgressiveResizing:

--- a/composer/algorithms/progressive_resizing/progressive_resizing.py
+++ b/composer/algorithms/progressive_resizing/progressive_resizing.py
@@ -129,6 +129,8 @@ class ProgressiveResizing(Algorithm):
                                                 mode='resize',
                                                 initial_scale=1.0,
                                                 finetune_fraction=0.2,
+                                                delay_fraction=0.2,
+                                                size_increment=32,
                                                 resize_targets=False
                                             )
             trainer = Trainer(
@@ -148,6 +150,9 @@ class ProgressiveResizing(Algorithm):
             value in between 0 and 1. Default: ``0.5``.
         finetune_fraction (float, optional): Fraction of training to reserve for finetuning on the
             full-sized inputs. Must be a value in between 0 and 1. Default: ``0.2``.
+        delay_fraction (float, optional): Fraction of training before resizing ramp begins.
+            Must be a value in between 0 and 1. Default: ``0.0``.
+        size_increment (int, optional): Align sizes to a multiple of this number. Default: ``1``.
         resize_targets (bool, optional): If True, resize targets also. Default: ``False``.
     """
 
@@ -155,6 +160,8 @@ class ProgressiveResizing(Algorithm):
                  mode: str = 'resize',
                  initial_scale: float = .5,
                  finetune_fraction: float = .2,
+                 delay_fraction: float = .0,
+                 size_increment: int = 1,
                  resize_targets: bool = False):
 
         if mode not in _VALID_MODES:
@@ -166,9 +173,15 @@ class ProgressiveResizing(Algorithm):
         if not (0 <= finetune_fraction <= 1):
             raise ValueError(f"finetune_fraction must be between 0 and 1: {finetune_fraction}")
 
+        if not (delay_fraction + finetune_fraction <= 1):
+            raise ValueError(
+                f"delay_fraction + finetune_fraction must be less than 1: {delay_fraction + finetune_fraction}")
+
         self.mode = mode
         self.initial_scale = initial_scale
         self.finetune_fraction = finetune_fraction
+        self.delay_fraction = delay_fraction
+        self.size_increment = size_increment
         self.resize_targets = resize_targets
 
     def match(self, event: Event, state: State) -> bool:
@@ -195,18 +208,26 @@ class ProgressiveResizing(Algorithm):
             "Multiple tensors not supported for this method yet."
 
         # Calculate the current size of the inputs to use
-        initial_size = self.initial_scale
-        finetune_fraction = self.finetune_fraction
         elapsed_duration = state.get_elapsed_duration()
         assert elapsed_duration is not None, "elapsed duration should be set on Event.AFTER_DATALOADER"
-        scale_frac_elapsed = min([elapsed_duration.value / (1 - finetune_fraction), 1])
+        if elapsed_duration.value >= self.delay_fraction:
+            scale_frac_elapsed = min([
+                (elapsed_duration.value - self.delay_fraction) / (1 - self.finetune_fraction - self.delay_fraction), 1
+            ])
+        else:
+            scale_frac_elapsed = 0.0
 
         # Linearly increase to full size at the start of the fine tuning period
-        scale_factor = initial_size + (1 - initial_size) * scale_frac_elapsed
+        scale_factor = self.initial_scale + (1 - self.initial_scale) * scale_frac_elapsed
+
+        # adjust scale factor so that we make width a multiple of size_increment
+        width = input.shape[3]
+        scaled_width_pinned = round(width * scale_factor / self.size_increment) * self.size_increment
+        scale_factor_pinned = scaled_width_pinned / width
 
         new_input, new_target = resize_batch(input=input,
                                              target=target,
-                                             scale_factor=scale_factor,
+                                             scale_factor=scale_factor_pinned,
                                              mode=self.mode,
                                              resize_targets=self.resize_targets)
         state.batch = (new_input, new_target)

--- a/tests/algorithms/test_progressive_resizing.py
+++ b/tests/algorithms/test_progressive_resizing.py
@@ -72,6 +72,16 @@ def finetune_fraction() -> float:
 
 
 @pytest.fixture
+def delay_fraction() -> float:
+    return 0.2
+
+
+@pytest.fixture
+def size_increment() -> float:
+    return 8
+
+
+@pytest.fixture
 def resize_targets() -> bool:
     return False
 
@@ -118,22 +128,25 @@ class TestResizeInputs:
         assert check_scaled_shape(y, yc, scale_factor)
 
 
-@pytest.mark.parametrize("mode,initial_scale,finetune_fraction", [("foo", 0.5, 0.2), ("crop", 1.2, 0.2),
-                                                                  ("crop", 0.5, 1.2)])
-def test_invalid_hparams(mode: str, initial_scale: float, finetune_fraction: float):
+@pytest.mark.parametrize("mode,initial_scale,finetune_fraction,delay_fraction,size_increment",
+                         [("foo", 0.5, 0.2, 0.2, 8), ("crop", 1.2, 0.2, 0.2, 8), ("crop", 0.5, 1.2, 0.2, 8),
+                          ("resize", 0.5, 0.6, 0.5, 8)])
+def test_invalid_hparams(mode: str, initial_scale: float, finetune_fraction: float, delay_fraction: float,
+                         size_increment: int):
     """Test that invalid hyperparameters error.
 
     Ideally this could be caught by the Hparams, but that's not yet supported in yahp.
     """
     with pytest.raises(ValueError):
-        ProgressiveResizing(mode, initial_scale, finetune_fraction, False)
+        ProgressiveResizing(mode, initial_scale, finetune_fraction, delay_fraction, size_increment, False)
 
 
 class TestProgressiveResizingAlgorithm:
 
     @pytest.fixture
-    def pr_algorithm(self, mode, initial_scale, finetune_fraction, resize_targets):
-        return ProgressiveResizing(mode, initial_scale, finetune_fraction, resize_targets)
+    def pr_algorithm(self, mode, initial_scale, finetune_fraction, delay_fraction, size_increment, resize_targets):
+        return ProgressiveResizing(mode, initial_scale, finetune_fraction, delay_fraction, size_increment,
+                                   resize_targets)
 
     @pytest.mark.parametrize("event", [Event.AFTER_DATALOADER])
     def test_match_correct(self, event: Event, pr_algorithm, minimal_state: State):
@@ -145,7 +158,7 @@ class TestProgressiveResizingAlgorithm:
         """Algo should NOT match INIT."""
         assert not pr_algorithm.match(event, minimal_state)
 
-    @pytest.mark.parametrize("epoch_frac", [0.0, 0.8, 1.0])
+    @pytest.mark.parametrize("epoch_frac", [0.0, 0.6, 0.8, 1.0])
     def test_apply(self, epoch_frac: float, X: torch.Tensor, y: torch.Tensor, pr_algorithm: ProgressiveResizing,
                    minimal_state: State, empty_logger: Logger):
         """Test apply at different epoch fractions (fraction of max epochs)"""
@@ -154,9 +167,19 @@ class TestProgressiveResizingAlgorithm:
         minimal_state.timer.epoch._value = int(epoch_frac * minimal_state.max_duration.value)
         s = pr_algorithm.initial_scale
         f = pr_algorithm.finetune_fraction
-        scale_factor = min([s + (1 - s) / (1 - f) * epoch_frac, 1.0])
+        d = pr_algorithm.delay_fraction
+        p = pr_algorithm.size_increment
+        if epoch_frac >= d:
+            scale_factor_elapsed = min([(epoch_frac - d) / (1 - f - d), 1.0])
+        else:
+            scale_factor_elapsed = 0.0
+        scale_factor = s + (1 - s) * scale_factor_elapsed
         minimal_state.batch = (X, y)
+        width = X.shape[3]
+        scaled_width_pinned = round(width * scale_factor / p) * p
+        scale_factor_pinned = scaled_width_pinned / width
+
         pr_algorithm.apply(Event.AFTER_DATALOADER, minimal_state, empty_logger)
 
         last_input, _ = minimal_state.batch
-        assert check_scaled_shape(X, last_input, scale_factor)
+        assert check_scaled_shape(X, last_input, scale_factor_pinned)


### PR DESCRIPTION
Add delay_fraction and pin_sizes hyperparameters to progressive resizing algorithm. Addition of these two new hyperparameters doesn't change the default behavior of progressive resizing. 

delay_fraction allows us  to skip a fraction of training in the beginning and progressive resizing keeps input initial_scale-sized during this period. 

pin_sizes allows us to pin sizes of images to a multiple of pin_sizes, i.e., if pin_sizes is 32 image width will always be a multple of 32 after progressive resizing. 