### PR TITLE
Fix `atexit()` shutdown procedure

### DIFF
--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -104,6 +104,22 @@ _EVENTS_WHERE_MAX_DURATION_IS_SET = [
     Event.EPOCH_CHECKPOINT,
 ]
 
+# Track whether atexit triggered _close(), which indicates whether the python process is shutting down
+# If so, do not run close() again via __del__(), as Python machinery (e.g. the ability to do conditional
+# imports) are destroyed between close() and __del__().
+# Using a global variable instead of an instance variable as _close() is not bound to the instance
+_did_atexit_run = False
+
+
+def _set_atexit_ran():
+    global _did_atexit_run
+    _did_atexit_run = True
+
+
+# Since atexit calls hooks in LIFO order, this hook will always be invoked after all atexit-triggered
+# _close() calls are invoked
+atexit.register(_set_atexit_ran)
+
 
 @dataclass
 class Trace():
@@ -324,6 +340,12 @@ class Engine():
                 cb.run_event(event, self.state, self.logger)
 
     def __del__(self):
+        global _did_atexit_run
+        if _did_atexit_run:
+            # Do not attempt to shutdown again, since close() already ran via __atexit__
+            # In this case, close() is no longer idempotent, since Python machenry (such as the ability to do
+            # conditional imports) has already been destroyed
+            return
         self.close()
 
     def close(self) -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,11 +1,15 @@
 # Copyright 2021 MosaicML. All Rights Reserved.
 
+import os
+import subprocess
 import sys
+import textwrap
 from typing import List, Sequence
 from unittest.mock import Mock
 
 import pytest
 
+import composer
 from composer.algorithms import SelectiveBackprop
 from composer.core import Engine, Event
 from composer.core.algorithm import Algorithm
@@ -160,3 +164,55 @@ def test_engine_closes_on_del(dummy_state: State, dummy_logger: Logger):
 
     # Assert it is closed
     assert is_closed_callback.is_closed
+
+
+def check_output(proc: subprocess.CompletedProcess):
+    # Check the subprocess output, and raise an exception with the stdout/stderr dump if there was a non-zero exit
+    # The `check=True` flag available in `subprocess.run` does not print stdout/stderr
+    if proc.returncode == 0:
+        return
+    error_msg = textwrap.dedent(f"""\
+        Command {proc.args} failed with exit code {proc.returncode}.
+        ----Begin stdout----
+        {proc.stdout}
+        ----End stdout------
+        ----Begin stderr----
+        {proc.stderr}
+        ----End stderr------""")
+
+    raise RuntimeError(error_msg)
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize("exception", [True, False])
+def test_engine_closes_on_atexit(exception: bool):
+    # Running this test via a subprocess, as atexit() must trigger
+
+    code = textwrap.dedent("""\
+    from composer import Trainer, Callback
+    from tests.common import SimpleModel
+
+    class CallbackWithConditionalCloseImport(Callback):
+        def post_close(self):
+            import requests
+
+    model = SimpleModel(3, 10)
+    cb = CallbackWithConditionCloseImport()
+    trainer = Trainer(
+        model=model,
+        callbacks=[cb],
+        max_duration="1ep",
+        train_dataloader=None,
+    )
+    """)
+    if exception:
+        # Should raise an exception, since no dataloader was provided
+        code += "trainer.fit()"
+
+    git_root_dir = os.path.join(os.path.dirname(composer.__file__), "..")
+    proc = subprocess.run(["python", "-c", code], cwd=git_root_dir, text=True, capture_output=True)
+    if exception:
+        # manually validate that there was no a conditional import exception
+        assert "ImportError: sys.meta_path is None, Python is likely shutting down" not in proc.stderr
+    else:
+        check_output(proc)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -197,7 +197,7 @@ def test_engine_closes_on_atexit(exception: bool):
             import requests
 
     model = SimpleModel(3, 10)
-    cb = CallbackWithConditionCloseImport()
+    cb = CallbackWithConditionalCloseImport()
     trainer = Trainer(
         model=model,
         callbacks=[cb],


### PR DESCRIPTION
- Track whether `atexit` triggered `Engine._close()`, which indicates whether the Python process is shutting down. If so, do not run `Engine._close()` again via `Engine.__del__()`, as Python machinery (e.g. the ability to do conditional imports, which is done with the WandB callback) is destroyed between when `atexit` and `__del__()` fire when Python exits with an exception.
- Added a test case to verify this fix