### PR TITLE
Fix TB Logger + ObjectStore quadratic complexity issue by doing 1 file per flush

### DIFF
--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -3,6 +3,7 @@
 
 """Log to `Tensorboard <https://www.tensorflow.org/tensorboard/>`_."""
 
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -55,6 +56,9 @@ class TensorboardLogger(LoggerDestination):
         self.flush_interval = flush_interval
         self.rank_zero_only = rank_zero_only
         self.writer: Optional[SummaryWriter] = None
+        self.flush_count = 0
+        self.event_file_base_file_path: Optional[str] = None
+        self.run_name: Optional[str] = None
 
     def log_data(self, state: State, log_level: LogLevel, data: Dict[str, Any]):
         del log_level
@@ -75,19 +79,33 @@ class TensorboardLogger(LoggerDestination):
                 pass
 
     def init(self, state: State, logger: Logger) -> None:
-        from torch.utils.tensorboard import SummaryWriter
+        self.run_name = state.run_name
 
         # We set the log_dir to a constant, so all runs can be co-located together.
         if self.log_dir is None:
             self.log_dir = 'tensorboard_logs'
 
+        self._initialize_summary_writer()
+
+    def _initialize_summary_writer(self):
+        from torch.utils.tensorboard import SummaryWriter
+
+        assert self.run_name is not None
+        assert self.log_dir is not None
         # We name the child directory after the run_name to ensure the run_name shows up
         # in the Tensorboard GUI.
-        summary_writer_log_dir = Path(self.log_dir) / state.run_name
+        summary_writer_log_dir = Path(self.log_dir) / self.run_name
 
         # To disable automatic flushing we set flushing to once a year ;)
         flush_secs = 365 * 3600 * 24
         self.writer = SummaryWriter(log_dir=summary_writer_log_dir, flush_secs=flush_secs)
+
+        if self.event_file_base_file_path is None:
+            self.event_file_base_file_path = self.writer.file_writer.event_writer._file_name
+
+        # Give event_file a unique name to avoid appending to the same file on every flush.
+        self.writer.file_writer.event_writer._file_name = self.event_file_base_file_path + f'-{self.flush_count}'
+        self.writer.file_writer.event_writer._async_writer._writer._writer.filename = self.writer.file_writer.event_writer._file_name
 
     def batch_end(self, state: State, logger: Logger) -> None:
         if int(state.timestamp.batch) % self.flush_interval == 0:
@@ -100,8 +118,6 @@ class TensorboardLogger(LoggerDestination):
         self._flush(logger)
 
     def fit_end(self, state: State, logger: Logger) -> None:
-        # Flush the file on fit_end, in case if was not flushed on epoch_end and the trainer is re-used
-        # (which would defer when `self.close()` would be invoked)
         self._flush(logger)
 
     def _flush(self, logger: Logger):
@@ -115,11 +131,32 @@ class TensorboardLogger(LoggerDestination):
         assert self.writer.file_writer is not None
         file_path = self.writer.file_writer.event_writer._file_name
 
+        # If no writes have happened since the last flush, then file_path won't exist, so
+        # we should skip doing flushing and skip filing the artifact since it will error
+        # out anyway (given that the file_path doesn't exist).
+        if not Path(file_path).exists():
+            return
+
+        assert self.writer is not None
+        self.writer.flush()
+
+
         logger.file_artifact(
             LogLevel.FIT,
             # For a file to be readable by Tensorboard, it must start with
             # 'events.out.tfevents'. Child directory is named after run_name, so the logs
             # are named properly in the Tensorboard GUI.
-            artifact_name='tensorboard_logs/{run_name}/events.out.tfevents-{run_name}-{rank}',
+            artifact_name=(
+                'tensorboard_logs/{run_name}/events.out.tfevents-{run_name}-{rank}'
+                # Append flush_count, so artifact has unique name.
+                + f'-{self.flush_count}'),
             file_path=file_path,
             overwrite=True)
+        
+        # Close writer and reinitialize it with a new log file path. This ensures that 
+        # we have one file per flush, which means `file_artifact` is always copying 
+        # data points that have never been copied before. Also this ensures no strange 
+        # issues with dropping of points when setting a new log file path.
+        self.writer.close()
+        self.flush_count += 1
+        self._initialize_summary_writer()

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -43,7 +43,6 @@ class TensorboardLogger(LoggerDestination):
             A setting of `False` may lead to logging of duplicate values.
             Default: :attr:`True`.
     """
-
     def __init__(self, log_dir: Optional[str] = None, flush_interval: int = 100, rank_zero_only: bool = True):
         try:
             from torch.utils.tensorboard import SummaryWriter
@@ -124,9 +123,6 @@ class TensorboardLogger(LoggerDestination):
         # To avoid empty log artifacts for each rank.
         if self.rank_zero_only and dist.get_global_rank() != 0:
             return
-
-        assert self.writer is not None
-        self.writer.flush()
 
         assert self.writer.file_writer is not None
         file_path = self.writer.file_writer.event_writer._file_name

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -5,7 +5,6 @@
 
 from pathlib import Path
 from typing import Any, Dict, Optional
-import uuid
 
 from composer.core.state import State
 from composer.loggers.logger import Logger, LogLevel
@@ -93,7 +92,8 @@ class TensorboardLogger(LoggerDestination):
         # in the Tensorboard GUI.
         summary_writer_log_dir = Path(self.log_dir) / self.run_name
 
-        # To disable automatic flushing we set flushing to once a year ;)
+        # Disable SummaryWriter's internal flushing to avoid file corruption while
+        # file staged for upload to an ObjectStore.
         flush_secs = 365 * 3600 * 24
         self.writer = SummaryWriter(log_dir=summary_writer_log_dir, flush_secs=flush_secs)
 

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -121,14 +121,15 @@ class TensorboardLogger(LoggerDestination):
 
         self.writer.flush()
         assert self.writer.file_writer is not None
+        
         file_path = self.writer.file_writer.event_writer._file_name
+        event_file_name = Path(file_path).stem
 
         logger.file_artifact(
             LogLevel.FIT,
             artifact_name=(
-                'tensorboard_logs/{run_name}/events.out.tfevents-{run_name}-{rank}'
-                # Append flush_count, so artifact has unique name.
-                + f'-{uuid.uuid4()}'),
+                'tensorboard_logs/{run_name}/'
+                + f'{event_file_name}-{dist.get_global_rank()}'),
             file_path=file_path,
             overwrite=True)
         

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -117,7 +117,6 @@ class TensorboardLogger(LoggerDestination):
             return
 
         assert self.writer is not None
-
         # Skip if no writes occurred since last flush.
         if not self.writer.file_writer:
             return

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -116,12 +116,13 @@ class TensorboardLogger(LoggerDestination):
         if self.rank_zero_only and dist.get_global_rank() != 0:
             return
 
+        assert self.writer is not None
+
         # Skip if no writes occurred since last flush.
         if not self.writer.file_writer:
             return
 
         self.writer.flush()
-        assert self.writer.file_writer is not None
 
         file_path = self.writer.file_writer.event_writer._file_name
         event_file_name = Path(file_path).stem

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -42,6 +42,7 @@ class TensorboardLogger(LoggerDestination):
             A setting of `False` may lead to logging of duplicate values.
             Default: :attr:`True`.
     """
+
     def __init__(self, log_dir: Optional[str] = None, flush_interval: int = 100, rank_zero_only: bool = True):
         try:
             from torch.utils.tensorboard import SummaryWriter
@@ -121,17 +122,15 @@ class TensorboardLogger(LoggerDestination):
 
         self.writer.flush()
         assert self.writer.file_writer is not None
-        
+
         file_path = self.writer.file_writer.event_writer._file_name
         event_file_name = Path(file_path).stem
 
-        logger.file_artifact(
-            LogLevel.FIT,
-            artifact_name=(
-                'tensorboard_logs/{run_name}/'
-                + f'{event_file_name}-{dist.get_global_rank()}'),
-            file_path=file_path,
-            overwrite=True)
-        
+        logger.file_artifact(LogLevel.FIT,
+                             artifact_name=('tensorboard_logs/{run_name}/' +
+                                            f'{event_file_name}-{dist.get_global_rank()}'),
+                             file_path=file_path,
+                             overwrite=True)
+
         # Close writer, which creates new log file.
         self.writer.close()


### PR DESCRIPTION
CO-690

This PR:
- [x] creates and logs to a new file for every flush by calling `writer.close()`
- [x] names the artifact based on the tfevents file to prevent overwriting on S3 or other objectstore

* Logging to a new file for every flush solves the quadratic complexity issue, where the same file was sent to S3, while it gradually increased in size.

[wandb report](https://wandb.ai/mosaic-ml/evan-tb-test/reports/Tensorboard-Fix-Plots--VmlldzoyMzE0MTEy?accessToken=bnqi0jaawy5xubsfcck9mz1izabzdyom29o34sdp2nn9ovy5vb8o2naq3aeo0rcb)