### PR TITLE
Update CutMix to work with segmentation style labels 

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ trainer = Trainer(
     algorithms=[
         BlurPool(replace_convs=True, replace_maxpools=True, blur_first=True),
         ChannelsLast(),
-        CutMix(num_classes=10),
+        CutMix(alpha=1.0),
         LabelSmoothing(smoothing=0.1),
     ]
 )
@@ -347,7 +347,7 @@ If you have any questions, please feel free to reach out to us on [Twitter](http
 # 💫 Contributors
 Composer is part of the broader Machine Learning community, and we welcome any contributions, pull requests, or issues!
 
-To start contributing, see our [Contributing](CONTRIBUTING.md) page. 
+To start contributing, see our [Contributing](CONTRIBUTING.md) page.
 
 # ✍️ Citation
 ```

--- a/composer/algorithms/cutmix/README.md
+++ b/composer/algorithms/cutmix/README.md
@@ -30,7 +30,6 @@ def training_loop(model, train_loader):
         for X, y in train_loader:
             X_cutmix, y_cutmix = cf.cutmix_batch(X,
                                                  y,
-                                                 num_classes=1000,
                                                  alpha=1.0)
 
             y_hat = model(X_cutmix)
@@ -49,7 +48,7 @@ def training_loop(model, train_loader):
 from composer.algorithms import CutMix
 from composer.trainer import Trainer
 
-cutmix = CutMix(num_classes=1000, alpha=1.0)
+cutmix = CutMix(alpha=1.0)
 
 trainer = Trainer(
     model=model,

--- a/composer/algorithms/cutmix/cutmix.py
+++ b/composer/algorithms/cutmix/cutmix.py
@@ -250,7 +250,7 @@ class CutMix(Algorithm):
                 target = ensure_targets_one_hot(state.outputs, target)
                 permuted_target = ensure_targets_one_hot(state.outputs, self._permuted_target)
                 # Interpolate to get the new target
-                target = (1 - self._adjusted_lambda) * target + self._adjusted_lambda * permuted_target
+                target = self._adjusted_lambda * target + (1 - self._adjusted_lambda) * permuted_target
             # Create the new batch
             state.batch = (input, target)
 
@@ -277,7 +277,7 @@ class CutMix(Algorithm):
                 raise NotImplementedError("Multiple losses not supported yet")
             if not isinstance(new_loss, torch.Tensor):
                 raise NotImplementedError("Multiple losses not supported yet")
-            state.loss = (1 - self._adjusted_lambda) * state.loss + self._adjusted_lambda * new_loss
+            state.loss = self._adjusted_lambda * state.loss + (1 - self._adjusted_lambda) * new_loss
 
 
 def _gen_indices(x: Tensor) -> Tensor:

--- a/composer/algorithms/cutmix/cutmix.py
+++ b/composer/algorithms/cutmix/cutmix.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from math import perm
 from typing import Optional, Tuple
 
 import numpy as np
@@ -14,7 +15,7 @@ from torch.nn import functional as F
 
 from composer.core import Algorithm, Event, State
 from composer.loggers import Logger
-from composer.loss.utils import check_for_index_targets
+from composer.loss.utils import ensure_targets_one_hot
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +24,6 @@ __all__ = ["CutMix", "cutmix_batch"]
 
 def cutmix_batch(input: Tensor,
                  target: Tensor,
-                 num_classes: int,
                  length: Optional[float] = None,
                  alpha: float = 1.,
                  bbox: Optional[Tuple] = None,
@@ -63,7 +63,6 @@ def cutmix_batch(input: Tensor,
             latter case, rows of ``target`` may be arbitrary vectors of targets,
             including, e.g., one-hot encoded class labels, smoothed class
             labels, or multi-output regression targets.
-        num_classes (int): total number of classes or output variables
         length (float, optional): Relative side length of the masked region.
             If specified, ``length`` is interpreted as a fraction of ``H`` and
             ``W``, and the resulting box is of size ``(length * H, length * W)``.
@@ -83,15 +82,10 @@ def cutmix_batch(input: Tensor,
     Returns:
         input_mixed (torch.Tensor): batch of inputs after cutmix has been
             applied.
-        target_mixed (torch.Tensor): soft labels for mixed input samples.
-            These are a convex combination of the (possibly one-hot-encoded)
-            labels from the original samples and the samples chosen to fill
-            the masked regions, with the relative weighting equal to the
-            fraction of the spatial size that is cut.
-            E.g., if a sample was originally an image with label ``0`` and
-            40% of the image of was replaced with data from an image with label
-            ``2``, the resulting labels, assuming only three classes, would be
-            ``[1, 0, 0] * 0.6 + [0, 0, 1] * 0.4 = [0.6, 0, 0.4]``.
+        target_perm (torch.Tensor): The labels of the mixed-in examples
+        area (float): The fractional area of the mixed region.
+        bounding_box (tuple): the ``(left, top, right, bottom)`` coordinates of
+            the bounding box that defines the mixed region.
 
     Raises:
         ValueError: If both ``length`` and ``bbox`` are provided.
@@ -106,9 +100,13 @@ def cutmix_batch(input: Tensor,
             num_classes = 10
             X = torch.randn(N, C, H, W)
             y = torch.randint(num_classes, size=(N,))
+<<<<<<< HEAD
             X_mixed, y_mixed = cutmix_batch(
                 X, y, num_classes=num_classes, alpha=0.2
             )
+=======
+            X_mixed, target_perm, area, _ = cutmix_batch(X, y, alpha=0.2)
+>>>>>>> 70a73ee (Initial cutmix changes)
     """
     if bbox is not None and length is not None:
         raise ValueError(f"Cannot provide both length and bbox; got {length} and {bbox}")
@@ -149,17 +147,8 @@ def cutmix_batch(input: Tensor,
 
     # Make a shuffled version of y for interpolation
     y_shuffled = target[shuffled_idx]
-    # Interpolate between labels using the adjusted lambda
-    # First check if labels are indices. If so, convert them to onehots.
-    # This is under the assumption that the loss expects torch.LongTensor, which is true for pytorch cross_entropy
-    if check_for_index_targets(target):
-        y_onehot = F.one_hot(target, num_classes=num_classes)
-        y_shuffled_onehot = F.one_hot(y_shuffled, num_classes=num_classes)
-        y_cutmix = adjusted_lambda * y_onehot + (1 - adjusted_lambda) * y_shuffled_onehot
-    else:
-        y_cutmix = adjusted_lambda * target + (1 - adjusted_lambda) * y_shuffled
 
-    return X_cutmix, y_cutmix
+    return X_cutmix, y_shuffled, adjusted_lambda, bbox
 
 
 class CutMix(Algorithm):
@@ -199,24 +188,23 @@ class CutMix(Algorithm):
             )
     """
 
-    def __init__(self, num_classes: int, alpha: float = 1., uniform_sampling: bool = False):
+    def __init__(self, num_classes: int, alpha: float = 1., interpolate_loss: bool = False, uniform_sampling: bool = False):
         self.num_classes = num_classes
         self.alpha = alpha
+        self.interpolate_loss = interpolate_loss
         self._uniform_sampling = uniform_sampling
+
         self._indices = torch.Tensor()
         self._cutmix_lambda = 0.0
         self._bbox: Tuple[int, int, int, int] = (0, 0, 0, 0)
+        self.permuted_target = torch.Tensor()
+        self.adjusted_lambda = 0.0
 
     def match(self, event: Event, state: State) -> bool:
-        """Runs on Event.INIT and Event.AFTER_DATALOADER.
-
-        Args:
-            event (:class:`Event`): The current event.
-            state (:class:`State`): The current state.
-        Returns:
-            bool: True if this algorithm should run now.
-        """
-        return event == Event.AFTER_DATALOADER
+        if self.interpolate_loss:
+            return event in [Event.BEFORE_FORWARD, Event.BEFORE_BACKWARD]
+        else:
+            return event in [Event.BEFORE_FORWARD, Event.BEFORE_LOSS]
 
     def apply(self, event: Event, state: State, logger: Logger) -> None:
         """Applies CutMix augmentation on State input.
@@ -232,22 +220,72 @@ class CutMix(Algorithm):
             "Multiple tensors for inputs or targets not supported yet."
         alpha = self.alpha
 
-        # these are saved only for testing
-        self._indices = _gen_indices(input)
-        _cutmix_lambda = _gen_cutmix_coef(alpha)
-        self._bbox = _rand_bbox(input.shape[2], input.shape[3], _cutmix_lambda, uniform_sampling=self._uniform_sampling)
-        self._cutmix_lambda = _adjust_lambda(_cutmix_lambda, input, self._bbox)
+        if event == Event.BEFORE_FORWARD:
+            if not isinstance(input, torch.Tensor):
+                raise NotImplementedError("Multiple tensors for inputs not supported yet.")
+            if not isinstance(target, torch.Tensor):
+                raise NotImplementedError("Multiple tensors for targets not supported yet.")
 
-        new_input, new_target = cutmix_batch(
-            input=input,
-            target=target,
-            num_classes=self.num_classes,
-            alpha=alpha,
-            bbox=self._bbox,
-            indices=self._indices,
-        )
+            # these are saved only for testing
+            self._indices = _gen_indices(input)
+            _cutmix_lambda = _gen_cutmix_coef(alpha)
+            self._bbox = _rand_bbox(input.shape[2], input.shape[3], _cutmix_lambda, uniform_sampling=self._uniform_sampling)
+            self._cutmix_lambda = _adjust_lambda(_cutmix_lambda, input, self._bbox)
 
-        state.batch = (new_input, new_target)
+            new_input, self.permuted_target, self.adjusted_lambda, _ = cutmix_batch(
+                input=input,
+                target=target,
+                alpha=self.alpha,
+                bbox=self._bbox,
+                indices=self._indices,
+                uniform_sampling=self._uniform_sampling
+            )
+
+            state.batch = (new_input, target)
+
+        if not self.interpolate_loss and event == Event.BEFORE_LOSS:
+            # Interpolate the targets
+            if not isinstance(state.outputs, torch.Tensor):
+                raise NotImplementedError("Multiple output tensors not supported yet")
+            if not isinstance(target, torch.Tensor):
+                raise NotImplementedError("Multiple target tensors not supported yet")
+            if self.permuted_target.ndim > 2 and self.permuted_target.shape[-2:] == input.shape[-2:]:
+                # Target has the same height and width as the input, no need to interpolate.
+                x1, y1, x2, y2 = self._bbox
+                target[..., x1:x2, y1:y2] = self.permuted_target[..., x1:x2, y1:y2]
+            else:
+                # Need to interpolate on dense/one-hot targets.
+                target = ensure_targets_one_hot(state.outputs, target)
+                permuted_target = ensure_targets_one_hot(state.outputs, self.permuted_target)
+                # Interpolate to get the new target
+                target = (1 - self.adjusted_lambda) * target + self.adjusted_lambda * permuted_target
+            # Create the new batch
+            state.batch = (input, target)
+
+        if self.interpolate_loss and event == Event.BEFORE_BACKWARD:
+            if self.permuted_target.ndim > 2 and self.permuted_target.shape[-2:] == input.shape[-2:]:
+                raise ValueError("Can't interpolate loss when target has the same height and width as the input")
+
+            # Grab the loss function
+            if hasattr(state.model, "loss"):
+                loss_fn = state.model.loss
+            elif hasattr(state.model, "module") and hasattr(state.model.module, "loss"):
+                if isinstance(state.model.module, torch.nn.Module):
+                    loss_fn = state.model.module.loss
+                else:
+                    raise TypeError("state.model.module must be a torch module")
+            else:
+                raise AttributeError("Loss must be accesable via model.loss or model.module.loss")
+            # Verify that the loss is callable
+            if not callable(loss_fn):
+                raise TypeError("Loss must be callable")
+            # Interpolate the loss
+            new_loss = loss_fn(state.outputs, (input, self.permuted_target))
+            if not isinstance(state.loss, torch.Tensor):
+                raise NotImplementedError("Multiple losses not supported yet")
+            if not isinstance(new_loss, torch.Tensor):
+                raise NotImplementedError("Multiple losses not supported yet")
+            state.loss = (1 - self.adjusted_lambda) * state.loss + self.adjusted_lambda * new_loss
 
 
 def _gen_indices(x: Tensor) -> Tensor:

--- a/composer/algorithms/hparams.py
+++ b/composer/algorithms/hparams.py
@@ -141,6 +141,8 @@ class CutMixHparams(AlgorithmHparams):
 
     alpha: float = hp.optional('Strength of interpolation, should be >= 0. No interpolation if alpha=0.', default=1.0)
     uniform_sampling: bool = hp.optional('Mix pixels with uniform probability', default=False)
+    interpolate_loss: bool = hp.optional('Use index labels and interpolate the loss instead of the labels.',
+                                         default=False)
 
     def initialize_object(self) -> CutMix:
         return CutMix(**asdict(self))

--- a/composer/algorithms/hparams.py
+++ b/composer/algorithms/hparams.py
@@ -139,7 +139,6 @@ class ColOutHparams(AlgorithmHparams):
 class CutMixHparams(AlgorithmHparams):
     """See :class:`CutMix`"""
 
-    num_classes: int = hp.required('Number of classes in the task labels.')
     alpha: float = hp.optional('Strength of interpolation, should be >= 0. No interpolation if alpha=0.', default=1.0)
     uniform_sampling: bool = hp.optional('Mix pixels with uniform probability', default=False)
 

--- a/composer/yamls/algorithms/cutmix.yaml
+++ b/composer/yamls/algorithms/cutmix.yaml
@@ -1,3 +1,2 @@
 alpha: 1.0
-num_classes: 1000
 uniform_sampling: False

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -137,7 +137,7 @@ we train an MNIST classifer with a recipe of methods:
         max_duration="2ep",
         algorithms=[
             LabelSmoothing(smoothing=0.1),
-            CutMix(num_classes=10),
+            CutMix(alpha=1.0),
             ChannelsLast(),
             ]
     )
@@ -158,4 +158,3 @@ Next steps
 * Try :doc:`/getting_started/notebooks` to see some of our speed-ups with notebooks on Colab.
 * See :doc:`/trainer/using_the_trainer` for more details on our trainer.
 * Read :doc:`/getting_started/welcome_tour` for a tour through the library.
-

--- a/tests/algorithms/algorithm_settings.py
+++ b/tests/algorithms/algorithm_settings.py
@@ -48,9 +48,7 @@ _settings = {
     'cutmix': {
         'model': common.SimpleConvModel,
         'dataset': common.RandomImageDataset,
-        'kwargs': {
-            'num_classes': 2
-        }
+        'kwargs': {}
     },
     'cutout': simple_vision_settings,
     'ema': simple_vision_settings,

--- a/tests/algorithms/test_algorithm_registry.py
+++ b/tests/algorithms/test_algorithm_registry.py
@@ -5,8 +5,7 @@ import dataclasses
 import pytest
 from torch.utils.data import Dataset
 
-from composer.algorithms import (AlgorithmHparams, AlibiHparams, CutMixHparams, StochasticDepthHparams,
-                                 algorithm_registry)
+from composer.algorithms import AlgorithmHparams, AlibiHparams, StochasticDepthHparams, algorithm_registry
 from composer.core.algorithm import Algorithm
 from composer.models.base import ComposerModel
 from tests.algorithms.algorithm_settings import get_settings
@@ -18,9 +17,6 @@ default_required_fields = {
         'attr_to_replace': '_attn',
         'alibi_attention': 'composer.algorithms.alibi._gpt2_alibi._attn',
         'mask_replacement_function': 'composer.algorithms.alibi._gpt2_alibi.enlarge_mask',
-    },
-    CutMixHparams: {
-        'num_classes': 1000
     },
     StochasticDepthHparams: {
         'target_layer_name': 'ResNetBottleneck',


### PR DESCRIPTION
This PR refactors CutMix to follow the way MixUp is done. This is mostly a usability change. The  goal is to accomplish 3 things:
1. Remove the need to specify `num_classes` as a hyper parameter. Now it should be inferred from the shape of the output tensor
2. Remove the requirement to use one-hot or dense labels by providing an `interpolate_loss` option which uses index labels and does interpolation directly on the loss, similar to the original implementation.
3. Enable the use of CutMix with segmentation style labels. 

Using `interpolate_loss=True` with both MixUp and CutMix can cause composition to behave strangely. A `NotIntendedUseWarning` should be raised in this case.

Runs:
[Current dev ResNet50-i1k-webdataset Accuracy 77.39%](https://wandb.ai/mosaic-ml/cory-debug/runs/1r00a1uk?workspace=user-corymosaicml)
[This PR ResNet50-i1k-webdataset + CutMix interpolate_loss=False Accuracy 77.27%](https://wandb.ai/mosaic-ml/cory-debug/runs/22i5l3qw?workspace=user-corymosaicml)
[This PR ResNet50-i1k-webdataset + CutMix interpolate_loss=True Accuracy 77.22%](https://wandb.ai/mosaic-ml/cory-debug/runs/32nyjwke?workspace=user-corymosaicml)
[This PR DeepLabV3+-ADE20k-webdataset interpolate_loss=False mIoU 44.9](https://wandb.ai/mosaic-ml/cory-debug/runs/2udwc4u9?workspace=user-corymosaicml)