### PR TITLE
Make `StreamingDataset` compression file easier to write/read

### DIFF
--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -139,11 +139,11 @@ class StreamingDataset(IterableDataset):
         self.batch_size = batch_size
 
         self.compression_scheme = None
-        if remote is not None and dist.get_local_rank() == 0:
+        if remote is not None and dist.get_global_rank() == 0:
             try:
                 compression_local = self._download_file(get_compression_scheme_basename())
                 with open(compression_local, 'r') as fp:
-                    compression_scheme = fp.read()
+                    compression_scheme = fp.read().rstrip('\n')
                     self.compression_scheme = compression_scheme if compression_scheme != '' else None
                     if remote == local and self.compression_scheme is not None:
                         raise DatasetCompressionException('cannot decompress when remote == local')

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -143,7 +143,7 @@ class StreamingDataset(IterableDataset):
             try:
                 compression_local = self._download_file(get_compression_scheme_basename())
                 with open(compression_local, 'r') as fp:
-                    compression_scheme = fp.read().rstrip('\n')
+                    compression_scheme = fp.read().rstrip()
                     self.compression_scheme = compression_scheme if compression_scheme != '' else None
                     if remote == local and self.compression_scheme is not None:
                         raise DatasetCompressionException('cannot decompress when remote == local')

--- a/composer/datasets/streaming/writer.py
+++ b/composer/datasets/streaming/writer.py
@@ -145,7 +145,7 @@ class StreamingDatasetWriter(object):
             raise RuntimeError('Attempted to write compression metadata file while samples are still being processed.')
         filename = os.path.join(self.dirname, get_compression_scheme_basename())
         with open(filename, 'x') as out:
-            out.write(self.compression_scheme)
+            out.write(self.compression_scheme + '\n')
 
     def _write_index(self) -> None:
         """Save dataset index file."""


### PR DESCRIPTION
Since our compression metadata is stored in a `.txt` file, it seems to imply that one could easily edit it. For example, I was trying to create some empty `compression.txt` files to upload to our older StreamingDatasets, for cleanliness.

But most text editors add a trailing newline when you try to save `.txt` files. They also display the file strangely if you open it and no newline exists.

What do you guys (@knighton, @milocress) think about adding this newline generally so that `compression.txt` is easily editable?