### PR TITLE
Add intersphinx references to hf datasets + transformers

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -154,6 +154,8 @@ intersphinx_mapping = {
     'libcloud': ('https://libcloud.readthedocs.io/en/stable/', None),
     'PIL': ('https://pillow.readthedocs.io/en/stable', None),
     'coolname': ('https://coolname.readthedocs.io/en/latest/', None),
+    'datasets': ('https://huggingface.co/docs/datasets/master/en/', None),
+    'transformers': ('https://huggingface.co/docs/transformers/master/en/', None),
 }
 
 nitpicky = False  # warn on broken links


### PR DESCRIPTION
Right now references to `transformers.Whatever` and `datasets.Whatever` don't link to the corresponding huggingface classes. This PR is a two-line change to our intersphinx mapping to fix this.

Can verify that links now work on the generated [models.BERT page](https://mosaicml-composer--1075.com.readthedocs.build/en/1075/api_reference/composer.models.bert.model.html?highlight=composertransformer) or [ComposerTransformer](https://mosaicml-composer--1075.com.readthedocs.build/en/1075/api_reference/composer.models.transformer_shared.html#composer.models.transformer_shared.ComposerTransformer) page. [Current docs](https://docs.mosaicml.com/en/stable/api_reference/composer.models.bert.model.html) (without working links) for reference.