### PR TITLE
Catching ChannelErrors on SFTP Failures

### DIFF
--- a/composer/utils/object_store/sftp_object_store.py
+++ b/composer/utils/object_store/sftp_object_store.py
@@ -169,7 +169,7 @@ class SFTPObjectStore(ObjectStore):
 
     @contextlib.contextmanager
     def _handle_transient_errors(self):
-        from paramiko import SSHException
+        from paramiko import ChannelException, SSHException
         try:
             yield
         except Exception as e:
@@ -182,7 +182,7 @@ class SFTPObjectStore(ObjectStore):
             if isinstance(e, SSHException):
                 if 'Server connection dropped:' in str(e):
                     raise ObjectStoreTransientError from e
-            if isinstance(e, (TimeoutError, ConnectionError, EOFError)):
+            if isinstance(e, (TimeoutError, ConnectionError, EOFError, ChannelException)):
                 raise ObjectStoreTransientError from e
             raise e
 


### PR DESCRIPTION
Addresses https://mosaicml.atlassian.net/browse/CO-639, which contains the traceback that was caused by SFTP object store errors.

We should also verify that this is the right place to add the exception.

I was able to re-run and have not seen another crash in ~30 minutes, but this exception is pretty rare to being with.