### PR TITLE
Fix Doc Tests

### DIFF
--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -158,7 +158,7 @@ def new_trainer_init(self, **kwargs: Any):
         kwargs["progress_bar"] = False  # hide tqdm logging
     if "log_to_console" not in kwargs:
         kwargs["log_to_console"] = False  # hide console logging
-    original_trainer_init(**kwargs)
+    original_trainer_init(self, **kwargs)
 
 
 Trainer.__init__ = new_trainer_init

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -190,10 +190,13 @@ def ObjectStoreLogger(fake_ellipses: None = None, **kwargs: Any):
     )
     return OriginalObjectStoreLogger(**kwargs)
 
+
 # Patch __init__ function to replace provider, container, key arguments. Since certain files
 # use ObjectStore in ``isinstance``, we can't wrap the class in a function like we do for
 # ``ObjectStoreLogger``
 original_init = ObjectStore.__init__
+
+
 def new_init(self, **kwargs: Any):
     os.makedirs("./object_store", exist_ok=True)
     kwargs.update(
@@ -204,6 +207,8 @@ def new_init(self, **kwargs: Any):
         },
     )
     original_init(self, **kwargs)
+
+
 ObjectStore.__init__ = new_init
 
 composer.loggers.object_store_logger.ObjectStoreLogger = ObjectStoreLogger

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -32,7 +32,7 @@ import composer.utils
 import composer.utils.checkpoint
 import composer.utils.file_helpers
 import composer.utils.object_store
-from composer import Trainer as OriginalTrainer
+from composer import Trainer
 from composer.core import Algorithm as Algorithm
 from composer.core import Callback as Callback
 from composer.core import DataSpec as DataSpec
@@ -48,7 +48,7 @@ from composer.datasets.synthetic import SyntheticBatchPairDataset
 from composer.loggers import InMemoryLogger as InMemoryLogger
 from composer.loggers import Logger as Logger
 from composer.loggers import LogLevel as LogLevel
-from composer.loggers import ObjectStoreLogger as OriginalObjectStoreLogger
+from composer.loggers import ObjectStoreLogger
 from composer.models import ComposerModel as ComposerModel
 from composer.optim.scheduler import ConstantScheduler
 from composer.utils import ObjectStore
@@ -137,10 +137,11 @@ def loss_fun(output, target, reduction="none"):
     return torch.ones_like(target)
 
 
-# patch the Trainer to accept ellipses and bind the required arguments to the Trainer
-# so it can be used without arguments in the doctests
-def Trainer(fake_ellipses: None = None, **kwargs: Any):
-    del fake_ellipses  # unused
+# Patch Trainer __init__ function to replace arguments while preserving type
+original_trainer_init = Trainer.__init__
+
+
+def new_trainer_init(self, **kwargs: Any):
     if "model" not in kwargs:
         kwargs["model"] = model
     if "optimizers" not in kwargs:
@@ -157,15 +158,10 @@ def Trainer(fake_ellipses: None = None, **kwargs: Any):
         kwargs["progress_bar"] = False  # hide tqdm logging
     if "log_to_console" not in kwargs:
         kwargs["log_to_console"] = False  # hide console logging
-    trainer = OriginalTrainer(**kwargs)
-
-    return trainer
+    original_trainer_init(**kwargs)
 
 
-# patch composer so that 'from composer import Trainer' calls do not override change above
-composer.Trainer = Trainer
-composer.trainer.Trainer = Trainer
-composer.trainer.trainer.Trainer = Trainer
+Trainer.__init__ = new_trainer_init
 
 
 # Do not attempt to validate cloud credentials
@@ -175,9 +171,11 @@ def do_not_validate(*args, **kwargs) -> None:
 
 composer.loggers.object_store_logger._validate_credentials = do_not_validate
 
+# Patch ObjectStoreLogger __init__ function to replace arguments while preserving type
+original_objectStoreLogger_init = ObjectStoreLogger.__init__
 
-def ObjectStoreLogger(fake_ellipses: None = None, **kwargs: Any):
-    # ignore all arguments, and use a local folder
+
+def new_objectStoreLogger_init(self, **kwargs: Any):
     os.makedirs("./object_store", exist_ok=True)
     kwargs.update(
         use_procs=False,
@@ -188,16 +186,16 @@ def ObjectStoreLogger(fake_ellipses: None = None, **kwargs: Any):
             'key': os.path.abspath("./object_store"),
         },
     )
-    return OriginalObjectStoreLogger(**kwargs)
+    original_objectStoreLogger_init(self, **kwargs)
 
 
-# Patch __init__ function to replace provider, container, key arguments. Since certain files
-# use ObjectStore in ``isinstance``, we can't wrap the class in a function like we do for
-# ``ObjectStoreLogger``
-original_init = ObjectStore.__init__
+ObjectStoreLogger.__init__ = new_objectStoreLogger_init
+
+# Patch ObjectStore __init__ function to replace arguments while preserving type
+original_objectStore_init = ObjectStore.__init__
 
 
-def new_init(self, **kwargs: Any):
+def new_objectStore_init(self, **kwargs: Any):
     os.makedirs("./object_store", exist_ok=True)
     kwargs.update(
         provider='local',
@@ -206,17 +204,7 @@ def new_init(self, **kwargs: Any):
             'key': os.path.abspath("./object_store"),
         },
     )
-    original_init(self, **kwargs)
+    original_objectStore_init(self, **kwargs)
 
 
-ObjectStore.__init__ = new_init
-
-composer.loggers.object_store_logger.ObjectStoreLogger = ObjectStoreLogger
-composer.loggers.ObjectStoreLogger = ObjectStoreLogger
-composer.loggers.logger_hparams.ObjectStoreLogger = ObjectStoreLogger
-composer.utils.object_store.ObjectStore = ObjectStore
-composer.utils.ObjectStore = ObjectStore
-composer.utils.checkpoint.ObjectStore = ObjectStore
-composer.utils.file_helpers.ObjectStore = ObjectStore
-composer.trainer.trainer.ObjectStore = ObjectStore
-composer.loggers.object_store_logger.ObjectStore = ObjectStore
+ObjectStore.__init__ = new_objectStore_init

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -141,7 +141,7 @@ def loss_fun(output, target, reduction="none"):
 original_trainer_init = Trainer.__init__
 
 
-def new_trainer_init(self, **kwargs: Any):
+def new_trainer_init(self, fake_ellipses: None = None, **kwargs: Any):
     if "model" not in kwargs:
         kwargs["model"] = model
     if "optimizers" not in kwargs:
@@ -175,7 +175,7 @@ composer.loggers.object_store_logger._validate_credentials = do_not_validate
 original_objectStoreLogger_init = ObjectStoreLogger.__init__
 
 
-def new_objectStoreLogger_init(self, **kwargs: Any):
+def new_objectStoreLogger_init(self, fake_ellipses: None = None, **kwargs: Any):
     os.makedirs("./object_store", exist_ok=True)
     kwargs.update(
         use_procs=False,
@@ -195,7 +195,7 @@ ObjectStoreLogger.__init__ = new_objectStoreLogger_init
 original_objectStore_init = ObjectStore.__init__
 
 
-def new_objectStore_init(self, **kwargs: Any):
+def new_objectStore_init(self, fake_ellipses: None = None, **kwargs: Any):
     os.makedirs("./object_store", exist_ok=True)
     kwargs.update(
         provider='local',


### PR DESCRIPTION
Replaces get fn for `ObjectStore` in doctest fixtures with patching init function, so we can still type check. It's a little hacky, but afaik it's the only way to change the init params while preserving the type. 