### PR TITLE
[xs] Fix progress bars in `get_file`

### DIFF
--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -407,6 +407,9 @@ def _get_callback(description: str):
         nonlocal pbar
         if num_bytes == 0 or pbar is None:
             pbar = tqdm.tqdm(desc=description, total=total_size, unit='iB', unit_scale=True)
-        pbar.update(num_bytes)
+        n = num_bytes - pbar.n
+        pbar.update(n)
+        if num_bytes == total_size:
+            pbar.close()
 
     return callback


### PR DESCRIPTION
`pbar.update` was called incorrectly -- it was called with the total length, rather than the delta, so it was finishing too quickly and instead showing `O(n^2)` length

Closes https://mosaicml.atlassian.net/browse/CO-577