### PR TITLE
Fix Dev Install Tests

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -34,6 +34,7 @@ pytestGpuImageTagsToTest = [
     'mosaicml/pytorch:latest',
     'mosaicml/pytorch_vision:latest',
 ]
+devInstallTestImage = 'mosaicml/pytorch:latest_cpu' // the image to use for the dev test installs
 
 // Lint settings
 lintImage = 'mosaicml/pytorch_vision:latest_cpu'
@@ -194,6 +195,7 @@ void scheduleJob(jobs, String image, buildArgs) {
     String markers = 'not daily and not remote'
     Boolean isLintImage = false
     Boolean isVisionImage = false
+    Boolean isDevTestInstallImage = false
     Boolean isGpu = false
     String tag = ''
     buildArgs.each { key, val ->
@@ -209,6 +211,7 @@ void scheduleJob(jobs, String image, buildArgs) {
             tag = val[0]
             val.each { tagName ->
                 isLintImage = isLintImage || tagName == lintImage
+                isDevTestInstallImage = isDevTestInstallImage || tagName == devInstallTestImage
             }
         }
     }
@@ -231,10 +234,14 @@ void scheduleJob(jobs, String image, buildArgs) {
     jobs << [
         "Pytest - ${tag}" : { -> runPytest(image, markers, extraDeps, isGpu) }
     ]
+    if (isDevTestInstallImage) {
+        jobs << [
+            'Pytest - extraDeps=dev': { -> runPytest(image, markers, 'dev', isGpu) },
+        ]
+    }
     if (isLintImage) {
         // and run lint and a dev install on this image
         jobs << [
-            'Pytest - extraDeps=dev': { -> runPytest(image, markers, 'dev', isGpu) },
             'Lint': { -> runLint(image) },
         ]
     }


### PR DESCRIPTION
#1133 effectively disabled tests for conditional imports, Previously Jenkins was configured to use the "lint" image for a dev install. Because the lint image was changed to `pytorch_vision` in #1133, pytest was being invoked with `-m vision`, which effectively selected no tests.

This PR fixes that by explicitely specifying that dev install tests should be run on the `mosaicml/pytorch:latest_cpu` image, which should apply the marker `-m 'not vision'`