### PR TITLE
Revert back to DeepSpeed FP16 defaults to prevent underflow

### DIFF
--- a/composer/trainer/_deepspeed.py
+++ b/composer/trainer/_deepspeed.py
@@ -97,10 +97,6 @@ def _add_precision_config(config: Dict[str, Any], state: State):
         fp16_config = config["fp16"]
         assert isinstance(fp16_config, dict)
 
-        # For equivalence with the non-DeepSpeed defaults of the Mosaic trainer.
-        fp16_config.setdefault("initial_scale_power", 16)
-        fp16_config.setdefault("loss_scale_window", 2000)
-
 
 def _add_other_config(config: Dict[str, Any], grad_clip_norm: float):
     if "gradient_clipping" in config:


### PR DESCRIPTION
Our custom defaults are causing convergence problems with DS+FP16 -- removing these yields proper convergence. I spoke to @abhi-mosaic about it and we should be able to remove it entirely.