### PR TITLE
Automatic Stochastic depth on residual blocks

### DIFF
--- a/tests/utils/test_fx_utils.py
+++ b/tests/utils/test_fx_utils.py
@@ -8,8 +8,9 @@ import torch
 from torch import nn
 from torch.fx import symbolic_trace
 from torch.fx.graph_module import GraphModule
+from torchvision import models
 
-from composer.utils.fx_utils import count_op_instances, fuse_parallel_linears, replace_op
+from composer.utils.fx_utils import apply_stochastic_residual, count_op_instances, fuse_parallel_linears, replace_op
 
 
 class MyTestModel(nn.Module):
@@ -153,3 +154,28 @@ def test_fuse_parallel_linears(model_cls, before_count, after_count):
     fuse_parallel_linears(traced)
 
     assert count_op_instances(traced, nn.Linear) == after_count
+
+
+@pytest.mark.parametrize(
+    'model_cls, block_count',
+    [(models.resnet18, 8)],
+)
+@pytest.mark.filterwarnings(
+    r'ignore:Attempted to insert a call_module Node with no underlying reference in the owning GraphModule!.*:UserWarning'
+)
+@pytest.mark.timeout(15)
+def test_stochastic_depth(model_cls, block_count):
+    model = model_cls()
+    traced = symbolic_trace(model)
+
+    assert isinstance(traced, GraphModule)
+
+    inp = torch.randn(1, 3, 224, 224)
+
+    traced_st_depth_no_drop, residual_count = apply_stochastic_residual(traced, 0.0)
+
+    out_traced = traced(inp)
+    out_traced_st_depth_no_drop = traced_st_depth_no_drop(inp)
+    assert torch.allclose(out_traced,
+                          out_traced_st_depth_no_drop), 'mismatch in outputs with 0 drop rate for stochastic modules'
+    assert residual_count == block_count


### PR DESCRIPTION
Detect residual blocks automatically and replace them with a stochastic version. See attached graphs for how transformation happens on ResNet50. 



~~TODO: Add tests.~~ Done


**Orig:** 
![orig_resnet50](https://user-images.githubusercontent.com/37562707/176974346-29a3f2f0-59dc-4fbb-8ab6-4a43dddca5c4.svg)

**Split into bottleneck and downsample:**
![split_resnet50](https://user-images.githubusercontent.com/37562707/176974363-5012df7e-4d68-4a7c-b5e7-c5b89feacd28.svg)

**Converted with a call to block_stochastic_module:**
![split_stochastic_resnet50](https://user-images.githubusercontent.com/37562707/176974368-b459a464-c0e5-471e-ac62-78bf36c7a9a5.svg)
 