### PR TITLE
Fix FP16 Precision with DeepSpeed

### DIFF
--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -35,6 +35,12 @@ class Precision(StringEnum):
 def get_precision_context(precision: Union[str, Precision]) -> Generator[None, None, None]:
     """Returns a context manager to automatically cast to a specific precision.
 
+    .. warning::
+
+        :attr:`.Precision.FP16` is only supported when using DeepSpeed, as PyTorch does not
+        natively support this precision. When this function is invoked with :attr:`.Precision.FP16`,
+        this function will be a no-op.
+
     Args:
         precision (str or Precision): Precision for the context
     """
@@ -47,6 +53,11 @@ def get_precision_context(precision: Union[str, Precision]) -> Generator[None, N
         else:
             # Yield here to avoid warnings about cuda not being available
             yield
+    elif precision == Precision.FP16:
+        # No-op if FP16. FP16 is only supported by DeepSpeed, which is configured via the `deepspeed_config`
+        # DeepSpeed ignores `get_precision_context`. The Trainer init validates that Precision.FP16 is used
+        # only when using DeepSpeed.
+        yield
     elif precision == Precision.AMP:
         # Retain compatibility with PyTorch < 1.10
         with torch.cuda.amp.autocast(True):

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -39,7 +39,7 @@ def get_precision_context(precision: Union[str, Precision]) -> Generator[None, N
 
         :attr:`.Precision.FP16` is only supported when using DeepSpeed, as PyTorch does not
         natively support this precision. When this function is invoked with :attr:`.Precision.FP16`,
-        this function will be a no-op.
+        the precision context will be a no-op.
 
     Args:
         precision (str or Precision): Precision for the context

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -725,6 +725,9 @@ class Trainer:
         if isinstance(precision, str):
             precision = Precision(precision)
 
+        if not self.deepspeed_enabled and precision == Precision.FP16:
+            raise ValueError("FP16 precision is only supported when training with DeepSpeed.")
+
         # optimizers and schedulers
         if not optimizers:
             optimizers = DecoupledSGDW(list(model.parameters()), lr=0.1)

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -450,9 +450,6 @@ class TrainerHparams(hp.Hparams):
             if isinstance(self.device, CPUDeviceHparams):
                 raise ValueError("Training on CPUs is not supported with DeepSpeed.")
 
-        elif self.precision == Precision.FP16:
-            raise ValueError("FP16 precision is only supported when training with DeepSpeed.")
-
         world_size = dist.get_world_size()
 
         if self.train_batch_size % world_size != 0:

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -45,6 +45,7 @@ class TestTrainerInit():
     @pytest.mark.parametrize("precision", list(Precision))
     def test_precision(self, config, precision: Precision):
         config['precision'] = precision
+        config['device'] = 'gpu'
 
         if precision == Precision.BF16:
             pytest.importorskip("torch", minversion="1.10", reason="BF16 precision requires PyTorch 1.10+")

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -40,6 +40,24 @@ class TestTrainerInit():
             'seed': rank_zero_seed,
         }
 
+    def test_init_errors_when_using_fp16_and_not_deepspeed(self, config):
+        config['precision'] = Precision.FP16
+
+        with pytest.raises(ValueError):
+            Trainer(**config)
+
+    @pytest.mark.gpu
+    @pytest.mark.parametrize("precision", [Precision.AMP, Precision.FP16, Precision.FP32])
+    def test_trainer_with_deepspeed(self, config, precision: Precision):
+        config['deepspeed'] = {}
+        config['precision'] = precision
+
+        trainer = Trainer(**config)
+
+        assert trainer.deepspeed_enabled
+
+        trainer.fit()
+
     def test_init(self, config):
         trainer = Trainer(**config)
         assert isinstance(trainer, Trainer)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -49,7 +49,7 @@ class TestTrainerInit():
     @pytest.mark.gpu
     @pytest.mark.parametrize("precision", [Precision.AMP, Precision.FP16, Precision.FP32])
     def test_trainer_with_deepspeed(self, config, precision: Precision):
-        config['deepspeed'] = {}
+        config['deepspeed_config'] = {}
         config['precision'] = precision
 
         trainer = Trainer(**config)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -57,6 +57,10 @@ class TestTrainerInit():
     def test_trainer_with_deepspeed(self, config, precision: Precision):
         config['deepspeed_config'] = {}
         config['precision'] = precision
+        config['device'] = 'gpu'
+
+        if precision == Precision.BF16:
+            pytest.importorskip("torch", minversion="1.10", reason="BF16 precision requires PyTorch 1.10+")
 
         trainer = Trainer(**config)
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -47,7 +47,7 @@ class TestTrainerInit():
             Trainer(**config)
 
     @pytest.mark.gpu
-    @pytest.mark.parametrize("precision", [Precision.AMP, Precision.FP16, Precision.FP32])
+    @pytest.mark.parametrize("precision", list(Precision))
     def test_trainer_with_deepspeed(self, config, precision: Precision):
         config['deepspeed_config'] = {}
         config['precision'] = precision


### PR DESCRIPTION
1. Move the check requiring DeepSpeed if using `Precision.FP16` to `Trainer.__init__()` from `TrainerHparams.validate()`.
1. Making `get_precision_context` be a no-op if `Precision.FP16` is provided.
1. Added tests to ensure that a) The trainer errors if `Precision.FP16` is used without DeepSpeed, and b) `Precision.FP16` works when using DeepSpeed.

Closes #968