### PR TITLE
Fix S3 remote paths for StreamingDataset download

### DIFF
--- a/composer/datasets/streaming/download.py
+++ b/composer/datasets/streaming/download.py
@@ -99,7 +99,7 @@ def dispatch_download(remote: Optional[str], local: str):
         raise ValueError('In the absence of local dataset, path to remote dataset must be provided')
     elif remote.startswith('s3://') or remote.startswith('sftp://'):
         url = urllib.parse.urlsplit(remote)
-        remote_path = url.path
+        remote_path = url.path.strip('/')
         object_store = get_object_store(remote)
         object_store.download_object(remote_path, local)
     elif remote.startswith('http://'):


### PR DESCRIPTION
Forward slash must be stripped, otherwise the `S3ObjectStore` fails to download files.

Is this bug intentional by the way? I tried doing some local tests and it seems like all our ObjectStore implementations don't do any stripping of the `object_name`.

Will follow up in Slack, but this is also a good reminder that when modifying `StreamingDataset` code, it's always necessary to run the remote tests which actually do a full E2E download from S3 (and can be run even from your laptop!). This is how I noticed something was failing:

```
pytest -s -m remote "tests/datasets/test_streaming_remote.py::test_streaming_remote_dataset[val-cifar10]"            
```