### PR TITLE
Skip libcloud tests

### DIFF
--- a/tests/loggers/test_object_store_logger.py
+++ b/tests/loggers/test_object_store_logger.py
@@ -112,20 +112,24 @@ def object_store_test_helper(tmp_path: pathlib.Path,
 
 
 def test_object_store_logger(tmp_path: pathlib.Path, dummy_state: State, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip('libcloud')
     object_store_test_helper(tmp_path=tmp_path, dummy_state=dummy_state, monkeypatch=monkeypatch, use_procs=False)
 
 
 @pytest.mark.timeout(15)
 def test_object_store_logger_use_procs(tmp_path: pathlib.Path, dummy_state: State, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip('libcloud')
     object_store_test_helper(tmp_path=tmp_path, dummy_state=dummy_state, monkeypatch=monkeypatch, use_procs=True)
 
 
 @pytest.mark.timeout(15)
 @pytest.mark.filterwarnings(r'ignore:((.|\n)*)FileExistsError((.|\n)*):pytest.PytestUnhandledThreadExceptionWarning')
 def test_object_store_logger_no_overwrite(tmp_path: pathlib.Path, dummy_state: State, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip('libcloud')
     object_store_test_helper(tmp_path=tmp_path, dummy_state=dummy_state, monkeypatch=monkeypatch, overwrite=False)
 
 
 def test_object_store_logger_should_log_artifact_filter(tmp_path: pathlib.Path, dummy_state: State,
                                                         monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip('libcloud')
     object_store_test_helper(tmp_path=tmp_path, dummy_state=dummy_state, monkeypatch=monkeypatch, should_filter=True)

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -280,10 +280,11 @@ def test_load_weights(
 
 @pytest.mark.timeout(90)
 @device('cpu', 'gpu')
-@pytest.mark.parametrize(
-    'use_object_store,delete_local_checkpoint',
-    [pytest.param(False, False), pytest.param(True, False),
-     pytest.param(True, True)])
+@pytest.mark.parametrize('use_object_store,delete_local_checkpoint', [
+    pytest.param(False, False),
+    pytest.param(True, False),
+    pytest.param(True, True),
+])
 def test_autoresume(
     device: str,
     composer_trainer_hparams: TrainerHparams,
@@ -304,6 +305,9 @@ def test_autoresume(
     if not isinstance(composer_trainer_hparams.val_dataset, SyntheticHparamsMixin):
         pytest.skip('Checkpointing tests require synthetic data')
         return
+    if use_object_store:
+        pytest.importorskip('libcloud')
+
     checkpoint_a_folder = 'first'
     checkpoint_b_folder = 'second'
     middle_checkpoint = 'ep1.pt'
@@ -467,6 +471,8 @@ def test_checkpoint_with_object_store_logger(
 
     Load model from object store and ensure it's the same.
     """
+    pytest.importorskip('libcloud')
+
     checkpoint_a_folder = 'first'
     final_checkpoint = 'ep2.pt'
     composer_trainer_hparams = get_two_epoch_composer_hparams(

--- a/tests/utils/object_store/test_libcloud_object_store.py
+++ b/tests/utils/object_store/test_libcloud_object_store.py
@@ -36,6 +36,8 @@ def _get_provider(remote_dir: pathlib.Path, chunk_size: int = 1024 * 1024):
 
 @pytest.mark.parametrize('chunk_size', [100, 128])
 def test_libcloud_object_store_callback(remote_dir: pathlib.Path, local_dir: pathlib.Path, chunk_size: int):
+    pytest.importorskip('libcloud')
+
     provider = _get_provider(remote_dir, chunk_size=chunk_size)
     local_file_path = os.path.join(local_dir, 'dummy_file')
     total_len = 1024

--- a/tests/utils/object_store/test_object_store.py
+++ b/tests/utils/object_store/test_object_store.py
@@ -49,6 +49,8 @@ def object_store(request, monkeypatch: pytest.MonkeyPatch,
             # Yield our object store
             yield request.param(**object_store_kwargs[request.param])
     elif request.param is LibcloudObjectStore:
+        pytest.importorskip('libcloud')
+
         remote_dir = tmp_path / 'remote_dir'
         os.makedirs(remote_dir)
         object_store_kwargs[request.param]['provider_kwargs']['key'] = remote_dir

--- a/tests/utils/object_store/test_object_store_hparams.py
+++ b/tests/utils/object_store/test_object_store_hparams.py
@@ -18,6 +18,8 @@ def test_object_store_hparams_is_constructable(
     constructor: Type[ObjectStoreHparams],
     monkeypatch: pytest.MonkeyPatch,
 ):
+    pytest.importorskip('libcloud')
+
     # The ObjectStoreLogger needs the OBJECT_STORE_KEY set
     yaml_dict = object_store_kwargs[constructor]
     if constructor is LibcloudObjectStoreHparams:

--- a/tests/utils/test_file_helpers.py
+++ b/tests/utils/test_file_helpers.py
@@ -35,6 +35,8 @@ def test_get_file_uri_not_found(tmp_path: pathlib.Path):
 
 
 def test_get_file_object_store(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip('libcloud')
+
     remote_dir = tmp_path / 'remote_dir'
     os.makedirs(remote_dir)
     monkeypatch.setenv('OBJECT_STORE_KEY', str(remote_dir))  # for the local option, the key is the path
@@ -55,6 +57,8 @@ def test_get_file_object_store(tmp_path: pathlib.Path, monkeypatch: pytest.Monke
 
 
 def test_get_file_object_store_with_symlink(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip('libcloud')
+
     remote_dir = tmp_path / 'remote_dir'
     os.makedirs(remote_dir)
     monkeypatch.setenv('OBJECT_STORE_KEY', str(remote_dir))  # for the local option, the key is the path
@@ -89,6 +93,8 @@ def test_get_file_object_store_with_symlink(tmp_path: pathlib.Path, monkeypatch:
 
 
 def test_get_file_object_store_not_found(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    pytest.importorskip('libcloud')
+
     remote_dir = tmp_path / 'remote_dir'
     os.makedirs(remote_dir)
     monkeypatch.setenv('OBJECT_STORE_KEY', str(remote_dir))  # for the local option, the key is the path


### PR DESCRIPTION
Currently with `pip install .[dev]`, the pytests will fail for tests that require `libcloud`. This PR adds a bunch of `pytest.importorskip('libcloud')` to the codebase.

Is there a cleaner way to do this, than to annotate every test? Seems like a lot of clutter.

After:
```
============= 1801 passed, 235 skipped, 440 deselected, 43 xfailed, 8 xpassed in 72.81s (0:01:12) =============
```