### PR TITLE
Update DeepLabv3+ Baseline Hyperparameters

### DIFF
--- a/composer/yamls/models/deeplabv3_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_ade20k_optimized.yaml
@@ -16,9 +16,9 @@ val_dataset:
     shuffle: false
 optimizers:
   decoupled_sgdw:
-    lr: 0.01
+    lr: 0.08
     momentum: 0.9
-    weight_decay: 2.0e-5
+    weight_decay: 5.0e-5
     dampening: 0
     nesterov: false
 schedulers:
@@ -34,10 +34,10 @@ model:
     is_backbone_pretrained: true
     backbone_url: https://download.pytorch.org/models/resnet101-cd907fc2.pth
     use_plus: true
-    sync_bn: true
+    sync_bn: false
 max_duration: 128ep
-train_batch_size: 32
-eval_batch_size: 32
+train_batch_size: 128
+eval_batch_size: 128
 seed: 17
 dataloader:
   pin_memory: true

--- a/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
@@ -22,9 +22,9 @@ val_dataset:
     shuffle: false
 optimizers:
   decoupled_sgdw:
-    lr: 0.01
+    lr: 0.08
     momentum: 0.9
-    weight_decay: 2.0e-5
+    weight_decay: 5.0e-5
     dampening: 0
     nesterov: false
 schedulers:
@@ -40,10 +40,10 @@ model:
     is_backbone_pretrained: true
     backbone_url: https://download.pytorch.org/models/resnet101-cd907fc2.pth
     use_plus: true
-    sync_bn: true
+    sync_bn: false
 max_duration: 128ep
-train_batch_size: 32
-eval_batch_size: 32
+train_batch_size: 128
+eval_batch_size: 128
 seed: 17
 dataloader:
   pin_memory: true


### PR DESCRIPTION
I swear this is the last time. Last week, it was noticed the deeplabv3+ could be trained on 4x the batch size while still maintaining the same performance across SSRs. This gives a modest reduction in training time on a single node, but could pretty impactful in multi-node settings. This also lets us remove sync batch norm.

Wandb for SSR=1: https://wandb.ai/mosaic-ml/landan-dlv3p-baseline/groups/baseline-bs128-ssr1.0/workspace?workspace=user-landanjs