### PR TITLE
Fix `traitlets` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ extra_deps["dev"] = [
     "sphinx_panels==0.6.0",
     "sphinxcontrib-images==0.9.4",
     "pytest_codeblocks==0.15.0",
+    "traitlets==5.1.1",  # required by testbook. Version 5.2.2 has an import bug, so pinning to 5.1.1, which worked previously.
 ]
 
 extra_deps["deepspeed"] = [


### PR DESCRIPTION
`traitlets` is required by `testbook`. `traitlets` version 5.2.2 has an import bug, so pinning to 5.1.1, which worked previously.