### PR TITLE
A utility to fuse parallel linear layers in FX-traced models

### DIFF
--- a/composer/utils/fx_utils.py
+++ b/composer/utils/fx_utils.py
@@ -7,15 +7,19 @@ Provides utilities to do FX-based model transformations.
 """
 
 import logging
-from typing import Any, Callable, List, Union
+import operator
+from typing import Any, Callable, Dict, List, Mapping, Tuple, Union
 
+import torch
+import torch.nn as nn
+from torch.fx import Node
 from torch.fx.graph_module import GraphModule
 
 from composer.utils import ensure_tuple
 
 log = logging.getLogger(__name__)
 
-__all__ = ['count_op_instances', 'replace_op']
+__all__ = ['count_op_instances', 'replace_op', 'fuse_parallel_linears']
 
 
 def count_op_instances(gm: GraphModule, ops: Union[Callable, str, List[Union[Callable, str]]]) -> int:
@@ -51,7 +55,15 @@ def count_op_instances(gm: GraphModule, ops: Union[Callable, str, List[Union[Cal
         int: The number of instances of ``ops`` in ``gm``
     """
     ops = list(ensure_tuple(ops))
-    return sum(any(n.target == op for op in ops) for n in gm.graph.nodes)
+    all_modules = dict(gm.named_modules())
+    count = 0
+    for n in gm.graph.nodes:
+        for op in ops:
+            if n.target == op:
+                count += 1
+            elif n.op == 'call_module' and isinstance(op, type) and isinstance(all_modules[n.target], op):
+                count += 1
+    return count
 
 
 def replace_op(gm: GraphModule, src_ops: Union[Callable, str, List[Union[Callable, str]]],
@@ -123,13 +135,107 @@ def replace_residual_with_stochastic(gm: GraphModule):
     raise NotImplementedError('replace_residual_with_stochastic is currently not implemented.')
 
 
-def fuse_parallel_linears(gm: GraphModule):
+def _can_linears_be_fused(linear_nodes: List[Node], all_modules: Mapping[str, nn.Module]) -> bool:
+    """Check if all the linears have bias."""
+    # Forcing node.target to str is fine here as we are dealing with nn.Modules
+    # and their target is a str.
+    bias = all_modules[str(linear_nodes[0].target)].bias is None
+
+    return all(bias == (all_modules[str(node.target)].bias is None) for node in linear_nodes)
+
+
+def _create_fused_linear(linear_nodes: List[Node],
+                         all_modules: Mapping[str, nn.Module],
+                         keep_weights: bool = False) -> Tuple[nn.Module, List[int]]:
+    """Check if the linears can be fused.
+
+    If the linears can be fused, create a fused nn.Linear instance and return it.
+    """
+    if keep_weights:
+        raise NotImplementedError('This feature is currently not implemented.')
+
+    assert len(linear_nodes) > 1, 'There should be at least 2 linears for fusion'
+    out_features = []
+    in_features = all_modules[str(linear_nodes[0].target)].in_features
+    bias = all_modules[str(linear_nodes[0].target)].bias is not None
+
+    for node in linear_nodes:
+        out_features.append(all_modules[str(node.target)].out_features)
+        assert in_features == all_modules[str(node.target)].in_features, 'mismatch in number of input features'
+        assert bias == (all_modules[str(node.target)].bias is not None), 'mismatch in bias'
+
+    return nn.Linear(in_features, sum(out_features), bias=bias), out_features  # type: ignore
+
+
+def fuse_parallel_linears(gm: GraphModule, keep_weights: bool = False) -> GraphModule:
     """If there are parallel linears in the model, fuse them together.
+
+    .. rubric:: Example
+
+    .. testsetup::
+
+        import torch
+        import torch.nn as nn
+        from torch.fx import symbolic_trace
+        from composer.utils.fx_utils import count_op_instances, fuse_parallel_linears
+
+    .. doctest::
+
+        >>> class M(nn.Module):
+        ...   def __init__(self):
+        ...     super().__init__()
+        ...     self.fc1 = nn.Linear(64, 64)
+        ...     self.fc2 = nn.Linear(64, 64)
+        ...   def forward(self, x):
+        ...     y = self.fc1(x)
+        ...     z = self.fc2(x)
+        ...     return y + z
+        >>> module = M()
+        >>> traced = symbolic_trace(module)
+        >>> count_op_instances(traced, nn.Linear)
+        2
+        >>> gm = fuse_parallel_linears(traced)
+        >>> count_op_instances(traced, nn.Linear)
+        1
 
     Arguments:
         gm (GraphModule): The source FX-traced graph.
 
     Returns:
-        GraphModule: Modified GraphModule.
+        GraphModule: Modified GraphModule with parallel linears fused.
     """
-    raise NotImplementedError('fuse_parallel_linears is currently not implemented.')
+    all_modules: Dict[str, nn.Module] = dict(gm.named_modules())
+    fused_count = 0
+    for node in gm.graph.nodes:
+        # There could be more than two parallel linears
+        linears_to_fuse = []
+
+        # Check all the users of current node and collect all linear layers
+        for user in list(node.users):
+            if user.op == 'call_module' and isinstance(all_modules[user.target], nn.Linear):
+                linears_to_fuse.append(user)
+
+        # Fuse if there are more than 1 parallel linear layers
+        if len(linears_to_fuse) > 1 and _can_linears_be_fused(linears_to_fuse, all_modules):
+            lin, out_features = _create_fused_linear(linears_to_fuse, all_modules, keep_weights)
+            gm.add_submodule(f'fused_linear_{fused_count}', lin)  # type: ignore
+            with gm.graph.inserting_after(node):
+                fused_node = gm.graph.call_module(f'fused_linear_{fused_count}', args=(node,))
+            # insert the split node
+            with gm.graph.inserting_after(fused_node):
+                kwargs = {'split_size_or_sections': out_features, 'dim': -1}
+                split_node = gm.graph.call_function(torch.split, args=(fused_node,), kwargs=kwargs)
+
+            insert_point = split_node
+            for idx, lin_node in enumerate(linears_to_fuse):
+                with gm.graph.inserting_after(insert_point):
+                    split_item = gm.graph.call_function(operator.getitem, (split_node, idx), {})
+                lin_node.replace_all_uses_with(split_item)
+                insert_point = split_item
+                gm.graph.erase_node(lin_node)
+            fused_count += 1
+            gm.graph.lint()
+
+    if fused_count > 0:
+        gm.recompile()
+    return gm

--- a/tests/utils/test_fx_utils.py
+++ b/tests/utils/test_fx_utils.py
@@ -9,7 +9,7 @@ from torch import nn
 from torch.fx import symbolic_trace
 from torch.fx.graph_module import GraphModule
 
-from composer.utils.fx_utils import count_op_instances, replace_op
+from composer.utils.fx_utils import count_op_instances, fuse_parallel_linears, replace_op
 
 
 class MyTestModel(nn.Module):
@@ -33,6 +33,7 @@ class AddModel(nn.Module):
 @pytest.mark.parametrize(
     'model_cls, ops, count',
     [
+        (MyTestModel, nn.ReLU, 1),
         (AddModel, operator.add, 1),
         (AddModel, [operator.add, torch.add], 2),
         (AddModel, [operator.add, torch.add, 'add'], 3),
@@ -62,3 +63,93 @@ def test_replace_op(model_cls, src_ops, tgt_op, count):
     replace_op(traced, src_ops, tgt_op)
 
     assert count_op_instances(traced, tgt_op) == count
+
+
+class SimpleParallelLinears(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(64, 64)
+        self.fc2 = nn.Linear(64, 64)
+
+    def forward(self, x):
+        y = self.fc1(x)
+        z = self.fc2(x)
+        return y + z
+
+
+class ParallelLinears(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(64, 64)
+        self.ln = nn.LayerNorm(64)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(64, 64)
+
+    def forward(self, x):
+        y = self.fc1(x)
+        y = self.ln(y)
+        y = self.relu(y)
+        z = self.fc2(x)
+        return y + z
+
+
+class NotFusibleLinears(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(64, 64, bias=False)
+        self.ln = nn.LayerNorm(64)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(64, 64)
+
+    def forward(self, x):
+        y = self.fc1(x)
+        y = self.ln(y)
+        y = self.relu(y)
+        z = self.fc2(x)
+        return y + z
+
+
+class NotParallelLinears(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(64, 64)
+        self.ln = nn.LayerNorm(64)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(64, 64)
+
+    def forward(self, x):
+        y = self.fc1(x)
+        y = self.ln(y)
+        y = self.relu(y)
+        z = self.fc2(y)
+        return x + z
+
+
+# Incorrect warning fixed in https://github.com/pytorch/pytorch/pull/61463
+@pytest.mark.parametrize(
+    'model_cls, before_count, after_count',
+    [
+        (SimpleParallelLinears, 2, 1),
+        (ParallelLinears, 2, 1),
+        (NotParallelLinears, 2, 2),
+        (NotFusibleLinears, 2, 2),
+    ],
+)
+@pytest.mark.filterwarnings(
+    r'ignore:Attempted to insert a call_module Node with no underlying reference in the owning GraphModule!.*:UserWarning'
+)
+def test_fuse_parallel_linears(model_cls, before_count, after_count):
+    model = model_cls()
+    traced = symbolic_trace(model)
+
+    assert isinstance(traced, GraphModule)
+
+    assert count_op_instances(traced, nn.Linear) == before_count
+
+    fuse_parallel_linears(traced)
+
+    assert count_op_instances(traced, nn.Linear) == after_count


### PR DESCRIPTION
- All parallel linears will be fused. It's not limited to 2. 
- Either all or none should have the bias for as a pre-condition of fusion. 
- If no parallel linears are found, unmodified GraphModule is returned. 

Example,

Before:
![Screen Shot 2022-06-17 at 9 53 03 AM](https://user-images.githubusercontent.com/37562707/174409140-25bf409e-befb-4e07-9fe8-c9842ef7c3b4.png)

After:
![Screen Shot 2022-06-17 at 9 53 22 AM](https://user-images.githubusercontent.com/37562707/174409136-19716e39-a435-41cd-a49f-fbd0d6d9cf4a.png)


CO-402
