### PR TITLE
Fix `Engine.close()` and WandB Atexit logic

### DIFF
--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -342,10 +342,8 @@ class Engine():
 
     def __del__(self):
         global _did_atexit_run
-        if _did_atexit_run:
-            # Do not attempt to shutdown again, since close() already ran via __atexit__
-            # In this case, close() is no longer idempotent, since Python machenry (such as the ability to do
-            # conditional imports) has already been destroyed
+        if _did_atexit_run or self._is_closed:
+            # Do not attempt to shutdown again, since close() already ran via __atexit__ or was already invoked
             return
         self.close()
 

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 import atexit
 import contextlib
 import logging
+import weakref
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import ContextManager, Dict, Optional, Sequence, Union, cast
@@ -144,6 +145,11 @@ def _setup_trace(algorithms: Sequence[Algorithm], event: Event) -> Traces:
     :class:`Trace`.
     """
     return OrderedDict([(f'{algo}/{event}', Trace()) for algo in algorithms])
+
+
+# Track which callbacks are already open, so it is possible to error and instruct the user to call
+# previous_trainer.close() if necessary before attempting to reuse a callback
+_OPEN_CALLBACKS = weakref.WeakSet()
 
 
 class Engine():
@@ -328,6 +334,19 @@ class Engine():
         """
         event = Event(event)
 
+        if event == Event.INIT:
+            # Some callbacks may be open from a previous training run
+            # If so, error and instruct the user that they must call `trainer.close()`
+            # so callbacks can clean up and reset their state properly
+            for cb in self.state.callbacks:
+                # If it's not in the dictionary, then the callback is new, so it's closed by definition
+                if cb in _OPEN_CALLBACKS:
+                    raise RuntimeError(
+                        ("Cannot create a new trainer with an open callback or logger from a previous trainer. "
+                         "To fix, call trainer.close() before creating this new trainer to ensure that all "
+                         "callbacks or loggers shut down properly."))
+                _OPEN_CALLBACKS.add(cb)
+
         for cb in self.state.callbacks:
             marker = None
             if self.state.profiler is not None:
@@ -348,7 +367,7 @@ class Engine():
         self.close()
 
     def close(self) -> None:
-        """Shutdown the enginge.
+        """Shutdown the engine.
 
         As part of the shutdown procedure, :meth:`~.Callback.close` and :meth:`~.Callback.post_close` is invoked
         for each callback. Note that :meth:`~.Callback.post_close` is invoked only for callbacks that did not raise
@@ -386,3 +405,5 @@ class Engine():
                     callback.post_close()
                 except Exception as e:
                     log.error(f"Error running {callback.__class__.__name__}.post_close().", exc_info=e, stack_info=True)
+                else:
+                    _OPEN_CALLBACKS.discard(callback)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -144,9 +144,14 @@ def test_engine_is_dead_after_close(dummy_state: State, dummy_logger: Logger):
 class IsClosedCallback(Callback):
 
     def __init__(self) -> None:
+        self.is_closed = True
+
+    def init(self, state: State, logger: Logger) -> None:
+        assert self.is_closed
         self.is_closed = False
 
     def close(self, state: State, logger: Logger) -> None:
+        assert not self.is_closed
         self.is_closed = True
 
 
@@ -165,6 +170,40 @@ def test_engine_closes_on_del(dummy_state: State, dummy_logger: Logger):
 
     # Assert it is closed
     assert is_closed_callback.is_closed
+
+
+class DummyTrainer:
+    """Helper to simulate what the trainer does w.r.t. events"""
+
+    def __init__(self, state: State, logger: Logger) -> None:
+        self.engine = Engine(state, logger)
+        for cb in self.engine.state.callbacks:
+            cb.run_event(Event.INIT, self.engine.state, self.engine.logger)
+
+    def close(self):
+        self.engine.close()
+
+
+def test_engine_triggers_close_only_once(dummy_state: State, dummy_logger: Logger):
+    # Create the trainer and run an event
+    is_closed_callback = IsClosedCallback()
+    dummy_state.callbacks.append(is_closed_callback)
+
+    # Create the trainer
+    trainer = DummyTrainer(dummy_state, dummy_logger)
+
+    # Close the trainer
+    trainer.close()
+
+    # Assert it is closed
+    assert is_closed_callback.is_closed
+
+    # Create a new trainer with the same callback. Should implicitly trigger __del__ AFTER
+    # AFTER DummyTrainer was constructed
+    trainer = DummyTrainer(dummy_state, dummy_logger)
+
+    # Assert it is open
+    assert not is_closed_callback.is_closed
 
 
 def check_output(proc: subprocess.CompletedProcess):


### PR DESCRIPTION
If a user something like this:

```python
cb = MyCallback()
trainer = Trainer(
  ...
  callbacks=cb,
)
trainer.close()
trainer = Trainer(
  ...
  callbacks=cb,
)
```

Then `__del__` for the first trainer will be triggered _after_ the new trainer is constructed. causing `MyCallback` to run `init()` (from the first trainer), `init()` (from the 2nd trainer), `close()` (from the first trainer), and then `close()` (from the second trainer). This ordering is incorrect.

This PR fixes it by: 
* Only calling `Engine.close()` if it has not been invoked already, so the sequence will be `init()`, `close()`, `init()`, `close()`.
* Erroring if the user forgets to call `trainer.close()`, since `__del__` from the new trainer would be invoked _after_ the new trainer would fire `Event.INIT` (it is not possible to elegantly close the previous trainer, since the new trainer would need access to the previous trainer's state and logger). Implemented via `weakref` in the engine as not to require any `super()` calls in the callback implementations to callback parent classes.


In addition, Weights and Biases has a bug where it errors if `wandb.finish` is called multiple times during an `atexit` procedure. To fix, this PR introduces another `atexit` callback into our own `WandBLogger` to ensure that `wandb.finish()` is _not_ called if `post_close()` was triggered by `atexit`. This is a bit hacky until WandB provides a reliable way to tell whether `wandb.finish()` has already been called.