### PR TITLE
Move grad_accum logging to every step

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1673,8 +1673,8 @@ class Trainer:
                     original_grad_accum = self.state.grad_accum
                     self.state.grad_accum = min(2 * self.state.grad_accum, device_batch_size)
                     log.info(('CUDA out of memory detected. Gradient Accumulation '
-                               f'increased from {original_grad_accum} -> {self.state.grad_accum}, '
-                               'and the batch will be retrained.'))
+                              f'increased from {original_grad_accum} -> {self.state.grad_accum}, '
+                              'and the batch will be retrained.'))
             elif caught_timeout_error:
                 # If not CUDA out of memory, raise exception to user. Note that this truncates the call stack
                 # back only to this newly raised error.

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1672,7 +1672,6 @@ class Trainer:
                 else:
                     original_grad_accum = self.state.grad_accum
                     self.state.grad_accum = min(2 * self.state.grad_accum, device_batch_size)
-                    self.logger.data_batch({'trainer/grad_accum': self.state.grad_accum})
                     log.debug(('CUDA out of memory detected. Gradient Accumulation '
                                f'increased from {original_grad_accum} -> {self.state.grad_accum}, '
                                'and the batch will be retrained.'))
@@ -1681,7 +1680,8 @@ class Trainer:
                 # back only to this newly raised error.
                 raise caught_timeout_error
             else:
-                # Otherwise, return calculated loss
+                # Otherwise, log grad_accum and return calculated loss
+                self.logger.data_batch({'trainer/grad_accum': self.state.grad_accum})
                 return total_loss
 
     def _train_microbatches(self, microbatches: Sequence[Batch], ddp_sync: bool = True):


### PR DESCRIPTION
Currently, the value of `grad_accum` is logged only when it is changed by `grad_accum="auto"`. This PR changes things such that the value of `grad_accum` is logged every step.

Example old behavior:
<img width="251" alt="Screen Shot 2022-06-17 at 11 47 57 AM" src="https://user-images.githubusercontent.com/83666378/174373431-6791824b-c457-4b46-862a-f17bba2d8611.png">

Example new behavior:
<img width="243" alt="Screen Shot 2022-06-17 at 11 48 52 AM" src="https://user-images.githubusercontent.com/83666378/174375250-ff4031c0-64ae-4bf6-a66b-65d89a599a5a.png">
 