### PR TITLE
Force `wandb` to version `0.12.17` or greater.

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - coolname >=1.1.0,<2
     - py-cpuinfo>=8.0.0
   run_constrained:
-    - wandb >=0.12.10,<0.13
+    - wandb >=0.12.17,<0.13
     - monai >=0.8.0,<0.9
     - scikit-learn >=1.0.1,<2
     # - timm >=0.5.4 # This timm version is not available on conda
@@ -58,7 +58,7 @@ test:
     - testbook ==0.4.2
     # Including all run_constrained requirements in the test requirements, so those tests will not be import-skipped
     - pip # Since deepspeed and timm are not available on anaconda, they are installed via pip.
-    - wandb >=0.12.10,<0.13
+    - wandb >=0.12.17,<0.13
     - monai >=0.8.0,<0.9
     - scikit-learn >=1.0.1,<2
     # - timm >=0.5.4 # This timm version is not available on conda; installing via pip

--- a/setup.py
+++ b/setup.py
@@ -129,8 +129,7 @@ extra_deps["deepspeed"] = [
 ]
 
 extra_deps["wandb"] = [
-    "wandb>=0.12.10,<0.12.17",
-    "protobuf<3.21.0",
+    "wandb>=0.12.17,<0.13",
 ]
 
 extra_deps["unet"] = [


### PR DESCRIPTION
Using old versions of `wandb`results in a protobuf error. This PR pins `"wandb>=0.12.17,<0.13"`.