### PR TITLE
Cleanup SFTP url parsing for StreamingDataset

### DIFF
--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -27,14 +27,14 @@ class StreamingDataset(IterableDataset):
 
     :class:`StreamingDataset` reads samples from binary `.mds` files that were written out by :class:`StreamingDatasetWriter`.
 
-    It currently supports downloading data from etiher S3 paths or local filepaths.
+    It currently supports downloading data from either remote paths (S3, SFTP) or local filepaths.
 
     It supports multi-gpu + multi-node training, and has smart local cacheing to minimize network bandwidth.
 
     It also provides best-effort shuffling to preserve randomness when ``shuffle=True``.
 
     Args:
-        remote (str): Download shards from this remote S3 path or directory.
+        remote (str): Download shards from this remote path or directory.
         local (str): Download shards to this local directory for for caching.
         shuffle (bool): Whether to shuffle the samples.  Note that if `shuffle=False`, the sample order is deterministic but dependent on the DataLoader's `num_workers`.
         decoders (Dict[str, Callable[bytes, Any]]]): For each sample field you wish to read, you must provide a decoder to convert the raw bytes to an object.

--- a/composer/datasets/streaming/download.py
+++ b/composer/datasets/streaming/download.py
@@ -45,7 +45,7 @@ def download_from_sftp(remote: str, local: str) -> None:
         local (str): Local path (local filesystem).
     """
     try:
-        from paramiko import AutoAddPolicy, RSAKey, SSHClient, SSHConfig
+        from paramiko import AutoAddPolicy, SSHClient
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='streaming', conda_package='paramiko') from e
 
@@ -61,24 +61,12 @@ def download_from_sftp(remote: str, local: str) -> None:
     port = url.port
     username = url.username
     password = url.password
-    key_filename = None
     remote_path = url.path
 
-    # Parse SSH Config if it exists
-    config = SSHConfig.from_path(os.path.abspath('/Users/abhinav/.ssh/config'))
-    host_config = config.lookup(hostname)
-    if 'hostname' in host_config:
-        hostname = host_config['hostname']
-    if 'port' in host_config:
-        port = host_config['port']
-    if 'user' in host_config:
-        username = host_config['user']
-    if 'password' in host_config:
-        password = host_config['password']
-    if 'identityfile' in host_config:
-        key_filename = host_config['identityfile'][0]
+    # Get SSH key file if specified
+    key_filename = os.environ.get('COMPOSER_SFTP_KEY_FILE', None)
 
-    # Defaults
+    # Default port
     port = port if port else 22
 
     # Local tmp

--- a/composer/datasets/streaming/download.py
+++ b/composer/datasets/streaming/download.py
@@ -7,7 +7,7 @@
 import os
 import shutil
 import time
-from urllib.parse import urlparse
+import urllib.parse
 
 from composer.utils import MissingConditionalImportError
 
@@ -27,7 +27,7 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='streaming', conda_package='boto3') from e
 
-    obj = urlparse(remote)
+    obj = urllib.parse.urlparse(remote)
     if obj.scheme != 's3':
         raise ValueError(f"Expected obj.scheme to be 's3', got {obj.scheme} for remote={remote}")
 
@@ -37,26 +37,49 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
 
 
 def download_from_sftp(remote: str, local: str) -> None:
-    """Download a file from remote to local.
+    """Download a file from remote SFTP server to local filepath.
+    Authentication must be provided via username/password in the `remote` URI,
+    or a valid SSH config, or a default key discoverable in ``~/.ssh/``.
     Args:
         remote (str): Remote path (SFTP).
         local (str): Local path (local filesystem).
     """
     try:
-        from paramiko import AutoAddPolicy, RSAKey, SSHClient
+        from paramiko import AutoAddPolicy, RSAKey, SSHClient, SSHConfig
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='streaming', conda_package='paramiko') from e
 
-    obj = urlparse(remote)
-    if obj.scheme != 'sftp':
-        raise ValueError(f"Expected obj.scheme to be 'sftp', got {obj.scheme} for remote={remote}")
-    remote_host = obj.netloc
-    remote_path = obj.path
+    # Parse URL
+    url = urllib.parse.urlsplit(remote)
+    if url.scheme.lower() != 'sftp':
+        raise ValueError('If specifying a URI, only the sftp scheme is supported.')
+    if not url.hostname:
+        raise ValueError('If specifying a URI, the URI must include the hostname.')
+    if url.query or url.fragment:
+        raise ValueError('Query and fragment parameters are not supported as part of a URI.')
+    hostname = url.hostname
+    port = url.port
+    username = url.username
+    password = url.password
+    key_filename = None
+    remote_path = url.path
 
-    # Read auth details from env var
-    private_key_path = os.environ['COMPOSER_SFTP_KEY_FILE']
-    pkey = RSAKey.from_private_key_file(private_key_path)
-    username = os.environ['COMPOSER_SFTP_USERNAME']
+    # Parse SSH Config if it exists
+    config = SSHConfig.from_path(os.path.abspath('/Users/abhinav/.ssh/config'))
+    host_config = config.lookup(hostname)
+    if 'hostname' in host_config:
+        hostname = host_config['hostname']
+    if 'port' in host_config:
+        port = host_config['port']
+    if 'user' in host_config:
+        username = host_config['user']
+    if 'password' in host_config:
+        password = host_config['password']
+    if 'identityfile' in host_config:
+        key_filename = host_config['identityfile'][0]
+
+    # Defaults
+    port = port if port else 22
 
     # Local tmp
     local_tmp = local + '.tmp'
@@ -66,7 +89,11 @@ def download_from_sftp(remote: str, local: str) -> None:
     with SSHClient() as ssh_client:
         # Connect SSH Client
         ssh_client.set_missing_host_key_policy(AutoAddPolicy)
-        ssh_client.connect(hostname=remote_host, port=22, username=username, pkey=pkey)
+        ssh_client.connect(hostname=hostname,
+                           port=port,
+                           username=username,
+                           password=password,
+                           key_filename=key_filename)
 
         # SFTP Client
         sftp_client = ssh_client.open_sftp()
@@ -111,7 +138,7 @@ def dispatch_download(remote, local, timeout: float):
 def download_or_wait(remote: str, local: str, wait: bool = False, max_retries: int = 2, timeout: float = 60) -> None:
     """Downloads a file from remote to local, or waits for it to be downloaded. Does not do any thread safety checks, so we assume the calling function is using ``wait`` correctly.
     Args:
-        remote (str): Remote path (S3 or local filesystem).
+        remote (str): Remote path (S3 or SFTP or local filesystem).
         local (str): Local path (local filesystem).
         wait (bool, default False): If ``true``, then do not actively download the file, but instead wait (up to ``timeout`` seconds) for the file to arrive.
         max_retries (int, default 2): Number of download re-attempts before giving up.

--- a/tests/datasets/test_streaming_remote.py
+++ b/tests/datasets/test_streaming_remote.py
@@ -29,6 +29,17 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
             'class': StreamingADE20k,
             'kwargs': {},
         },
+        'ade20k_sftp': {
+            'remote':
+                'sftp://mosaicml-test@s-d26bfe922c2141cca.server.transfer.us-west-2.amazonaws.com:22/mosaicml-internal-dataset-ade20k/mds/1',
+            'num_samples': {
+                'train': 20206,
+                'val': 2000,
+            },
+            'class':
+                StreamingADE20k,
+            'kwargs': {},
+        },
         'imagenet1k': {
             'remote': 's3://mosaicml-internal-dataset-imagenet1k/mds/1/',
             'num_samples': {
@@ -85,6 +96,7 @@ def get_dataset(name: str, local: str, split: str, shuffle: bool,
 @pytest.mark.filterwarnings(r'ignore::pytest.PytestUnraisableExceptionWarning')
 @pytest.mark.parametrize('name', [
     'ade20k',
+    'ade20k_sftp',
     'imagenet1k',
     'coco',
     'cifar10',


### PR DESCRIPTION
This PR allows SFTP urls passed to StreamingDataset to accept the same information (username, port, etc.) that we currently can for our SFTPObjectStore. This also eliminates the need for the `COMPOSER_SFTP_USERNAME` enviornment variable.