### PR TITLE
Fix Tensorboard with ObjectStore quadratic complexity issue and switch from flush_interval -> flush_secs

### DIFF
--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -143,6 +143,7 @@ class TensorboardLogger(LoggerDestination):
             file_path=file_path,
             overwrite=True)
 
+        self.flush_count += 1
         # Close writer and reinitialize it to ensure no strange issues with dropping
         # of points.
         self.writer.close()
@@ -152,5 +153,3 @@ class TensorboardLogger(LoggerDestination):
         # Give event_file a unique name to avoid appending to the same file on every flush.
         self.writer.file_writer.event_writer._file_name = self.event_file_base_file_path + f'-{self.flush_count}'
         self.writer.file_writer.event_writer._async_writer._writer._writer.filename = self.event_file_base_file_path + f'-{self.flush_count}'
-
-        self.flush_count += 1

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -28,7 +28,7 @@ class TensorboardLogger(LoggerDestination):
     `events.out.tfevents.*`
 
     Args:
-        log_dir (str, optional): The path to the directory where all the Tensorboard logs
+        log_dir (str, optional): The path to the directory where all the tensorboard logs
             will be saved. This is also the value that should be specified when starting
             a tensorboard server. e.g. `tensorboard --logdir={log_dir}`. If not specified
             `./tensorboard_logs` will be used.

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -12,6 +12,7 @@ from composer.loggers.logger import Logger, LogLevel
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import dist
 from composer.utils.import_helpers import MissingConditionalImportError
+import copy
 
 __all__ = ['TensorboardLogger']
 
@@ -132,7 +133,7 @@ class TensorboardLogger(LoggerDestination):
         self.writer.flush()
 
         assert self.writer.file_writer is not None
-        file_path = self.writer.file_writer.event_writer._file_name
+        file_path = copy.deepcopy(self.writer.file_writer.event_writer._file_name)
 
         logger.file_artifact(
             LogLevel.FIT,

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -43,7 +43,8 @@ class TensorboardLogger(LoggerDestination):
             Default: :attr:`True`.
     """
 
-    def __init__(self, log_dir: Optional[str] = None, flush_interval: int = 100, rank_zero_only: bool = True):
+    def __init__(self, log_dir: Optional[str] = None, flush_interval: int = 100,
+                       rank_zero_only: bool = True):
         try:
             from torch.utils.tensorboard import SummaryWriter
         except ImportError as e:
@@ -57,6 +58,7 @@ class TensorboardLogger(LoggerDestination):
         self.writer: Optional[SummaryWriter] = None
         self.flush_count = 0
         self.event_file_base_file_path: Optional[str] = None
+
 
     def log_data(self, state: State, log_level: LogLevel, data: Dict[str, Any]):
         del log_level

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -129,7 +129,7 @@ class TensorboardLogger(LoggerDestination):
         self.writer.flush()
 
         assert self.writer.file_writer is not None
-        file_path = self.writer.file_writer.event_writer._file_name
+        file_path = self.event_file_base_file_path + f'-{self.flush_count}'
 
         logger.file_artifact(
             LogLevel.FIT,

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -150,6 +150,7 @@ class TensorboardLogger(LoggerDestination):
 
         assert self.event_file_base_file_path is not None
         # Give event_file a unique name to avoid appending to the same file on every flush.
+        self.writer.file_writer.event_writer._file_name = self.event_file_base_file_path + f'-{self.flush_count}'
         self.writer.file_writer.event_writer._async_writer._writer._writer.filename = self.event_file_base_file_path + f'-{self.flush_count}'
 
         self.flush_count += 1


### PR DESCRIPTION
CO-690

This PR:
- [x] creates and logs to a new file for every flush
- [x] re-initializes a new SummaryWriter for each flush
- [x] names the artifact based on flush count to prevent overwriting on S3 or other objectstore
- [x] changes flushing interval specification to by time instead of number of batches (`flush_interval` -> `flush_secs`)

* Logging to a new file for every flush solves the quadratic complexity issue, where the same file was sent to S3, while it gradually increased in size.
* Re-initializing a new SummaryWriter fixed various weird issues (dropping of datapoints) when changing a log file name midway through the life of a SummaryWriter object's life.
* Append flush_count to artifact_name, so we create a unique artifact after every flush and don't overwrite the previous one.
* flushing interval changed to seconds because it is more intuitive, easier to tune, and holds the same meaning regardless of workload.

[wandb report](https://wandb.ai/mosaic-ml/evan-tb-test/reports/Tensorboard-Logger-Fix---VmlldzoyMzEzNzIx?accessToken=r57f3nfquc4hv5qp28h413hc8rmr33zof2aznuh47cm2u6l9160o8gojqx827li5) showing scaling of Tensorboard logging over the course of training (linear increase in bytes sent, and no increase in thropughput is good!)