### PR TITLE
Pin `protobufs<3.21.0` when using `wandb`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ extra_deps["deepspeed"] = [
 
 extra_deps["wandb"] = [
     "wandb>=0.12.10,<0.12.17",
+    "protobuf<3.21.0",
 ]
 
 extra_deps["unet"] = [


### PR DESCRIPTION
Installing composer with `pip install mosaicml[all]` and then performing `import composer` was generating the following error message:

```
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

To fix, this PR forces the protobuf package to be `<3.21.0`.