### PR TITLE
Speed Monitor Part 1: ignoring validation time from training time

### DIFF
--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -59,7 +59,7 @@ class SpeedMonitor(Callback):
     +-----------------------+-------------------------------------------------------------+
     |``wall_clock/val``     | Total elapsed validation time                               |
     +-----------------------+-------------------------------------------------------------+
-    |``wall_clock/total``   | Total elapsed time                                          |
+    |``wall_clock/total``   | Total elapsed time (wall_clock/train + wall_clock/val)      |
     +-----------------------+-------------------------------------------------------------+
 
     Args:

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -66,8 +66,19 @@ class SpeedMonitor(Callback):
     def __init__(self, window_size: int = 100):
         super().__init__()
         self.train_examples_per_epoch = 0
+
+        # log the total wall clock time that this program has been running for
+        self.wall_clock_total = 0.0
+
+        # log the total wall clock_time that has been spent in training
         self.wall_clock_train = 0.0
+
+        # log the total wall clock_time that has been spent in validation
+        self.wall_clock_val = 0.0
+
         self.epoch_start_time = 0.0
+        self.validation_start_time = 0.0
+        self.epoch_time_in_validation = 0.0
         self.batch_start_num_samples = None
         self.batch_end_times: Deque[float] = deque(maxlen=window_size + 1)  # rolling list of batch end times
         self.batch_num_samples: Deque[int] = deque(maxlen=window_size)  # rolling list of num samples in batch.
@@ -85,7 +96,9 @@ class SpeedMonitor(Callback):
         current_time = time.time()
         return {
             "train_examples_per_epoch": self.train_examples_per_epoch,
-            "wall_clock_train": self.wall_clock_train,
+            "wall_clock/train": self.wall_clock_train,
+            "wall_clock/val": self.wall_clock_val,
+            "wall_clock/total": self.wall_clock_total,
             "epoch_duration": current_time - self.epoch_start_time,
             "batch_durations": [current_time - x for x in self.batch_end_times],
             "batch_num_samples": self.batch_num_samples,
@@ -104,7 +117,9 @@ class SpeedMonitor(Callback):
         current_time = time.time()
         if self.loaded_state is not None:
             self.train_examples_per_epoch = self.loaded_state["train_examples_per_epoch"]
-            self.wall_clock_train = self.loaded_state["wall_clock_train"]
+            self.wall_clock_train = self.loaded_state["wall_clock/train"]
+            self.wall_clock_val = self.loaded_state["wall_clock/val"]
+            self.wall_clock_total = self.loaded_state["wall_clock/total"]
             self.epoch_start_time = current_time - self.loaded_state["epoch_duration"]
             self.batch_end_times = deque([current_time - x for x in self.loaded_state["batch_durations"]],
                                          maxlen=self.window_size + 1)
@@ -133,15 +148,35 @@ class SpeedMonitor(Callback):
         self.train_examples_per_epoch += batch_num_samples
         if len(self.batch_end_times) == self.window_size + 1:
             throughput = sum(self.batch_num_samples) / (self.batch_end_times[-1] - self.batch_end_times[0])
-            logger.data_batch({'throughput/step': throughput})
+            logger.data_batch({'samples/step': throughput})
+
+    def eval_start(self, state: State, logger: Logger):
+        del state, logger  # unused
+        self.validation_start_time = time.time()
+
+    def eval_end(self, state: State, logger: Logger):
+        del state, logger  # unused
+        self.epoch_time_in_validation += time.time() - self.validation_start_time
 
     def epoch_end(self, state: State, logger: Logger):
         del state  # unused
-        epoch_time = time.time() - self.epoch_start_time
-        self.wall_clock_train += epoch_time
+
+        epoch_time_in_train = time.time() - self.epoch_start_time - self.epoch_time_in_validation
+        self.wall_clock_train += epoch_time_in_train
+        self.wall_clock_val += self.epoch_time_in_validation
+        self.wall_clock_total += epoch_time_in_train + self.epoch_time_in_validation
+        assert (self.wall_clock_train + self.wall_clock_val) == self.wall_clock_total
+
         logger.data_epoch({
-            "wall_clock_train": self.wall_clock_train,
+            "wall_clock/train": self.wall_clock_train,
         })
         logger.data_epoch({
-            "throughput/epoch": self.train_examples_per_epoch / epoch_time,
+            "wall_clock/val": self.wall_clock_val,
         })
+        logger.data_epoch({
+            "wall_clock/total": self.wall_clock_total,
+        })
+        logger.data_epoch({
+            "throughput/epoch/train": self.train_examples_per_epoch / epoch_time_in_train,
+        })
+        self.epoch_time_in_validation = 0.0

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -20,8 +20,8 @@ class SpeedMonitor(Callback):
 
     The training throughput in terms of number of samples per second is logged on the
     :attr:`~composer.core.event.Event.BATCH_END` event if we have reached the ``window_size`` threshold.  Per epoch
-    average throughput and wall clock train time is also logged on the :attr:`~composer.core.event.Event.EPOCH_END`
-    event.
+    average throughput and wall clock train, validation, and total time is also logged on the
+    :attr:`~composer.core.event.Event.EPOCH_END` event.
 
     Example
 
@@ -55,7 +55,11 @@ class SpeedMonitor(Callback):
     |                       | Number of samples processed per second (averaged over       |
     | ``throughput/epoch``  | an entire epoch)                                            |
     +-----------------------+-------------------------------------------------------------+
-    |``wall_clock_train``   | Total elapsed training time                                 |
+    |``wall_clock/train``   | Total elapsed training time                                 |
+    +-----------------------+-------------------------------------------------------------+
+    |``wall_clock/val``     | Total elapsed validation time                               |
+    +-----------------------+-------------------------------------------------------------+
+    |``wall_clock/total``   | Total elapsed time                                          |
     +-----------------------+-------------------------------------------------------------+
 
     Args:
@@ -177,6 +181,6 @@ class SpeedMonitor(Callback):
             "wall_clock/total": self.wall_clock_total,
         })
         logger.data_epoch({
-            "throughput/epoch/train": self.train_examples_per_epoch / epoch_time_in_train,
+            "samples/epoch": self.train_examples_per_epoch / epoch_time_in_train,
         })
         self.epoch_time_in_validation = 0.0

--- a/tests/callbacks/test_speed_monitor.py
+++ b/tests/callbacks/test_speed_monitor.py
@@ -26,15 +26,21 @@ def test_speed_monitor(composer_trainer_hparams: TrainerHparams):
 
     throughput_epoch_calls = 0
     wall_clock_train_calls = 0
+    wall_clock_val_calls = 0
+    wall_clock_total_calls = 0
     throughput_step_calls = 0
     for call_ in log_destination.log_data.mock_calls:
         metrics = call_[1][2]
-        if "throughput/step" in metrics:
+        if "samples/step" in metrics:
             throughput_step_calls += 1
-        if "throughput/epoch" in metrics:
+        if "samples/epoch" in metrics:
             throughput_epoch_calls += 1
-        if 'wall_clock_train' in metrics:
+        if 'wall_clock/train' in metrics:
             wall_clock_train_calls += 1
+        if 'wall_clock/val' in metrics:
+            wall_clock_val_calls += 1
+        if 'wall_clock/total' in metrics:
+            wall_clock_total_calls += 1
 
     assert isinstance(trainer.state.dataloader, collections.abc.Sized)
     assert trainer.state.dataloader_label is not None
@@ -42,4 +48,6 @@ def test_speed_monitor(composer_trainer_hparams: TrainerHparams):
     expected_step_calls = (trainer.state.dataloader_len - speed_monitor_hparams.window_size) * max_epochs
     assert throughput_step_calls == expected_step_calls
     assert throughput_epoch_calls == max_epochs
+    assert wall_clock_total_calls == max_epochs
     assert wall_clock_train_calls == max_epochs
+    assert wall_clock_val_calls == max_epochs


### PR DESCRIPTION
This refactors the `speed_monitor` to ignore validation time, and plots three quantities instead: (a) wall-clock time spent in training, (b) wall-clock time spent in validation, and (c) wall-clock time spent overall. 

Let's limit the scope of this PR to just fixing measuring validation on the current implementation. I agree that the speed monitor needs to be refactored, and can even get some of that in a separate PR today. However, I want to unblock others from starting runs tomorrow.

Correctness:
[Here's a WandB report](https://wandb.ai/mosaic-ml/speed_monitor_testing/reports/Ensuring-SpeedMonitor-Correctness--VmlldzoyMDIwMjE0) where I ablate the size of the validation set with three runs:
1) A baseline that trains for 1000 batches and evaluates every 1000 batches. Therefore, it runs evaluation once. 
2) A version that trains for 1000 batches and evaluates every 500 batches. Therefore, it runs evaluation twice. You should see that the time spent in `wall_clock/val` is roughly double the time that the baseline spends.
3) A version that trains for 750 batches and evaluates every 500 batches. Therefore, it runs evaluation once. You should see that the time spent in `wall_clock/train` is less than the baseline, but the time spent in `wall_clock/val` is the same as the baseline, and half the version that does it twice.

Finally, if one examines the dip in `samples/step`, then they can sanity check `wall_clock/val` against the seconds that are spent in the dip. The code should be correct.

There are quite a few improvements to this PR, such as:
1. Augment `samples/step` into `samples/train/step` and `samples/val/step`.
2. Augment `samples` into anything tracked by the Time object, such as batches, samples, or tokens.
3. Clean up the implementation
4. Rename `speed_monitor` to `throughput_monitor` or `timing_monitor`.

We should brainstorm general improvements to the `speed_monitor` during a meeting, and I'm happy to take those on in a future PR!

This should resolve #984 