### PR TITLE
Throw an error for block-wise stochastic depth

### DIFF
--- a/composer/algorithms/stochastic_depth/stochastic_depth.py
+++ b/composer/algorithms/stochastic_depth/stochastic_depth.py
@@ -34,8 +34,8 @@ _STOCHASTIC_LAYER_MAPPING = {
 
 def apply_stochastic_depth(model: torch.nn.Module,
                            target_layer_name: str,
-                           stochastic_method: str = 'block',
-                           drop_rate: float = 0.2,
+                           stochastic_method: str = 'sample',
+                           drop_rate: float = 0.05,
                            drop_distribution: str = 'linear',
                            use_same_gpu_seed: bool = True,
                            optimizers: Optional[Union[Optimizer, Sequence[Optimizer]]] = None) -> torch.nn.Module:
@@ -160,8 +160,8 @@ class StochasticDepth(Algorithm):
 
     def __init__(self,
                  target_layer_name: str,
-                 stochastic_method: str = 'block',
-                 drop_rate: float = 0.2,
+                 stochastic_method: str = 'sample',
+                 drop_rate: float = 0.05,
                  drop_distribution: str = 'linear',
                  drop_warmup: Union[float, Time, str] = 0.0,
                  use_same_gpu_seed: bool = True):
@@ -249,6 +249,9 @@ def _validate_stochastic_hparams(target_layer_name: str,
                                  drop_distribution: str,
                                  drop_warmup: str = "0dur"):
     """Helper function to validate the Stochastic Depth hyperparameter values."""
+
+    if stochastic_method == 'block':
+        raise ValueError("Block-wise Stochastic Depth is under development, use 'sample' instead for regularization.")
 
     if stochastic_method and (stochastic_method not in _STOCHASTIC_LAYER_MAPPING):
         raise ValueError(f"stochastic_method {stochastic_method} is not supported."

--- a/composer/yamls/algorithms/stochastic_depth.yaml
+++ b/composer/yamls/algorithms/stochastic_depth.yaml
@@ -1,6 +1,6 @@
-stochastic_method: block
+stochastic_method: sample
 target_layer_name: ResNetBottleneck
-drop_rate: 0.2
+drop_rate: 0.05
 drop_distribution: "linear"
 use_same_gpu_seed: false
 drop_warmup: 0.0dur

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -103,7 +103,6 @@ Composer is part of the broader Machine Learning community, and we welcome any c
    method_cards/selective_backprop.md
    method_cards/seq_length_warmup.md
    method_cards/squeeze_excite.md
-   method_cards/stochastic_depth.md
    method_cards/stochastic_depth_samplewise.md
    method_cards/swa.md
 


### PR DESCRIPTION
Block-wise stochastic depth started to freeze training at some point, maybe when the optimizers were integrated into model surgery. This is a pretty bad bug, so it is better to throw an error if block-wise SD is used and to change the defaults to use sample-wise SD. Also, remove the method card from documentation.