### PR TITLE
Add `min_channels` to blurpool

### DIFF
--- a/composer/algorithms/blurpool/blurpool.py
+++ b/composer/algorithms/blurpool/blurpool.py
@@ -97,7 +97,7 @@ class BlurPool(Algorithm):
             applied with a stride of 1 before the blurring, resulting in
             significant overhead (though more closely matching the paper).
             See :class:`.BlurConv2d` for further discussion. Default: ``True``.
-        min_channels (int, optional): Skip replacing layers with less than ``min_channels``.
+        min_channels (int, optional): Skip replacing layers with in_channels < min_channels.
             Commonly used to prevent the blurring of the first layer. Default: 16.
     """
 

--- a/composer/algorithms/hparams.py
+++ b/composer/algorithms/hparams.py
@@ -94,6 +94,7 @@ class BlurPoolHparams(AlgorithmHparams):
     replace_convs: bool = hp.optional('Replace Conv2d with BlurConv2d if stride > 1', default=True)
     replace_maxpools: bool = hp.optional('Replace MaxPool2d with BlurMaxPool2d', default=True)
     blur_first: bool = hp.optional('Blur input before convolution', default=True)
+    min_channels: int = hp.optional('Skip layers with in_channels < min_channels', default=16)
 
     def initialize_object(self) -> "BlurPool":
         return BlurPool(**asdict(self))

--- a/tests/algorithms/test_blurpool.py
+++ b/tests/algorithms/test_blurpool.py
@@ -142,6 +142,12 @@ def test_blurpool_noeffectwarning():
         apply_blurpool(model)
 
 
+def test_blurpool_min_channels():
+    model = torch.nn.Conv2d(in_channels=32, out_channels=64, stride=1, kernel_size=(3, 3))
+    with pytest.warns(NoEffectWarning):
+        apply_blurpool(model, min_channels=64)
+
+
 def test_blurconv2d_optimizer_params_updated():
 
     model = ConvModel()


### PR DESCRIPTION
BlurPool currently uses the hardcoded heuristic of `in_channels > 16` to prevent bluring the first input layer (essentially blurring the input image). 

This PR exposes that as an argument to surface the behavior and allow it to be configured. This helps with testing blurpool as we can then use existing `SimpleConvModel` (in_channels=8).

NB: unclear to me if we actually want to continue using this heuristic, or if a `ignore_first_layer: bool = True` is more appropriate, as using `min_channels` seems a bit of a hack. 