### PR TITLE
Add packaging to `meta.yaml`; add `py-cpuinfo` max version

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - psutil >=5.8.0,<6
     - coolname >=1.1.0,<2
     - py-cpuinfo>=8.0.0
+    - packaging >=21.3.0,<22
   run_constrained:
     - wandb >=0.12.17,<0.13
     - monai >=0.8.0,<0.9

--- a/meta.yaml
+++ b/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - numpy >=1.21.5,<2
     - psutil >=5.8.0,<6
     - coolname >=1.1.0,<2
-    - py-cpuinfo>=8.0.0
+    - py-cpuinfo>=8.0.0,<9
     - packaging >=21.3.0,<22
   run_constrained:
     - wandb >=0.12.17,<0.13

--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,8 @@ install_requires = [
     'numpy>=1.21.5,<2',
     'psutil>=5.8.0,<6',
     'coolname>=1.1.0,<2',
-    'py-cpuinfo>=8.0.0',
-    'packaging>=21.3.0'
+    'py-cpuinfo>=8.0.0,<9',
+    'packaging>=21.3.0,<22',
 ]
 extra_deps = {}
 


### PR DESCRIPTION
* Follow up on #1612 to add packaging to the `meta.yaml`.
* Constrain `py-cpuinfo` to a max version of 9.0.0