### PR TITLE
Fix docker /tmp folder

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,9 @@
 # Base image to use for the docker build.
 BASE_IMAGE ?= 'nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04'
 
+# The linux distro of the base image
+LINUX_DISTRO ?= ubuntu2004
+
 # Python version to install. Composer requires python>=3.7
 PYTHON_VERSION ?='3.9'
 
@@ -56,6 +59,7 @@ pytorch:
 		--build-arg MMCV_VERSION=$(MMCV_VERSION) \
 		--build-arg MMCV_TORCH_VERSION=$(MMCV_TORCH_VERSION) \
 		--build-arg MOFED_VERSION=${MOFED_VERSION} \
+		--build-arg LINUX_DISTRO=${LINUX_DISTRO} \
 		--build-arg MOFED_OS_VERSION=${MOFED_OS_VERSION} \
 		.
 

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -104,7 +104,8 @@ ARG PILLOW_SIMD_VERSION=7.0.0.post3
 COPY pillow_stub /tmp/pillow_stub
 
 RUN pip${PYTHON_VERSION} install --no-cache-dir --upgrade /tmp/pillow_stub && \
-    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pillow_simd==${PILLOW_SIMD_VERSION}
+    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pillow_simd==${PILLOW_SIMD_VERSION} && \
+    rm -rf /tmp/pillow_stub
 
 #################
 # Install Pytorch
@@ -125,16 +126,12 @@ ARG MOFED_VERSION
 ARG MOFED_OS_VERSION
 
 RUN if [ -n "$MOFED_VERSION" ] ; then \
-        wget -nv -P /tmp http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}.tgz && \
-        tar -zxvf /tmp/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}.tgz -C /tmp && \
-        /tmp/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}/mlnxofedinstall --user-space-only --without-fw-update --force ; \
+        mkdir -p /tmp/mofed && \
+        wget -nv -P /tmp/mofed http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}.tgz && \
+        tar -zxvf /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}.tgz -C /tmp/mofed && \
+        /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}/mlnxofedinstall --user-space-only --without-fw-update --force && \
+        rm -rf /tmp/mofed \
     fi
-
-#########
-# Cleanup
-#########
-RUN rm -rf /tmp/*
-
 
 #######################
 # Set the shell to bash

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -16,9 +16,14 @@ RUN if [ -n "$CUDA_VERSION" ] ; then \
         rm -f /etc/apt/sources.list.d/nvidia-ml.list && \
         apt-get update &&  \
         apt-get install -y --no-install-recommends wget && \
+        apt-get autoclean && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* \
         apt-key del 7fa2af80 && \
-        wget --no-check-certificate https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_DISTRO}/x86_64/cuda-keyring_1.0-1_all.deb && \
-        dpkg -i cuda-keyring_1.0-1_all.deb ; \
+        mkdir -p /tmp/cuda-keyring && \
+        wget -P /tmp/cuda-keyring https://developer.download.nvidia.com/compute/cuda/repos/${LINUX_DISTRO}/x86_64/cuda-keyring_1.0-1_all.deb && \
+        dpkg -i /tmp/cuda-keyring/cuda-keyring_1.0-1_all.deb && \
+        rm -rf /tmp/cuda-keyring ; \
     fi
 
 RUN apt-get update && \
@@ -130,7 +135,7 @@ RUN if [ -n "$MOFED_VERSION" ] ; then \
         wget -nv -P /tmp/mofed http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}.tgz && \
         tar -zxvf /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}.tgz -C /tmp/mofed && \
         /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_OS_VERSION}/mlnxofedinstall --user-space-only --without-fw-update --force && \
-        rm -rf /tmp/mofed \
+        rm -rf /tmp/mofed ; \
     fi
 
 #######################


### PR DESCRIPTION
Somehow the `/tmp` folder was getting removed in the Dockerimage. This PR fixes that by not `rm -rf /tmp/*` but rather by removing the specific files written to `/tmp` in the proper build step.