### PR TITLE
Ignore params in checkpoint loading

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -491,6 +491,8 @@ class Trainer:
             Ignored if ``load_path`` is either ``None`` or a local file path. (default: ``1,048,675``)
         load_progress_bar (bool, optional): Display the progress bar for downloading the checkpoint.
             Ignored if ``load_path`` is either ``None`` or a local file path. (default: ``True``)
+        load_ignore_model_keys (List[str], optional): List of model keys to ignore when loading. For example, this can
+            be used to replace a model head in a fine-tuning run by ignoring the previous head. (default: ``None``)
         save_folder (str, optional): Format string for the folder where checkpoints are saved.
             If ``None``, checkpoints will not be saved. (default: ``None``)
 
@@ -669,6 +671,7 @@ class Trainer:
         load_strict: bool = False,
         load_chunk_size: int = 1_048_576,
         load_progress_bar: bool = True,
+        load_ignore_model_keys: Optional[List[str]] = None,
 
         # Save Checkpoint
         save_folder: Optional[str] = None,
@@ -943,7 +946,8 @@ class Trainer:
                                               load_weights_only=load_weights_only,
                                               strict_model_weights=load_strict,
                                               chunk_size=load_chunk_size,
-                                              progress_bar=load_progress_bar)
+                                              progress_bar=load_progress_bar,
+                                              ignore_model_keys=load_ignore_model_keys)
             log.info(f"Setting seed to {self.state.seed}")
             reproducibility.seed_all(self.state.seed)
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -268,6 +268,7 @@ class TrainerHparams(hp.Hparams):
         load_strict_model_weights (bool, optional): See :class:`.Trainer`.
         load_chunk_size (int, optional): See :class:`.Trainer`.
         load_progress_bar (bool, optional): See :class:`.Trainer`.
+        load_ignore_model_keys (List[str], optional): See :class:`.Trainer`.
 
         save_folder (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
         save_filename (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
@@ -416,6 +417,10 @@ class TrainerHparams(hp.Hparams):
               "This parameter has no effect if `load_path` is not specified.")),
         default=False,
     )
+    load_ignore_model_keys: List[str] = hp.optional(
+        doc=(("List of model keys to ignore when loading. For example, this can "
+              "be used to replace a model head in a fine-tuning run by ignoring the previous head.")),
+        default=None)
 
     load_chunk_size: int = hp.optional(
         doc=(("Chunk size (in bytes) to use when downloading checkpoints. "
@@ -654,6 +659,7 @@ class TrainerHparams(hp.Hparams):
             load_strict=self.load_strict_model_weights,
             load_chunk_size=self.load_chunk_size,
             load_progress_bar=self.load_progress_bar,
+            load_ignore_model_keys=self.load_ignore_model_keys,
 
             # Checkpoint Saving
             save_folder=self.save_folder,

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -417,11 +417,6 @@ class TrainerHparams(hp.Hparams):
               "This parameter has no effect if `load_path` is not specified.")),
         default=False,
     )
-    load_ignore_model_keys: List[str] = hp.optional(
-        doc=(("List of model keys to ignore when loading. For example, this can "
-              "be used to replace a model head in a fine-tuning run by ignoring the previous head.")),
-        default=None)
-
     load_chunk_size: int = hp.optional(
         doc=(("Chunk size (in bytes) to use when downloading checkpoints. "
               "This parameter has no effect if `load_path` is not specified or it is a local file path.")),
@@ -431,6 +426,11 @@ class TrainerHparams(hp.Hparams):
         doc=(("Whether to show a progress bar when downloading checkpoints. "
               "This parameter has no effect if `load_path` is not specified or it is a local file path.")),
         default=True,
+    )
+    load_ignore_model_keys: Optional[List[str]] = hp.optional(
+        doc=(("List of model keys to ignore when loading. For example, this can "
+              "be used to replace a model head in a fine-tuning run by ignoring the previous head.")),
+        default=None
     )
 
     # Save Checkpoint


### PR DESCRIPTION
- deletes ignored params from keys in state dict
- for DeepSpeed, passes custom fn for loading which removes keys and then follows same codepath as normal loading

TODO:
- test implementation

Issues:
- current version of deepspeed we use doesn't have the callback_fn