### PR TITLE
Treat `DeprecationWarning` as a warning in tests, not error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ markers = [
 ]
 filterwarnings = [
     "error",  # Mark all warnings as errors
+    "default::DeprecationWarning",  # But treat all deprecation warnings as warnings
     'ignore:Deterministic mode is activated:UserWarning',  # All tests run with deterministic mode
     'ignore:SubsetNumBatchesWarning',  # SubsetNumBatches is used extensively in testing
     # allow training metrics


### PR DESCRIPTION
Deprecation or other warnings can occur whenever a new package version is released that we haven't tested against yet (even minor releases). For contributors, that means that their local pytest returns an error on parts of the codebase that is not part of their actual contribution, making it difficult to make progress.

e.g. someone contributing an algo would be forced to fix warnings in esoteric parts of the codebase. Or, end up figuring out how to add filterwarnings to an unrelated test, and make that judgement call.