### PR TITLE
Merge v0.8.0 into dev

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -364,7 +364,10 @@ stage('Build') {
                     // not 'mosaicml/composer'
                     def subJobs = [:]
                     scheduleJob(subJobs, stagingImageTag, buildArgs, originalTags)
-                    subJobs.failFast = true
+                    if (!isMergeCommit) {
+                        // Fail fast only on PR builds
+                        subJobs.failFast = true
+                    }
                     parallel(subJobs)
                 }
             }]
@@ -412,7 +415,10 @@ stage('Build') {
             }
         ]
     }
-    jobs.failFast = true
+    if (!isMergeCommit) {
+        // Fail fast only on PR builds
+        jobs.failFast = true
+    }
     try {
         parallel(jobs)
     }

--- a/composer/__init__.py
+++ b/composer/__init__.py
@@ -24,4 +24,4 @@ __all__ = [
     'Trainer',
 ]
 
-__version__ = '0.7.0'
+__version__ = '0.8.0'

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -348,7 +348,7 @@ def print_env(file: Optional[TextIO] = None) -> None:
 
         Composer information
         --------------------
-        Composer version: 0.7.0
+        Composer version: 0.8.0
         Host processor model name: AMD EPYC 7502 32-Core Processor
         Host processor core count: 64
         Number of nodes: 1

--- a/docker/README.md
+++ b/docker/README.md
@@ -17,8 +17,8 @@ all dependencies for both NLP and Vision models. They are built on top of the
 |--------------------|----------------|--------------------------------|
 | latest             | Yes            | `mosaicml/composer:latest`     |
 | latest             | No             | `mosaicml/composer:latest_cpu` |
-| 0.7.1              | Yes            | `mosaicml/composer:0.7.1`      |
-| 0.7.1              | No             | `mosaicml/composer:0.7.1_cpu`  |
+| 0.8.0              | Yes            | `mosaicml/composer:0.8.0`      |
+| 0.8.0              | No             | `mosaicml/composer:0.8.0_cpu`  |
 <!-- END_COMPOSER_BUILD_MATRIX -->
 
 

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -90,21 +90,21 @@
   TARGET: composer_stage
   TORCHVISION_VERSION: 0.12.0
 - BASE_IMAGE: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
-  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.7.1
+  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.8.0
   CUDA_VERSION: 11.3.1
   PYTHON_VERSION: '3.9'
   PYTORCH_VERSION: 1.11.0
   TAGS:
-  - mosaicml/composer:0.7.1
+  - mosaicml/composer:0.8.0
   TARGET: composer_stage
   TORCHVISION_VERSION: 0.12.0
 - BASE_IMAGE: ubuntu:20.04
-  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.7.1
+  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.8.0
   CUDA_VERSION: ''
   PYTHON_VERSION: '3.9'
   PYTORCH_VERSION: 1.11.0
   TAGS:
-  - mosaicml/composer:0.7.1_cpu
+  - mosaicml/composer:0.8.0_cpu
   TARGET: composer_stage
   TORCHVISION_VERSION: 0.12.0
 - BASE_IMAGE: nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -157,7 +157,7 @@ def _main():
     composer_entries = []
 
     # The `GIT_COMMIT` is a placeholder and Jenkins will substitute it with the actual git commit for the `composer_staging` images
-    composer_versions = ['', '==0.7.1', 'GIT_COMMIT']  # Only build images for the latest composer version
+    composer_versions = ['', '==0.8.0', 'GIT_COMMIT']  # Only build images for the latest composer version
     composer_python_versions = ['3.9']  # just build composer against the latest
 
     for product in itertools.product(composer_python_versions, composer_versions, cuda_options):

--- a/meta.yaml
+++ b/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: mosaicml
-  version: "0.7.0"
+  version: "0.8.0"
 
 source:
   git_url: ./

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ if package_name != 'mosaicml':
     print(f'`Building composer as `{package_name}`)', file=sys.stderr)
 
 setup(name=package_name,
-      version='0.7.0',
+      version='0.8.0',
       author='MosaicML',
       author_email='team@mosaicml.com',
       description='Composer provides well-engineered implementations of efficient training methods to give '


### PR DESCRIPTION
Merge the v0.8.0 release back into dev. This effectively bumps the version on dev and incorporates any fixes which were pushed directly to the release branch.

Do not merge this PR through the GH UI; instead do a traditional merge through the CLI. Opening a (Draft) PR to trigger Jenkins builds.