### PR TITLE
Track dataloader samples and tokens; remove `batch_num_samples` and `batch_num_tokens` from the state.

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -105,8 +105,6 @@ class State(Serializable):
     Attributes:
         batch (types.Batch): The batch. This will be the entire batch during the :attr:`.Event.AFTER_DATALOADER`, or a
             microbatch between :attr:`.Event.BATCH_START` and :attr:`.Event.BATCH_END`.
-        batch_num_samples (int): The number of samples in the :attr:`batch`.
-        batch_num_tokens (int): The number of tokens in the :attr:`batch`.
         current_metrics (Dict[str, Dict[str, Any]]): The current computed metrics, organized by dataloader label
             and then by metric name. The train dataloader is labeled ``'train'``. If not using an :class:`.Evaluator`,
             the eval dataloader is labeled ``'eval'``. Otherwise, the evaluator label is used.
@@ -266,8 +264,6 @@ class State(Serializable):
 
         # Set defaults for transient variables (to make pyright happy)
         self.batch: Any = None
-        self.batch_num_samples = 0
-        self.batch_num_tokens = 0
         self.loss: Union[torch.Tensor, Sequence[torch.Tensor]] = torch.Tensor()
         self.outputs: Union[torch.Tensor, Sequence[torch.Tensor]] = torch.Tensor()
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1427,8 +1427,8 @@ class Trainer:
 
                     self.state.batch = self._device.batch_to_device(self.state.batch)
                     self.state.batch = self._train_data_spec.device_transforms(self.state.batch)
-                    self.state.batch_num_samples = self._train_data_spec.get_num_samples_in_batch(self.state.batch)
-                    self.state.batch_num_tokens = self._train_data_spec.get_num_tokens_in_batch(self.state.batch)
+                    rank_num_samples = self._train_data_spec.get_num_samples_in_batch(self.state.batch)
+                    rank_num_tokens = self._train_data_spec.get_num_tokens_in_batch(self.state.batch)
 
                     if self.deepspeed_enabled:
                         self.state.batch = _fix_batch_precision_for_deepspeed(self.state.batch, self.state.precision)
@@ -1443,9 +1443,6 @@ class Trainer:
                                 self.train_metrics.update(*self._original_model.validate(eval_microbatch))
 
                     self.state.model.train()
-
-                    rank_num_samples = self.state.batch_num_samples
-                    rank_num_tokens = self.state.batch_num_tokens
 
                     self.engine.run_event(Event.AFTER_DATALOADER)
 
@@ -1568,16 +1565,6 @@ class Trainer:
                     log_level=log_level,
                 )
 
-    def _handle_cuda_oom(self):
-        """Handles CUDA Out of Memory and rescales if using adaptive grad_accum."""
-        # Raise runtime error if training 1 sample at a time still resulted in CUDA out of memory
-        if self.state.grad_accum == self.state.batch_num_samples:
-            raise RuntimeError(("CUDA out of memory. The train loop failed with an internal microbatch of size 1."
-                                "The GPU does not have enough memory to process even 1 sample."))
-        else:
-            self.state.grad_accum = min(2 * self.state.grad_accum, self.state.batch_num_samples)
-            self.logger.data_batch({'trainer/grad_accum': self.state.grad_accum})
-
     def _train_batch(self, use_grad_scaling: bool):
         """Compute loss by training on a full batch of data. Adaptively change microbatch size if enabled to maximize
         GPU usage.
@@ -1637,7 +1624,15 @@ class Trainer:
             if int(should_handle_cuda_oom.item()) == 1:
                 # If any rank hit CUDA OOM, update grad_accum and retry. Ignore any caught_timeout_error since
                 # it is likely transient, e.g. timeout because certain ranks OOMed and didn't reach barrier.
-                self._handle_cuda_oom()
+                # Raise runtime error if training 1 sample at a time still resulted in CUDA out of memory
+                device_batch_size = self._train_data_spec.get_num_samples_in_batch(device_batch)
+                if self.state.grad_accum == device_batch_size:
+                    raise RuntimeError(
+                        ("CUDA out of memory. The train loop failed with an internal microbatch of size 1."
+                         "The GPU does not have enough memory to process even 1 sample."))
+                else:
+                    self.state.grad_accum = min(2 * self.state.grad_accum, device_batch_size)
+                    self.logger.data_batch({'trainer/grad_accum': self.state.grad_accum})
             elif caught_timeout_error:
                 # If not CUDA out of memory, raise exception to user. Note that this truncates the call stack
                 # back only to this newly raised error.
@@ -1807,16 +1802,16 @@ class Trainer:
             self.engine.run_event(Event.PREDICT_START)
 
             for self.state.batch in self._iter_dataloader():
-                # Update the batch size and num tokens
-                self.state.batch_num_samples = data_spec.get_num_samples_in_batch(self.state.batch)
-                self.state.batch_num_tokens = data_spec.get_num_tokens_in_batch(self.state.batch)
-
                 # Move the batch onto the device
                 self.state.batch = self._device.batch_to_device(self.state.batch)
 
                 # Perform any device transforms
                 if data_spec.device_transforms is not None:
                     self.state.batch = data_spec.device_transforms(self.state.batch)
+
+                # Count the batch size and num tokens before any events run
+                rank_num_samples = data_spec.get_num_samples_in_batch(self.state.batch)
+                rank_num_tokens = data_spec.get_num_tokens_in_batch(self.state.batch)
 
                 # Fix the batch if using DeepSpeed
                 if self.deepspeed_enabled:
@@ -1832,8 +1827,8 @@ class Trainer:
                 batch_time = now - last_wct
 
                 total_num_samples, total_num_tokens, batch_time = self._accumulate_time_across_ranks(
-                    num_samples=self.state.batch_num_samples,
-                    num_tokens=self.state.batch_num_tokens,
+                    num_samples=rank_num_samples,
+                    num_tokens=rank_num_tokens,
                     batch_time=batch_time,
                 )
 
@@ -1926,8 +1921,10 @@ class Trainer:
                 self.state.batch = self._device.batch_to_device(self.state.batch)
                 if data_spec.device_transforms is not None:
                     self.state.batch = data_spec.device_transforms(self.state.batch)
-                self.state.batch_num_samples = data_spec.get_num_samples_in_batch(self.state.batch)
-                self.state.batch_num_tokens = data_spec.get_num_tokens_in_batch(self.state.batch)
+
+                # Count the batch size and num tokens before any events run
+                rank_num_samples = data_spec.get_num_samples_in_batch(self.state.batch)
+                rank_num_tokens = data_spec.get_num_tokens_in_batch(self.state.batch)
 
                 if self.deepspeed_enabled:
                     self.state.batch = _fix_batch_precision_for_deepspeed(self.state.batch, self.state.precision)
@@ -1945,8 +1942,8 @@ class Trainer:
                 batch_time = now - last_wct
 
                 total_num_samples, total_num_tokens, batch_time = self._accumulate_time_across_ranks(
-                    num_samples=self.state.batch_num_samples,
-                    num_tokens=self.state.batch_num_tokens,
+                    num_samples=rank_num_samples,
+                    num_tokens=rank_num_tokens,
                     batch_time=batch_time,
                 )
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -858,7 +858,7 @@ class AssertDataAugmented(Callback):
         if state.grad_accum != 1:
             raise ValueError(f'This check assumes grad_accum of 1, got {state.grad_accum}')
         batch_idx = state.timestamp.batch_in_epoch.value
-        batch_size = state.batch_num_samples
+        batch_size = len(state.batch[0])
         original_batch = self.dataset[batch_idx:batch_idx + batch_size]
         original_outputs = state.model(original_batch)
 


### PR DESCRIPTION
Implement what was decided during design reivew on https://www.notion.so/Fix-Time-Tracking-d63e5ed67245405ca7c07032c3d5385c