### PR TITLE
Disable Multiprocessing Coverage Reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ timeout_func_only = true  # exclude fixtures from the timeout
 [tool.coverage.run]
 parallel = true
 branch = true
-concurrency = ["thread", "multiprocessing"]
+concurrency = ["thread"]
 include = [
     "composer/*"
 ]


### PR DESCRIPTION
There's a bug with using `concurrency=multiprocessing` with pytorch dataloader workers, as identified in the streaming dataloader tests that run daily. Disabling multiprocessing coverage reports for now.

Example of bug:

```
python -m coverage run --concurrency=multiprocessing -m pytest --timeout 100000 ./tests/datasets/test_streaming.py::test_dataloader_single_device[False-False-1-False-1] -m "daily"
```

But this works:
```
python -m coverage run -m pytest --timeout 100000 ./tests/datasets/test_streaming.py::test_dataloader_single_device[False-False-1-False-1] -m "daily"
```