### PR TITLE
Fix module surgery for training resumptions with optimizers that save state

### DIFF
--- a/tests/algorithms/test_algorithm_resumption.py
+++ b/tests/algorithms/test_algorithm_resumption.py
@@ -10,8 +10,7 @@ import pytest
 import torch
 
 from composer import Algorithm, Trainer
-from composer.algorithms import (SAM, BlurPool, Factorize, GatedLinearUnits, LayerFreezing, SqueezeExcite,
-                                 StochasticDepth)
+from composer.algorithms import SAM, LayerFreezing, StochasticDepth
 from tests.algorithms.algorithm_settings import get_alg_dataloader, get_alg_kwargs, get_alg_model, get_algs_with_marks
 from tests.common import deep_compare
 
@@ -34,8 +33,8 @@ def test_algorithm_resumption(
     if alg_cls is LayerFreezing:
         pytest.xfail('Known issues')
 
-    if alg_cls in (GatedLinearUnits, SAM, SqueezeExcite, StochasticDepth, Factorize, BlurPool):
-        pytest.xfail('Incompatible with optimizers that store state, e.g. Adam.')
+    if alg_cls in (SAM, StochasticDepth):
+        pytest.xfail('Mismatch in weights when resuming from a checkpoint.')
 
     optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=5)

--- a/tests/utils/test_module_surgery.py
+++ b/tests/utils/test_module_surgery.py
@@ -170,3 +170,27 @@ def test_optimizer_surgery_params_not_removed_still_there(optimizer_surgery_stat
     for module in orig_linear_modules:
         assert isinstance(module.bias, torch.nn.parameter.Parameter)
         assert _param_in_optimizer(module.bias, opt)
+
+
+class ParamTestModel(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+        self.fc1 = nn.Linear(8, 8)
+        self.fc2 = nn.Linear(16, 16)
+        self.fc3 = nn.Linear(32, 32)
+        self.fc4 = nn.Linear(64, 64)
+
+
+def test_update_params_in_optimizer():
+    m1 = ParamTestModel()
+    m2 = ParamTestModel()
+    optimizer = torch.optim.Adam(m1.parameters(), lr=0.01)
+    current_order = list(m2.parameters())
+    module_surgery.update_params_in_optimizer(old_params=m1.parameters(),
+                                              new_params=m2.parameters(),
+                                              optimizers=optimizer)
+    post_replacement_order = optimizer.param_groups[0]['params']
+    for idx, value in enumerate(current_order):
+        assert torch.all(value.eq(post_replacement_order[idx]))


### PR DESCRIPTION
Currently, when we attempt to save/load check points when:
(1) a surgery algorithm has been used that modifies the pytorch otpimizer state
(2) the trainer is using an optimizer that has state (.e.g., adam) 

it fails. 

This fixes it. However, SAM still fails with mismatch and not sure what's the root cause. 

CO-382