### PR TITLE
Update defaults and docs for progressive resizing

### DIFF
--- a/composer/algorithms/hparams.py
+++ b/composer/algorithms/hparams.py
@@ -269,8 +269,8 @@ class ProgressiveResizingHparams(AlgorithmHparams):
     initial_scale: float = hp.optional(doc="Initial scale factor", default=0.5)
     finetune_fraction: float = hp.optional(doc="Fraction of training to reserve for finetuning on full-sized inputs",
                                            default=0.2)
-    delay_fraction: float = hp.optional(doc="Fraction of training before resizing ramp begins", default=0.0)
-    size_increment: int = hp.optional(doc="Align sizes to a multiple of this number.", default=1)
+    delay_fraction: float = hp.optional(doc="Fraction of training before resizing ramp begins", default=0.5)
+    size_increment: int = hp.optional(doc="Align sizes to a multiple of this number.", default=4)
     resize_targets: bool = hp.optional(doc="Also resize targets", default=False)
 
     def initialize_object(self) -> ProgressiveResizing:

--- a/composer/algorithms/progressive_resizing/README.md
+++ b/composer/algorithms/progressive_resizing/README.md
@@ -55,8 +55,8 @@ TODO(Cory): A brief description of how this works under the hood.-->
 
 ## Suggested Hyperparameters
 
-We found `initial_scale = 0.5` (starting training on images where each side length has been reduced by 50%) and `finetune_fraction = 0.2` (reserving the final 20% of training for full-sized images) to work well for ResNet-50 on ImageNet.
-These are the hyperparameters we used for our runs in the [MosaicML Explorer](https://app.mosaicml.com/explorer/imagenet).
+We found `initial_scale = 0.5` (starting training on images where each side length has been reduced by 50%), `finetune_fraction = 0.2` (reserving the final 20% of training for full-sized images),
+`delay_fraction = 0.5` (reserving the first 50% of training for initial\_scale-sized images) and `size_increment = 4` (pegging image size to the nearest multiple of 4) to work well for ResNet-50 on ImageNet.
 
 ## Technical Details
 

--- a/composer/algorithms/progressive_resizing/progressive_resizing.py
+++ b/composer/algorithms/progressive_resizing/progressive_resizing.py
@@ -151,8 +151,8 @@ class ProgressiveResizing(Algorithm):
         finetune_fraction (float, optional): Fraction of training to reserve for finetuning on the
             full-sized inputs. Must be a value in between 0 and 1. Default: ``0.2``.
         delay_fraction (float, optional): Fraction of training before resizing ramp begins.
-            Must be a value in between 0 and 1. Default: ``0.0``.
-        size_increment (int, optional): Align sizes to a multiple of this number. Default: ``1``.
+            Must be a value in between 0 and 1. Default: ``0.5``.
+        size_increment (int, optional): Align sizes to a multiple of this number. Default: ``4``.
         resize_targets (bool, optional): If True, resize targets also. Default: ``False``.
     """
 
@@ -160,8 +160,8 @@ class ProgressiveResizing(Algorithm):
                  mode: str = 'resize',
                  initial_scale: float = .5,
                  finetune_fraction: float = .2,
-                 delay_fraction: float = .0,
-                 size_increment: int = 1,
+                 delay_fraction: float = .5,
+                 size_increment: int = 4,
                  resize_targets: bool = False):
 
         if mode not in _VALID_MODES:


### PR DESCRIPTION
delay_fraction = 0.5 and size_increment=4 provide the best speedup and accuracy. 