### PR TITLE
Fix recipe yamls for `v0.8`, add testing

### DIFF
--- a/composer/trainer/devices/device_gpu.py
+++ b/composer/trainer/devices/device_gpu.py
@@ -29,6 +29,8 @@ class DeviceGPU(Device):
     dist_backend = 'nccl'
 
     def __init__(self, device_id: Optional[int] = None):
+        if not torch.cuda.is_available():
+            raise ValueError('DeviceGPU cannot be created as torch.cuda is not available.')
         if not device_id:
             device_id = dist.get_local_rank()
         self._device = torch.device(f'cuda:{device_id}')

--- a/composer/yamls/recipes/resnet50_medium.yaml
+++ b/composer/yamls/recipes/resnet50_medium.yaml
@@ -46,13 +46,13 @@ loggers:
 model:
   resnet:
     initializers:
-    - KAIMING_NORMAL
-    - BN_UNIFORM
-    - LINEAR_LOG_CONSTANT_BIAS
+      - KAIMING_NORMAL
+      - BN_UNIFORM
+      - LINEAR_LOG_CONSTANT_BIAS
     loss_name: binary_cross_entropy_with_logits
     model_name: resnet50
     num_classes: 1000
-optimizer:
+optimizers:
   decoupled_sgdw:
     dampening: 0.0
     lr: 2.048
@@ -61,7 +61,7 @@ optimizer:
     weight_decay: 0.0005
 precision: AMP
 max_duration: 90ep
-scale_schedule_ratio: # Fraction of 90 epochs to train for. 0.75-2.6 for medium recipe
+scale_schedule_ratio: 1.5 # Fraction of 90 epochs to train for. 0.75-2.6 for medium recipe
 schedulers:
   cosine_decay_with_warmup:
     alpha_f: 0.0
@@ -75,7 +75,7 @@ train_dataset:
     # datadir: not needed because we're using FFCV
     drop_last: true
     ffcv_dest: imagenet_train.ffcv
-    ffcv_dir: # /path/to/ffcv/data/directory
+    ffcv_dir: /path/to/ffcv # /path/to/ffcv/data/directory
     ffcv_write_dataset: false
     is_train: true
     resize_size: -1
@@ -87,7 +87,7 @@ val_dataset:
     # datadir: not needed because we're using FFCV
     drop_last: false
     ffcv_dest: imagenet_val.ffcv
-    ffcv_dir: # /path/to/ffcv/data/directory
+    ffcv_dir: /path/to/ffcv # /path/to/ffcv/data/directory
     ffcv_write_dataset: false
     is_train: false
     resize_size: 232

--- a/composer/yamls/recipes/resnet50_mild.yaml
+++ b/composer/yamls/recipes/resnet50_mild.yaml
@@ -39,12 +39,13 @@ loggers:
 model:
   resnet:
     initializers:
-    - KAIMING_NORMAL
-    - BN_UNIFORM
-    - LINEAR_LOG_CONSTANT_BIAS
+      - KAIMING_NORMAL
+      - BN_UNIFORM
+      - LINEAR_LOG_CONSTANT_BIAS
     loss_name: binary_cross_entropy_with_logits
     model_name: resnet50
-optimizer:
+    num_classes: 1000
+optimizers:
   decoupled_sgdw:
     dampening: 0.0
     lr: 2.048
@@ -53,7 +54,7 @@ optimizer:
     weight_decay: 0.0005
 precision: AMP
 max_duration: 90ep
-scale_schedule_ratio: # Fraction of 90 epochs to train for. 0-0.75 for mild recipe
+scale_schedule_ratio: 0.4 # Fraction of 90 epochs to train for. 0-0.75 for mild recipe
 schedulers:
   cosine_decay_with_warmup:
     alpha_f: 0.0
@@ -67,7 +68,7 @@ train_dataset:
     # datadir: not needed because we're using FFCV
     drop_last: true
     ffcv_dest: imagenet_train.ffcv
-    ffcv_dir: # /path/to/ffcv/data/directory
+    ffcv_dir: /path/to/ffcv # /path/to/ffcv/data/directory
     ffcv_write_dataset: false
     is_train: true
     resize_size: -1
@@ -79,7 +80,7 @@ val_dataset:
     # datadir: not needed because we're using FFCV
     drop_last: false
     ffcv_dest: imagenet_val.ffcv
-    ffcv_dir: # /path/to/ffcv/data/directory
+    ffcv_dir: /path/to/ffcv # /path/to/ffcv/data/directory
     ffcv_write_dataset: false
     is_train: false
     resize_size: 232

--- a/composer/yamls/recipes/resnet50_spicy.yaml
+++ b/composer/yamls/recipes/resnet50_spicy.yaml
@@ -40,7 +40,6 @@ algorithms:
     drop_warmup: 0.0dur
     stochastic_method: sample
     target_layer_name: ResNetBottleneck
-    use_same_gpu_seed: false
 callbacks:
   lr_monitor: {}
   speed_monitor:
@@ -53,6 +52,7 @@ dataloader:
   timeout: 0.0
 device:
   gpu: {}
+eval_batch_size: 2048
 loggers:
   progress_bar:
     console_log_level: EPOCH
@@ -61,15 +61,15 @@ model:
   resnet:
     groups: 1
     initializers:
-    - KAIMING_NORMAL
-    - BN_UNIFORM
-    - LINEAR_LOG_CONSTANT_BIAS
+      - KAIMING_NORMAL
+      - BN_UNIFORM
+      - LINEAR_LOG_CONSTANT_BIAS
     loss_name: binary_cross_entropy_with_logits
     model_name: resnet50
     num_classes: 1000
     pretrained: false
     width_per_group: 64
-optimizer:
+optimizers:
   decoupled_sgdw:
     dampening: 0.0
     lr: 2.048
@@ -78,7 +78,7 @@ optimizer:
     weight_decay: 0.0003
 precision: AMP
 max_duration: 90ep
-scale_schedule_ratio: # Fraction of 90 epochs to train for. >2.6 for spicy recipe
+scale_schedule_ratio: 3 # Fraction of 90 epochs to train for. >2.6 for spicy recipe
 schedulers:
   cosine_decay_with_warmup:
     alpha_f: 0.0
@@ -89,14 +89,14 @@ train_batch_size: 2048
 train_dataset:
   imagenet:
     crop_size: 176
-    datadir: # /path/to/imagenet
+    datadir: /path/to/imagenet # /path/to/imagenet
     drop_last: true
     is_train: true
 train_subset_num_batches: -1
 val_dataset:
   imagenet:
     crop_size: 224
-    datadir: # /path/to/imagenet
+    datadir: /path/to/imagenet # /path/to/imagenet
     drop_last: false
     is_train: false
     resize_size: 232

--- a/tests/models/test_model_yamls.py
+++ b/tests/models/test_model_yamls.py
@@ -78,7 +78,6 @@ class TestHparamsCreate:
 
         with open(hparams_file, 'r') as f:
             yaml_dict = yaml.safe_load(f)
-            print(yaml_dict)
 
         yaml_dict = self._ensure_device_cpu(yaml_dict)
 

--- a/tests/models/test_model_yamls.py
+++ b/tests/models/test_model_yamls.py
@@ -31,6 +31,7 @@ class TestHparamsCreate:
 
     def _ensure_device_cpu(self, yaml_dict: Dict[str, Any]):
         yaml_dict['device'] = {'cpu': {}}
+        yaml_dict['precision'] = 'fp32'
         return yaml_dict
 
     def test_hparams_create(self, hparams_file: str):


### PR DESCRIPTION
This PR:
* fixes the recipe yamls to work with the latest version of COmposer
* expands our test coverage to include those yamls to prevent future regressions

Note: this is a UX change, as the recipe yamls will now have default ssr ratios, as well as datasets path. @growlix what do you prefer? It's easy to patch the yaml during the test if you would prefer to keep those unfilled.