### PR TITLE
Remove no schedulers warning

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -846,7 +846,7 @@ class Trainer:
         else:
             self._scheduler_step_frequency = TimeUnit.BATCH if step_schedulers_every_batch else TimeUnit.EPOCH
 
-        if len(ensure_tuple(schedulers)) == 0:
+        if len(ensure_tuple(self.state.schedulers)) == 0:
             warnings.warn(f"NoSchedulerWarning: No schedulers were specified. The learning rate will be constant.")
 
         # Evaluators
@@ -1243,7 +1243,7 @@ class Trainer:
             if step_schedulers_every_batch is not None:
                 raise ValueError("Specifying `step_schedulers_every_batch` without `schedulers` has no effect.")
 
-        if len(ensure_tuple(schedulers)) == 0:
+        if len(ensure_tuple(self.state.schedulers)) == 0:
             warnings.warn(f"NoSchedulerWarning: No schedulers were specified. The learning rate will be constant.")
 
         # Evaluators

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -846,9 +846,6 @@ class Trainer:
         else:
             self._scheduler_step_frequency = TimeUnit.BATCH if step_schedulers_every_batch else TimeUnit.EPOCH
 
-        if len(ensure_tuple(self.state.schedulers)) == 0:
-            warnings.warn(f"NoSchedulerWarning: No schedulers were specified. The learning rate will be constant.")
-
         # Evaluators
         if eval_dataloader is None:
             evaluators: List[Evaluator] = []
@@ -1242,9 +1239,6 @@ class Trainer:
 
             if step_schedulers_every_batch is not None:
                 raise ValueError("Specifying `step_schedulers_every_batch` without `schedulers` has no effect.")
-
-        if len(ensure_tuple(self.state.schedulers)) == 0:
-            warnings.warn(f"NoSchedulerWarning: No schedulers were specified. The learning rate will be constant.")
 
         # Evaluators
         if eval_dataloader is not None:


### PR DESCRIPTION
`.fit` warns that no schedulers are set if they are set on `init`. switched warning to check for schedulers from `state.schedulers`.