### PR TITLE
Change YAHP to YAPF in STYLE_GUIDE

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -29,7 +29,7 @@ Composer uses the [yapf](https://github.com/google/yapf) formatter for general f
 (see section 2.2). These checks can also be run manually via:
 
 ```
-pre-commit run yahp --all-files  # for yahp
+pre-commit run yapf --all-files  # for yahp
 pre-commit run isort --all-files  # for isort
 ```
 


### PR DESCRIPTION
The docs mention YAHP, but I think we mean YAPF for code formatting.