### PR TITLE
Libcloud downloads to a tempfile

### DIFF
--- a/composer/utils/libcloud_object_store.py
+++ b/composer/utils/libcloud_object_store.py
@@ -5,7 +5,6 @@
 import os
 import sys
 import tempfile
-import time
 import uuid
 from typing import Any, Dict, Iterator, Optional, Union
 
@@ -206,14 +205,14 @@ class LibcloudObjectStore:
 
         obj = self._get_object(object_name)
         # Download first to a tempfile, and then rename, in case if the file gets corrupted in transit
-        tmp_filepath = destination_path + f".{time.time()}.tmp"
+        tmp_filepath = destination_path + f".{uuid.uuid4()}.tmp"
         try:
             self._provider.download_object(
                 obj=obj,
                 destination_path=tmp_filepath,
             )
         except:
-            # The download failed for some reason. Make a best-effort attempt to remote the temporary file.
+            # The download failed for some reason. Make a best-effort attempt to remove the temporary file.
             try:
                 os.remove(tmp_filepath)
             except OSError:


### PR DESCRIPTION
Modified `download_object` for the libcloud object store to first download to a tempfile and then rename if successful, as to eliminate partially downloaded corrupted files at the ``destination_path``.