### PR TITLE
Set SFTP Object Store Private Key Filepath from an Environ

### DIFF
--- a/composer/utils/object_store/object_store_hparams.py
+++ b/composer/utils/object_store/object_store_hparams.py
@@ -240,6 +240,10 @@ class SFTPObjectStoreHparams(ObjectStoreHparams):
     username: Optional[str] = hp.auto(SFTPObjectStore, 'username')
     known_hosts_filename: Optional[str] = hp.auto(SFTPObjectStore, 'known_hosts_filename')
     key_filename: Optional[str] = hp.auto(SFTPObjectStore, 'key_filename')
+    key_filename_environ: str = hp.optional(
+        ('The name of an environment variable containing '
+         'the path to a SSH keyfile. Note that `key_filename` takes precedence over this variable.'),
+        default='COMPOSER_SFTP_KEY_FILE')
     missing_host_key_policy: str = hp.auto(SFTPObjectStore, 'missing_host_key_policy')
     cwd: str = hp.auto(SFTPObjectStore, 'cwd')
     connect_kwargs: Optional[Dict[str, Any]] = hp.auto(SFTPObjectStore, 'connect_kwargs')
@@ -248,7 +252,11 @@ class SFTPObjectStoreHparams(ObjectStoreHparams):
         return SFTPObjectStore
 
     def get_kwargs(self) -> Dict[str, Any]:
-        return dataclasses.asdict(self)
+        kwargs = dataclasses.asdict(self)
+        del kwargs['key_filename_environ']
+        if self.key_filename_environ in os.environ and self.key_filename is None:
+            kwargs['key_filename'] = os.environ[self.key_filename_environ]
+        return kwargs
 
 
 object_store_registry: Dict[str, Type[ObjectStoreHparams]] = {

--- a/tests/utils/object_store/test_object_store_hparams.py
+++ b/tests/utils/object_store/test_object_store_hparams.py
@@ -7,7 +7,8 @@ from typing import Type
 import pytest
 
 from composer.utils.object_store import ObjectStore
-from composer.utils.object_store.object_store_hparams import ObjectStoreHparams, object_store_registry
+from composer.utils.object_store.object_store_hparams import (ObjectStoreHparams, SFTPObjectStoreHparams,
+                                                              object_store_registry)
 from tests.common.hparams import assert_in_registry, construct_from_yaml
 from tests.utils.object_store.object_store_settings import (get_object_store_ctx, object_store_hparams,
                                                             object_store_kwargs)
@@ -30,3 +31,13 @@ def test_object_store_hparams_is_constructable(
 @pytest.mark.parametrize('constructor', object_store_hparams)
 def test_hparams_in_registry(constructor: Type[ObjectStoreHparams]):
     assert_in_registry(constructor, object_store_registry)
+
+
+def test_sftp_key_file_environ(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):
+    private_key_filepath = '/path/to/private/key/file'
+    monkeypatch.setenv('COMPOSER_SFTP_KEY_FILE', private_key_filepath)
+    hparams = SFTPObjectStoreHparams(host='host',)
+    assert hparams.get_kwargs()['key_filename'] == private_key_filepath
+    with get_object_store_ctx(hparams.get_object_store_cls(), monkeypatch, tmp_path):
+        with hparams.initialize_object() as object_store:
+            assert isinstance(object_store, ObjectStore)


### PR DESCRIPTION
This PR allows the SFTP Object Store filepath to be set via an environ when using the yahp codepath. The enviorn defaults to `COMPOSER_SFTP_KEY_FILE` to match what is used by streaming datasets; however, this variable can be overridden via the `key_filename_environ` argument (to support multiple sftp object stores with different keys).

Closes https://mosaicml.atlassian.net/browse/CO-573