### PR TITLE
[nit] Default to `python3` in the `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DURATION ?= all  # pytest duration, one of short, long or all
 WORLD_SIZE ?= 1  # world size for launcher tests
 MASTER_PORT ?= 26000 # port for distributed tests
-PYTHON ?= python  # Python command
+PYTHON ?= python3  # Python command
 PYTEST ?= pytest  # Pytest command
 PYRIGHT ?= pyright  # Pyright command. Pyright must be installed seperately -- e.g. `node install -g pyright`
 EXTRA_ARGS ?=  # extra arguments for pytest


### PR DESCRIPTION
When not in a virtualenv, `python` could point to `python2`. Setting the `PYTHON ?= python3` is a better default.