### PR TITLE
Allow object name prefix for S3ObjectStore

### DIFF
--- a/composer/utils/object_store/object_store_hparams.py
+++ b/composer/utils/object_store/object_store_hparams.py
@@ -193,7 +193,7 @@ class S3ObjectStoreHparams(ObjectStoreHparams):
 
     Args:
         bucket (str): See :class:`.S3ObjectStore`.
-        prefix (str, optional): See :class:`.S3ObjectStore`.
+        prefix (str): See :class:`.S3ObjectStore`.
         region_name (str, optional): See :class:`.S3ObjectStore`.
         endpoint_url (str, optional): See :class:`.S3ObjectStore`.
         client_config (dict, optional): See :class:`.S3ObjectStore`.

--- a/composer/utils/object_store/object_store_hparams.py
+++ b/composer/utils/object_store/object_store_hparams.py
@@ -193,6 +193,7 @@ class S3ObjectStoreHparams(ObjectStoreHparams):
 
     Args:
         bucket (str): See :class:`.S3ObjectStore`.
+        prefix (str, optional): See :class:`.S3ObjectStore`.
         region_name (str, optional): See :class:`.S3ObjectStore`.
         endpoint_url (str, optional): See :class:`.S3ObjectStore`.
         client_config (dict, optional): See :class:`.S3ObjectStore`.
@@ -200,6 +201,7 @@ class S3ObjectStoreHparams(ObjectStoreHparams):
     """
 
     bucket: str = hp.auto(S3ObjectStore, 'bucket')
+    prefix: str = hp.auto(S3ObjectStore, 'prefix')
     region_name: Optional[str] = hp.auto(S3ObjectStore, 'region_name')
     endpoint_url: Optional[str] = hp.auto(S3ObjectStore, 'endpoint_url')
     # Not including the credentials as part of the hparams -- they should be specified through the default

--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -83,8 +83,13 @@ class S3ObjectStore(ObjectStore):
             from botocore.config import Config
         except ImportError as e:
             raise MissingConditionalImportError('s3', 'boto3') from e
-        self.bucket = bucket
-        self.prefix = prefix
+
+        # Format paths
+        self.bucket = bucket.strip('/')
+        self.prefix = prefix.strip('/')
+        if self.prefix:
+            self.prefix += '/'
+
         if client_config is None:
             client_config = {}
         config = Config(**client_config)
@@ -102,7 +107,7 @@ class S3ObjectStore(ObjectStore):
         self.transfer_config = TransferConfig(**transfer_config)
 
     def get_uri(self, object_name: str) -> str:
-        return os.path.join('s3://', self.bucket, self.prefix, object_name)
+        return f's3://{self.bucket}/{self.prefix}{object_name}'
 
     def get_object_size(self, object_name: str) -> int:
         try:

--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -50,6 +50,7 @@ class S3ObjectStore(ObjectStore):
 
     Args:
         bucket (str): The bucket name.
+        prefix (str): A path prefix such as `folder/subfolder/` to prepend to object names. Defaults to ''.
         region_name (str, optional): The region name. Must be specified if not available in
             a config file or environment variables. Defaults to None.
         endpoint_url (str, optional): The URL to an S3-Compatible object store. Must be specified if using something
@@ -67,6 +68,7 @@ class S3ObjectStore(ObjectStore):
     def __init__(
         self,
         bucket: str,
+        prefix: str = '',
         region_name: Optional[str] = None,
         endpoint_url: Optional[str] = None,
         aws_access_key_id: Optional[str] = None,
@@ -82,6 +84,7 @@ class S3ObjectStore(ObjectStore):
         except ImportError as e:
             raise MissingConditionalImportError('s3', 'boto3') from e
         self.bucket = bucket
+        self.prefix = prefix
         if client_config is None:
             client_config = {}
         config = Config(**client_config)
@@ -99,7 +102,7 @@ class S3ObjectStore(ObjectStore):
         self.transfer_config = TransferConfig(**transfer_config)
 
     def get_uri(self, object_name: str) -> str:
-        return f's3://{self.bucket}/{object_name}'
+        return os.path.join('s3://', self.bucket, self.prefix, object_name)
 
     def get_object_size(self, object_name: str) -> int:
         try:

--- a/tests/utils/object_store/object_store_settings.py
+++ b/tests/utils/object_store/object_store_settings.py
@@ -70,6 +70,7 @@ object_store_kwargs: Dict[Union[Type[ObjectStore], Type[ObjectStoreHparams]], Di
     },
     S3ObjectStore: {
         'bucket': 'my-bucket',
+        'prefix': 'folder/subfolder'
     },
     S3ObjectStoreHparams: {
         'bucket': 'my-bucket',

--- a/tests/utils/object_store/test_object_store.py
+++ b/tests/utils/object_store/test_object_store.py
@@ -59,7 +59,7 @@ class TestObjectStore:
     def test_get_uri(self, object_store: ObjectStore):
         uri = object_store.get_uri('tmpfile_object_name')
         if isinstance(object_store, S3ObjectStore):
-            assert uri == 's3://my-bucket/tmpfile_object_name'
+            assert uri == 's3://my-bucket/folder/subfolder/tmpfile_object_name'
         elif isinstance(object_store, LibcloudObjectStore):
             assert uri == 'local://./tmpfile_object_name'
         elif isinstance(object_store, SFTPObjectStore):


### PR DESCRIPTION
This makes it easy to specify a folder-like prefix for objects that are stored in S3. 

This will be pretty important for users who share a bucket for artifacts like checkpoints, but use folders like `my-name/my-project/` within to separate work. 

It will also be important for this to land before connecting ObjectStore with StreamingDatasets (#1248) because the basic unit being referenced is a "folder" that is rarely an entire bucket.

