### PR TITLE
Update Resnet Cifar README.md

### DIFF
--- a/composer/models/resnet_cifar/README.md
+++ b/composer/models/resnet_cifar/README.md
@@ -56,7 +56,7 @@ schedulers:
         - "120ep"
       gamma: 0.1
 train_batch_size: 1024
-max_duration: 16ep
+max_duration: 160ep
 ```
 
 ## Attribution


### PR DESCRIPTION
Fix #1016 

> "Model card should say 160 epochs, not 16 epochs"