### PR TITLE
Fix Composer staging dockerimages

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -316,8 +316,6 @@ stage('Build') {
     pytorchDockerBuildMatrix.each { buildArgs ->
         Boolean isComposerImage = buildArgs['TARGET'] == 'composer_stage'
         Boolean shouldPushToDestinations = isMergeCommit && gitBranch == baseBranch
-        String label = buildArgs['TAGS'][0]
-
         Boolean shouldBuildImage = didDockerChange  // Always build the image if the ./docker folder changed
 
         if (!shouldPushToDestinations) {
@@ -344,7 +342,7 @@ stage('Build') {
             String stagingImageTag = generateStagingImageTag()
             buildArgs['TAGS'] << stagingImageTag
             String kanikoCommand = getKanikoCommand(buildArgs)
-            jobs << [ "${label}": { ->
+            jobs << [ "${buildArgs}": { ->
                 trackBuild(
                     job: jenkinsShellJobName,
                     parameters: [

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -114,7 +114,7 @@ def getKanikoCommand(buildArgs) {
     // Constructs a kaniko command from the buildArgs
     def cliArgsList = []
     def tags = []
-     buildArgs.each { key, val ->
+    buildArgs.each { key, val ->
         if (key == 'TAGS') {
             val.each { tag ->
                 tags << tag
@@ -128,18 +128,16 @@ def getKanikoCommand(buildArgs) {
         cliArgsList << "--build-arg '$key=$val'"
     }
     String cliArgs = cliArgsList.join(' ')
-
-    cliArgs = "$cliArgs --dockerfile Dockerfile --context ./docker"
-    String destinations = ""
+    String kanikoCommand = '/kaniko/executor --cache=true --dockerfile Dockerfile --context ./docker --cleanup'
+    kanikoCommand += " --cache-repo=${cacheRepo} ${cliArgs}"
     for (tag in tags) {
-        destinations = "$destinations --destination $tag"
+        kanikoCommand += " --destination $tag"
     }
 
     if (cliArgs.contains(cacheRepo)) {
         error("The kaniko args should not ever attempt to push images to the cache repo, ${cacheRepo}")
     }
 
-    String kanikoCommand = "/kaniko/executor --cache=true --cache-repo=${cacheRepo} ${cliArgs} --cleanup"
     return kanikoCommand
 }
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -318,30 +318,29 @@ stage('Build') {
         Boolean shouldPushToDestinations = isMergeCommit && gitBranch == baseBranch
         String label = buildArgs['TAGS'][0]
 
+        Boolean shouldBuildImage = didDockerChange  // Always build the image if the ./docker folder changed
+
         if (!shouldPushToDestinations) {
             buildArgs['TAGS'] = []
         }
 
-        if (isComposerImage) {
-            if (!buildArgs['COMPOSER_INSTALL_COMMAND'].contains('==')) {
-                // If this is a composer image and it is the latest tag, skip it -- build the versioned tag instead
-                return
-            }
+        if (isComposerImage && buildArgs['COMPOSER_INSTALL_COMMAND'] == 'mosaicml[all]GIT_COMMIT') {
+            // If this is a composer image and it is the 'GIT_COMMIT' entry in the matrix
+            // then build and publish the image on the staging repo
             if (!isMergeCommit) {
                 // Skip composer images except on merge commits -- it's slow!
-                return
+                // return  // TODO (ravi) -- uncomment this line
             }
-            // Then set the install command to the git commit string, and build and push it to
-            // the mosaicml/composer_staging repo
             String stagingTagName = "mosaicml/composer_staging:${gitCommitHash[0..6]}"
             if (!buildArgs['CUDA_VERSION']) {
                 stagingTagName += '_cpu'
             }
             buildArgs['COMPOSER_INSTALL_COMMAND'] = "mosaicml[all] @ git+https://github.com/mosaicml/composer.git@${gitCommitHash}"
             buildArgs['TAGS'] << stagingTagName
+            shouldBuildImage = true  // always build the image if it's a composer image
         }
 
-        if (didDockerChange || isComposerImage) {
+        if (shouldBuildImage) {
             String stagingImageTag = generateStagingImageTag()
             buildArgs['TAGS'] << stagingImageTag
             String kanikoCommand = getKanikoCommand(buildArgs)
@@ -372,7 +371,7 @@ stage('Build') {
                 }
             }]
         }
-        else {
+        else if (!isComposerImage) {
             // If not rebuilding the docker image, and it's not a composer image, then run CPU tests acorss all images,
             // and run GPU tests only on the "latest" image
             // Only run tests on the 'mosaicml/pytorch' or 'mosaicml/pytorch_vision' images -- not 'mosaicml/composer'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -103,11 +103,10 @@ Boolean isPathModified(...prefixes) {
     return false
 }
 
-String generateStagingImage() {
+String generateStagingImageTag() {
     // Generates a staging image tag
     String stagingTag = UUID.randomUUID()
-    String stagingImage = "${stagingDockerRepo}:${stagingTag}"
-    return stagingImage
+    return "${stagingDockerRepo}:${stagingTag}"
 }
 
 def getKanikoCommand(buildArgs) {
@@ -343,8 +342,8 @@ stage('Build') {
         }
 
         if (didDockerChange || isComposerImage) {
-            String stagingImage = generateStagingImage()
-            buildArgs['TAGS'] << stagingImage
+            String stagingImageTag = generateStagingImageTag()
+            buildArgs['TAGS'] << stagingImageTag
             String kanikoCommand = getKanikoCommand(buildArgs)
             jobs << [ "${label}": { ->
                 trackBuild(
@@ -367,7 +366,7 @@ stage('Build') {
                     // Only run tests on the 'mosaicml/pytorch' or 'mosaicml/pytorch_vision' images,
                     // not 'mosaicml/composer'
                     def subJobs = [:]
-                    scheduleJob(subJobs, stagingImage, buildArgs)
+                    scheduleJob(subJobs, stagingImageTag, buildArgs)
                     subJobs.failFast = true
                     parallel(subJobs)
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -298,7 +298,7 @@ stage('Prepare') {
         echo "gitBranch: $gitBranch"
         echo "gitCommit: $gitCommit"
 
-        didDockerChange = true  // TODO(Ravi) Unset this hardcode. isPathModified('docker/')
+        didDockerChange = isPathModified('docker/')
         pytorchDockerBuildMatrix = readYaml(file:  './docker/build_matrix.yaml')
 
         // Keep track of whether dependencies changed, in which case a conda build should be tested

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -102,57 +102,46 @@ Boolean isPathModified(...prefixes) {
     return false
 }
 
-def getDockerBuildMatrix(String buildConfigYamlPath, String buildContext, String dockerfile) {
-    /*
-    Generates a build matrix from the given yaml file
-    For each entry in the matrix, it returns a tuple of
-    (
-        (str) base kaniko command,
-        (str) destinations. To push the image to these destinations, append this string to the base kaniko command.
-        (str) the staging image to where the base kaniko command always pushes
-        (list) a list of (key, value) pairs of build args
-    )
-    */
-
-    def buildMatrix = readYaml(file: buildConfigYamlPath)
-
-    return buildMatrix.collect { buildArgs ->
-
-        def cliArgsList = []
-        def tags = []
-
-        buildArgs.each { key, val ->
-            if (key == 'TAGS') {
-                val.each { tag ->
-                    tags << tag
-                }
-                return
-            }
-            if (key == 'TARGET') {
-                cliArgsList << "--target '$val'"
-                return
-            }
-            cliArgsList << "--build-arg '$key=$val'"
-        }
-        String cliArgs = cliArgsList.join(' ')
-        String stagingTag = UUID.randomUUID()
-        cliArgs = "$cliArgs --dockerfile $dockerfile --context $buildContext"
-        cliArgs = "$cliArgs --destination ${stagingDockerRepo}:${stagingTag}"
-        String destinations = ""
-        for (tag in tags) {
-            destinations = "$destinations --destination $tag"
-        }
-
-        if (cliArgs.contains(cacheRepo)) {
-            error("The kaniko args should not ever attempt to push images to the cache repo, ${cacheRepo}")
-        }
-
-        String kanikoCommand = "/kaniko/executor --cache=true --cache-repo=${cacheRepo} ${cliArgs} --cleanup"
-        String stagingImage = "${stagingDockerRepo}:${stagingTag}"
-
-        return [kanikoCommand, destinations, stagingImage, buildArgs]
-    }
+String generateStagingImage() {
+    // Generates a staging image tag
+    String stagingTag = UUID.randomUUID()
+    String stagingImage = "${stagingDockerRepo}:${stagingTag}"
+    return stagingImage
 }
+
+def getKanikoCommand(buildArgs) {
+    // Constructs a kaniko command from the buildArgs
+    def cliArgsList = []
+    def tags = []
+     buildArgs.each { key, val ->
+        if (key == 'TAGS') {
+            val.each { tag ->
+                tags << tag
+            }
+            return
+        }
+        if (key == 'TARGET') {
+            cliArgsList << "--target '$val'"
+            return
+        }
+        cliArgsList << "--build-arg '$key=$val'"
+    }
+    String cliArgs = cliArgsList.join(' ')
+
+    cliArgs = "$cliArgs --dockerfile Dockerfile --context ./docker"
+    String destinations = ""
+    for (tag in tags) {
+        destinations = "$destinations --destination $tag"
+    }
+
+    if (cliArgs.contains(cacheRepo)) {
+        error("The kaniko args should not ever attempt to push images to the cache repo, ${cacheRepo}")
+    }
+
+    String kanikoCommand = "/kaniko/executor --cache=true --cache-repo=${cacheRepo} ${cliArgs} --cleanup"
+    return kanikoCommand
+}
+
 
 void trackBuild(Map buildArgs) {
     // 1. Run a build() command, but manually echo a link to the spawned job, since it may not show up
@@ -311,12 +300,8 @@ stage('Prepare') {
         echo "gitBranch: $gitBranch"
         echo "gitCommit: $gitCommit"
 
-        didDockerChange = isPathModified('docker/')
-
-        String dockerfile = 'Dockerfile'
-        String buildContext = './docker'
-        String buildMatrix = './docker/build_matrix.yaml'
-        pytorchDockerBuildMatrix = getDockerBuildMatrix(buildMatrix, buildContext, dockerfile)
+        didDockerChange = true  // TODO(Ravi) Unset this hardcode. isPathModified('docker/')
+        pytorchDockerBuildMatrix = readYaml(file:  './docker/build_matrix.yaml')
 
         // Keep track of whether dependencies changed, in which case a conda build should be tested
         dependenciesChanged = isPathModified('setup.py') || isPathModified('meta.yaml')
@@ -330,22 +315,13 @@ stage('Build') {
         isMergeCommit = false
     }
 
-    pytorchDockerBuildMatrix.each { entry ->
-        // Extract the values from the buildMatrix
-        String kanikoCommand = entry[0]  // kanikoCommand is the command to run
-        String destinations = entry[1]  // The destinations to append to the kanikoCommand to push the image
-        String stagingImage = entry[2]  // stagingImage is where the built docker image is always pushed
-        // buildArgs contains the entry from the build matrix. It has the format [{key: key, value: value}, ...].
-        def buildArgs = entry[3]
+    pytorchDockerBuildMatrix.each { buildArgs ->
         Boolean isComposerImage = buildArgs['TARGET'] == 'composer_stage'
-
-            // If changing docker, build the docker images first
-            // Then, run pytest in the newly-built image
-
         Boolean shouldPushToDestinations = isMergeCommit && gitBranch == baseBranch
+        String label = buildArgs['TAGS'][0]
 
-        if (shouldPushToDestinations) {
-            kanikoCommand = "$kanikoCommand $destinations"
+        if (!shouldPushToDestinations) {
+            buildArgs['TAGS'].clear()
         }
 
         if (isComposerImage) {
@@ -355,7 +331,7 @@ stage('Build') {
             }
             if (!isMergeCommit) {
                 // Skip composer images except on merge commits -- it's slow!
-                return
+                // return // TODO(ravi) Uncomment this line
             }
             // Then set the install command to the git commit string, and build and push it to
             // the mosaicml/composer_staging repo
@@ -368,7 +344,10 @@ stage('Build') {
         }
 
         if (didDockerChange || isComposerImage) {
-            jobs << [ "$buildArgs": { ->
+            String stagingImage = generateStagingImage()
+            buildArgs['TAGS'] << stagingImage
+            String kanikoCommand = getKanikoCommand(buildArgs)
+            jobs << [ "${label}": { ->
                 trackBuild(
                     job: jenkinsShellJobName,
                     parameters: [

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -321,7 +321,7 @@ stage('Build') {
         String label = buildArgs['TAGS'][0]
 
         if (!shouldPushToDestinations) {
-            buildArgs['TAGS'][:] = []
+            buildArgs['TAGS'] = []
         }
 
         if (isComposerImage) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -321,7 +321,7 @@ stage('Build') {
         String label = buildArgs['TAGS'][0]
 
         if (!shouldPushToDestinations) {
-            buildArgs['TAGS'].clear()
+            buildArgs['TAGS'][:] = []
         }
 
         if (isComposerImage) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -329,7 +329,7 @@ stage('Build') {
             }
             if (!isMergeCommit) {
                 // Skip composer images except on merge commits -- it's slow!
-                // return // TODO(ravi) Uncomment this line
+                return
             }
             // Then set the install command to the git commit string, and build and push it to
             // the mosaicml/composer_staging repo

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -176,16 +176,17 @@ void runLint(String pDockerImage) {
     )
 }
 
-void scheduleJob(jobs, String image, buildArgs) {
+void scheduleJob(jobs, String image, buildArgs, originalTags) {
     // jobs: The list of jobs. Modified in-place.
     // buildArgs: The build args matrix
+    // originalTags: The original tags
 
     String markers = 'not daily and not remote'
     Boolean isLintImage = false
     Boolean isVisionImage = false
     Boolean isDevTestInstallImage = false
     Boolean isGpu = false
-    String tag = ''
+    String tag = originalTags[0]
     buildArgs.each { key, val ->
         if (key == 'CUDA_VERSION') {
             if (val != '') {
@@ -195,13 +196,10 @@ void scheduleJob(jobs, String image, buildArgs) {
         if (key == 'TARGET' && val == 'vision_stage') {
             isVisionImage = true
         }
-        if (key == 'TAGS') {
-            tag = val[0]
-            val.each { tagName ->
-                isLintImage = isLintImage || tagName == lintImage
-                isDevTestInstallImage = isDevTestInstallImage || tagName == devInstallTestImage
-            }
-        }
+    }
+    originalTags.each { tagName ->
+        isLintImage = isLintImage || tagName == lintImage
+        isDevTestInstallImage = isDevTestInstallImage || tagName == devInstallTestImage
     }
     String extraDeps = 'all'
 
@@ -318,6 +316,8 @@ stage('Build') {
         Boolean shouldPushToDestinations = isMergeCommit && gitBranch == baseBranch
         Boolean shouldBuildImage = didDockerChange  // Always build the image if the ./docker folder changed
 
+        def originalTags = buildArgs['TAGS']
+
         if (!shouldPushToDestinations) {
             buildArgs['TAGS'] = []
         }
@@ -363,7 +363,7 @@ stage('Build') {
                     // Only run tests on the 'mosaicml/pytorch' or 'mosaicml/pytorch_vision' images,
                     // not 'mosaicml/composer'
                     def subJobs = [:]
-                    scheduleJob(subJobs, stagingImageTag, buildArgs)
+                    scheduleJob(subJobs, stagingImageTag, buildArgs, originalTags)
                     subJobs.failFast = true
                     parallel(subJobs)
                 }
@@ -376,15 +376,15 @@ stage('Build') {
             Boolean isCpuImage = buildArgs['CUDA_VERSION'] == ''
             Boolean shouldRunGpuTests = false
 
-            buildArgs['TAGS'].each { tag ->
+            originalTags.each { tag ->
                 if (pytestGpuImageTagsToTest.contains(tag)) {
                     shouldRunGpuTests = true
                 }
             }
 
             if (isCpuImage || shouldRunGpuTests) {
-                String existingImageTag = buildArgs['TAGS'][0]
-                scheduleJob(jobs, existingImageTag, buildArgs)
+                String existingImageTag = originalTags[0]
+                scheduleJob(jobs, existingImageTag, buildArgs, originalTags)
             }
         }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -79,7 +79,8 @@ Boolean isPathModified(...prefixes) {
     // starts with any specified prefix
     def changedFiles = []
 
-    // Adapted from https://stackoverflow.com/questions/50437626/how-to-get-list-of-all-modified-files-in-pipeline-jenkins
+    // Adapted from
+    // https://stackoverflow.com/questions/50437626/how-to-get-list-of-all-modified-files-in-pipeline-jenkins
     currentBuild.changeSets.each { entries ->
         entries.each { entry ->
             entry.affectedFiles.each { file ->
@@ -326,7 +327,7 @@ stage('Build') {
 
         if (isComposerImage) {
             if (!buildArgs['COMPOSER_INSTALL_COMMAND'].contains('==')) {
-                // If this is a composer image and it is the latest tag, skip it -- we'll build the versioned tag instead
+                // If this is a composer image and it is the latest tag, skip it -- build the versioned tag instead
                 return
             }
             if (!isMergeCommit) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -327,7 +327,7 @@ stage('Build') {
             // then build and publish the image on the staging repo
             if (!isMergeCommit) {
                 // Skip composer images except on merge commits -- it's slow!
-                // return  // TODO (ravi) -- uncomment this line
+                return
             }
             String stagingTagName = "mosaicml/composer_staging:${gitCommitHash[0..6]}"
             if (!buildArgs['CUDA_VERSION']) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -340,7 +340,7 @@ stage('Build') {
                 stagingTagName += '_cpu'
             }
             buildArgs['COMPOSER_INSTALL_COMMAND'] = "mosaicml[all] @ git+https://github.com/mosaicml/composer.git@${gitCommitHash}"
-            kanikoCommand = "$kanikoCommand --destination $stagingTagName"
+            buildArgs['TAGS'] << stagingTagName
         }
 
         if (didDockerChange || isComposerImage) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,7 +58,7 @@ ARG CUPY_VERSION='>=10.2.0'
 # Build the composer image on the vision image
 ARG COMPOSER_BASE=vision_stage
 
-# The command that is passed to `pip install` -- e.g. `pip install ${COMPOSER_INSTALL_COMMAND}`
+# The command that is passed to `pip install` -- e.g. `pip install "${COMPOSER_INSTALL_COMMAND}"`
 ARG COMPOSER_INSTALL_COMMAND='mosaicml[all]'
 
 #########################
@@ -319,4 +319,4 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ARG COMPOSER_INSTALL_COMMAND
 
-RUN pip install ${COMPOSER_INSTALL_COMMAND}
+RUN pip install "${COMPOSER_INSTALL_COMMAND}"

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -107,3 +107,19 @@
   - mosaicml/composer:0.7.1_cpu
   TARGET: composer_stage
   TORCHVISION_VERSION: 0.12.0
+- BASE_IMAGE: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
+  COMPOSER_INSTALL_COMMAND: mosaicml[all]GIT_COMMIT
+  CUDA_VERSION: 11.3.1
+  PYTHON_VERSION: '3.9'
+  PYTORCH_VERSION: 1.11.0
+  TAGS: []
+  TARGET: composer_stage
+  TORCHVISION_VERSION: 0.12.0
+- BASE_IMAGE: ubuntu:20.04
+  COMPOSER_INSTALL_COMMAND: mosaicml[all]GIT_COMMIT
+  CUDA_VERSION: ''
+  PYTHON_VERSION: '3.9'
+  PYTORCH_VERSION: 1.11.0
+  TAGS: []
+  TARGET: composer_stage
+  TORCHVISION_VERSION: 0.12.0

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -84,6 +84,9 @@ def _get_composer_tags(composer_version: str, use_cuda: bool):
     if not composer_version:
         composer_version = 'latest'
     composer_version = composer_version.lstrip('=')
+    if composer_version == 'GIT_COMMIT':
+        # Jenkins will set the tag
+        return []
     tag = f'mosaicml/composer:{composer_version}'
     if not use_cuda:
         tag += '_cpu'
@@ -153,7 +156,8 @@ def _main():
 
     composer_entries = []
 
-    composer_versions = ['', '==0.7.1']  # Only build images for the latest composer version
+    # The `GIT_COMMIT` is a placeholder and will be substituted with the actual git commit
+    composer_versions = ['', '==0.7.1', 'GIT_COMMIT']  # Only build images for the latest composer version
     composer_python_versions = ['3.9']  # just build composer against the latest
 
     for product in itertools.product(composer_python_versions, composer_versions, cuda_options):
@@ -208,6 +212,10 @@ def _main():
     headers = ['Composer Version', 'CUDA Support', 'Docker Tag']
     table = []
     for entry in composer_entries:
+
+        if len(entry['TAGS']) == 0:
+            continue
+
         table.append([
             entry['TAGS'][0].split(':')[1].replace('_cpu', ''),  # Composer version, or 'latest'
             'No' if entry['BASE_IMAGE'].startswith('ubuntu:') else 'Yes',  # Whether there is Cuda support

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -156,7 +156,7 @@ def _main():
 
     composer_entries = []
 
-    # The `GIT_COMMIT` is a placeholder and will be substituted with the actual git commit
+    # The `GIT_COMMIT` is a placeholder and Jenkins will substitute it with the actual git commit for the `composer_staging` images
     composer_versions = ['', '==0.7.1', 'GIT_COMMIT']  # Only build images for the latest composer version
     composer_python_versions = ['3.9']  # just build composer against the latest
 

--- a/docs/source/model_cards/BERT.md
+++ b/docs/source/model_cards/BERT.md
@@ -1,4 +1,4 @@
-# ![bert](https://storage.googleapis.com/docs.mosaicml.com/images/models/bert.gif) BERT
+# 🦭 BERT
 
 Category of Task: ``NLP``
 


### PR DESCRIPTION
#1197, which introduced composer image staging builds, installs Composer from pypi rather than from github. This PR fixes that by ensuring the modified buildArgs are passed to kaniko correctly.