### PR TITLE
[WIP] Add support for Apple M1

### DIFF
--- a/composer/trainer/devices/device_hparams.py
+++ b/composer/trainer/devices/device_hparams.py
@@ -13,6 +13,7 @@ import yahp as hp
 from composer.trainer.devices.device import Device
 from composer.trainer.devices.device_cpu import DeviceCPU
 from composer.trainer.devices.device_gpu import DeviceGPU
+from composer.trainer.devices.device_mps import DeviceMPS
 
 __all__ = ["DeviceHparams", "CPUDeviceHparams", "GPUDeviceHparams"]
 
@@ -40,3 +41,11 @@ class CPUDeviceHparams(DeviceHparams):
 
     def initialize_object(self) -> DeviceCPU:
         return DeviceCPU()
+
+
+@dataclass
+class MPSDeviceHparams(DeviceHparams):
+    """Used to construct a :class:`.DeviceCPU`"""
+
+    def initialize_object(self) -> DeviceMPS:
+        return DeviceMPS()

--- a/composer/trainer/devices/device_mps.py
+++ b/composer/trainer/devices/device_mps.py
@@ -1,0 +1,43 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The GPU device used for training."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, TypeVar
+
+import torch
+import torch.cuda.amp
+import torch.utils.data
+
+from composer.trainer.devices.device import Device
+
+__all__ = ["DeviceMPS"]
+
+T_nnModule = TypeVar("T_nnModule", bound=torch.nn.Module)
+
+
+class DeviceMPS(Device):
+    """An extension of :class:`~composer.trainer.devices.device.Device` for MPS,
+    which is Apple's backend for training models on M1 chips.
+
+    This class takes no arguments.
+    """
+    dist_backend = ""
+
+    def __init__(self):
+        self._device = torch.device("mps")
+
+    def module_to_device(self, module: T_nnModule) -> T_nnModule:
+        return module.to(self._device)
+
+    def tensor_to_device(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor.to(self._device, non_blocking=True)
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {}
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        if len(state) != 0:
+            raise ValueError("MPS device has no state.")

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -38,6 +38,7 @@ from composer.trainer._scale_schedule import scale_pytorch_scheduler
 from composer.trainer._scaler import ClosureGradScaler
 from composer.trainer.ddp import DDPSyncStrategy, ddp_sync_context, prepare_ddp_module
 from composer.trainer.devices import Device, DeviceCPU, DeviceGPU
+from composer.trainer.devices.device_mps import DeviceMPS
 from composer.utils import dist, ensure_tuple, format_name_with_dist, map_collection, module_surgery, reproducibility
 from composer.utils.checkpoint import load_checkpoint, save_checkpoint
 from composer.utils.file_helpers import GetFileNotFoundException
@@ -167,8 +168,10 @@ def _get_device(device: Optional[Union[str, Device]]):
             device = DeviceCPU()
         elif device.lower() == 'gpu':
             device = DeviceGPU()
+        elif device.lower() in ['mps', 'apple', 'm1']:
+            device = DeviceMPS()
         else:
-            raise ValueError(f'device ({device}) must be one of (cpu, gpu).')
+            raise ValueError(f'device ({device}) must be one of (cpu, gpu, mps).')
     return device
 
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -43,6 +43,7 @@ from composer.optim import (AdamHparams, AdamWHparams, ComposerScheduler, Consta
 from composer.profiler.profiler_hparams import ProfilerHparams
 from composer.trainer.ddp import DDPSyncStrategy
 from composer.trainer.devices import CPUDeviceHparams, DeviceHparams, GPUDeviceHparams
+from composer.trainer.devices.device_hparams import MPSDeviceHparams
 from composer.trainer.trainer import Trainer
 from composer.utils import dist, reproducibility
 from composer.utils.object_store import ObjectStoreHparams
@@ -114,6 +115,7 @@ callback_registry = {
 device_registry = {
     "gpu": GPUDeviceHparams,
     "cpu": CPUDeviceHparams,
+    "mps": MPSDeviceHparams,
 }
 
 evaluator_registry = {"evaluator": EvaluatorHparams}


### PR DESCRIPTION
This PR adds the `mps` device, to support training models on apple m1 chips. Users will currently need to install the pytorch-nightly version. 

```
>> python examples/adding_custom_models.py  # after adding in `device='mds'`
Epoch     0 train 100%|█████████████████████████| 235/235 [00:08<00:00, 26.44it/s, loss/train=0.4254]                 
Epoch     1 train 100%|█████████████████████████| 235/235 [00:09<00:00, 24.56it/s, loss/train=0.2338]                 
Epoch     2 train 100%|█████████████████████████| 235/235 [00:10<00:00, 23.04it/s, loss/train=0.2006]
```

This is a WIP PR -> there are still some remaining issues with using the `mds` device. e.g. using an eval_dataloader yields an error:
```
raise ValueError("The `target` has to be a non-negative tensor.")
    ValueError: The `target` has to be a non-negative tensor.
```


Update: this is blocked by https://github.com/pytorch/pytorch/issues/77849