### PR TITLE
Fix Printing of the Stack Trace on POSIX Signal Exits

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -414,7 +414,7 @@ def _cleanup_processes(processes: Dict[int, subprocess.Popen]):
     for global_rank, process in processes.items():
         process.poll()
         if process.returncode is not None and process.returncode != 0:
-            if process.returncode < 0 and -process.returncode in (signal.SIGKILL, signal.SIGTERM):
+            if -process.returncode in (signal.SIGKILL, signal.SIGTERM):
                 # Negative return codes indicate the process was killed via a signal
                 # If the launcher script killed the training process (which would happen via SIGKILL or SIGTERM),
                 # then do not print the stack trace.

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -413,10 +413,14 @@ def _cleanup_processes(processes: Dict[int, subprocess.Popen]):
                         pass
     for global_rank, process in processes.items():
         process.poll()
-        if process.returncode is not None and process.returncode > 0:
+        if process.returncode is not None and process.returncode != 0:
+            if process.returncode < 0 and -process.returncode in (signal.SIGKILL, signal.SIGTERM):
+                # Negative return codes indicate the process was killed via a signal
+                # If the launcher script killed the training process (which would happen via SIGKILL or SIGTERM),
+                # then do not print the stack trace.
+                continue
             # only print the processes that have actually crashed,
-            # not the ones that were killed, which would result in
-            # a negative exit code
+            # not the ones that were killed
             _print_process_exit_status(global_rank, process)
 
 


### PR DESCRIPTION
When using the launcher script, the stack trace would not be printed when the process is terminated via a POSIX signal (e.g. `SIGABRT` -- see #1165). This is to prevent cluttering the logs when the launcher script terminates the process via SIGTERM or SIGKILL.

Instead of skipping the stack trace on all negative exit codes (e.g. all signals), this PR skips the stack trace only when the process was terminated via SIGKILL or SIGTERM, which are the two codes that the launcher script uses to terminate processes.