### PR TITLE
make ComposerClassifier torchscriptable

### DIFF
--- a/composer/models/tasks/classification.py
+++ b/composer/models/tasks/classification.py
@@ -7,8 +7,6 @@
 classification training loop with :func:`.soft_cross_entropy` loss and accuracy logging.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Any, Optional, Tuple, Union
 
@@ -85,7 +83,7 @@ class ComposerClassifier(ComposerModel):
     def metrics(self, train: bool = False) -> Union[Metric, MetricCollection]:
         return self.train_acc if train else MetricCollection([self.val_acc, self.val_loss])
 
-    def forward(self, batch: Any) -> Tensor:
+    def forward(self, batch: Tuple[Tensor, Tensor]) -> Tensor:
         inputs, _ = batch
         outputs = self.module(inputs)
         return outputs

--- a/tests/models/test_composer_model.py
+++ b/tests/models/test_composer_model.py
@@ -5,8 +5,16 @@ import copy
 import pickle
 from typing import Iterable
 
+import pytest
+import torch
+
 from composer.trainer import Trainer
-from tests.common.models import SimpleModel
+from tests.common.models import SimpleConvModel, SimpleModel
+
+
+@pytest.mark.parametrize('model', [SimpleConvModel, SimpleModel])
+def test_composermodel_torchscriptable(model):
+    torch.jit.script(model())
 
 
 def test_model_access_to_logger(dummy_train_dataloader: Iterable):


### PR DESCRIPTION
`ComposerClassifier` class was not torchscript-compatible due to:
* torchscript does not support `from future import __annotations__`
* torchscript does not support using a variable of type `Any` is a tuple, e.g. 
```
def forward(self, batch: Any):
    input, target = batch
```
instead, the type needs to be expliciti: `Tuple[Tensor, Tensor]`.

This PR fixes those issues.