### PR TITLE
Catch botocore ClientError 403

### DIFF
--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -15,7 +15,7 @@ from composer.utils.object_store.object_store import ObjectStore
 
 __all__ = ['S3ObjectStore']
 
-_NOT_FOUND_CODES = ('404', 'NoSuchKey')
+_NOT_FOUND_CODES = ('403', '404', 'NoSuchKey')
 
 
 def _ensure_not_found_errors_are_wrapped(uri: str, e: Exception):


### PR DESCRIPTION
We have a rare issue that occurs when a user has no S3 credentials, and is trying to use a `StreamingDataset` that is not compressed (no `compression.txt` file present) from a bucket that has all public files.

Our `StreamingDataset` always looks for `compression.txt` and gracefully handles if not found. For filesystems this check is easy but for remote paths like S3, we catch different types of network errors and basically re-interpret them as `FileNotFound`.

It turns out that even if all the `.mds` files are public, the _bucket_ itself is not, so when we try to download `compression.txt`, we don't actually have permission to call `HeadObject` on the bucket and check if the file exists, so we get a 403. 

This PR adds the ClientError 403 to our list of "errors we interpret as FileNotFound"