### PR TITLE
Allow the package name to be set via an env variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,12 @@ composer_data_files = ["py.typed"]
 composer_data_files += package_files("composer", "yamls", ".yaml")
 composer_data_files += package_files("composer", "algorithms", ".json")
 
-setup(name=os.environ.get('COMPOSER_PACKAGE_NAME', "mosaicml"),
+package_name = os.environ.get('COMPOSER_PACKAGE_NAME', "mosaicml")
+
+if package_name != "mosaicml":
+    print(f"`Building composer as `{package_name}`)", file=sys.stderr)
+
+setup(name=package_name,
       version="0.6.0",
       author="MosaicML",
       author_email="team@mosaicml.com",

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ composer_data_files = ["py.typed"]
 composer_data_files += package_files("composer", "yamls", ".yaml")
 composer_data_files += package_files("composer", "algorithms", ".json")
 
-setup(name="mosaicml",
+setup(name=os.environ.get('COMPOSER_PACKAGE_NAME', "mosaicml"),
       version="0.6.0",
       author="MosaicML",
       author_email="team@mosaicml.com",


### PR DESCRIPTION
Allow the pip package name in `setup.py` to be specified by an environment variable, `COMPOSER_PACKAGE_NAME`. This change will allow for automatic pip publishing, as we use a different package name when publishing to https://test.pypi.org.