### PR TITLE
ProgressBar Units

### DIFF
--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -63,14 +63,14 @@ class _ProgressBar:
         else:
             n = int(timestamp.get(self.unit))
 
-        self.pbar.n = n
-        self.pbar.refresh()
+        n = n - self.pbar.n
+        self.pbar.update(int(n))
 
     def close(self):
         self.pbar.close()
 
     def state_dict(self) -> Dict[str, Any]:
-        pbar_state = self.pbar.format_dict()
+        pbar_state = self.pbar.format_dict
 
         return {
             'total': pbar_state['total'],

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -124,6 +124,7 @@ class ProgressBarLogger(LoggerDestination):
         console_log_level: Union[LogLevel, str, Callable[[State, LogLevel], bool]] = LogLevel.EPOCH,
         stream: Union[str, TextIO] = sys.stderr,
     ) -> None:
+
         self.show_pbar = progress_bar
         self.train_pbar: Optional[_ProgressBar] = None
         self.eval_pbar: Optional[_ProgressBar] = None
@@ -133,20 +134,17 @@ class ProgressBarLogger(LoggerDestination):
             log_to_console = not progress_bar
 
         if not log_to_console:
-            console_log_level = lambda state, ll: False
-
-        # create should_log callable based on console_log_level
-        if isinstance(console_log_level, str):
-            console_log_level = LogLevel(console_log_level)
-        if isinstance(console_log_level, LogLevel):
-
-            def should_log(state: State, log_level: LogLevel, console_log_level: LogLevel = console_log_level):
-                del state  # unused
-                return log_level <= console_log_level
-
-            self.should_log = should_log
+            # never log to console
+            self.should_log = lambda state, ll: False
         else:
-            self.should_log = console_log_level
+            # set should_log to a Callable[[State, LogLevel], bool]
+            if isinstance(console_log_level, str):
+                console_log_level = LogLevel(console_log_level)
+
+            if isinstance(console_log_level, LogLevel):
+                self.should_log = lambda state, ll: ll <= console_log_level
+            else:
+                self.should_log = console_log_level
 
         # set the stream
         if isinstance(stream, str):

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -179,7 +179,7 @@ class ProgressBarLogger(LoggerDestination):
             self.log_to_console(log_str)
 
     def log_to_console(self, log_str: str):
-        """ Logs to the console, avoiding interleaving with a progress bar"""
+        """Logs to the console, avoiding interleaving with a progress bar."""
         if self.current_pbar:
             # use tqdm.write to avoid interleaving
             self.current_pbar.pbar.write(log_str)

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -217,14 +217,13 @@ class ProgressBarLogger(LoggerDestination):
         position = 0 if is_train else 1
         split = 'train' if is_train else 'val'
 
-        assert state.max_duration is not None, 'max_duration should be set'
         assert self.is_train is not None
         if epoch_style:
             assert state.dataloader_len is not None, 'dataloader_len should be set'
             total = int(state.dataloader_len)
 
             # handle when # batches is less than an epoch
-            if state.max_duration.unit == TimeUnit.BATCH:
+            if state.max_duration is not None and state.max_duration.unit == TimeUnit.BATCH:
                 total = min(total, state.max_duration.value)
 
             unit = TimeUnit.BATCH
@@ -234,9 +233,12 @@ class ProgressBarLogger(LoggerDestination):
                 n = max(0, n - 1)
             desc = f'Epoch {n:5d} {split:5s}'
         else:
+            assert state.max_duration is not None, 'max_duration should be set'
+
             total = state.max_duration.value
             unit = state.max_duration.unit
             desc = f'{unit.name.capitalize():<11} {split:5s}'
+
         return _ProgressBar(
             file=self.stream,
             total=total,

--- a/tests/common/compare.py
+++ b/tests/common/compare.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 
 from composer import Time
+from composer.core.time import TimeUnit
 
 
 def deep_compare(item1: Any, item2: Any, atol: float = 0.0, rtol: float = 0.0):
@@ -26,7 +27,7 @@ def _check_item(item1: Any, item2: Any, path: str, rtol: float = 0.0, atol: floa
     if item1 is None:
         assert item2 is None, f'{path} differs: {item1} != {item2}'
         return
-    if isinstance(item1, (str, float, int, bool, Time, datetime.timedelta)):
+    if isinstance(item1, (str, float, int, bool, Time, datetime.timedelta, TimeUnit)):
         assert type(item1) == type(item2)
         assert item1 == item2, f'{path} differs: {item1} != {item2}'
         return

--- a/tests/loggers/test_progress_bar_logger.py
+++ b/tests/loggers/test_progress_bar_logger.py
@@ -8,6 +8,7 @@ import torch.utils.data
 from _pytest.monkeypatch import MonkeyPatch
 from tqdm import auto
 
+from composer.core.time import Time, TimeUnit
 from composer.trainer.trainer import Trainer
 from composer.utils import dist
 from tests.common import RandomClassificationDataset, SimpleModel
@@ -17,46 +18,72 @@ from tests.common import RandomClassificationDataset, SimpleModel
     pytest.param(1),
     pytest.param(2, marks=pytest.mark.world_size(2)),
 ])
+@pytest.mark.parametrize(
+    'max_duration',
+    [Time.from_timestring('2ep'),
+     Time.from_timestring('100sp'),
+     Time.from_timestring('5ba')],
+)
 @pytest.mark.timeout(10)
-def test_progress_bar_logger(monkeypatch: MonkeyPatch, world_size: int):
-    is_train_to_mock_tqdms = {
-        True: [],
-        False: [],
-    }
+def test_progress_bar_logger(max_duration: Time[int], monkeypatch: MonkeyPatch, world_size: int):
 
-    def get_mock_tqdm(position: int, *args: object, **kwargs: object):
+    mock_tqdms_train = []
+    mock_tqdms_eval = []
+
+    def get_mock_tqdm(bar_format: str, *args: object, **kwargs: object):
         del args, kwargs  # unused
-        is_train = position == 0
         mock_tqdm = MagicMock()
-        is_train_to_mock_tqdms[is_train].append(mock_tqdm)
+
+        # store for testing later
+        if 'train' in bar_format:
+            mock_tqdms_train.append(mock_tqdm)
+        else:
+            mock_tqdms_eval.append(mock_tqdm)
+
         return mock_tqdm
 
     monkeypatch.setattr(auto, 'tqdm', get_mock_tqdm)
 
-    max_epochs = 2
-    eval_epochs = 1
+    eval_interval = 1
+    eval_subset_num_batches = 2
+    batch_size = 10
+    train_dataset = RandomClassificationDataset()
+    eval_dataset = RandomClassificationDataset()
 
     trainer = Trainer(
         model=SimpleModel(),
-        max_duration=max_epochs,
-        eval_interval=eval_epochs,
+        max_duration=max_duration,
+        eval_interval=eval_interval,
         progress_bar=True,
         compute_training_metrics=True,
-        train_dataloader=torch.utils.data.DataLoader(RandomClassificationDataset()),
-        eval_dataloader=torch.utils.data.DataLoader(RandomClassificationDataset()),
-        eval_subset_num_batches=1,
+        train_dataloader=torch.utils.data.DataLoader(train_dataset, batch_size=batch_size),
+        eval_dataloader=torch.utils.data.DataLoader(eval_dataset, batch_size=batch_size),
+        eval_subset_num_batches=eval_subset_num_batches,
     )
 
     trainer.fit()
-    if dist.get_global_rank() == 1:
+
+    if dist.get_local_rank() != 0:
         return
-    assert len(is_train_to_mock_tqdms[True]) == max_epochs
-    assert len(is_train_to_mock_tqdms[False]) == eval_epochs * max_epochs
-    for mock_tqdm in is_train_to_mock_tqdms[True]:
-        assert trainer.state.dataloader_len is not None
-        assert trainer.state.dataloader_label == 'train'
-        assert mock_tqdm.update.call_count == int(trainer.state.dataloader_len)
-        mock_tqdm.close.assert_called_once()
-    for mock_tqdm in is_train_to_mock_tqdms[False]:
-        assert mock_tqdm.update.call_count == trainer.state.evaluators[0].subset_num_batches
-        mock_tqdm.close.assert_called_once()
+
+    # either have #epoch pbars, or only have 1 train pbar
+    if max_duration.unit == TimeUnit.EPOCH:
+        assert len(mock_tqdms_train) == max_duration.value
+    else:
+        assert len(mock_tqdms_train) == 1
+
+    # test train pbar
+    if max_duration.unit == TimeUnit.EPOCH:
+        for mt in mock_tqdms_train:
+            assert trainer.state.dataloader_len is not None
+            assert mt.update.call_count == int(trainer.state.dataloader_len)
+    elif max_duration.unit == TimeUnit.BATCH:
+        for mt in mock_tqdms_train:
+            assert mt.update.call_count == max_duration.value
+    elif max_duration.unit == TimeUnit.SAMPLE:
+        for mt in mock_tqdms_train:
+            assert mt.update.call_count == max_duration.value // batch_size
+
+    # test eval pbar
+    for mt in mock_tqdms_eval:
+        assert mt.update.call_count == eval_subset_num_batches

--- a/tests/loggers/test_progress_bar_logger.py
+++ b/tests/loggers/test_progress_bar_logger.py
@@ -82,7 +82,7 @@ def test_progress_bar_logger(max_duration: Time[int], monkeypatch: MonkeyPatch, 
             assert mt.update.call_count == max_duration.value
     elif max_duration.unit == TimeUnit.SAMPLE:
         for mt in mock_tqdms_train:
-            assert mt.update.call_count == max_duration.value // batch_size
+            assert mt.update.call_count == max_duration.value // batch_size / world_size
 
     # test eval pbar
     for mt in mock_tqdms_eval:


### PR DESCRIPTION
This PR:
* lightly refactors the ProgressBar for code clarity
* renders the progress bar in units of `max_duration`
* fixes interleaving of train/eval progress bars (see: #1191 )

## Refactor notes:
* Adds `current_pbar` property instead of using dictionaries for progress bars
* renames `_ProgressBarLoggerInstance` -> `_ProgressBar` for clarity/bervity. The object is a progress bar ala tqdm, not an instance of the logger itself. 
* Removes ProgressBarLoggerInstanceState, as unneccessary.
* Folds local rank zero guards into `show_pbar` property

## New behavior:

`max_duration=10ep`, `eval_interval=1ep`

```
Epoch     0 train 100%|█████████████████████████| 29/29 [00:09<00:00,  3.14ba/s, ...
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.35ba/s, ...
```

`max_duration=1000ba`, `eval_interval=10ba`
```
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 22.36ba/s, 
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 22.30ba/s, 
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 22.04ba/s, 
Batch       train   7%|█▋                       | 68/1000 [00:13<02:58,  5.21ba/s, loss/train=0.
```

`max_duration=1e6sp`, `eval_interval=1ep`
```
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 22.20ba/s, 
Epoch     1 val   100%|█████████████████████████| 10/10 [00:00<00:00, 22.08ba/s,
Sample      train  15%|███▊                     | 150528/1000000 [00:22<02:06, 6725.71sp/s, 
# note different units for val vs. train. "ba/s" vs "sp/s". We have no access to the # of 
# samples in the eval dataloader ahead of time, so must count in batches.
```

Note: In cases where the `eval_interval` happens when the training bar is still active, the training bar will pause during eval, and then resume. The training bar will be sorted to the bottom, once training resumes, because terminals only support editing the last line (see last two examples above).