### PR TITLE
Remove `pyright` from precommit hoook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 default_language_version:
-    python: python3
+  python: python3
 repos:
--   repo: https://github.com/google/yapf
+  - repo: https://github.com/google/yapf
     rev: v0.32.0
     hooks:
-    -   id: yapf
+      - id: yapf
         name: yapf
         description: "A formatter for Python files."
         entry: yapf
@@ -13,46 +13,18 @@ repos:
         types: [python]
         additional_dependencies:
           - "toml"
--   repo: https://github.com/pycqa/isort
+  - repo: https://github.com/pycqa/isort
     hooks:
       - id: isort
     rev: 5.10.1
-# -   repo: https://github.com/pycqa/pylint
-#     hooks:
-#         - id: pylint
-#           entry: pylint
-#           args: ['composer', 'examples', 'tests']
-#           language: python
-#           types: [python]
-#           require_serial: true
-#     rev: v2.12.2
--   repo: local
-    hooks:
-    -   id: pyright
-        name: pyright
-        entry: pyright
-        language: node
-        types: [python]
-        pass_filenames: false
-        additional_dependencies: ["pyright@1.1.224"]
-# -   repo: https://github.com/PyCQA/pydocstyle
-#     hooks:
-#     -   id: pydocstyle
-#         name: pydocstyle
-#         entry: pydocstyle
-#         language: python
-#         types: [python]
-#         additional_dependencies:
-#           - "toml"
-#     rev: 6.1.1
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
-    # -   id: trailing-whitespace  # TODO(ravi): Enable this check later. Generates a large diff.
-    # -   id: end-of-file-fixer  # TODO(ravi): Enable this check later. Generates a large diff.
-    -   id: check-docstring-first
-    -   id: check-yaml
-    -   id: debug-statements
+      # -   id: trailing-whitespace  # TODO(ravi): Enable this check later. Generates a large diff.
+      # -   id: end-of-file-fixer  # TODO(ravi): Enable this check later. Generates a large diff.
+      - id: check-docstring-first
+      - id: check-yaml
+      - id: debug-statements
     # -   id: name-tests-test  # TODO(ravi): Enable this check later. Generates a large diff.
     #     args: ['--django']
     # -   id: double-quote-string-fixer  # TODO(ravi): Enable this check later. Generates a large diff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,20 +14,27 @@ Have a new algorithm you'd like to contribute to the library as part of your res
 
 ## Prerequisites
 
-To set up the development environment in your local box, run the commands below.
+To set up the development environment in your local box, run the command below.
 
-1\. Install the dependencies needed for testing and linting the code:
+1\. This should bring most the dependencies needed for testing and linting the code:
 
 ```bash
 pip install -e .[dev]
 ```
 
-2\. Configure [pre-commit](https://pre-commit.com/), which automatically formats code before
-each commit:
+2\. Next, you need to install `pyright` (we have not included it in `setup.py` because we have found that pyright is unreliable when it comes to version pinning). For this, you will need to first install NodeJS, more instructions can be found at https://nodejs.org/en/download/package-manager/. Then, to install pyright run:
 
+```bash
+# NOTE. You might need sudo permissions.
+npm install -g pyright@1.1.224
+```
+
+Optionally, configure [pre-commit](https://pre-commit.com/) to automatically format code before
+each commit:
 ```bash
 pre-commit install
 ```
+
 
 ## Submitting a contribution
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ EXTRA_LAUNCHER_ARGS ?= # extra arguments for the composer cli launcher
 # Force append the duration flag to extra args
 override EXTRA_ARGS += --duration $(DURATION)
 
+dirs := composer examples tests
+
 test:
 	$(PYTHON) -m $(PYTEST) $(EXTRA_ARGS)
 
@@ -26,5 +28,18 @@ test-dist-gpu:
 
 clean-notebooks:
 	$(PYTHON) scripts/clean_notebooks.py -i notebooks/*.ipynb
+
+# run this to autoformat your code
+style:
+	$(PYTHON) -m isort $(dirs)
+	$(PYTHON) -m yapf -rip $(dirs)
+	$(PYTHON) -m docformatter -ri --wrap-summaries 120 --wrap-descriptions 120 $(dirs)
+
+# this only checks for style & pyright, makes no code changes
+lint:
+	$(PYTHON) -m isort -c --diff $(dirs)
+	$(PYTHON) -m yapf -dr $(dirs)
+	$(PYTHON) -m docformatter -r --wrap-summaries 120 --wrap-descriptions 120 $(dirs)
+	$(PYRIGHT) $(dirs)
 
 .PHONY: test test-gpu test-dist test-dist-gpu lint style clean-notebooks


### PR DESCRIPTION
`pyright` currently emits a verbose logs on failure, making the dev workflow difficult to use. Instead, this PR:
1. Removes `pyright` from the precommit hook
2. Restores `make style` and `make lint` so users can manually invoke
3. edits the CONTRIBUTING file to make the use of precommits optional.

The precommit hook will still handle auto-formatting for the user, which is a significant dev workflow improvement.