### PR TITLE
Fix StreamingDataset compression with multi-rank

### DIFF
--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -138,10 +138,10 @@ class StreamingDataset(IterableDataset):
         self.timeout = timeout
         self.batch_size = batch_size
 
-        compression_basename = get_compression_scheme_basename()
-        if remote is not None:
+        self.compression_scheme = None
+        if remote is not None and dist.get_local_rank() == 0:
             try:
-                compression_local = self._download_file(compression_basename, wait=(dist.get_local_rank() != 0))
+                compression_local = self._download_file(get_compression_scheme_basename())
                 with open(compression_local, 'r') as fp:
                     compression_scheme = fp.read()
                     self.compression_scheme = compression_scheme if compression_scheme != '' else None
@@ -152,9 +152,12 @@ class StreamingDataset(IterableDataset):
                 os.remove(compression_local)
 
             except FileNotFoundError:
-                self.compression_scheme = None
-        else:
-            self.compression_scheme = None
+                pass
+
+        # Broadcast compression scheme to all ranks
+        compression_scheme_list = [self.compression_scheme]
+        dist.broadcast_object_list(compression_scheme_list)
+        self.compression_scheme = compression_scheme_list[0]
 
         # Load the index file containing the shard metadata
         # This file contains the shard and offset in bytes of each sample (for direct access).

--- a/composer/datasets/streaming/download.py
+++ b/composer/datasets/streaming/download.py
@@ -172,13 +172,14 @@ def download_or_wait(remote: Optional[str],
         max_retries (int, default 2): Number of download re-attempts before giving up.
         timeout (float, default 60): How long to wait for file to download before raising an exception.
     """
+    local_decompressed, _ = split_compression_suffix(local)
     last_error = None
     error_msgs = []
     for _ in range(1 + max_retries):
         try:
             if wait:
                 start = time.time()
-                while not os.path.exists(local):
+                while not os.path.exists(local_decompressed):
                     if time.time() - start > timeout:
                         raise TimeoutError(f'Waited longer than {timeout}s for other worker to download {local}.')
                     time.sleep(0.25)


### PR DESCRIPTION
This PR addresses 2 issues:

1) When multiple processes use a file, one of them downloads the file, and the others wait (by design there should be no download conflicts). When waiting for a compressed file, it is important to wait for the **uncompressed** local file to exist, not the compressed one, because that is when the shard is ready to use.

2) When a remote dataset is missing its`compression.txt` file, the rank0 process notices right away with a `FileNotFoundError` and proceeds. But the other ranks, which are waiting for rank0 to complete it's download, may wait up to 3min (3 tries * 60s) to understand that the file is missing and proceed. The `dist.broadcast` behavior change here will make the init time in this case much faster.