### PR TITLE
Add version to the composer launcher; fixed `python -m composer`

### DIFF
--- a/composer/__main__.py
+++ b/composer/__main__.py
@@ -1,4 +1,6 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Composer CLI."""
+"""Runs the Composer CLI."""
+
+from composer.cli import __main__

--- a/composer/cli/__main__.py
+++ b/composer/cli/__main__.py
@@ -1,0 +1,10 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runs the Composer CLI."""
+
+import sys
+
+from composer.cli.launcher import main
+
+sys.exit(main())

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,13 +21,18 @@ from typing import Any, Dict, List
 
 import psutil
 
+import composer
+
 CLEANUP_TIMEOUT = datetime.timedelta(seconds=30)
 
 log = logging.getLogger(__name__)
 
 
 def _get_parser():
+    # from composer import __version__
     parser = ArgumentParser(description="Utility for launching distributed machine learning jobs.")
+
+    parser.add_argument("--version", action="version", version=f'composer {composer.__version__}')
 
     required_args = parser.add_argument_group("required arguments")
 

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -29,7 +29,6 @@ log = logging.getLogger(__name__)
 
 
 def _get_parser():
-    # from composer import __version__
     parser = ArgumentParser(description="Utility for launching distributed machine learning jobs.")
 
     parser.add_argument("--version", action="version", version=f'composer {composer.__version__}')

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,4 +1,2 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
-"""Composer CLI."""

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -10,6 +10,7 @@ import pytest
 import composer
 
 
+@pytest.mark.daily
 @pytest.mark.parametrize("args", [
     ["composer", "--version"],
     [sys.executable, "-m", "composer", "--version"],

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,0 +1,22 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import sys
+from typing import List
+
+import pytest
+
+import composer
+
+
+@pytest.mark.parametrize("args", [
+    ["composer", "--version"],
+    [sys.executable, "-m", "composer", "--version"],
+    [sys.executable, "-m", "composer.cli", "--version"],
+    [sys.executable, "-m", "composer.cli.launcher", "--version"],
+])
+@pytest.mark.timeout(5)  # spawning a subprocess is slow
+def test_cli_version(args: List[str]):
+    version_str = subprocess.check_output(args, text=True)
+    assert version_str == f"composer {composer.__version__}\n"


### PR DESCRIPTION
1. Added the composer version argument to the launcher
2. Fixed `python -m composer` so it runs the launch script
3. Added test cases to ensure the version is printed correctly
4. Added a shebang to the launcher script
5. Removed the re-export of the launcher, since that caused a `RuntimeWarning`

Closes #309 