### PR TITLE
Replace "or" with "|" in docstring type annotations

### DIFF
--- a/composer/algorithms/augmix/augmix.py
+++ b/composer/algorithms/augmix/augmix.py
@@ -56,7 +56,7 @@ def augmix_image(img: ImgT,
             )
 
     Args:
-        img (PIL.Image.Image or torch.Tensor): Image or batch of images to be AugMix'd.
+        img (PIL.Image.Image | torch.Tensor): Image or batch of images to be AugMix'd.
         severity (int, optional): See :class:`.AugMix`.
         depth (int, optional): See :class:`.AugMix`.
         width (int, optional): See :class:`.AugMix`.

--- a/composer/algorithms/blurpool/blurpool_layers.py
+++ b/composer/algorithms/blurpool/blurpool_layers.py
@@ -34,7 +34,7 @@ def blur_2d(input: torch.Tensor, stride: _size_2_t = 1, filter: Optional[torch.T
 
     Args:
         input (:class:`torch.Tensor`): a 4d tensor of shape NCHW
-        stride (int or tuple, optional): stride(s) along H and W axes. If a single value is passed, this
+        stride (int | tuple, optional): stride(s) along H and W axes. If a single value is passed, this
             value is used for both dimensions.
         filter (:class:`torch.Tensor`, optional): a 2d or 4d tensor to be cross-correlated with the input tensor
             at each spatial position, within each channel. If 4d, the structure
@@ -99,15 +99,15 @@ def blurmax_pool2d(input: torch.Tensor,
 
     Args:
         input (:class:`torch.Tensor`): a 4d tensor of shape NCHW
-        kernel_size (int or tuple, optional): size(s) of the spatial neighborhoods over which to pool.
+        kernel_size (int | tuple, optional): size(s) of the spatial neighborhoods over which to pool.
             This is mostly commonly 2x2. If only a scalar ``s`` is provided, the
             neighborhood is of size ``(s, s)``. Default: ``(2, 2)``.
-        stride (int or tuple, optional): stride(s) along H and W axes. If a single value is passed, this
+        stride (int | tuple, optional): stride(s) along H and W axes. If a single value is passed, this
             value is used for both dimensions. Default: 2.
-        padding (int or tuple, optional): implicit zero-padding to use. For the default 3x3 low-pass
+        padding (int | tuple, optional): implicit zero-padding to use. For the default 3x3 low-pass
             filter, ``padding=1`` (the default) returns output of the same size
             as the input. Default: 0.
-        dilation (int or tuple, optional): amount by which to "stretch" the pooling region for a given
+        dilation (int | tuple, optional): amount by which to "stretch" the pooling region for a given
             total size. See :class:`~torch.nn.MaxPool2d`
             for our favorite explanation of how this works. Default: 1.
         ceil_mode (bool): when True, will use ceil instead of floor to compute the output shape. Default: ``False``.

--- a/composer/algorithms/cutout/cutout.py
+++ b/composer/algorithms/cutout/cutout.py
@@ -27,7 +27,7 @@ def cutout_batch(input: ImgT, num_holes: int = 1, length: float = 0.5, uniform_s
     """See :class:`CutOut`.
 
     Args:
-        input (PIL.Image.Image or torch.Tensor): Image or batch of images. If
+        input (PIL.Image.Image | torch.Tensor): Image or batch of images. If
             a :class:`torch.Tensor`, must be a single image of shape ``(C, H, W)``
             or a batch of images of shape ``(N, C, H, W)``.
         num_holes: Integer number of holes to cut out. Default: ``1``.

--- a/composer/algorithms/factorize/factorize.py
+++ b/composer/algorithms/factorize/factorize.py
@@ -46,7 +46,7 @@ def apply_factorization(model: torch.nn.Module,
             this many input and output channels, it will be ignored. Modules with
             few channels are unlikely to be accelerated by factorization due
             to poor hardware utilization. Default: ``512``.
-        latent_channels (int or float, optional): number of latent channels to use in factorized
+        latent_channels (int | float, optional): number of latent channels to use in factorized
             convolutions. Can be specified as either an integer > 1 or as
             float within [0, 1). In the latter case, the value is
             interpreted as a fraction of ``min(in_channels, out_channels)``
@@ -56,7 +56,7 @@ def apply_factorization(model: torch.nn.Module,
             this many input and output features, it will be ignored. Modules with
             few features are unlikely to be accelerated by factorization due
             to poor hardware utilization. Default: ``512``.
-        latent_features (int or float, optional): size of the latent space for factorized linear modules.
+        latent_features (int | float, optional): size of the latent space for factorized linear modules.
             Can be specified as either an integer > 1 or as a float within [0, 0.5).
             In the latter case, the value is interpreted as a fraction of
             ``min(in_features, out_features)`` for each :class:`~torch.nn.Linear`

--- a/composer/algorithms/factorize/factorize_modules.py
+++ b/composer/algorithms/factorize/factorize_modules.py
@@ -47,7 +47,7 @@ def factorizing_could_speedup(module: torch.nn.Module, latent_size: Union[int, f
     Args:
         module (torch.nn.Module): a :py:class:`~torch.nn.Conv2d`, :py:class:`~torch.nn.Linear`,
             :py:class:`~FactorizedConv2d`, or :py:class:`~FactorizedLinear`.
-        latent_size (int or float): number of channels (for convolution) or
+        latent_size (int | float): number of channels (for convolution) or
             features (for linear) in the latent representation. Can be
             specified as either an integer > 1 or as float within [0, 1).
             In the latter case, the value is interpreted as a fraction of
@@ -238,8 +238,8 @@ class FactorizedConv2d(_FactorizedModule):
     Args:
         in_channels (int): number of channels in the input image
         out_channels (int): number of channels produced by the convolution
-        kernel_size (int or tuple, optional): size of the convolving kernel
-        latent_channels (int or float, optional): number of channels in the
+        kernel_size (int | tuple, optional): size of the convolving kernel
+        latent_channels (int | float, optional): number of channels in the
             latent representation produced by the first small convolution.
             Can be specified as either an integer > 1 or as float within
             [0, 1). In the latter case, the value is interpreted as a fraction
@@ -384,7 +384,7 @@ class FactorizedLinear(_FactorizedModule):
         in_features (int): size of each input sample
         out_features (int): size of each output sample
         bias (bool): If set to False, the layer will not learn an additive bias.
-        latent_features (int or float, optional): size of the latent space.
+        latent_features (int | float, optional): size of the latent space.
             Can be specified as either an integer > 1 or as a float within
             [0, 0.5). In the latter case, the value is interpreted as a fraction
             of ``min(in_features, out_features)``, and is converted to the

--- a/composer/algorithms/randaugment/randaugment.py
+++ b/composer/algorithms/randaugment/randaugment.py
@@ -52,7 +52,7 @@ def randaugment_image(img: ImgT,
             )
 
     Args:
-        img (PIL.Image.Image or torch.Tensor): Image or batch of images to be RandAugmented.
+        img (PIL.Image.Image | torch.Tensor): Image or batch of images to be RandAugmented.
         severity (int, optional): See :class:`.RandAugment`.
         depth (int, optional): See :class:`.RandAugment`.
         augmentation_set (str, optional): See

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -110,8 +110,8 @@ class Trace():
     """Record of an algorithm's execution.
 
     Attributes:
-        exit_code (int or None): Optional return value from an algorithm. Default: None.
-        order (int or None): Order in which the algorithm was executed
+        exit_code (int | None): Optional return value from an algorithm. Default: None.
+        order (int | None): Order in which the algorithm was executed
                              in the list of algorithms. None means algorithm was not run.
         run (bool): Whether the algorithm was run. Default: False
     """
@@ -175,7 +175,7 @@ class Engine():
 
 
         Args:
-            event (Event or str): The current :class:`~.event.Event`. It can be the enum member values or a
+            event (Event | str): The current :class:`~.event.Event`. It can be the enum member values or a
                 string with the event value.
         Returns:
             traces (Traces): Ordered dictionary of trace for each algorithm.

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -42,7 +42,7 @@ def get_precision_context(precision: Union[str, Precision]) -> Generator[None, N
         the precision context will be a no-op.
 
     Args:
-        precision (str or Precision): Precision for the context
+        precision (str | Precision): Precision for the context
     """
 
     precision = Precision(precision)

--- a/composer/core/time.py
+++ b/composer/core/time.py
@@ -110,8 +110,8 @@ class Time(Generic[TValue]):
     Time(2, TimeUnit.EPOCH)
 
     Args:
-        value (int or float): The amount of time.
-        unit (str or TimeUnit): The :class:`TimeUnit` for ``value``.
+        value (int | float): The amount of time.
+        unit (str | TimeUnit): The :class:`TimeUnit` for ``value``.
     """
 
     def __init__(
@@ -437,7 +437,7 @@ class Timer(Serializable):
         """Returns the current time in the specified unit.
 
         Args:
-            unit (str or TimeUnit): The desired unit.
+            unit (str | TimeUnit): The desired unit.
 
         Returns:
             Time: The current time, in the specified unit.
@@ -462,8 +462,8 @@ class Timer(Serializable):
             samples and/or tokens trained across all ranks before invoking this function.
 
         Args:
-            samples (int or Time, optional): The number of samples trained in the batch. Defaults to 0.
-            tokens (int or Time, optional): The number of tokens trained in the batch. Defaults to 0.
+            samples (int | Time, optional): The number of samples trained in the batch. Defaults to 0.
+            tokens (int | Time, optional): The number of tokens trained in the batch. Defaults to 0.
         """
         self._batch += Time(1, TimeUnit.BATCH)
         self._batch_in_epoch += Time(1, TimeUnit.BATCH)

--- a/composer/datasets/dataloader.py
+++ b/composer/datasets/dataloader.py
@@ -81,7 +81,7 @@ class DataLoaderHparams(hp.Hparams):
         Args:
             dataset (Dataset): The dataset.
             batch_size (int): The per-device batch size.
-            sampler (torch.utils.data.Sampler[int] or None): The sampler to use for the dataloader.
+            sampler (torch.utils.data.Sampler[int] | None): The sampler to use for the dataloader.
             drop_last (bool): Whether to drop the last batch if the number of
                 samples is not evenly divisible by the batch size.
             collate_fn (callable, optional): Custom collate function. Default: ``None``.

--- a/composer/loggers/in_memory_logger.py
+++ b/composer/loggers/in_memory_logger.py
@@ -50,7 +50,7 @@ class InMemoryLogger(LoggerDestination):
             trainer.engine.close()
 
     Args:
-        log_level (str or LogLevel, optional):
+        log_level (str | LogLevel, optional):
             :class:`~.logger.LogLevel` (i.e. unit of resolution) at
             which to record. Defaults to
             :attr:`~.LogLevel.BATCH`, which records

--- a/composer/loggers/logger_hparams.py
+++ b/composer/loggers/logger_hparams.py
@@ -234,7 +234,7 @@ class InMemoryLoggerHparams(LoggerDestinationHparams):
     hyperparameters.
 
     Args:
-        log_level (str or LogLevel, optional):
+        log_level (str | LogLevel, optional):
             See :class:`~composer.loggers.in_memory_logger.InMemoryLogger`.
     """
     log_level: LogLevel = hp.optional("The maximum verbosity to log. Default: BATCH", default=LogLevel.BATCH)

--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -210,7 +210,7 @@ class StepScheduler(ComposerScheduler):
     :math:`\gamma` represents the multiplicative decay factor.
     
     Args:
-        step_size (str or Time): Time between changes to the learning rate.
+        step_size (str | Time): Time between changes to the learning rate.
         gamma (float): Multiplicative decay factor. Default = ``0.1``.
     """
 
@@ -243,7 +243,7 @@ class MultiStepScheduler(ComposerScheduler):
     multiplicative decay factor.
     
     Args:
-        milestones (List[str or Time]): Times at which the learning rate should change.
+        milestones (List[str | Time]): Times at which the learning rate should change.
         gamma (float): Multiplicative decay factor. Default = ``0.1``.
     """
 
@@ -280,7 +280,7 @@ class ConstantScheduler(ComposerScheduler):
     
     Args:
         alpha (float): Learning rate multiplier to maintain while this scheduler is active. Default = ``1.0``.
-        t_max (str or Time): Duration of this scheduler. Default = ``"1dur"``.
+        t_max (str | Time): Duration of this scheduler. Default = ``"1dur"``.
     """
 
     def __init__(self, alpha: float = 1.0, t_max: Union[str, Time] = "1dur") -> None:
@@ -326,7 +326,7 @@ class LinearScheduler(ComposerScheduler):
     Args:
         alpha_i (float): Initial learning rate multiplier. Default = ``1.0``.
         alpha_f (float): Final learning rate multiplier. Default = ``0.0``.
-        t_max (str or Time): The duration of this scheduler. Default = ``"1dur"``.
+        t_max (str | Time): The duration of this scheduler. Default = ``"1dur"``.
     """
 
     def __init__(self, alpha_i: float = 1.0, alpha_f: float = 0.0, t_max: Union[str, Time] = "1dur"):
@@ -360,7 +360,7 @@ class ExponentialScheduler(ComposerScheduler):
     Where :math:`\rho` represents the decay period, and :math:`\gamma` represents the multiplicative decay factor.
     
     Args:
-        decay_period (str or Time): Decay period. Default = ``"1ep"``.
+        decay_period (str | Time): Decay period. Default = ``"1ep"``.
         gamma (float): Multiplicative decay factor.
     """
 
@@ -406,7 +406,7 @@ class CosineAnnealingScheduler(ComposerScheduler):
     represents the duration of this scheduler, and :math:`\alpha_f` represents the learning rate multiplier to decay to.
     
     Args:
-        t_max (str or Time): The duration of this scheduler. Default = ``"1dur"``.
+        t_max (str | Time): The duration of this scheduler. Default = ``"1dur"``.
         alpha_f (float): Learning rate multiplier to decay to. Default = ``0.0``.
     """
 
@@ -447,7 +447,7 @@ class CosineAnnealingWarmRestartsScheduler(ComposerScheduler):
     cycles, and :math:`\alpha_f` represents the learning rate multiplier to decay to.
     
     Args:
-        t_0 (str or Time): The period of the first cycle.
+        t_0 (str | Time): The period of the first cycle.
         t_mult (float): The multiplier for the duration of successive cycles. Default = ``1.0``.
         alpha_f (float): Learning rate multiplier to decay to. Default = ``0.0``.
     """
@@ -495,7 +495,7 @@ class PolynomialScheduler(ComposerScheduler):
 
     Args:
         power (float): The exponent to be used for the proportionality relationship.
-        t_max (str or Time): The duration of this scheduler. Default = ``"1dur"``.
+        t_max (str | Time): The duration of this scheduler. Default = ``"1dur"``.
         alpha_f (float): Learning rate multiplier to decay to. Default = ``0.0``.
     """
 
@@ -543,8 +543,8 @@ class MultiStepWithWarmupScheduler(ComposerScheduler):
         will still be scaled accordingly.
 
     Args:
-        t_warmup (str or Time): Warmup time.
-        milestones (List[str or Time]): Times at which the learning rate should change.
+        t_warmup (str | Time): Warmup time.
+        milestones (List[str | Time]): Times at which the learning rate should change.
         gamma (float): Multiplicative decay factor. Default = ``0.1``.
     """
 
@@ -601,10 +601,10 @@ class LinearWithWarmupScheduler(ComposerScheduler):
         slightly distorted from what would otherwise be expected.
 
     Args:
-        t_warmup (str or Time): Warmup time.
+        t_warmup (str | Time): Warmup time.
         alpha_i (float): Initial learning rate multiplier. Default = ``1.0``.
         alpha_f (float): Final learning rate multiplier. Default = ``0.0``.
-        t_max (str or Time): The duration of this scheduler. Default = ``"1dur"``.
+        t_max (str | Time): The duration of this scheduler. Default = ``"1dur"``.
     """
 
     def __init__(self,
@@ -667,8 +667,8 @@ class CosineAnnealingWithWarmupScheduler(ComposerScheduler):
         slightly distorted from what would otherwise be expected.
     
     Args:
-        t_warmup (str or Time): Warmup time.
-        t_max (str or Time): The duration of this scheduler. Default = ``"1dur"``.
+        t_warmup (str | Time): Warmup time.
+        t_max (str | Time): The duration of this scheduler. Default = ``"1dur"``.
         alpha_f (float): Learning rate multiplier to decay to. Default = ``0.0``.
     """
 

--- a/composer/trainer/ddp.py
+++ b/composer/trainer/ddp.py
@@ -52,7 +52,7 @@ def ddp_sync_context(state: State, is_final_microbatch: bool, sync_strategy: Uni
         state (State): The state of the :class:`~composer.trainer.trainer.Trainer`.
         is_final_microbatch (bool): Whether or not the context is being used during the final
             microbatch of the gradient accumulation steps.
-        sync_strategy (str or DDPSyncStrategy): The ddp sync strategy to use. If a string
+        sync_strategy (str | DDPSyncStrategy): The ddp sync strategy to use. If a string
             is provided, the string must be one of the values in :class:`DDPSyncStrategy`.
     """
     if not isinstance(state.model, DistributedDataParallel):

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -147,7 +147,7 @@ class Trainer:
             with Composer.
 
             .. seealso:: :mod:`composer.models` for models built into Composer.
-        train_dataloader (Iterable, DataSpec, or dict, optional): The dataloader, :class:`.DataSpec`,
+        train_dataloader (Iterable | DataSpec | dict, optional): The dataloader, :class:`.DataSpec`,
             or dict of :class:`.DataSpec` kwargs for the training data. In order to specify custom
             preprocessing steps on each data batch, specify a :class:`.DataSpec` instead of a dataloader.
             It is recommended that the dataloader, whether specified directly or as part of a :class:`.DataSpec`,
@@ -158,7 +158,7 @@ class Trainer:
                 desired optimization batch size is ``2048`` and training is happening across 8 GPUs, then each
                 ``train_dataloader`` should yield a batch of size ``2048 / 8 = 256``. If ``grad_accum = 2``,
                 then the per-rank batch will be divided into microbatches of size ``256 / 2 = 128``.
-        max_duration (int, str, or Time): The maximum duration to train. Can be an integer, which will be
+        max_duration (int | str | Time): The maximum duration to train. Can be an integer, which will be
             interpreted to be epochs, a str (e.g. ``1ep``, or ``10ba``), or a :class:`.Time` object.
         eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): The dataloader,
             :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
@@ -182,7 +182,7 @@ class Trainer:
             (default: ``None``).
 
             .. seealso:: :mod:`composer.optim.scheduler` for the different schedulers built into Composer.
-        device (str or Device, optional): The device to use for training. Either ``cpu`` or ``gpu``.
+        device (str | Device, optional): The device to use for training. Either ``cpu`` or ``gpu``.
             (default: ``cpu``)
         grad_accum (Union[int, str], optional): The number of microbatches to split a per-device batch into. Gradients
             are summed over the microbatches per device. If set to ``auto``, dynamically increases grad_accum
@@ -213,7 +213,7 @@ class Trainer:
             ``eval_dataloader`` is not specified.
         compute_training_metrics (bool, optional): ``True`` to compute metrics on training data and ``False`` to not.
             (default: ``False``)
-        precision (str or Precision, optional): Numerical precision to use for training. One of ``fp32``, ``fp16``
+        precision (str | Precision, optional): Numerical precision to use for training. One of ``fp32``, ``fp16``
             or ``amp`` (recommended). (default: ``Precision.FP32``)
 
             .. note::
@@ -247,7 +247,7 @@ class Trainer:
             (default: ``None``)
         dist_timeout (float, optional): Timeout, in seconds, for initializing the distributed process group.
             (default: ``15.0``)
-        ddp_sync_strategy (str or DDPSyncStrategy, optional): The strategy to use for synchronizing gradients.
+        ddp_sync_strategy (str | DDPSyncStrategy, optional): The strategy to use for synchronizing gradients.
             Leave unset to let the trainer auto-configure this. See :class:`.DDPSyncStrategy`
             for more details.
         seed (int, optional): The seed used in randomization. If ``None``, then a random seed
@@ -461,7 +461,7 @@ class Trainer:
             This parameter has no effect if ``eval_dataloader`` is not specified, it is greater than
             ``len(eval_dataloader)``, or ``eval_dataloader`` is an :class:`.Evaluator` and ``subset_num_batches``
             was specified as part of the :class:`.Evaluator`.
-        deepspeed_config (bool or Dict[str, Any], optional): Configuration for DeepSpeed, formatted as a JSON
+        deepspeed_config (bool | Dict[str, Any], optional): Configuration for DeepSpeed, formatted as a JSON
             according to `DeepSpeed's documentation <https://www.deepspeed.ai/docs/config-json/>`_. If ``True`` is
             provided, the trainer will initialize the DeepSpeed engine with an empty config ``{}``. If ``False``
             is provided, deepspeed will not be used. (default: ``False``)


### PR DESCRIPTION
I used the regex ` or .*\):` to find docstring type annotations with "or" in them. Replaced these docstrings with `|`.

Closes #736