### PR TITLE
Load from wandb logger

### DIFF
--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -144,10 +144,13 @@ class WandBLogger(LoggerDestination):
         with tempfile.TemporaryDirectory() as tmpdir:
             artifact_folder = os.path.join(tmpdir, "artifact_folder")
             artifact.download(root=artifact_folder)
+            artifact_names = os.listdir(artifact_folder)
             # We only log one file per artifact
-            checkpoint_name = os.listdir(artifact_folder)[0]
-            checkpoint_path = os.path.join(artifact_folder, checkpoint_name)
-            shutil.move(checkpoint_path, destination)
+            if len(artifact_names) > 1:
+                raise RuntimeError("Found more than one file in artifact. We assume the checkpoint is the only file in the artifact.")
+            artifact_name = artifact_names[0]
+            artifact_path = os.path.join(artifact_folder, artifact_name)
+            shutil.move(artifact_path, destination)
 
     def post_close(self) -> None:
         import wandb

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 import os
 import pathlib
 import re
+import shutil
 import sys
+import tempfile
 import textwrap
 import warnings
 from typing import Any, Dict, Optional
@@ -126,6 +128,26 @@ class WandBLogger(LoggerDestination):
             artifact = wandb.Artifact(name=new_artifact_name, type=extension)
             artifact.add_file(os.path.abspath(file_path))
             wandb.log_artifact(artifact, aliases=aliases)
+
+    def get_file_artifact(
+        self,
+        artifact_name: str,
+        destination: str,
+        chunk_size: int = 2**20,
+        progress_bar: bool = True,
+    ):
+        # Note: Wandb doesn't support progress bars for downloading
+        del chunk_size, progress_bar
+        import wandb
+
+        artifact = wandb.use_artifact(artifact_name)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_folder = os.path.join(tmpdir, "artifact_folder")
+            artifact.download(root=artifact_folder)
+            # We only log one file per artifact
+            checkpoint_name = os.listdir(artifact_folder)[0]
+            checkpoint_path = os.path.join(artifact_folder, checkpoint_name)
+            shutil.move(checkpoint_path, destination)
 
     def post_close(self) -> None:
         import wandb

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -147,7 +147,8 @@ class WandBLogger(LoggerDestination):
             artifact_names = os.listdir(artifact_folder)
             # We only log one file per artifact
             if len(artifact_names) > 1:
-                raise RuntimeError("Found more than one file in artifact. We assume the checkpoint is the only file in the artifact.")
+                raise RuntimeError(
+                    "Found more than one file in artifact. We assume the checkpoint is the only file in the artifact.")
             artifact_name = artifact_names[0]
             artifact_path = os.path.join(artifact_folder, artifact_name)
             shutil.move(artifact_path, destination)


### PR DESCRIPTION
Adds support to load checkpoints from wandb logger. 

**Testing:**
Adding unit tests for this is a pain because you need to start saving and loading checkpoints from wandb, so you need to throw in wandb credentials and every time tests are run, we read and write from there. I spent a bit of time playing around with this, but I'm strongly in favor of not adding a unit test for this behavior. It's not ideal, but I think it's far better than constantly writing to wandb with each github action

To verify it works, I ran two runs which save and load from there. Run 1: 
```
composer -n 1 examples/run_composer_trainer.py -f composer/yamls/models/resnet56_cifar10.yaml 
        --train_dataset.cifar10.datadir /localdisk/CIFAR10/ 
        --val_dataset.cifar10.datadir /localdisk/CIFAR10/ 
        --loggers progress_bar wandb 
        --save_folder experiments  
        --save_overwrite True 
        --loggers.wandb.log_artifacts True 
        --loggers.wandb.entity mosaic-ml 
        --loggers.wandb.name ckpt-test 
        --loggers.wandb.project ckpt
```
which saves to wandb. Run 2: 
```
composer -n 1 examples/run_composer_trainer.py -f composer/yamls/models/resnet56_cifar10.yaml 
        --train_dataset.cifar10.datadir /localdisk/CIFAR10/ 
        --val_dataset.cifar10.datadir /localdisk/CIFAR10/ 
        --loggers progress_bar wandb 
        --save_folder experiments  
        --save_overwrite True 
        --loggers.wandb.log_artifacts True 
        --loggers.wandb.entity mosaic-ml 
        --loggers.wandb.name ckpt-test 
        --loggers.wandb.project ckpt
```
which loads from wandb and continues training. Run 2 uses a slightly different yaml which includes
```
load_logger_destination: 
  wandb:
    entity: mosaic-ml
    name: ckpt-test
    project: ckpt
```
The resulting output is that it continues training from the checkpoint! Woo 
<img width="602" alt="image" src="https://user-images.githubusercontent.com/17102158/167223866-7189c1be-eb8b-43c5-98da-9cdd042cd24d.png">
