### PR TITLE
Add Event.FIT_END to the training loop

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1529,6 +1529,7 @@ class Trainer:
                         )
 
                 self.engine.run_event(Event.EPOCH_CHECKPOINT)
+        self.engine.run_event(Event.FIT_END)
 
     def _handle_cuda_oom(self):
         """Handles CUDA Out of Memory and rescales if using adaptive grad_accum."""


### PR DESCRIPTION
I might be absolutely blind, but I see that we [run `Event.FIT_START`](https://github.com/mosaicml/composer/blob/dev/composer/trainer/trainer.py#L1365) in `_train_loop(...)` but never see `Event.FIT_END` actually run. If correct, then this PR aims to resolve that.