### PR TITLE
Fix `grad_accum='auto'` microbatch override

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1587,9 +1587,9 @@ class Trainer:
         """
         assert self._train_data_spec is not None, "The train data spec should be set on __init__ or fit()"
 
-        # Cache the device minibatch, because `self.state.batch` gets overridden in microbatching loop
-        # TODO: fix this name collision!!
-        minibatch = self.state.batch
+        # Cache the device batch, because `self.state.batch` gets overridden in microbatching loop
+        # TODO: fix this name collision!
+        device_batch = self.state.batch
 
         # Retry until we successfully complete training and return loss
         while True:
@@ -1599,7 +1599,7 @@ class Trainer:
             caught_timeout_error = None
             try:
                 assert self.state.scaler is not None
-                microbatches = self._train_data_spec.split_batch(minibatch, self.state.grad_accum)
+                microbatches = self._train_data_spec.split_batch(device_batch, self.state.grad_accum)
                 if self.deepspeed_enabled:
                     total_loss = self._train_microbatches(microbatches)
                 elif self._use_closures():

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1587,6 +1587,10 @@ class Trainer:
         """
         assert self._train_data_spec is not None, "The train data spec should be set on __init__ or fit()"
 
+        # Cache the device minibatch, because `self.state.batch` gets overridden in microbatching loop
+        # TODO: fix this name collision!!
+        minibatch = self.state.batch
+
         # Retry until we successfully complete training and return loss
         while True:
             total_loss = None
@@ -1595,7 +1599,7 @@ class Trainer:
             caught_timeout_error = None
             try:
                 assert self.state.scaler is not None
-                microbatches = self._train_data_spec.split_batch(self.state.batch, self.state.grad_accum)
+                microbatches = self._train_data_spec.split_batch(minibatch, self.state.grad_accum)
                 if self.deepspeed_enabled:
                     total_loss = self._train_microbatches(microbatches)
                 elif self._use_closures():

--- a/tests/callbacks/test_early_stopper.py
+++ b/tests/callbacks/test_early_stopper.py
@@ -16,7 +16,7 @@ from tests.metrics import MetricSetterCallback
 
 
 @device('cpu', 'gpu')
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 @pytest.mark.parametrize('metric_sequence', [[0.1, 0.2, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.2, 1.3], [0.1, 0.2]])
 @pytest.mark.parametrize('unit', [TimeUnit.EPOCH, TimeUnit.BATCH])
 def test_early_stopper(metric_sequence: List[float], unit: TimeUnit, device: str):

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -41,6 +41,7 @@ def write_synthetic_streaming_dataset(dirname: str, samples: List[Dict[str, byte
         writer.write_samples(samples=samples)
 
 
+@pytest.mark.timeout(10)
 @pytest.mark.parametrize("num_samples", [100, 10000])
 @pytest.mark.parametrize("shard_size_limit", [1 << 8, 1 << 16, 1 << 24])
 def test_writer(remote_local: Tuple[str, str], num_samples: int, shard_size_limit: int) -> None:
@@ -61,6 +62,7 @@ def test_writer(remote_local: Tuple[str, str], num_samples: int, shard_size_limi
     assert len(files) == expected_num_files, f"Files written ({len(files)}) != expected ({expected_num_files})."
 
 
+@pytest.mark.timeout(10)
 @pytest.mark.parametrize("batch_size", [None, 1, 2])
 @pytest.mark.parametrize("share_remote_local", [False, True])
 @pytest.mark.parametrize("shuffle", [False, True])


### PR DESCRIPTION
This PR addresses an issue with `grad_accum: auto` due to Composer's internal `state.batch` overriding behavior.

Assume we are in a situation like `train_batch_size: 128`, on 8 GPUs, and `grad_accum: auto`, but in truth we can only fit device microbatches of size `1` (not known ahead of time). So we should expect `Trainer` keep catching OOMs and increasing `grad_accum` until it hits `grad_accum: 16`.

Here's what currently happens:

> We start with `grad_accum = 1` by default.
> On step 0 we have `self.state.batch` == "the device batch", of size 128 // 8 = 16.
> We enter the microbatching loop
> Then `self.state.batch` is overwritten to be "the device microbatch", which is size 16 // 1 = 16
> We OOM, catch it, double the `grad_accum=2`, and start again

> **Here is the bug**: On this attempt, we have `self.state.batch` == "the device microbatch", which is still 16
> We enter the microbatching loop
> Then `self.state.batch` is overwritten to be "the device microbatch", which is size 16 // 2 = 8
> We OOM, catch it, double the `grad_accum=4`, and start again

> **Here is the bug**: On this attempt, we have `self.state.batch` == "the device microbatch", **which is now 8**
> We enter the microbatching loop
> Then `self.state.batch` is overwritten to be "the device microbatch", which is size 8 // 4 = 2
> We OOM, catch it, double the `grad_accum=8`, and start again

> **Here is the bug**: On this attempt, we have `self.state.batch` == "the device microbatch", **which is now 2**
> We enter the microbatching loop
> Then `self.state.batch` is overwritten to be "the device microbatch", which is size 2 // 8 = ???
> We get an exception like "cannot split a batch of size 2 into 8 chunks"


I ran into this bug when attempting to use `grad_accum: auto` with some NLP workloads that require small device microbatch sizes. I've tested on this branch since and everything seems to work :) 