### PR TITLE
BERT and C4 updates

### DIFF
--- a/composer/datasets/streaming/writer.py
+++ b/composer/datasets/streaming/writer.py
@@ -7,7 +7,7 @@
 import gzip as gz
 import os
 from io import BufferedWriter
-from threading import Lock, Thread
+from threading import Thread
 from types import TracebackType
 from typing import Dict, Iterable, List, Optional, Tuple, Type, Union
 

--- a/composer/datasets/streaming/writer.py
+++ b/composer/datasets/streaming/writer.py
@@ -135,7 +135,7 @@ class StreamingDatasetWriter(object):
         basename = get_shard_basename(shard, compression_name=self.compression_scheme)
         filename = os.path.join(self.dirname, basename)
 
-        Thread(target=self._thread_flush_shard, args=(self.new_samples, filename), daemon=True).start()
+        Thread(target=self._thread_flush_shard, args=(self.new_samples, filename), daemon=False).start()
 
         self.samples_per_shard.append(len(self.new_samples))
         self.bytes_per_shard.append(self.new_shard_size)

--- a/composer/yamls/models/bert-base.yaml
+++ b/composer/yamls/models/bert-base.yaml
@@ -8,7 +8,7 @@ model:
 # Train the model on the English C4 corpus
 train_dataset:
   streaming_c4:
-    remote: s3://allenai-c4/mds/1/
+    remote: s3://allenai-c4/mds/1-gz/
     local: /tmp/mds-cache/mds-c4/
     split: train
     shuffle: true
@@ -32,7 +32,7 @@ evaluators:
     label: bert_pre_training
     eval_dataset:
       streaming_c4:
-        remote: s3://allenai-c4/mds/1/
+        remote: s3://allenai-c4/mds/1-gz/
         local: /tmp/mds-cache/mds-c4/
         split: val
         shuffle: false
@@ -51,30 +51,30 @@ eval_interval: 1000ba
 # Use the decoupled AdamW optimizer with learning rate warmup
 optimizers:
   decoupled_adamw:
-    lr: 5.0e-4                     # Peak learning rate
+    lr: 5.0e-4 # Peak learning rate
     betas:
       - 0.9
       - 0.98
     eps: 1.0e-06
-    weight_decay: 1.0e-5           # Amount of weight decay regularization
+    weight_decay: 1.0e-5 # Amount of weight decay regularization
 schedulers:
   linear_decay_with_warmup:
-    t_warmup: 0.06dur              # Point when peak learning rate is reached
+    t_warmup: 0.06dur # Point when peak learning rate is reached
     alpha_f: 0.02
 
-max_duration: 275184000sp          # Subsample the training data for 275M samples
-train_batch_size: 4000             # Number of training examples to use per update
-eval_batch_size: 2000
+max_duration: 286720000sp # Subsample the training data for ~275M samples
+train_batch_size: 4096 # Number of training examples to use per update
+eval_batch_size: 2048
 
-precision: amp                     # Use mixed-precision training
-grad_clip_norm: -1.0               # Turn off gradient clipping
-grad_accum: 'auto'                 # Use automatic gradient accumulation to avoid OOMs
+precision: amp # Use mixed-precision training
+grad_clip_norm: -1.0 # Turn off gradient clipping
+grad_accum: auto # Use automatic gradient accumulation to avoid OOMs
 
-save_folder: bert_checkpoints      # The directory to save checkpoints to
-save_interval: 3500ba              # Save checkpoints every 3500 batches
+save_folder: bert_checkpoints # The directory to save checkpoints to
+save_interval: 3500ba # Save checkpoints every 3500 batches
 
 loggers:
-  progress_bar: {}                 # Add a TQDM progress bar
+  progress_bar: {} # Add a TQDM progress bar
   # Optional, some nice default parameters for object store checkpointing. Uncomment this if you want to checkpoint to cloud.
   # object_store:
   #  object_store_hparams:

--- a/composer/yamls/models/bert-base.yaml
+++ b/composer/yamls/models/bert-base.yaml
@@ -66,6 +66,8 @@ max_duration: 286720000sp # Subsample the training data for ~275M samples
 train_batch_size: 4096 # Number of training examples to use per update
 eval_batch_size: 2048
 
+seed: 17
+
 precision: amp # Use mixed-precision training
 grad_clip_norm: -1.0 # Turn off gradient clipping
 grad_accum: auto # Use automatic gradient accumulation to avoid OOMs

--- a/scripts/mds/c4.py
+++ b/scripts/mds/c4.py
@@ -86,7 +86,7 @@ def each(dataset: IterableDataset) -> Iterable[Dict[str, bytes]]:
 
 
 def main(args: Namespace) -> None:
-    """Main: create C4 streaming dataset, with 'gz' compression.
+    """Main: create C4 streaming dataset.
 
     Args:
         args (Namespace): Commandline arguments.
@@ -104,7 +104,7 @@ def main(args: Namespace) -> None:
         with StreamingDatasetWriter(dirname=os.path.join(args.out_root, split_new_name),
                                     fields=fields,
                                     shard_size_limit=args.shard_size_limit,
-                                    compression='gz') as out:
+                                    compression=None) as out:
             out.write_samples(samples=each(dataset), use_tqdm=bool(args.tqdm), total=expected_num_samples)
 
 

--- a/scripts/mds/c4.py
+++ b/scripts/mds/c4.py
@@ -69,6 +69,8 @@ def each(dataset: IterableDataset) -> Iterable[Dict[str, bytes]]:
     """
     num_workers = min(64, dataset.num_shards())
     batch_size = 512
+    # If using multiple workers, configure each worker to prefetch as many samples as it can, up to the aggregate device batch size
+    # If not using workers, the torch DataLoader expects the default value for prefetch_factor, which non-intuitively must be 2.
     prefetch_factor = max(1, 2 * batch_size // num_workers) if num_workers > 0 else 2
 
     loader = DataLoader(

--- a/scripts/mds/c4.py
+++ b/scripts/mds/c4.py
@@ -43,7 +43,7 @@ def get(split: str) -> IterableDataset:
             self.dataset = datasets.load_dataset(path='c4', name='en', split=split, streaming=True)
 
         def num_shards(self):
-          return len(self.dataset._ex_iterable.kwargs['filepaths'])
+            return len(self.dataset._ex_iterable.kwargs['filepaths'])
 
         def __iter__(self):
             worker_info = get_worker_info()
@@ -84,12 +84,9 @@ def each(dataset: IterableDataset) -> Iterable[Dict[str, bytes]]:
         for idx in range(current_bs):
             yield {key: batch_values[idx].encode('utf-8') for key, batch_values in batch.items()}
 
-    # for sample in dataset:
-    #     yield {key: value.encode('utf-8') for key, value in sample.items()}
-
 
 def main(args: Namespace) -> None:
-    """Main: create C4 streaming dataset.
+    """Main: create C4 streaming dataset, with 'gz' compression.
 
     Args:
         args (Namespace): Commandline arguments.
@@ -107,7 +104,7 @@ def main(args: Namespace) -> None:
         with StreamingDatasetWriter(dirname=os.path.join(args.out_root, split_new_name),
                                     fields=fields,
                                     shard_size_limit=args.shard_size_limit,
-                                    compression=None) as out:
+                                    compression='gz') as out:
             out.write_samples(samples=each(dataset), use_tqdm=bool(args.tqdm), total=expected_num_samples)
 
 

--- a/scripts/mds/c4.py
+++ b/scripts/mds/c4.py
@@ -22,7 +22,7 @@ def parse_args() -> Namespace:
     """Parse commandline arguments."""
     args = ArgumentParser()
     args.add_argument('--out_root', type=str, required=True)
-    args.add_argument('--shard_size_limit', type=int, default=1 << 30)
+    args.add_argument('--shard_size_limit', type=int, default=1 << 28)
     args.add_argument('--tqdm', type=int, default=1)
     return args.parse_args()
 


### PR DESCRIPTION
I've got a couple BERT+C4 usability improvements here that I packaged to avoid 3 tiny PRs, but if there's a lot of discussion I can split it up. Opening in draft mode as well.

1) (@knighton) Make the `StreamingDatasetWriter` shard flushing async, which helps overlap work a bit when writing `.mds` datasets. I see a small but meaningful perf improvement, and no more intermittent "pausing" in the progress bar. @knighton

2) (@knighton) Improve our C4 to `.mds` conversion example so that it all happens via streaming and ~saves to compressed `gz` format.~ not doing this right now b/c our compression during writing is way too slow, and we need to use pigz-python.

I added a quick wrapper around the HF dataset to make it multi-worker compatible, and now we don't need to pre-download the dataset any more. The entire train dataset (360M samples, 770GB of text) can be converted in about 2hr with `num_workers=8`, and about 1.1hr with `num_workers=64`. Results may vary depending on system, and the latter result is probably an indicator of the limits of our single-stream writer, but this seems pretty good to me! 

 * Note: since HF Datasets 2.3.0, the streaming dataset multiprocessing issue [might be fixed upstream](https://github.com/huggingface/datasets/pull/4375), so we should investigate whether it's time to upgrade to HF datasets 2.0+ and refactor our HF C4 implementation to take advantage of this new feature. In general, we should keep a closer eye here... It appears HF even has a [streaming ImageNet1k dataset now.](https://huggingface.co/datasets/imagenet-1k). 

3) (@moinnadeem) Update the `bert-base-uncased` YAML to use a power-of-2 batch size, a max_duration that converts cleanly to 70k batches, and use the new compressed public C4 `StreamingDataset` 