### PR TITLE
Write imagenet in ffcv format using streaming

### DIFF
--- a/composer/datasets/ffcv_utils.py
+++ b/composer/datasets/ffcv_utils.py
@@ -43,7 +43,6 @@ def ffcv_monkey_patches():
 
 
 def write_ffcv_dataset(dataset: Optional[Dataset] = None,
-                       remote: Optional[str] = None,
                        write_path: str = "/tmp/dataset.ffcv",
                        max_resolution: Optional[int] = None,
                        num_workers: int = 16,
@@ -51,11 +50,10 @@ def write_ffcv_dataset(dataset: Optional[Dataset] = None,
                        compress_probability: float = 0.50,
                        jpeg_quality: float = 90,
                        chunk_size: int = 100):
-    """Converts PyTorch ``dataset`` or streaming dataset at ``remote`` into FFCV format at filepath ``write_path``.
+    """Converts PyTorch compatible ``dataset`` into FFCV format at filepath ``write_path``.
 
     Args:
         dataset (Iterable[Sample]): A PyTorch dataset. Default: ``None``.
-        remote (str): A remote path for a streaming dataset. Default: ``None``.
         write_path (str): Write results to this file. Default: ``"/tmp/dataset.ffcv"``.
         max_resolution (int): Limit resolution if provided. Default: ``None``.
         num_workers (int): Numbers of workers to use. Default: ``16``.
@@ -66,8 +64,8 @@ def write_ffcv_dataset(dataset: Optional[Dataset] = None,
     """
 
     _require_ffcv()
-    if dataset is None and remote is None:
-        raise ValueError("At least one of dataset or remote should not be None.")
+    if dataset is None:
+        raise ValueError("dataset should not be None.")
 
     log.info(f"Writing dataset in FFCV <file>.ffcv format to {write_path}.")
     writer = ffcv.writer.DatasetWriter(write_path, {
@@ -80,7 +78,4 @@ def write_ffcv_dataset(dataset: Optional[Dataset] = None,
             ffcv.fields.IntField()
     },
                                        num_workers=num_workers)
-    if dataset:
-        writer.from_indexed_dataset(dataset, chunksize=chunk_size)
-    elif remote is not None:
-        raise NotImplementedError("FFCV with remote datasets is not implemented")
+    writer.from_indexed_dataset(dataset, chunksize=chunk_size)

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -14,7 +14,6 @@ from typing import Any, Callable, Dict, Iterator, Optional, Tuple
 import numpy as np
 from PIL import Image
 from torch.utils.data import IterableDataset
-from torchvision import transforms
 
 from composer.datasets.streaming.download import download_or_wait
 from composer.datasets.streaming.format import (StreamingDatasetIndex, bytes_to_sample_dict, get_index_basename,
@@ -388,7 +387,7 @@ class StreamingImageClassDataset(StreamingDataset):
                          max_retries=max_retries,
                          timeout=timeout,
                          batch_size=batch_size)
-        self.transform = transform or transforms.ToTensor()
+        self.transform = transform
 
     def __getitem__(self, idx: int) -> Tuple[Any, Any]:
         """Get the decoded and transformed (image, class) pair by ID.
@@ -401,6 +400,6 @@ class StreamingImageClassDataset(StreamingDataset):
         """
         obj = super().__getitem__(idx)
         x = obj['x']
-        x = self.transform(x)
+        x = self.transform(x) if self.transform else x
         y = obj['y']
         return x, y


### PR DESCRIPTION
Add support for writing imagenet dataset in ffcv format using streaming dataset. 

Test:

Imagenet
```
python scripts/ffcv/create_ffcv_datasets.py
python scripts/ffcv/create_ffcv_datasets.py --split val
```