### PR TITLE
Updated cuda to 11.5.2 for pytorch 1.11

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -9,13 +9,13 @@ MM Segmentation, and FFCV dependencies.
 <!-- BEGIN_BUILD_MATRIX -->
 | Linux Distro   | Flavor   | PyTorch Version   | CUDA Version   | Python Version   | Docker Tags                                                                                      |
 |----------------|----------|-------------------|----------------|------------------|--------------------------------------------------------------------------------------------------|
-| Ubuntu 20.04   | Base     | 1.11.0            | 11.3.1         | 3.9              | `mosaicml/pytorch:latest`, `mosaicml/pytorch:1.11.0_cu113-python3.9-ubuntu20.04`                 |
+| Ubuntu 20.04   | Base     | 1.11.0            | 11.5.2         | 3.9              | `mosaicml/pytorch:latest`, `mosaicml/pytorch:1.11.0_cu115-python3.9-ubuntu20.04`                 |
 | Ubuntu 20.04   | Base     | 1.11.0            | cpu            | 3.9              | `mosaicml/pytorch:latest_cpu`, `mosaicml/pytorch:1.11.0_cpu-python3.9-ubuntu20.04`               |
 | Ubuntu 20.04   | Base     | 1.10.2            | 11.3.1         | 3.8              | `mosaicml/pytorch:1.10.2_cu113-python3.8-ubuntu20.04`                                            |
 | Ubuntu 20.04   | Base     | 1.10.2            | cpu            | 3.8              | `mosaicml/pytorch:1.10.2_cpu-python3.8-ubuntu20.04`                                              |
 | Ubuntu 20.04   | Base     | 1.9.1             | 11.1.1         | 3.7              | `mosaicml/pytorch:1.9.1_cu111-python3.7-ubuntu20.04`                                             |
 | Ubuntu 20.04   | Base     | 1.9.1             | cpu            | 3.7              | `mosaicml/pytorch:1.9.1_cpu-python3.7-ubuntu20.04`                                               |
-| Ubuntu 20.04   | Vision   | 1.11.0            | 11.3.1         | 3.9              | `mosaicml/pytorch_vision:latest`, `mosaicml/pytorch_vision:1.11.0_cu113-python3.9-ubuntu20.04`   |
+| Ubuntu 20.04   | Vision   | 1.11.0            | 11.5.2         | 3.9              | `mosaicml/pytorch_vision:latest`, `mosaicml/pytorch_vision:1.11.0_cu115-python3.9-ubuntu20.04`   |
 | Ubuntu 20.04   | Vision   | 1.11.0            | cpu            | 3.9              | `mosaicml/pytorch_vision:latest_cpu`, `mosaicml/pytorch_vision:1.11.0_cpu-python3.9-ubuntu20.04` |
 <!-- END_BUILD_MATRIX -->
 

--- a/docker/pytorch/build_matrix.yaml
+++ b/docker/pytorch/build_matrix.yaml
@@ -43,22 +43,22 @@
   - mosaicml/pytorch:1.10.2_cpu-python3.8-ubuntu20.04
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.11.3
-- BASE_IMAGE: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
-  CUDA_VERSION: 11.3.1
-  CUDA_VERSION_TAG: cu113
+- BASE_IMAGE: nvidia/cuda:11.5.2-cudnn8-devel-ubuntu20.04
+  CUDA_VERSION: 11.5.2
+  CUDA_VERSION_TAG: cu115
   LINUX_DISTRO: ubuntu2004
   MOFED_OS_VERSION: ubuntu20.04-x86_64
   MOFED_VERSION: 5.5-1.0.3.2
   PYTHON_VERSION: '3.9'
   PYTORCH_VERSION: 1.11.0
   TAGS:
-  - mosaicml/pytorch:1.11.0_cu113-python3.9-ubuntu20.04
+  - mosaicml/pytorch:1.11.0_cu115-python3.9-ubuntu20.04
   - mosaicml/pytorch:latest
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.12.0
-- BASE_IMAGE: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
-  CUDA_VERSION: 11.3.1
-  CUDA_VERSION_TAG: cu113
+- BASE_IMAGE: nvidia/cuda:11.5.2-cudnn8-devel-ubuntu20.04
+  CUDA_VERSION: 11.5.2
+  CUDA_VERSION_TAG: cu115
   LINUX_DISTRO: ubuntu2004
   MMCV_TORCH_VERSION: torch1.11.0
   MMCV_VERSION: 1.4.8
@@ -67,7 +67,7 @@
   PYTHON_VERSION: '3.9'
   PYTORCH_VERSION: 1.11.0
   TAGS:
-  - mosaicml/pytorch_vision:1.11.0_cu113-python3.9-ubuntu20.04
+  - mosaicml/pytorch_vision:1.11.0_cu115-python3.9-ubuntu20.04
   - mosaicml/pytorch_vision:latest
   TARGET: vision_stage
   TORCHVISION_VERSION: 0.12.0

--- a/docker/pytorch/generate_build_matrix.py
+++ b/docker/pytorch/generate_build_matrix.py
@@ -42,11 +42,7 @@ def _get_torchvision_version(pytorch_version: str):
 def _get_base_image(cuda_version: str):
     if cuda_version == 'cpu':
         return 'ubuntu:20.04'
-    if cuda_version == '11.1.1':
-        return 'nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04'
-    if cuda_version == '11.3.1':
-        return 'nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04'
-    raise ValueError(f'Invalid cuda_version: {cuda_version}')
+    return f'nvidia/cuda:{cuda_version}-cudnn8-devel-ubuntu20.04'
 
 
 def _get_cuda_version(pytorch_version: str, use_cuda: bool):
@@ -54,19 +50,17 @@ def _get_cuda_version(pytorch_version: str, use_cuda: bool):
         return 'cpu'
     if pytorch_version == '1.9.1':
         return '11.1.1'
-    if pytorch_version in ('1.10.2', '1.11.0'):
+    if pytorch_version == '1.10.2':
         return '11.3.1'
+    if pytorch_version == '1.11.0':
+        return '11.5.2'
     raise ValueError(f'Invalid pytorch_version: {str}')
 
 
 def _get_cuda_version_tag(cuda_version: str):
     if cuda_version == 'cpu':
         return 'cpu'
-    if cuda_version == '11.1.1':
-        return 'cu111'
-    if cuda_version == '11.3.1':
-        return 'cu113'
-    raise ValueError(f'Invalid cuda_version: {cuda_version}')
+    return 'cu' + ''.join(cuda_version.split('.')[:2])
 
 
 def _get_tags(python_version: str, pytorch_version: str, cuda_version_tag: str, cuda_version: str, stage: str):


### PR DESCRIPTION
Some cuda drivers require pytorch to be built against a later version of the cuda sdk.