### PR TITLE
Add warnings to Layer Freezing

### DIFF
--- a/composer/algorithms/layer_freezing/layer_freezing.py
+++ b/composer/algorithms/layer_freezing/layer_freezing.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 import logging
 import textwrap
-from typing import List, Optional, Sequence, Tuple, Union
+import warnings
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 from torch.optim import Optimizer
@@ -146,6 +147,13 @@ class LayerFreezing(Algorithm):
             'layer_freezing/layers_frozen': freeze_depth,
             'layer_freezing/percentage_frozen': freeze_percentage
         })
+
+    def state_dict(self) -> Dict[str, Any]:
+        warnings.warn("Checkpoints with layer freezing cannot reliably be used to resume training.")
+        return {}
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        warnings.warn("Checkpoints with layer freezing cannot reliably be used to resume training.")
 
 
 def _freeze_schedule(current_duration: float, freeze_start: float, freeze_level: float) -> float:

--- a/composer/algorithms/layer_freezing/layer_freezing.py
+++ b/composer/algorithms/layer_freezing/layer_freezing.py
@@ -149,11 +149,13 @@ class LayerFreezing(Algorithm):
         })
 
     def state_dict(self) -> Dict[str, Any]:
-        warnings.warn("Checkpoints with layer freezing cannot reliably be used to resume training.")
+        warnings.warn(("Checkpoints with layer freezing cannot reliably be used to resume training."
+                       "See: https://github.com/mosaicml/composer/issues/1002"))
         return {}
 
     def load_state_dict(self, state: Dict[str, Any]) -> None:
-        warnings.warn("Checkpoints with layer freezing cannot reliably be used to resume training.")
+        warnings.warn(("Checkpoints with layer freezing cannot reliably be used to resume training."
+                       "See: https://github.com/mosaicml/composer/issues/1002"))
 
 
 def _freeze_schedule(current_duration: float, freeze_start: float, freeze_level: float) -> float:

--- a/composer/datasets/streaming/download.py
+++ b/composer/datasets/streaming/download.py
@@ -39,8 +39,8 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
         timeout (float): How long to wait for shard to download before raising an exception.
     """
     try:
-        import boto3
-        from botocore import Config
+        import boto3  # type: ignore (third-party)
+        from botocore import Config  # type: ignore (third-party)
     except ImportError as e:
         raise ImportError(
             textwrap.dedent("""\

--- a/tests/algorithms/test_algorithm_resumption.py
+++ b/tests/algorithms/test_algorithm_resumption.py
@@ -15,7 +15,7 @@ from tests.common import deep_compare, device
 
 
 @pytest.mark.timeout(180)
-@device('cpu')
+@device('gpu')
 @pytest.mark.parametrize(
     "seed,save_interval,save_filename,resume_file,final_checkpoint",
     [
@@ -42,7 +42,7 @@ def test_algorithm_resumption(
         # see: https://github.com/mosaicml/composer/issues/362
         pytest.importorskip("torch", minversion="1.10", reason="Pytorch 1.10 required.")
 
-    if algorithm in ('layer_freezing', 'swa', 'stochastic_depth'):
+    if algorithm in ('layer_freezing', 'swa', 'stochastic_depth', 'ema'):
         pytest.xfail('Known issues')
 
     setting = get_settings(algorithm)


### PR DESCRIPTION
* switched algorithm resumption to running on GPUs (faster), and also catches resumption issues with EMA.
* Adds a warning to layer freezing about algorithm resumption. Layer freezing will not be Serialization compatible until we invest in a redesign. Note that trying to save a model with Layer freezing currently fails already due to the freezing not removing params from the optimizer state. 