### PR TITLE
Only push docker images if the branch is `dev`

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -162,7 +162,7 @@ stage('Prepare') {
         isPathModified = load "$jenkinsfileWorkspace/utils/isPathModified.groovy"
 
         if (isPathModified('docker/pytorch/')) {
-            Boolean shouldPush = gitBranch == 'dev' || gitBranch == 'main'
+            Boolean shouldPush = gitBranch == 'dev'
             String dockerfile = 'Dockerfile'
             String buildContext = './docker/pytorch'
             String buildMatrix = './docker/pytorch/build_matrix.yaml'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -179,9 +179,10 @@ stage('Build') {
     if (env.CHANGE_ID) {
         isMergeCommit = false
     }
-    if (pytorchDockerBuildMatrix) {
+    if (pytorchDockerBuildMatrix && (!isMergeCommit || gitBranch == 'dev')) {
         // If changing docker, build the docker images first
         // Then, run pytest in the newly-built image
+        // Only need to run the build if it's a PR commit (not a merge commit), or it's a merge commit into dev.
         pytorchDockerBuildMatrix.each { entry ->
             String command = entry[0]  // command is the command to run
             String stagingImage = entry[1]  // stagingImage is where the built docker image is pushed


### PR DESCRIPTION
Docker changes should only be pushed if the branch is `dev`, not `main`, as not all dockerfile changes may be cherry-picked in a maintenance release. Since all commits already go on the dev branch, the docker images are already up-to-date, so they should not be updated again when the `main` branch is updated for releases.