### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "image": "mosaicml/pytorch_vision:latest",
+    "remoteUser": "mosaicml",
+    "postCreateCommand": "pip install -e .[all] && pre-commit install"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
     "image": "mosaicml/pytorch_vision:latest",
-    "remoteUser": "root",
-    "postCreateCommand": "pip install --user -e .[all] && pre-commit install"
+    "remoteUser": "mosaicml",
+    "postCreateCommand": "pip install -e .[all] && pre-commit install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
     "image": "mosaicml/pytorch_vision:latest",
-    "remoteUser": "mosaicml",
-    "postCreateCommand": "pip install -e .[all] && pre-commit install"
+    "remoteUser": "root",
+    "postCreateCommand": "pip install --user -e .[all] && pre-commit install"
 }


### PR DESCRIPTION
* Add a devcontainer config for development in a container when using vscode. Makes it easier to develop on the docker image, which has system level dependencies installed.
* Using the `mosaicml` user to avoid permission issues that would occur when developing as root. However, `sudo` is still available if a user needs to switch into root inside the container.
* Using the `mosaicml/pytorch_vision:latest` image, so it will work on gpu machines and so it can run all tests (including vision ones).