### PR TITLE
Test for other export options (torch.fx, ONNX)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,11 @@ extra_deps["streaming"] = [
     "boto3>=1.21.45,<2",
 ]
 
+extra_deps["onnx"] = [
+    "onnx>=1.11.0,<2",
+    "onnxruntime>=1.11.0,<2",
+]
+
 extra_deps["all"] = set(dep for deps in extra_deps.values() for dep in deps)
 
 composer_data_files = ["py.typed"]

--- a/tests/algorithms/test_torch_export.py
+++ b/tests/algorithms/test_torch_export.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+import torch.fx
 from torchvision.models import resnet50
 
 from composer.functional import (apply_blurpool, apply_channels_last, apply_factorization, apply_ghost_batchnorm,
@@ -63,3 +64,25 @@ def test_surgery_torchscript_eval(surgery_method, input):
     scripted_func.eval()  # type: ignore (third-party)
     model.eval()
     torch.testing.assert_allclose(scripted_func(input), model(input))  # type: ignore (third-party)
+
+
+@pytest.mark.parametrize("surgery_method", [
+    pytest.param(apply_blurpool, marks=pytest.mark.xfail(reason="control flow")),
+    pytest.param(apply_factorization),
+    pytest.param(apply_ghost_batchnorm, marks=pytest.mark.xfail(reason="control flow")),
+    pytest.param(apply_squeeze_excite),
+    pytest.param(apply_stochastic_depth),
+    pytest.param(apply_channels_last)
+])
+@pytest.mark.timeout(5)
+def test_surgery_torchfx_eval(surgery_method, input):
+    """Tests torch.fx model in eval mode."""
+    model = resnet50()
+    kwargs = algo_kwargs.get(surgery_method, {})
+
+    surgery_method(model, **kwargs)
+
+    model.eval()
+
+    traced_func = torch.fx.symbolic_trace(model)
+    torch.testing.assert_allclose(traced_func(input), model(input))  # type: ignore (third-party)

--- a/tests/algorithms/test_torch_export.py
+++ b/tests/algorithms/test_torch_export.py
@@ -2,6 +2,8 @@
 Tests a variety of export options with our surgery methods applied, including
 torchscript, torch.fx, and ONNX.
 """
+import os
+
 import pytest
 import torch
 import torch.fx
@@ -26,7 +28,7 @@ def input():
     return torch.Tensor(4, 3, 224, 224)
 
 
-""" torchscript export """
+# <--- torchscript export --->
 
 
 @pytest.mark.parametrize("surgery_method", [
@@ -73,7 +75,7 @@ def test_surgery_torchscript_eval(surgery_method, input):
     torch.testing.assert_allclose(scripted_func(input), model(input))  # type: ignore (third-party)
 
 
-""" torch.fx export """
+# <--- torch.fx export --->
 
 
 @pytest.mark.parametrize("surgery_method", [
@@ -98,7 +100,7 @@ def test_surgery_torchfx_eval(surgery_method, input):
     torch.testing.assert_allclose(traced_func(input), model(input))  # type: ignore (third-party)
 
 
-"""ONNX export"""
+# <--- onnx export --->
 
 
 @pytest.mark.parametrize("surgery_method", [

--- a/tests/algorithms/test_torch_export.py
+++ b/tests/algorithms/test_torch_export.py
@@ -107,7 +107,7 @@ def test_surgery_torchfx_eval(surgery_method, input):
     pytest.param(apply_blurpool),
     pytest.param(apply_factorization),
     pytest.param(apply_ghost_batchnorm),
-    pytest.param(apply_squeeze_excite),
+    pytest.param(apply_squeeze_excite, marks=pytest.mark.daily),
     pytest.param(apply_stochastic_depth),
     pytest.param(apply_channels_last)
 ])


### PR DESCRIPTION
This PR adds simple tests for whether our surgery algorithms are exportable for inference via `torch.fx` or `ONNX`. This is an extension of #926 to other export options. 

`test_torchscript.py` is now renamed to `test_torch_export.py` to reflect the additional options.

Currently, the `torch.fx` option fails for several algorithms because their layers have unsupported control flow. 

With these updates, the current status of export support for **inference** is as follows (X=supported):

|                        | torchscript | torch.fx | ONNX |
|------------------------|-------------|----------|------|
| apply_blurpool         | X           |          | X    |
| apply_factorization    |             | X        | X    |
| apply_ghost_batchnorm  | X           |          | X    |
| apply_squeeze_excite   | X           | X        | X    |
| apply_stochastic_depth | X           | X        | X    |
| apply_channels_last    | X           | X        | X    |
