### PR TITLE
Don't download HF Model Config when passing in a manual config

### DIFF
--- a/composer/models/bert/model.py
+++ b/composer/models/bert/model.py
@@ -87,9 +87,10 @@ def create_bert_mlm(use_pretrained: Optional[bool] = False,
         model = transformers.AutoModelForMaskedLM.from_pretrained(pretrained_model_name_or_path=pretrained_model_name,
                                                                   **model_config)
     else:
-        config = transformers.AutoConfig.from_pretrained(pretrained_model_name, **model_config)
-        assert transformers.AutoModelForMaskedLM.from_config is not None, 'AutoModelForMaskedLM has from_config method'
-        model = transformers.AutoModelForMaskedLM.from_config(config)
+        if len(model_config) == 0:
+            model_config = transformers.AutoConfig.from_pretrained(pretrained_model_name, **model_config)
+            assert transformers.AutoModelForMaskedLM.from_config is not None, 'AutoModelForMaskedLM has from_config method'
+        model = transformers.AutoModelForMaskedLM.from_config(model_config)
 
     if gradient_checkpointing:
         model.gradient_checkpointing_enable()  # type: ignore
@@ -190,8 +191,9 @@ def create_bert_classification(num_labels: Optional[int] = 2,
         model = transformers.AutoModelForSequenceClassification.from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name, **model_config)
     else:
-        config = transformers.AutoConfig.from_pretrained(pretrained_model_name, **model_config)
-        assert transformers.AutoModelForSequenceClassification.from_config is not None, 'AutoModelForSequenceClassification has from_config method'
+        if len(model_config) == 1:
+            config = transformers.AutoConfig.from_pretrained(pretrained_model_name, **model_config)
+            assert transformers.AutoModelForSequenceClassification.from_config is not None, 'AutoModelForSequenceClassification has from_config method'
         model = transformers.AutoModelForSequenceClassification.from_config(config)
 
     if gradient_checkpointing:

--- a/composer/models/gpt2/model.py
+++ b/composer/models/gpt2/model.py
@@ -99,9 +99,10 @@ def create_gpt2(use_pretrained: Optional[bool] = False,
         model = transformers.AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=pretrained_model_name,
                                                                   **model_config)
     else:
-        config = transformers.AutoConfig.from_pretrained(pretrained_model_name, **model_config)
-        assert transformers.AutoModelForCausalLM.from_config is not None, 'AutoModelForCausalLM has from_config method'
-        model = transformers.AutoModelForCausalLM.from_config(config)
+        if len(model_config) == 0:
+            model_config = transformers.AutoConfig.from_pretrained(pretrained_model_name, **model_config)
+            assert transformers.AutoModelForCausalLM.from_config is not None, 'AutoModelForCausalLM has from_config method'
+        model = transformers.AutoModelForCausalLM.from_config(model_config)
 
     if gradient_checkpointing:
         model.gradient_checkpointing_enable()  # type: ignore


### PR DESCRIPTION
The refactor of the HF integration downloads the model config if it is passed in as an argument. We want to avoid this, so if the user has specified custom values, we should avoid loading the pretrained config.