### PR TITLE
Support sequence of losses in backwards pass

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1814,7 +1814,7 @@ class Trainer:
                     loss.mul_(microbatch_num_samples / current_batch_size)
                     total_loss += loss.detach().clone()
             else:
-                final_loss = 0
+                final_loss = self._device.tensor_to_device(torch.zeros(size=(1,)))
                 for loss in ensure_tuple(self.state.loss):
                     final_loss += loss
                 final_loss.backward(create_graph=self._backwards_create_graph)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1814,8 +1814,10 @@ class Trainer:
                     loss.mul_(microbatch_num_samples / current_batch_size)
                     total_loss += loss.detach().clone()
             else:
+                final_loss = 0
                 for loss in ensure_tuple(self.state.loss):
-                    loss.backward(create_graph=self._backwards_create_graph)
+                    final_loss += loss
+                final_loss.backward(create_graph=self._backwards_create_graph)
 
             self.engine.run_event(Event.AFTER_BACKWARD)
 


### PR DESCRIPTION
For the non-deepspeed sections in trainer.py, it seems like the trainer aims to handle models that return a tuple of losses. One issue is that the backwards pass is called on each individual loss which will cause the error:

```
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
RuntimeError: Trying to backward through the graph a second time (or directly access saved tensors after they have already been freed). Saved intermediate values of the graph are freed when you call .backward() or autograd.grad(). Specify retain_graph=True if you need to backward through the graph a second time or if you need to access saved tensors after calling backward.
```

In practice, most people sum multiple losses, then call backwards on the summed losses. This PR aims to do just that. This allows models that return a tuple of losses to be trained and will make it easier to log multiple losses in the future