### PR TITLE
Fix device inference in module surgery

### DIFF
--- a/composer/algorithms/blurpool/blurpool_layers.py
+++ b/composer/algorithms/blurpool/blurpool_layers.py
@@ -187,7 +187,7 @@ class BlurMaxPool2d(nn.Module):
                               filter=self.filt2d)
 
     @staticmethod
-    def from_maxpool2d(module: torch.nn.MaxPool2d, module_index: int):
+    def from_maxpool2d(module: torch.nn.MaxPool2d, module_index: int) -> BlurMaxPool2d:
         return BlurMaxPool2d(kernel_size=module.kernel_size,
                              stride=module.stride,
                              padding=module.padding,

--- a/composer/algorithms/blurpool/blurpool_layers.py
+++ b/composer/algorithms/blurpool/blurpool_layers.py
@@ -187,7 +187,7 @@ class BlurMaxPool2d(nn.Module):
                               filter=self.filt2d)
 
     @staticmethod
-    def from_maxpool2d(module: torch.nn.MaxPool2d, module_index: int) -> BlurMaxPool2d:
+    def from_maxpool2d(module: torch.nn.MaxPool2d, module_index: int) -> 'BlurMaxPool2d':
         return BlurMaxPool2d(kernel_size=module.kernel_size,
                              stride=module.stride,
                              padding=module.padding,

--- a/composer/utils/module_surgery.py
+++ b/composer/utils/module_surgery.py
@@ -221,8 +221,8 @@ def _infer_device(module: torch.nn.Module) -> Optional[torch.device]:
         p = next(itertools.chain(module.parameters(), module.buffers()))
     except StopIteration:
         return None
-
-    return p.device
+    else:
+        return p.device
 
 
 def count_module_instances(module: torch.nn.Module, module_class: Union[Type[torch.nn.Module],

--- a/composer/utils/module_surgery.py
+++ b/composer/utils/module_surgery.py
@@ -22,6 +22,7 @@ Attributes:
 """
 import collections
 import logging
+import itertools
 import textwrap
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, OrderedDict, Sequence, Tuple, Type, Union
 
@@ -165,6 +166,9 @@ def replace_module_classes(
                                                                            str]]] = collections.OrderedDict()
     _add_children_recursive(module, children_to_parents_and_names)
     indices = indices if indices is not None else {c: 0 for c in policies}
+
+    default_device = _infer_device(module)
+
     while len(children_to_parents_and_names) > 0:
         child, parents = children_to_parents_and_names.popitem(last=False)
         for policy_class, replacement_fn in policies.items():
@@ -179,14 +183,14 @@ def replace_module_classes(
             if replacement is not None:
                 assert child not in replaced_pairs
 
-                # Preserve the device with surgery
-                try:
-                    p = next(child.parameters())
-                except StopIteration:
-                    # Some children don't have any parameters
-                    pass
-                else:
-                    replacement = replacement.to(p.device)
+                # if no device inferred (child has no parameters, e.g. Pool2d),
+                # use the default device inferred from the entire module.
+                device = _infer_device(child)
+                if device is None:
+                    device = default_device
+
+                if device:
+                    replacement = replacement.to(device)
 
                 replaced_pairs[child] = replacement
                 for parent, name in parents:
@@ -209,6 +213,14 @@ def replace_module_classes(
 
     return replaced_pairs
 
+def _infer_device(module: torch.nn.Module) -> Optional[torch.device]:
+    """Attempt to infer a module's device by inspecting its parameters and buffers."""
+    try:
+        p = next(itertools.chain(module.parameters(), module.buffers()))
+    except StopIteration:
+        return None
+
+    return p.device
 
 def count_module_instances(module: torch.nn.Module, module_class: Union[Type[torch.nn.Module],
                                                                         Tuple[Type[torch.nn.Module], ...]]) -> int:

--- a/composer/utils/module_surgery.py
+++ b/composer/utils/module_surgery.py
@@ -21,8 +21,8 @@ Attributes:
         Returns: Optional[torch.nn.Module]: The replacement module, or ``None`` to indicate no modification.
 """
 import collections
-import logging
 import itertools
+import logging
 import textwrap
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, OrderedDict, Sequence, Tuple, Type, Union
 
@@ -196,6 +196,7 @@ def replace_module_classes(
                 for parent, name in parents:
                     # update each parent with the replaced child
                     setattr(parent, name, replacement)
+
                 # recurse on new child object
                 if recurse_on_replacements:
                     children_to_parents_and_names[replacement] = list(parents)  # copy the parents list
@@ -213,6 +214,7 @@ def replace_module_classes(
 
     return replaced_pairs
 
+
 def _infer_device(module: torch.nn.Module) -> Optional[torch.device]:
     """Attempt to infer a module's device by inspecting its parameters and buffers."""
     try:
@@ -221,6 +223,7 @@ def _infer_device(module: torch.nn.Module) -> Optional[torch.device]:
         return None
 
     return p.device
+
 
 def count_module_instances(module: torch.nn.Module, module_class: Union[Type[torch.nn.Module],
                                                                         Tuple[Type[torch.nn.Module], ...]]) -> int:

--- a/tests/utils/test_module_surgery.py
+++ b/tests/utils/test_module_surgery.py
@@ -40,10 +40,15 @@ class SimpleReplacementPolicy(nn.Module):
             return RecursiveLinear(cast(int, module.in_features), cast(int, module.out_features))
         return None
 
+    @staticmethod
+    def replace_pool(module: torch.nn.Module, module_index: int):
+        assert isinstance(module, nn.MaxPool2d)
+        return BlurMaxPool2d.from_maxpool2d(module, module_index)
+
     def policy(self) -> Mapping[Type[torch.nn.Module], module_surgery.ReplacementFunction]:
         return {
             nn.Linear: self.maybe_replace_linear,
-            nn.MaxPool2d: BlurMaxPool2d.from_maxpool2d,
+            nn.MaxPool2d: self.replace_pool,
         }
 
     def validate_replacements(self, recurse_on_replacements: bool):

--- a/tests/utils/test_module_surgery.py
+++ b/tests/utils/test_module_surgery.py
@@ -1,6 +1,7 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import itertools
 from typing import List, Mapping, Tuple, Type, cast
 from unittest.mock import Mock
 
@@ -9,6 +10,7 @@ import torch
 from torch import nn
 from torch.optim import Optimizer
 
+from composer.algorithms.blurpool import BlurMaxPool2d
 from composer.utils import module_surgery
 from tests.common import SimpleModel
 
@@ -29,6 +31,7 @@ class SimpleReplacementPolicy(nn.Module):
         super().__init__()
         self.fc1 = nn.Linear(in_features=16, out_features=32)
         self.fc2 = nn.Linear(in_features=32, out_features=10)
+        self.pool = nn.MaxPool2d(kernel_size=3)
 
     @staticmethod
     def maybe_replace_linear(module: torch.nn.Module, module_index: int):
@@ -38,11 +41,15 @@ class SimpleReplacementPolicy(nn.Module):
         return None
 
     def policy(self) -> Mapping[Type[torch.nn.Module], module_surgery.ReplacementFunction]:
-        return {nn.Linear: self.maybe_replace_linear}
+        return {
+            nn.Linear: self.maybe_replace_linear,
+            nn.MaxPool2d: BlurMaxPool2d.from_maxpool2d,
+        }
 
     def validate_replacements(self, recurse_on_replacements: bool):
         assert type(self.fc1) is nn.Linear
         assert type(self.fc2) is RecursiveLinear
+        assert type(self.pool) is BlurMaxPool2d
 
         if recurse_on_replacements:
             assert type(self.fc2.submodule) is RecursiveLinear
@@ -110,7 +117,7 @@ def test_module_replacement_gpu():
     model.validate_replacements(False)
 
     # Validate the model devices are correct
-    for p in model.parameters():
+    for p in itertools.chain(model.parameters(), model.buffers()):
         assert p.device.type == 'cuda'
 
 


### PR DESCRIPTION
During module surgery, the new layers need a device assignment. The previous code to infer that device had a few bugs:
(1) If the original layer did not have any `parameters()` but had `buffers()`, no device would be found.
(2) If the original layer had no parameters or buffers, no replacement would be done.

This leads to a device mismatch on algorithms such as BlurPool.

This PR will infer the device from the original layer's `parameters` _and_ `buffers`. If no device can be inferred, then the device inferred from the whole model will be used instead.

Also adds a test case for this edge condition.