### PR TITLE
Fix mnist download for single GPU

### DIFF
--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -445,11 +445,12 @@ def run_local_rank_zero_first():
     """
     if not is_initialized():
         yield
+        return
+    
+    # hold non-zero ranks until rank zero done
+    if get_local_rank() != 0:
+        dist.barrier()
+        yield
     else:
-        # hold non-zero ranks until rank zero done
-        if get_local_rank() != 0:
-            dist.barrier()
-            yield
-        else:
-            yield
-            dist.barrier()
+        yield
+        dist.barrier()

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -446,7 +446,7 @@ def run_local_rank_zero_first():
     if not is_initialized():
         yield
         return
-    
+
     # hold non-zero ranks until rank zero done
     if get_local_rank() != 0:
         dist.barrier()

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -444,12 +444,12 @@ def run_local_rank_zero_first():
     same location.
     """
     if not is_initialized():
-        return
-
-    # hold non-zero ranks until rank zero done
-    if get_local_rank() != 0:
-        dist.barrier()
         yield
     else:
-        yield
-        dist.barrier()
+        # hold non-zero ranks until rank zero done
+        if get_local_rank() != 0:
+            dist.barrier()
+            yield
+        else:
+            yield
+            dist.barrier()


### PR DESCRIPTION
When `dist` is not initialized, the context manager should yield instead of return