### PR TITLE
Pre commit hooks

### DIFF
--- a/.ci/lint_doctests.sh
+++ b/.ci/lint_doctests.sh
@@ -6,7 +6,6 @@ set -euxo pipefail
 # executed only once on an install with all dependencies
 
 # Install dependencies
-sudo npm install -g pyright@1.1.224
 pip install .[all]
 
 # Clean and make the output directory

--- a/.ci/lint_doctests.sh
+++ b/.ci/lint_doctests.sh
@@ -8,6 +8,9 @@ set -euxo pipefail
 # Install dependencies
 pip install .[all]
 
+# Mark the root folder folder as trusted (necessarry for pre-commit hooks to work)
+git config --global --add safe.directory $WORKSPACE
+
 # Clean and make the output directory
 BUILD_DIR="build/output"
 rm -rf ${BUILD_DIR}

--- a/.ci/lint_doctests.sh
+++ b/.ci/lint_doctests.sh
@@ -8,7 +8,7 @@ set -euxo pipefail
 # Install dependencies
 pip install .[all]
 
-# Mark the root folder folder as trusted (necessarry for pre-commit hooks to work)
+# Mark the root folder as trusted (necessarry for pre-commit hooks to work on Jenkins)
 git config --global --add safe.directory $WORKSPACE
 
 # Clean and make the output directory

--- a/.ci/test_lint_doctests.py
+++ b/.ci/test_lint_doctests.py
@@ -3,12 +3,14 @@
 # Running these checks through pytest allows us to report any errors in Junit format,
 # which is posted directly on the PR
 
-import subprocess
 import os
-import pytest
-import shutil
 import pathlib
+import shutil
+import subprocess
 import textwrap
+
+import pytest
+
 
 def check_output(proc: subprocess.CompletedProcess):
     # Check the subprocess output, and raise an exception with the stdout/stderr dump if there was a non-zero exit
@@ -26,10 +28,18 @@ def check_output(proc: subprocess.CompletedProcess):
 
     raise RuntimeError(error_msg)
 
+
 @pytest.mark.timeout(0)
-def test_run_make_lint():
+def test_run_pre_commit_hooks():
     composer_root = os.path.join(os.path.dirname(__file__), "..")
-    check_output(subprocess.run(["make", "lint"], cwd=composer_root, capture_output=True, text=True))
+    check_output(
+        subprocess.run(
+            ["pre-commit", "run", "--all-files", "--show-diff-on-failure"],
+            cwd=composer_root,
+            capture_output=True,
+            text=True,
+        ))
+
 
 @pytest.mark.timeout(0)
 def test_run_doctests():

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,58 @@
+default_language_version:
+    python: python3
+repos:
+-   repo: https://github.com/google/yapf
+    rev: v0.32.0
+    hooks:
+    -   id: yapf
+        name: yapf
+        description: "A formatter for Python files."
+        entry: yapf
+        args: [-i, -vv, -p] #inplace
+        language: python
+        types: [python]
+        additional_dependencies:
+          - "toml"
+-   repo: https://github.com/pycqa/isort
+    hooks:
+      - id: isort
+    rev: 5.10.1
+# -   repo: https://github.com/pycqa/pylint
+#     hooks:
+#         - id: pylint
+#           entry: pylint
+#           args: ['composer', 'examples', 'tests']
+#           language: python
+#           types: [python]
+#           require_serial: true
+#     rev: v2.12.2
+-   repo: local
+    hooks:
+    -   id: pyright
+        name: pyright
+        entry: pyright
+        language: node
+        types: [python]
+        pass_filenames: false
+        additional_dependencies: ["pyright@1.1.224"]
+# -   repo: https://github.com/PyCQA/pydocstyle
+#     hooks:
+#     -   id: pydocstyle
+#         name: pydocstyle
+#         entry: pydocstyle
+#         language: python
+#         types: [python]
+#         additional_dependencies:
+#           - "toml"
+#     rev: 6.1.1
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    # -   id: trailing-whitespace  # TODO(ravi): Enable this check later. Generates a large diff.
+    # -   id: end-of-file-fixer  # TODO(ravi): Enable this check later. Generates a large diff.
+    -   id: check-docstring-first
+    -   id: check-yaml
+    -   id: debug-statements
+    # -   id: name-tests-test  # TODO(ravi): Enable this check later. Generates a large diff.
+    #     args: ['--django']
+    # -   id: double-quote-string-fixer  # TODO(ravi): Enable this check later. Generates a large diff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,26 +14,19 @@ Have a new algorithm you'd like to contribute to the library as part of your res
 
 ## Prerequisites
 
-To set up the development environment in your local box, run the command below.
+To set up the development environment in your local box, run the commands below.
 
-1\. This should bring most the dependencies needed for testing and linting the code:
+1\. Install the dependencies needed for testing and linting the code:
 
 ```bash
 pip install -e .[dev]
 ```
 
-2\. Next, you'' want to configure [pre-commit](https://pre-commit.com/), which automatically formats code before
-each commit. To configure, run:
+2\. Configure [pre-commit](https://pre-commit.com/), which automatically formats code before
+each commit:
 
 ```bash
 pre-commit install
-```
-
-
-
-```bash
-# NOTE. You might need sudo permissions.
-npm install -g pyright@1.1.224
 ```
 
 ## Submitting a contribution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Have a new algorithm you'd like to contribute to the library as part of your res
 
 ## Prerequisites
 
-To set up the development environment in your local box, run the command below. 
+To set up the development environment in your local box, run the command below.
 
 1\. This should bring most the dependencies needed for testing and linting the code:
 
@@ -22,7 +22,14 @@ To set up the development environment in your local box, run the command below.
 pip install -e .[dev]
 ```
 
-2\. Next, you need to install `pyright` (we have not included it in `setup.py` because we have found that pyright is unreliable when it comes to version pinning). For this, you will need to first install NodeJS, more instructions can be found at https://nodejs.org/en/download/package-manager/. Then, to install pyright run:
+2\. Next, you'' want to configure [pre-commit](https://pre-commit.com/), which automatically formats code before
+each commit. To configure, run:
+
+```bash
+pre-commit install
+```
+
+
 
 ```bash
 # NOTE. You might need sudo permissions.
@@ -49,17 +56,7 @@ git remote add upstream https://github.com/mosaicml/composer.git
 git checkout -b cool-new-feature
 ```
 
-4\. We use a few formatters for code style, and you run the following to autocorrect your files:
-
-```bash
-make style
-```
-
-That will run the [yapf](https://github.com/google/yapf) formatter for general formatting,
-[isort](https://github.com/PyCQA/isort) to sort imports, and
-[docformatter](https://github.com/myint/docformatter) to format docstrings.
-
-5\. When you are ready, submit a pull request into the composer repository! If merged, we'll reach out to send you some free swag :)
+4\. When you are ready, submit a pull request into the composer repository! If merged, we'll reach out to send you some free swag :)
 
 ## Running Tests
 
@@ -81,7 +78,8 @@ See the [Makefile](https://github.com/mosaicml/composer/blob/dev/Makefile) for m
 ## Code Style & Typing
 
 Follow Google's
-[Python Style Guide](https://google.github.io/styleguide/pyguide.html) for how to format and structure code. Many of these guidelines are already taken care of by the `make style` command above.
+[Python Style Guide](https://google.github.io/styleguide/pyguide.html) for how to format and structure code.
+Many of these guidelines are already taken care of by the pre commit hooks.
 
 Composer aims to annotate all functions with type annotations (introduced in
 [PEP 526](https://www.python.org/dev/peps/pep-0526/)). Don't worry if you are not a Python typing expert; put in the pull request, and we'll help you with getting the code into shape.

--- a/Makefile
+++ b/Makefile
@@ -11,21 +11,6 @@ EXTRA_LAUNCHER_ARGS ?= # extra arguments for the composer cli launcher
 # Force append the duration flag to extra args
 override EXTRA_ARGS += --duration $(DURATION)
 
-dirs := composer examples tests
-
-# run this to autoformat your code
-style:
-	$(PYTHON) -m isort $(dirs)
-	$(PYTHON) -m yapf -rip $(dirs)
-	$(PYTHON) -m docformatter -ri --wrap-summaries 120 --wrap-descriptions 120 $(dirs)
-
-# this only checks for style & pyright, makes no code changes
-lint:
-	$(PYTHON) -m isort -c --diff $(dirs)
-	$(PYTHON) -m yapf -dr $(dirs)
-	$(PYTHON) -m docformatter -r --wrap-summaries 120 --wrap-descriptions 120 $(dirs)
-	$(PYRIGHT) $(dirs)
-
 test:
 	$(PYTHON) -m $(PYTEST) $(EXTRA_ARGS)
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -5,21 +5,32 @@
 Composer generally follows Google's
 [Python Style Guide](https://google.github.io/styleguide/pyguide.html) for how to format and structure code.
 
-### 2.2. Code Formatting
+### 2.2. Pre-Commit Hooks
 
-Composer uses the [yapf](https://github.com/google/yapf) formatter for general formatting,
-[isort](https://github.com/PyCQA/isort) to sort imports, and
-[docformatter](https://github.com/myint/docformatter) to format docstrings.
-
-To (auto)format code, run
-
-```bash
-make style
+Composer uses [Pre Commit](https://pre-commit.com/) to enforce style checks. To configure, run
+```
+pip install .[dev]  # if not already installed
+pre-commit install
 ```
 
-To verify that styling and typing (see below) is correct, run:
-```bash
-make lint
+The pre-commit hooks will now be run before each commit. You can also run the hooks manually via:
+
+```
+pre-commit run  # run all hooks on changed files
+pre-commit run --all-files  # or, run all hooks on all files
+```
+
+
+
+### 2.3. Code Formatting
+
+Composer uses the [yapf](https://github.com/google/yapf) formatter for general formatting
+[isort](https://github.com/PyCQA/isort) to sort imports. These checks run through pre-commit
+(see section 2.2). These checks can also be run manually via:
+
+```
+pre-commit run yahp --all-files  # for yahp
+pre-commit run isort --all-files  # for isort
 ```
 
 The configuration is stored in [pyproject.toml](pyproject.toml).
@@ -32,10 +43,11 @@ Composer aims to annotate all functions with type annotations (introduced in
 `AttributeError` bugs, in addition to other benefits, as outlined in the PEP.
 
 Composer uses [pyright](https://github.com/microsoft/pyright)
-to validate type annotations. To check typing, run:
+to validate type annotations. PyRight is automatically run as part of the pre-commit hooks, but you can also
+run PyRight specifically via:
 
-```bash
-make lint
+```
+pre-commit run pyright --all-files
 ```
 
 The pyright configuration is stored in [pyproject.toml](pyproject.toml).

--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -1,6 +1,11 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-"""Logger Hyperparameter classes."""
+"""Logger Hyperparameter classes.
+
+Attributes:
+    logger_registry (Dict[str, Type[LoggerDestinationHparams]]): The registry of all known
+        :class:`.LoggerDestinationHparams`.
+"""
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
@@ -294,4 +299,3 @@ logger_registry = {
     "in_memory": InMemoryLoggerHparams,
     "object_store": ObjectStoreLoggerHparams,
 }
-logger_registry.__doc__ = "The registry of all known :class:`.LoggerDestinationHparams`."

--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -294,4 +294,4 @@ logger_registry = {
     "in_memory": InMemoryLoggerHparams,
     "object_store": ObjectStoreLoggerHparams,
 }
-"""The registry of all known :class:`.LoggerDestinationHparams`."""
+logger_registry.__doc__ = "The registry of all known :class:`.LoggerDestinationHparams`."

--- a/composer/profiler/profiler_hparams.py
+++ b/composer/profiler/profiler_hparams.py
@@ -1,6 +1,11 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
-"""Example usage and definition of hparams."""
+"""Hyperparameter classes for the :mod:`~composer.profiler`.
+
+Attributes:
+    trace_handler_registry (Dict[str, Type[TraceHandlerHparams]]): Trace handler registry.
+    profiler_scheduler_registry (Dict[str, Type[ProfileScheduleHparams]]): Profiler scheduler registry.
+"""
 
 from __future__ import annotations
 
@@ -17,7 +22,7 @@ from composer.profiler.profiler_schedule import cyclic_schedule
 from composer.profiler.trace_handler import TraceHandler
 
 __all__ = [
-    "TraceHandlerHparams", "JSONTraceHparams", "trace_handler_registory", "ProfileScheduleHparams",
+    "TraceHandlerHparams", "JSONTraceHparams", "trace_handler_registry", "ProfileScheduleHparams",
     "CyclicProfilerScheduleHparams", "profiler_scheduler_registry"
 ]
 
@@ -64,8 +69,7 @@ class JSONTraceHparams(TraceHandlerHparams):
         return JSONTraceHandler(**dataclasses.asdict(self))
 
 
-trace_handler_registory = {"json": JSONTraceHparams}
-trace_handler_registory.__doc__ = "Trace handler registry."
+trace_handler_registry = {"json": JSONTraceHparams}
 
 
 @dataclasses.dataclass
@@ -106,4 +110,3 @@ class CyclicProfilerScheduleHparams(ProfileScheduleHparams):
 
 
 profiler_scheduler_registry = {'cyclic': CyclicProfilerScheduleHparams}
-profiler_scheduler_registry.__doc__ = "Profiler scheduler registry."

--- a/composer/profiler/profiler_hparams.py
+++ b/composer/profiler/profiler_hparams.py
@@ -65,7 +65,7 @@ class JSONTraceHparams(TraceHandlerHparams):
 
 
 trace_handler_registory = {"json": JSONTraceHparams}
-"""Trace handler registry."""
+trace_handler_registory.__doc__ = "Trace handler registry."
 
 
 @dataclasses.dataclass
@@ -106,4 +106,4 @@ class CyclicProfilerScheduleHparams(ProfileScheduleHparams):
 
 
 profiler_scheduler_registry = {'cyclic': CyclicProfilerScheduleHparams}
-"""Profiler scheduler registry."""
+profiler_scheduler_registry.__doc__ = "Profiler scheduler registry."

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -35,7 +35,7 @@ from composer.optim import (AdamHparams, AdamWHparams, ConstantSchedulerHparams,
                             MultiStepWithWarmupSchedulerHparams, OptimizerHparams, PolynomialSchedulerHparams,
                             RAdamHparams, RMSpropHparams, SchedulerHparams, SGDHparams, StepSchedulerHparams)
 from composer.profiler.profiler_hparams import (ProfileScheduleHparams, TraceHandlerHparams,
-                                                profiler_scheduler_registry, trace_handler_registory)
+                                                profiler_scheduler_registry, trace_handler_registry)
 from composer.trainer.ddp import DDPSyncStrategy
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
 from composer.trainer.trainer import Trainer
@@ -243,7 +243,7 @@ class TrainerHparams(hp.Hparams):
         "val_dataset": dataset_registry,
         "callbacks": callback_registry,
         "device": device_registry,
-        "prof_trace_handlers": trace_handler_registory,
+        "prof_trace_handlers": trace_handler_registry,
         "prof_schedule": profiler_scheduler_registry,
         "evaluators": evaluator_registry,
     }

--- a/scripts/ffcv/create_ffcv_datasets.py
+++ b/scripts/ffcv/create_ffcv_datasets.py
@@ -8,10 +8,12 @@ from argparse import ArgumentParser
 
 from torch.utils.data import Subset
 from torchvision.datasets import CIFAR10, ImageFolder
+
 from composer.core.types import Dataset
 from composer.datasets.ffcv_utils import write_ffcv_dataset
 
 log = logging.getLogger(__name__)
+
 
 def get_parser():
     parser = ArgumentParser(description="Utility for converting datasets to ffcv format.")

--- a/scripts/webdatasets/ade20k.py
+++ b/scripts/webdatasets/ade20k.py
@@ -7,24 +7,20 @@ from PIL import Image
 
 from composer.datasets.webdataset_utils import create_webdataset
 
-
-"""
-Directory layout:
-
-    ADE20k/
-        annotations/
-            train/
-                ADE_train_%08d.png
-            val/
-                ADE_val_%08d.png
-        images/
-            test/
-                ADE_test_%08d.jpg
-            train/
-                ADE_train_%08d.jpg
-            val/
-                ADE_val_%08d.jpg
-"""
+# Directory layout:
+#     ADE20k/
+#         annotations/
+#             train/
+#                 ADE_train_%08d.png
+#             val/
+#                 ADE_val_%08d.png
+#         images/
+#             test/
+#                 ADE_test_%08d.jpg
+#             train/
+#                 ADE_train_%08d.jpg
+#             val/
+#                 ADE_val_%08d.jpg
 
 
 def parse_args() -> Namespace:

--- a/scripts/webdatasets/tinyimagenet200.py
+++ b/scripts/webdatasets/tinyimagenet200.py
@@ -8,24 +8,21 @@ from tqdm import tqdm
 
 from composer.datasets.webdataset_utils import create_webdataset
 
+# Input directory layout:
 
-"""
-Input directory layout:
-
-    tiny-imagenet-200/
-        test/
-            images/
-                (10k images)
-        train/
-            (200 wnids)/
-                (500 images per dir)
-        val/
-            images/
-                (10k images)
-            val_annotations.txt  # 10k rows of (file, wnid, x, y, h, w)
-        wnids.txt  # 200 rows of (wnid)
-        words.txt  # 82115 rows of (wnid, wordnet category name)
-"""
+#     tiny-imagenet-200/
+#         test/
+#             images/
+#                 (10k images)
+#         train/
+#             (200 wnids)/
+#                 (500 images per dir)
+#         val/
+#             images/
+#                 (10k images)
+#             val_annotations.txt  # 10k rows of (file, wnid, x, y, h, w)
+#         wnids.txt  # 200 rows of (wnid)
+#         words.txt  # 82115 rows of (wnid, wordnet category name)
 
 
 def parse_args() -> Namespace:

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,6 @@ extra_deps["dev"] = [
     "fasteners==0.17.3",  # object store tests require fasteners
     "pytest==7.1.0",
     "toml==0.10.2",
-    "yapf==0.32.0",
-    "isort==5.10.1",
     "ipython==7.32.0",
     "ipykernel==6.9.2",
     "jupyter==1.0.0",
@@ -110,8 +108,6 @@ extra_deps["dev"] = [
     "sphinx-copybutton==0.5.0",
     "testbook==0.4.2",
     "myst-parser==0.16.1",
-    "pylint==2.12.2",
-    "docformatter==1.4",
     "sphinx_panels==0.6.0",
     "sphinxcontrib-images==0.9.4",
     # need webdataset to run pyright. Including here to pass pyright.

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ extra_deps["dev"] = [
     "pytest-timeout==2.1.0",
     "recommonmark==0.7.1",
     "sphinx==4.4.0",
+    "pre-commit>=2.18.1,<3",
     # embedding md in rst require docutils>=0.17. See
     # https://myst-parser.readthedocs.io/en/latest/sphinx/use.html?highlight=parser#include-markdown-files-into-an-rst-file
     "docutils==0.17.1",
@@ -182,10 +183,8 @@ setup(name="mosaicml",
       ],
       install_requires=install_requires,
       entry_points={
-          "console_scripts": [
-              "composer = composer.cli.launcher:main",
-              "composer_collect_env = composer.utils.collect_env:main"
-              ],
+          "console_scripts":
+              ["composer = composer.cli.launcher:main", "composer_collect_env = composer.utils.collect_env:main"],
       },
       extras_require=extra_deps,
       dependency_links=["https://developer.download.nvidia.com/compute/redist"],

--- a/tests/algorithms/algorithm_test_template.py
+++ b/tests/algorithms/algorithm_test_template.py
@@ -9,9 +9,7 @@ def state(minimal_state):
     return minimal_state
 
 
-"""Every algorithm test should have the functional and the algorithm
-usage demonstrated below in the tests.
-"""
+# Every algorithm test should have the functional and the algorithm usage demonstrated below in the tests.
 
 
 def test_myalgo_functional():
@@ -22,8 +20,7 @@ def test_myalgo_algorithm(state, empty_logger):
     ...
 
 
-""" Results from logging and hparams initialization should also be tested.
-"""
+# Results from logging and hparams initialization should also be tested.
 
 
 def test_myalgo_logging(state):

--- a/tests/algorithms/test_channels_last.py
+++ b/tests/algorithms/test_channels_last.py
@@ -68,9 +68,7 @@ def test_channels_last_algorithm(state: State, empty_logger: Logger, device: str
     assert _infer_memory_format(state.model.conv1.weight) == 'nhwc'
 
 
-"""
-Test helper utility _infer_memory_format
-"""
+# Test helper utility _infer_memory_format
 
 
 @pytest.fixture(params=[True, False])

--- a/tests/algorithms/test_selective_backprop.py
+++ b/tests/algorithms/test_selective_backprop.py
@@ -234,12 +234,10 @@ class TestSelectiveBackprop:
         assert MATCH in str(execinfo.value)
 
 
-"""
-Test Selective Backprop Algorithm
-"""
-
-
 class TestSelectiveBackpropAlgorithm:
+    """
+    Test Selective Backprop Algorithm
+    """
 
     @pytest.fixture
     def sb_algorithm(self, scale_factor, keep) -> SelectiveBackprop:

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -299,21 +299,19 @@ class TestTrainerEvents():
             trainer.fit()
 
 
-"""
-The below is a catch-all test that runs the Trainer
-with each algorithm, callback, and loggers. Success
-is defined as a successful training run.
-
-This should eventually be replaced by functional
-tests for each object, in situ of our trainer.
-
-We use the hparams_registry associated with our
-config management to retrieve the objects to test.
-"""
-
-
 @pytest.mark.timeout(15)
 class TestTrainerAssets:
+    """
+    The below is a catch-all test that runs the Trainer
+    with each algorithm, callback, and loggers. Success
+    is defined as a successful training run.
+
+    This should eventually be replaced by functional
+    tests for each object, in situ of our trainer.
+
+    We use the hparams_registry associated with our
+    config management to retrieve the objects to test.
+    """
 
     @pytest.fixture(params=[1, 2], ids=['ga-1', 'ga-2'])
     def config(self, rank_zero_seed: int, request):


### PR DESCRIPTION
- Switched to using pre-commit hooks for pyright, yapf, isort, and some additional checks.
- Removed `make lint` and `make style`; updated docs to direct users to user pre commit
- Updated files that were failing the pre-commit checks. Moved attribute-level docstrings to the module's docstring (via the "Attributes" section, since attributes don't have `__doc__`. Converted non-docstring triple-quote comments to `#` comment notation (since they were being recognized as docstrings) or moved into the class for a class-level docstring.
- Currently disabling the checks that would result in a large diff; will enable later when there are few PRs out to minimize merge conflicts.

Closes #642 