### PR TITLE
Update getting_started.ipynb

### DIFF
--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -135,7 +135,7 @@
    "outputs": [],
    "source": [
     "from composer import models\n",
-    "model = models.composer_resnet_cifar(model_name='resnet_56', num_classes=10)"
+    "model = models.ComposerResNetCIFAR(model_name='resnet_56', num_classes=10)"
    ]
   },
   {


### PR DESCRIPTION
Probably due to changed names - `AttributeError: module 'composer.models' has no attribute 'composer_resnet_cifar'`