### PR TITLE
Fix `ComposerModel` copying and pickling

### DIFF
--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -60,7 +60,7 @@ class ComposerModel(torch.nn.Module, abc.ABC):
         # directly. Hence, this helper getter, which the @property(logger) uses below, is monkey-patched.
         # This trick preserves the ability to `deepcopy` the model (which is required by some algorithms, such as SWA),
         # as the Logger cannot be deepcopied. (The Logger is attached to the state, and the state has file objects).
-        # This trick works because methods are not copied but are instead re-bound by reference).
+        # This trick works because methods are not copied but are instead re-bound by reference.
         return None
 
     @property

--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import abc
+import copy
 from typing import Any, Optional, Sequence, Tuple, Union
 
 import torch
@@ -49,30 +50,43 @@ class ComposerModel(torch.nn.Module, abc.ABC):
                 # pass batches and `forward` outputs to the loss
                 _, targets = batch
                 return F.cross_entropy(outputs, targets)
+
+    Attributes:
+        logger (Optional[Logger]): The training :class:`.Logger`.
+            The trainer sets the :class:`.Logger` on the:attr:`~composer.core.event.Event.INIT` event.
     """
 
     def __init__(self) -> None:
         super().__init__()
+        self.logger: Optional[Logger] = None
 
-    def _get_logger(self) -> Optional[Logger]:
-        # The trainer monkey-patches this getter to set the logger.
-        # Since properties are bound to the class (and not the instance), the `logger` @property cannot be monkey-patched
-        # directly. Hence, this helper getter, which the @property(logger) uses below, is monkey-patched.
-        # This trick preserves the ability to `deepcopy` the model (which is required by some algorithms, such as SWA),
-        # as the Logger cannot be deepcopied. (The Logger is attached to the state, and the state has file objects).
-        # This trick works because methods are not copied but are instead re-bound by reference.
-        return None
+    def __deepcopy__(self, memo: dict):
+        # From https://stackoverflow.com/questions/1500718/how-to-override-the-copy-deepcopy-operations-for-a-python-object
+        # The `logger` should not be copied
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k == "logger":
+                copied_v = v
+            else:
+                copied_v = copy.deepcopy(v, memo)
+            setattr(result, k, copied_v)
+        return result
 
-    @property
-    def logger(self) -> Optional[Logger]:
-        """The training :class:`.Logger`.
+    def __copy__(self):
+        # From https://stackoverflow.com/questions/1500718/how-to-override-the-copy-deepcopy-operations-for-a-python-object
+        # Need to manually define `__copy__` so it does not rely on `__getstate__`, which would not copy the logger.
+        cls = self.__class__
+        result = cls.__new__(cls)
+        result.__dict__.update(self.__dict__)
+        return result
 
-        The trainer sets the :class:`.Logger` on the:attr:`~composer.core.event.Event.INIT` event.
-
-        Returns:
-            Optional[Logger]: The logger, if it is set, otherwise ``None``.
-        """
-        return self._get_logger()
+    def __getstate__(self):
+        # Don't pickle the logger
+        state = self.__dict__.copy()
+        state['logger'] = None
+        return state
 
     @abc.abstractmethod
     def forward(self, batch: Batch) -> Union[Tensor, Sequence[Tensor]]:

--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -49,9 +49,6 @@ class ComposerModel(torch.nn.Module, abc.ABC):
                 # pass batches and `forward` outputs to the loss
                 _, targets = batch
                 return F.cross_entropy(outputs, targets)
-
-    Attributes:
-        logger (Optional[Logger]): The :class:`.Logger`.
     """
 
     def __init__(self) -> None:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -862,7 +862,7 @@ class Trainer:
             self.train_metrics = None
 
         # Set the logger
-        model._get_logger = lambda: self.logger
+        model.logger = self.logger
 
         self.engine.run_event(Event.INIT)
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -861,7 +861,8 @@ class Trainer:
         else:
             self.train_metrics = None
 
-        model.logger = self.logger
+        # Set the logger
+        model._get_logger = lambda: self.logger
 
         self.engine.run_event(Event.INIT)
 

--- a/tests/models/test_composer_model.py
+++ b/tests/models/test_composer_model.py
@@ -1,3 +1,5 @@
+import copy
+
 from composer.core.types import DataLoader
 from composer.trainer import Trainer
 from tests.fixtures.models import SimpleBatchPairModel
@@ -8,3 +10,11 @@ def test_model_access_to_logger(dummy_train_dataloader: DataLoader):
     assert model.logger is None
     trainer = Trainer(model=model, max_duration="1ep", train_dataloader=dummy_train_dataloader)
     assert model.logger is trainer.logger
+
+
+def test_model_deepcopy(dummy_train_dataloader: DataLoader):
+    model = SimpleBatchPairModel(num_channels=1, num_classes=1)
+    assert model.logger is None
+    trainer = Trainer(model=model, max_duration="1ep", train_dataloader=dummy_train_dataloader)
+    assert model.logger is not None
+    copy.deepcopy(trainer.state.model)

--- a/tests/models/test_composer_model.py
+++ b/tests/models/test_composer_model.py
@@ -1,4 +1,5 @@
 import copy
+import pickle
 
 from composer.core.types import DataLoader
 from composer.trainer import Trainer
@@ -17,4 +18,28 @@ def test_model_deepcopy(dummy_train_dataloader: DataLoader):
     assert model.logger is None
     trainer = Trainer(model=model, max_duration="1ep", train_dataloader=dummy_train_dataloader)
     assert model.logger is not None
-    copy.deepcopy(trainer.state.model)
+    copied_model = copy.deepcopy(trainer.state.model)
+    assert copied_model.logger is model.logger
+    assert model.num_channels == copied_model.num_channels
+
+
+def test_model_copy(dummy_train_dataloader: DataLoader):
+    model = SimpleBatchPairModel(num_channels=1, num_classes=1)
+    assert model.logger is None
+    trainer = Trainer(model=model, max_duration="1ep", train_dataloader=dummy_train_dataloader)
+    assert model.logger is not None
+    copied_model = copy.copy(trainer.state.model)
+    assert copied_model.logger is model.logger
+    assert model.num_channels == copied_model.num_channels
+
+
+def test_model_pickle(dummy_train_dataloader: DataLoader):
+    model = SimpleBatchPairModel(num_channels=1, num_classes=1)
+    assert model.logger is None
+    trainer = Trainer(model=model, max_duration="1ep", train_dataloader=dummy_train_dataloader)
+    assert model.logger is not None
+    pickled_model = pickle.dumps(trainer.state.model)
+    restored_model = pickle.loads(pickled_model)
+    # after pickling the model, the restored loggers should be None, since the logger cannot be serialized
+    assert restored_model.logger is None
+    assert model.num_channels == restored_model.num_channels


### PR DESCRIPTION
-  #944 broke `copy.deepcopy(state.model)` and `pickle.dumps(state.model`), since it bound the Logger to the model, and the Logger cannot be serialized.
- Fixed by manually defining `__copy__`, `__deepcopy__`, and `__getstate__` on the `ComposerModel` base class.
- Added a test case