### PR TITLE
Fix interleaving train/eval progress bars

### DIFF
--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -179,7 +179,7 @@ class ProgressBarLogger(LoggerDestination):
             self.log_to_console(log_str)
 
     def log_to_console(self, log_str: str):
-        """ Logs to the console, avoiding interleaving with a progress bar"""
+        """Logs to the console, avoiding interleaving with a progress bar."""
         if self.current_pbar:
             # use tqdm.write to avoid interleaving
             self.current_pbar.pbar.write(log_str)
@@ -223,6 +223,7 @@ class ProgressBarLogger(LoggerDestination):
             self.current_pbar.update()
 
     def batch_end(self, state: State, logger: Logger) -> None:
+        self.is_train = True
         self._update()
 
     def eval_after_forward(self, state: State, logger: Logger) -> None:


### PR DESCRIPTION
Before:
```
******************************
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.60it/s, metri
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.99it/s, metri
Epoch     0 train  34%|████████▌                | 10/29 [00:10<00:19,  1.01s/it, loss/
Epoch     1 val   100%|█████████████████████████| 10/10 [00:00<00:00, 20.55it/s, metri
Epoch     1 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.86it/s, metri
Epoch     1 val   100%|█████████████████████████| 10/10 [00:00<00:00, 22.05it/s, metri
Epoch     1 train   3%|▊                        | 1/29 [00:09<04:29,  9.61s/it, loss/t
Epoch     2 val   100%|█████████████████████████| 10/10 [00:00<00:00, 22.36it/s, metri
Epoch     2 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.93it/s, metri
Epoch     2 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.92it/s, metri
Epoch     2 train   7%|█▋                       | 2/29 [00:09<02:08,  4.75s/it, loss/t
Epoch     3 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.80it/s, metri
Epoch     3 val   100%|█████████████████████████| 10/10 [00:00<00:00, 22.03it/s, metri
Epoch     3 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.85it/s, metri
```

After:
```
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.68it/s, metri
Epoch     0 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.56it/s, metri
Epoch     0 train 100%|█████████████████████████| 29/29 [00:10<00:00,  2.80it/s, loss/
Epoch     1 val   100%|█████████████████████████| 10/10 [00:00<00:00, 20.77it/s, metri
Epoch     1 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.05it/s, metri
Epoch     1 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.61it/s, metri
Epoch     1 train 100%|█████████████████████████| 29/29 [00:09<00:00,  2.92it/s, loss/
Epoch     2 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.87it/s, metri
Epoch     2 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.52it/s, metri
Epoch     2 val   100%|█████████████████████████| 10/10 [00:00<00:00, 21.47it/s, metri
Epoch     2 train 100%|█████████████████████████| 29/29 [00:09<00:00,  2.94it/s, loss/
```

This is with `eval_interval=20ba`. Note: the train pbar for epoch 0 will show up after the eval pbar for epoch 0 (even though chronologically they are reversed). 

Depends on #1190 