### PR TITLE
Update serialized format, adding magic and version

### DIFF
--- a/composer/datasets/ade20k.py
+++ b/composer/datasets/ade20k.py
@@ -501,7 +501,7 @@ class StreamingADE20kHparams(DatasetHparams):
 
     Args:
         remote (str): Remote directory (S3 or local filesystem) where dataset is stored.
-            Default: ``'s3://mosaicml-internal-dataset-ade20k/md/```
+            Default: ``'s3://mosaicml-internal-dataset-ade20k/mds/1/```
         local (str): Local filesystem directory where dataset is cached during operation.
             Default: ``'/tmp/mds-cache/mds-ade20k/```
         split (str): The dataset split to use, either 'train' or 'val'. Default: ``'train```.
@@ -514,7 +514,7 @@ class StreamingADE20kHparams(DatasetHparams):
     """
 
     remote: str = hp.optional("Remote directory (S3 or local filesystem) where dataset is stored",
-                              default="s3://mosaicml-internal-dataset-ade20k/mds/")
+                              default="s3://mosaicml-internal-dataset-ade20k/mds/1/")
     local: str = hp.optional("Local filesystem directory where dataset is cached during operation",
                              default="/tmp/mds-cache/mds-ade20k/")
     split: str = hp.optional("Which split of the dataset to use. Either ['train', 'val']", default='train')

--- a/composer/datasets/coco.py
+++ b/composer/datasets/coco.py
@@ -258,14 +258,14 @@ class StreamingCOCOHparams(DatasetHparams):
 
     Args:
         remote (str): Remote directory (S3 or local filesystem) where dataset is stored.
-            Default: ``'s3://mosaicml-internal-dataset-coco/mds/```
+            Default: ``'s3://mosaicml-internal-dataset-coco/mds/1/```
         local (str): Local filesystem directory where dataset is cached during operation.
             Default: ``'/tmp/mds-cache/mds-coco/```
         split (str): The dataset split to use, either 'train' or 'val'. Default: ``'train```.
     """
 
     remote: str = hp.optional('Remote directory (S3 or local filesystem) where dataset is stored',
-                              default='s3://mosaicml-internal-dataset-coco/mds/')
+                              default='s3://mosaicml-internal-dataset-coco/mds/1/')
     local: str = hp.optional('Local filesystem directory where dataset is cached during operation',
                              default='/tmp/mds-cache/mds-coco/')
     split: str = hp.optional("Which split of the dataset to use. Either ['train', 'val']", default='train')

--- a/composer/datasets/coco.py
+++ b/composer/datasets/coco.py
@@ -246,10 +246,15 @@ class StreamingCOCO(StreamingDataset):
 
     def __getitem__(self, idx: int) -> Any:
         x = super().__getitem__(idx)
-        args = x['img'], x['img_id'], (x['htot'], x['wtot']), x['bbox_sizes'], x['bbox_labels']
+        img = x['img']
+        img_id = x['img_id']
+        htot = x['htot']
+        wtot = x['wtot']
+        bbox_sizes = x['bbox_sizes']
+        bbox_labels = x['bbox_labels']
         if self.transform:
-            args = self.transform(*args)
-        return args
+            img, (htot, wtot), bbox_sizes, bbox_labels = self.transform(img, (htot, wtot), bbox_sizes, bbox_labels)
+        return img, img_id, (htot, wtot), bbox_sizes, bbox_labels
 
 
 @dataclass

--- a/composer/datasets/imagenet.py
+++ b/composer/datasets/imagenet.py
@@ -259,7 +259,7 @@ class StreamingImageNet1kHparams(DatasetHparams):
 
     Args:
         remote (str): Remote directory (S3 or local filesystem) where dataset is stored.
-            Default: ``'s3://mosaicml-internal-dataset-imagenet1k/mds/```
+            Default: ``'s3://mosaicml-internal-dataset-imagenet1k/mds/1/```
         local (str): Local filesystem directory where dataset is cached during operation.
             Default: ``'/tmp/mds-cache/mds-imagenet1k/```
         split (str): The dataset split to use, either 'train' or 'val'. Default: ``'train```.
@@ -268,7 +268,7 @@ class StreamingImageNet1kHparams(DatasetHparams):
     """
 
     remote: str = hp.optional('Remote directory (S3 or local filesystem) where dataset is stored',
-                              default='s3://mosaicml-internal-dataset-imagenet1k/mds/')
+                              default='s3://mosaicml-internal-dataset-imagenet1k/mds/1/')
     local: str = hp.optional('Local filesystem directory where dataset is cached during operation',
                              default='/tmp/mds-cache/mds-imagenet1k/')
     split: str = hp.optional("Which split of the dataset to use. Either ['train', 'val']", default='train')

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -86,7 +86,7 @@ class StreamingDataset(IterableDataset):
                  local: str,
                  shuffle: bool,
                  decoders: Dict[str, Callable[[bytes], Any]],
-                 timeout: float = 20,
+                 timeout: float = 60,
                  batch_size: Optional[int] = None) -> None:
 
         self.remote = remote
@@ -393,7 +393,7 @@ class StreamingImageClassDataset(StreamingDataset):
                  local: str,
                  shuffle: bool,
                  transform: Optional[Callable] = None,
-                 timeout: float = 20,
+                 timeout: float = 60,
                  batch_size: Optional[int] = None) -> None:
         decoders = {
             'x': self.decode_image,

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -41,7 +41,7 @@ class StreamingDataset(IterableDataset):
         local (str): Download shards to this local directory for for caching.
         shuffle (bool): Whether to shuffle the samples.  Note that if `shuffle=False`, the sample order is deterministic but dependent on the DataLoader's `num_workers`.
         decoders (Dict[str, Callable[bytes, Any]]]): For each sample field you wish to read, you must provide a decoder to convert the raw bytes to an object.
-        timeout (float): How long to wait for shard to download before raising an exception. Default: 20 sec.
+        timeout (float): How long to wait for shard to download before raising an exception. Default: 60 sec.
         batch_size (Optional[int]): Hint the batch_size that will be used on each device's DataLoader. Default: ``None``.
                                     Worker indices will be constructed so that there is at most 1 incomplete batch at the end of each epoch.
                                     E.g. if the DataLoader is reading over (samples=[0, 1, 2, 3, 4, 5, 6, 7], num_workers=3, batch_size=2, drop_last=True)
@@ -357,12 +357,12 @@ class StreamingImageClassDataset(StreamingDataset):
        This is a subclass of :class:`StreamingDataset`.
 
     Args:
-        remote (str): Download shards from this remote directory.
+        remote (str): Download shards from this remote S3 path or directory.
         local (str): Download shards to this local filesystem directory for reuse.
         shuffle (bool): Whether to shuffle the samples. Note that if `shuffle=False`, the sample order is deterministic but dependent on the DataLoader's `num_workers`.
         transform (Optional[Callable]): Optional input data transform for data augmentation, etc.
-        timeout (float): How long to wait for shard to download before raising an exception. Default: 20 sec.
-        batch_size (Optional[int]): Hint the batch_size that will be used on each device's DataLoader.
+        timeout (float): How long to wait for shard to download before raising an exception. Default: 60 sec.
+        batch_size (Optional[int]): Hint the batch_size that will be used on each device's DataLoader. Default: ``None``.
                                     Worker indices will be constructed so that there is at most 1 incomplete batch at the end of each epoch.
     """
 

--- a/composer/datasets/streaming/download.py
+++ b/composer/datasets/streaming/download.py
@@ -19,7 +19,7 @@ def wait_for_download(local: str, timeout: float = 60) -> None:
 
     Args:
         local (str): Path to file.
-        timeout (float): How long to wait before raising an exception. Default: 20 sec.
+        timeout (float): How long to wait before raising an exception. Default: 60 sec.
     """
     start_time = time()
     while True:
@@ -101,7 +101,7 @@ def safe_download(remote: str, local: str, timeout: float = 60) -> None:
     Args:
         remote (str): Remote path (S3 or local filesystem).
         local (str): Local path (local filesystem).
-        timeout (float): How long to wait for shard to download before raising an exception. Default: 20 sec.
+        timeout (float): How long to wait for shard to download before raising an exception. Default: 60 sec.
     """
     # If we already have the file cached locally, we are done.
     if os.path.exists(local):

--- a/composer/datasets/streaming/download.py
+++ b/composer/datasets/streaming/download.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 __all__ = ["safe_download"]
 
 
-def wait_for_download(local: str, timeout: float = 20) -> None:
+def wait_for_download(local: str, timeout: float = 60) -> None:
     """Block until another worker's shard download completes.
 
     Args:
@@ -92,7 +92,7 @@ def download(remote: str, local: str, timeout: float) -> None:
         raise TimeoutError(f'Waited too long (more than {timeout:.3f} sec) for download')
 
 
-def safe_download(remote: str, local: str, timeout: float = 20) -> None:
+def safe_download(remote: str, local: str, timeout: float = 60) -> None:
     """Safely downloads a file from remote to local.
        Handles multiple threads attempting to download the same shard.
        Gracefully deletes stale tmp files from crashed runs.

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -113,12 +113,12 @@ class StreamingDatasetIndex(object):
     Args:
         samples_per_shard (NDArray[np.int64]): Number of samples of each shard.
         bytes_per_shard (NDArray[np.int64]): Size in bytes of each shard.
-        bytes_per_sample (NDArray[np.uint32]): Size in bytes of each sample across all shards.
+        bytes_per_sample (NDArray[np.int64]): Size in bytes of each sample across all shards.
         fields (List[str]): The names of the samples' fields in order.
     """
 
     def __init__(self, samples_per_shard: NDArray[np.int64], bytes_per_shard: NDArray[np.int64],
-                 bytes_per_sample: NDArray[np.uint32], fields: List[str]) -> None:
+                 bytes_per_sample: NDArray[np.int64], fields: List[str]) -> None:
         self.samples_per_shard = samples_per_shard
         self.bytes_per_shard = bytes_per_shard
         self.bytes_per_sample = bytes_per_sample
@@ -160,15 +160,30 @@ class StreamingDatasetIndex(object):
         Returns:
             cls: The loaded object.
         """
-        magic, version = read_array(fp, 2, np.uint32)
+        magic, version, num_shards = read_array(fp, 3, np.uint32)
         assert magic == 0xDA7AD06E
         assert version == 1
-        total_bytes, total_samples, num_shards, num_fields = read_array(fp, 4, np.int64)
+        total_samples, total_bytes = read_array(fp, 2, np.int64)
         del total_bytes
         samples_per_shard = read_array(fp, num_shards, np.int64)
         bytes_per_shard = read_array(fp, num_shards, np.int64)
-        bytes_per_sample = read_array(fp, total_samples, np.uint32)
-        bytes_per_field = read_array(fp, num_fields, np.int64)
+        bps_format, = read_array(fp, 1, np.int32)
+        if not bps_format:
+            sample_bytes, = read_array(fp, 1, np.int64)
+            bytes_per_sample = np.full(total_samples, sample_bytes)
+        elif bps_format == 1:
+            bytes_per_sample = read_array(fp, total_samples, np.int8)
+        elif bps_format == 2:
+            bytes_per_sample = read_array(fp, total_samples, np.int16)
+        elif bps_format == 4:
+            bytes_per_sample = read_array(fp, total_samples, np.int32)
+        elif bps_format == 8:
+            bytes_per_sample = read_array(fp, total_samples, np.int64)
+        else:
+            assert False
+        bytes_per_sample = bytes_per_sample.astype(np.int64)
+        num_fields, = read_array(fp, 1, np.int32)
+        bytes_per_field = read_array(fp, num_fields, np.int32)
         fields = [fp.read(size).decode('utf-8') for size in bytes_per_field]
         return cls(samples_per_shard, bytes_per_shard, bytes_per_sample, fields)
 
@@ -180,10 +195,33 @@ class StreamingDatasetIndex(object):
         """
         magic = 0xDA7AD06E
         version = 1
-        header = np.array([magic, version], np.uint32)
-        totals = np.array([self.total_bytes, self.total_samples, self.num_shards, self.num_fields], np.int64)
-        bytes_per_field = np.array([len(field.encode('utf-8')) for field in self.fields], np.int64)
-        arrays = header, totals, self.samples_per_shard, self.bytes_per_shard, self.bytes_per_sample, bytes_per_field
+        header = np.array([magic, version, self.num_shards], np.uint32)
+        totals = np.array([self.total_samples, self.total_bytes], np.int64)
+        if not len(self.bytes_per_sample):
+            bps_format = 1
+            bps = self.bytes_per_sample.astype(np.int8)
+        elif len(set(self.bytes_per_sample)) == 1:
+            bps_format = 0
+            bps = np.int64(self.bytes_per_sample[0])
+        else:
+            max_bps = self.bytes_per_sample.max()
+            if max_bps < 256:
+                bps_format = 1
+                bps = self.bytes_per_sample.astype(np.int8)
+            elif max_bps < (1 << 16):
+                bps_format = 2
+                bps = self.bytes_per_sample.astype(np.int16)
+            elif max_bps < (1 << 32):
+                bps_format = 4
+                bps = self.bytes_per_sample.astype(np.int32)
+            else:
+                bps_format = 8
+                bps = self.bytes_per_sample
+        bps_format = np.int32(bps_format)
+        num_fields = np.int32(len(self.fields))
+        bytes_per_field = np.array([len(field.encode('utf-8')) for field in self.fields], np.int32)
+        arrays = (header, totals, self.samples_per_shard, self.bytes_per_shard, bps_format, bps, num_fields,
+                  bytes_per_field)
         array_bytes = b''.join([arr.tobytes() for arr in arrays])
         field_bytes = b''.join([field.encode('utf-8') for field in self.fields])
         return array_bytes + field_bytes

--- a/composer/datasets/streaming/writer.py
+++ b/composer/datasets/streaming/writer.py
@@ -100,11 +100,13 @@ class StreamingDatasetWriter(object):
         if self.new_samples:
             raise RuntimeError("Attempted to write index file while samples are still being processed.")
         filename = os.path.join(self.dirname, get_index_basename())
-        ndarray_samples_per_shard = np.asarray(self.samples_per_shard, np.int64)
-        ndarray_bytes_per_shard = np.asarray(self.bytes_per_shard, np.int64)
-        ndarray_bytes_per_sample = np.asarray(self.bytes_per_sample, np.int64)
-        index = StreamingDatasetIndex(ndarray_samples_per_shard, ndarray_bytes_per_shard, ndarray_bytes_per_sample,
-                                      self.fields)
+        samples_per_shard = np.array(self.samples_per_shard, np.int64)
+        bytes_per_shard = np.array(self.bytes_per_shard, np.int64)
+        bytes_per_sample = np.array(self.bytes_per_sample, np.int64)
+        assert (0 <= bytes_per_sample).all()
+        assert (bytes_per_sample < (1 << 32)).all()
+        bytes_per_sample = bytes_per_sample.astype(np.uint32)
+        index = StreamingDatasetIndex(samples_per_shard, bytes_per_shard, bytes_per_sample, self.fields)
         with open(filename, 'xb') as out:
             index.dump(out)
 

--- a/composer/datasets/streaming/writer.py
+++ b/composer/datasets/streaming/writer.py
@@ -103,9 +103,6 @@ class StreamingDatasetWriter(object):
         samples_per_shard = np.array(self.samples_per_shard, np.int64)
         bytes_per_shard = np.array(self.bytes_per_shard, np.int64)
         bytes_per_sample = np.array(self.bytes_per_sample, np.int64)
-        assert (0 <= bytes_per_sample).all()
-        assert (bytes_per_sample < (1 << 32)).all()
-        bytes_per_sample = bytes_per_sample.astype(np.uint32)
         index = StreamingDatasetIndex(samples_per_shard, bytes_per_shard, bytes_per_sample, self.fields)
         with open(filename, 'xb') as out:
             index.dump(out)

--- a/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
@@ -1,6 +1,6 @@
 train_dataset:
   streaming_ade20k:
-    remote: s3://mosaicml-internal-dataset-ade20k/mds/
+    remote: s3://mosaicml-internal-dataset-ade20k/mds/1/
     local: /tmp/mds-cache/mds-ade20k/
     split: train
     base_size: 512
@@ -12,7 +12,7 @@ train_dataset:
     shuffle: true
 val_dataset:
   streaming_ade20k:
-    remote: s3://mosaicml-internal-dataset-ade20k/mds/
+    remote: s3://mosaicml-internal-dataset-ade20k/mds/1/
     local: /tmp/mds-cache/mds-ade20k/
     split: val
     base_size: 512

--- a/composer/yamls/models/resnet50_streaming.yaml
+++ b/composer/yamls/models/resnet50_streaming.yaml
@@ -1,6 +1,6 @@
 train_dataset:
   streaming_imagenet1k:
-    remote: s3://mosaicml-internal-dataset-imagenet1k/mds/
+    remote: s3://mosaicml-internal-dataset-imagenet1k/mds/1/
     local: /tmp/mds-cache/mds-imagenet1k/
     split: train
     resize_size: -1
@@ -9,7 +9,7 @@ train_dataset:
     drop_last: true
 val_dataset:
   streaming_imagenet1k:
-    remote: s3://mosaicml-internal-dataset-imagenet1k/mds/
+    remote: s3://mosaicml-internal-dataset-imagenet1k/mds/1/
     local: /tmp/mds-cache/mds-imagenet1k/
     split: val
     resize_size: 256

--- a/scripts/mds/coco.py
+++ b/scripts/mds/coco.py
@@ -17,9 +17,8 @@ def parse_args() -> Namespace:
     args = ArgumentParser()
     args.add_argument('--in_root', type=str, required=True)
     args.add_argument('--out_root', type=str, required=True)
-    args.add_argument('--shard_size_limit', type=int, default=1 << 26)
+    args.add_argument('--shard_size_limit', type=int, default=1 << 25)
     args.add_argument('--tqdm', type=int, default=1)
-    args.add_argument('--splits', type=str, default='train,val')
     return args.parse_args()
 
 
@@ -59,8 +58,10 @@ def main(args: Namespace) -> None:
         args (Namespace): Commandline arguments.
     """
     fields = ['img', 'img_id', 'htot', 'wtot', 'bbox_sizes', 'bbox_labels']
-    splits = args.splits.split(',')
-    for split in splits:
+    for (split, expected_num_samples, shuffle) in [
+        ("train", 117266, True),
+        ("val", 4952, False),
+    ]:
         split_dir = os.path.join(args.out_root, split)
 
         img_folder = os.path.join(args.in_root, f'{split}2017')

--- a/scripts/mds/imagenet1k.py
+++ b/scripts/mds/imagenet1k.py
@@ -14,7 +14,7 @@ def parse_args() -> Namespace:
     args = ArgumentParser()
     args.add_argument('--in_root', type=str, required=True)
     args.add_argument('--out_root', type=str, required=True)
-    args.add_argument('--shard_size_limit', type=int, default=1 << 27)
+    args.add_argument('--shard_size_limit', type=int, default=1 << 25)
     args.add_argument('--tqdm', type=int, default=1)
     return args.parse_args()
 

--- a/tests/datasets/test_streaming_remote.py
+++ b/tests/datasets/test_streaming_remote.py
@@ -16,7 +16,7 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
                 batch_size: Optional[int]) -> Tuple[int, StreamingDataset]:
     dataset_map = {
         "ade20k": {
-            "remote": "s3://mosaicml-internal-dataset-ade20k/mds1/",
+            "remote": "s3://mosaicml-internal-dataset-ade20k/mds/1/",
             "num_samples": {
                 "train": 20206,
                 "val": 2000,
@@ -24,7 +24,7 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
             "class": StreamingADE20k,
         },
         "imagenet1k": {
-            "remote": "s3://mosaicml-internal-dataset-imagenet1k/mds1/",
+            "remote": "s3://mosaicml-internal-dataset-imagenet1k/mds/1/",
             "num_samples": {
                 "train": 1281167,
                 "val": 50000,
@@ -32,7 +32,7 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
             "class": StreamingImageNet1k
         },
         "coco": {
-            "remote": "s3://mosaicml-internal-dataset-coco/mds1/",
+            "remote": "s3://mosaicml-internal-dataset-coco/mds/1/",
             "num_samples": {
                 "train": 117266,
                 "val": 4952,
@@ -55,7 +55,7 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
 @pytest.mark.parametrize("name", [
     "ade20k",
     "imagenet1k",
-    pytest.param("coco", marks=pytest.mark.skip(reason="StreamingCOCO dataset needs to be debugged.")),
+    "coco",
 ])
 @pytest.mark.parametrize("split", ["val"])
 def test_streaming_remote_dataset(tmpdir: pathlib.Path, name: str, split: str) -> None:
@@ -92,7 +92,7 @@ def test_streaming_remote_dataset(tmpdir: pathlib.Path, name: str, split: str) -
 @pytest.mark.parametrize("name", [
     "ade20k",
     "imagenet1k",
-    pytest.param("coco", marks=pytest.mark.skip(reason="StreamingCOCO dataset needs to be debugged.")),
+    "coco",
 ])
 @pytest.mark.parametrize("split", ["val"])
 def test_streaming_remote_dataloader(tmpdir: pathlib.Path, name: str, split: str) -> None:
@@ -133,8 +133,8 @@ def test_streaming_remote_dataloader(tmpdir: pathlib.Path, name: str, split: str
     for epoch in range(3):
         rcvd_samples = 0
         epoch_start = time.time()
-        for _, (images, _) in enumerate(loader):
-            n_samples = images.shape[0]
+        for _, batch in enumerate(loader):
+            n_samples = batch[0].shape[0]
             rcvd_samples += n_samples
         epoch_end = time.time()
         epoch_dur = epoch_end - epoch_start

--- a/tests/datasets/test_streaming_remote.py
+++ b/tests/datasets/test_streaming_remote.py
@@ -16,7 +16,7 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
                 batch_size: Optional[int]) -> Tuple[int, StreamingDataset]:
     dataset_map = {
         "ade20k": {
-            "remote": "s3://mosaicml-internal-dataset-ade20k/mds/",
+            "remote": "s3://mosaicml-internal-dataset-ade20k/mds1/",
             "num_samples": {
                 "train": 20206,
                 "val": 2000,
@@ -24,7 +24,7 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
             "class": StreamingADE20k,
         },
         "imagenet1k": {
-            "remote": "s3://mosaicml-internal-dataset-imagenet1k/mds/",
+            "remote": "s3://mosaicml-internal-dataset-imagenet1k/mds1/",
             "num_samples": {
                 "train": 1281167,
                 "val": 50000,
@@ -32,7 +32,7 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
             "class": StreamingImageNet1k
         },
         "coco": {
-            "remote": "s3://mosaicml-internal-dataset-coco/mds/",
+            "remote": "s3://mosaicml-internal-dataset-coco/mds1/",
             "num_samples": {
                 "train": 117266,
                 "val": 4952,


### PR DESCRIPTION
Also switch the serialization of bytes_per_sample from i64 to u32, which cuts the index size in half while restricting samples to <4GB

~TODO~ DONE:
* re-generate all StreamingDataset implmentations (ADE20k, ImageNet, COCO), and upload to S3
* change defaults in YAMLs to point to new versions (e.g. `.../mds/1/`)