### PR TITLE
Remove the `composer_train` entrypoint; put it back in `examples`

### DIFF
--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -10,10 +10,8 @@ import dataclasses
 import datetime
 import logging
 import os
-import sys
-import tempfile
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 import torch
 import yahp as hp
@@ -889,53 +887,3 @@ class ExperimentHparams(hp.Hparams):
         ]
 
         return trainer, fit_kwargs, eval_kwargs
-
-
-def _warning_on_one_line(message: str, category: Type[Warning], filename: str, lineno: int, file=None, line=None):
-    # From https://stackoverflow.com/questions/26430861/make-pythons-warnings-warn-not-mention-itself
-    return f'{category.__name__}: {message} (source: {filename}:{lineno})\n'
-
-
-def train_via_hparams() -> None:
-    """Entrypoint to train a model via hparams."""
-    warnings.formatwarning = _warning_on_one_line
-
-    if len(sys.argv) == 1:
-        sys.argv.append('--help')
-
-    hparams = TrainerHparams.create(cli_args=True)  # reads cli args from sys.argv
-
-    trainer = hparams.initialize_object()
-
-    # if using wandb, store the config inside the wandb run
-    try:
-        import wandb
-    except ImportError:
-        pass
-    else:
-        if wandb.run is not None:
-            wandb.config.update(hparams.to_dict())
-
-    # Only log the config once, since it should be the same on all ranks.
-    if dist.get_global_rank() == 0:
-        with tempfile.NamedTemporaryFile(mode='x+') as f:
-            f.write(hparams.to_yaml())
-            trainer.logger.file_artifact(
-                LogLevel.FIT,
-                artifact_name=f'{trainer.state.run_name}/hparams.yaml',
-                file_path=f.name,
-                overwrite=True,
-            )
-
-    # Print the config to the terminal and log to artifact store if on each local rank 0
-    if dist.get_local_rank() == 0:
-        print('*' * 30)
-        print('Config:')
-        print(hparams.to_yaml())
-        print('*' * 30)
-
-    trainer.fit()
-
-
-if __name__ == '__main__':
-    train_via_hparams()

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -2,30 +2,69 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Entrypoint to train via hparams.
+"""Entrypoint that runs the Composer trainer on a provided YAML hparams file.
 
-.. deprecated:: 0.8.0
+Example that trains MNIST with label smoothing:
 
-    This entrypoint was deprecated in composer v0.8.0 and will be removed in v0.9.0.
-    Instead, use the `composer-train` command -- e.g.
+.. code-block:: console
 
-    .. code-block:: console
-
-        composer-train -f path/to/hparams.yaml
-
-    Or, with the launcher script:
-
-    .. code-block:: console
-
-        composer -c composer-train -f path/to/hparams.yaml
+    python examples/run_composer_trainer.py -f composer/yamls/models/classify_mnist_cpu.yaml --algorithms label_smoothing --alpha 0.1
 """
 
+import sys
+import tempfile
 import warnings
+from typing import Type
 
-from composer.trainer.trainer_hparams import train_via_hparams
+from composer.loggers import LogLevel
+from composer.trainer.trainer_hparams import TrainerHparams
+from composer.utils import dist
+
+
+def _warning_on_one_line(message: str, category: Type[Warning], filename: str, lineno: int, file=None, line=None):
+    # From https://stackoverflow.com/questions/26430861/make-pythons-warnings-warn-not-mention-itself
+    return f'{category.__name__}: {message} (source: {filename}:{lineno})\n'
+
+
+def _main():
+    warnings.formatwarning = _warning_on_one_line
+
+    if len(sys.argv) == 1:
+        sys.argv.append('--help')
+
+    hparams = TrainerHparams.create(cli_args=True)  # reads cli args from sys.argv
+
+    trainer = hparams.initialize_object()
+
+    # if using wandb, store the config inside the wandb run
+    try:
+        import wandb
+    except ImportError:
+        pass
+    else:
+        if wandb.run is not None:
+            wandb.config.update(hparams.to_dict())
+
+    # Only log the config once, since it should be the same on all ranks.
+    if dist.get_global_rank() == 0:
+        with tempfile.NamedTemporaryFile(mode='x+') as f:
+            f.write(hparams.to_yaml())
+            trainer.logger.file_artifact(
+                LogLevel.FIT,
+                artifact_name=f'{trainer.state.run_name}/hparams.yaml',
+                file_path=f.name,
+                overwrite=True,
+            )
+
+    # Print the config to the terminal and log to artifact store if on each local rank 0
+    if dist.get_local_rank() == 0:
+        print('*' * 30)
+        print('Config:')
+        print(hparams.to_yaml())
+        print('*' * 30)
+
+    trainer.fit()
+
 
 if __name__ == '__main__':
-    warnings.warn(('examples/run_composer_trainer.py is deprecated. Instead, please use the `composer-train` command. '
-                   'This entrypoint will be removed in Composer v0.9.0.'),
-                  category=DeprecationWarning)
-    train_via_hparams()
+    _main()

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,6 @@ setup(name=package_name,
           'console_scripts': [
               'composer = composer.cli.launcher:main',
               'composer_collect_env = composer.utils.collect_env:main',
-              'composer_train = composer.trainer.trainer_hparams:train_via_hparams',
           ],
       },
       extras_require=extra_deps,


### PR DESCRIPTION
This PR partially reverts #1195 and removes the `composer_train` entrypoint from the pip package. Decided against including this in the pip package as it is very opinionated (e.g. with wandb config logging) and hides how users should use their own entrypoints.

It was also confusing to use it with the launcher script -- `composer -c composer_train` is unintuitive.

Instead, for users who want to use our example entrypoint with a `pip install` of composer, they can `wget` it from github.com at runtime.