### PR TITLE
Only catch OOM if `grad_accum='auto'`

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1645,7 +1645,7 @@ class Trainer:
                         else:
                             optimizer.step()
             except RuntimeError as e:
-                if _is_cuda_oom(e):
+                if self.adaptive_gradient_accumulation and _is_cuda_oom(e):
                     log.debug((f"Rank {dist.get_global_rank()} OOM'd. "
                                'grad_accum will be increased prior to reattempting training on the current batch.'))
                     should_handle_cuda_oom = 1

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1673,9 +1673,9 @@ class Trainer:
                     original_grad_accum = self.state.grad_accum
                     self.state.grad_accum = min(2 * self.state.grad_accum, device_batch_size)
                     self.logger.data_batch({'trainer/grad_accum': self.state.grad_accum})
-                    log.debug(
-                        f'CUDA OOM detected. Gradient Accumulation increased from {original_grad_accum} -> {self.state.grad_accum}'
-                    )
+                    log.debug(('CUDA out of memory detected. Gradient Accumulation '
+                               f'increased from {original_grad_accum} -> {self.state.grad_accum}, '
+                               'and the batch will be retrained.'))
             elif caught_timeout_error:
                 # If not CUDA out of memory, raise exception to user. Note that this truncates the call stack
                 # back only to this newly raised error.


### PR DESCRIPTION
This PR fixes a reported bug where gradient accumulation was always automatic.

Coming along for the ride -> some better logging of the grad accum increases.