### PR TITLE
Use global batch size for dataloader length calculation

### DIFF
--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -274,8 +274,8 @@ class MLPerfCallback(Callback):
                 constants.SEED: state.seed,
                 constants.GLOBAL_BATCH_SIZE: batch_size * dist.get_world_size(),
                 constants.GRADIENT_ACCUMULATION_STEPS: state.grad_accum,
-                constants.TRAIN_SAMPLES: num_samples,
-                constants.EVAL_SAMPLES: eval_num_samples,
+                constants.TRAIN_SAMPLES: num_samples * dist.get_world_size(),
+                constants.EVAL_SAMPLES: eval_num_samples * dist.get_world_size(),
             })
 
         if _local_rank_zero():


### PR DESCRIPTION
* Currently MLPerf callback prints MLLOG using device batch size, thus train/val sample counts are 8x off
* Fixes issue raised in https://github.com/mlcommons/submissions_training_2.0/issues/57