### PR TITLE
Require JIRA Links

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -296,12 +296,7 @@ stage('Prepare') {
             // off of the "fix version" field in JIRA
 
             if (!pullRequest.body.contains('https://mosaicml.atlassian.net/browse/CO-')) {
-                pullRequest.createStatus(
-                    status: 'error',
-                    context: 'ci/jenkins/pr-merge/has-jira-link',
-                    description: 'The PR description must contain a link to the corresponding JIRA bug or story',
-                    targetUrl: "${env.JOB_URL}/testResults",
-                )
+                pullRequest.comment('The PR description must contain a link to the corresponding JIRA bug or story')
             }
 
         }
@@ -447,6 +442,10 @@ stage('Build') {
                         fingerprintArtifacts: true,
                         optional: true,
                     )
+                }
+
+                if (env.CHANGE_ID && !pullRequest.body.contains('https://mosaicml.atlassian.net/browse/CO-')) {
+                    error('The PR description must contain a link to the corresponding JIRA bug or story')
                 }
 
                 sh "mkdir -p $buildOutputFolder"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -445,8 +445,6 @@ stage('Build') {
                     )
                 }
 
-
-
                 sh "mkdir -p $buildOutputFolder"
 
                 archiveArtifacts(artifacts: artifactsGlob, fingerprint: true, allowEmptyArchive: true)

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -290,6 +290,20 @@ stage('Prepare') {
         if (env.CHANGE_ID) {
             // Use the origin/pr/PR_NUMBER/merge to support commits in external repos
             gitCommit = "origin/pr/${pullRequest.number}/merge"
+
+            // Require that all pullRequests link to a JIRA story
+            // Why? Makes it much easier to find which commits to cherry-pick into any given release, based
+            // off of the "fix version" field in JIRA
+
+            if (!pullRequest.body.contains('https://mosaicml.atlassian.net/browse/CO-')) {
+                pullRequest.createStatus(
+                    status: 'error',
+                    context: 'ci/jenkins/pr-merge/has-jira-link',
+                    description: 'The PR description must contain a link to the corresponding JIRA bug or story',
+                    targetUrl: "${env.JOB_URL}/testResults",
+                )
+            }
+
         }
 
         echo "gitUrl: $gitUrl"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -290,15 +290,6 @@ stage('Prepare') {
         if (env.CHANGE_ID) {
             // Use the origin/pr/PR_NUMBER/merge to support commits in external repos
             gitCommit = "origin/pr/${pullRequest.number}/merge"
-
-            // Require that all pullRequests link to a JIRA story
-            // Why? Makes it much easier to find which commits to cherry-pick into any given release, based
-            // off of the "fix version" field in JIRA
-
-            if (!pullRequest.body.contains('https://mosaicml.atlassian.net/browse/CO-')) {
-                pullRequest.comment('The PR description must contain a link to the corresponding JIRA bug or story')
-            }
-
         }
 
         echo "gitUrl: $gitUrl"
@@ -430,6 +421,16 @@ stage('Build') {
     }
     try {
         parallel(jobs)
+
+        if (env.CHANGE_ID && !pullRequest.body.contains('https://mosaicml.atlassian.net/browse/CO-')) {
+            error(
+                'The PR built successfully, but the PR description is missing a link to the corresponding ' +
+                'JIRA issue. All PRs require a JIRA issue link to simplify release management. ' +
+                'If you are a MosaicML employee, please add a link of the form ' +
+                'https://mosaicml.atlassian.net/browse/CO-XXX into the PR description, where XXX is the issue ' +
+                'number. If you are an external contributor, we will add this link for you into the PR description.'
+            )
+        }
     }
     finally {
         stage('Merge Artifacts') {
@@ -444,9 +445,7 @@ stage('Build') {
                     )
                 }
 
-                if (env.CHANGE_ID && !pullRequest.body.contains('https://mosaicml.atlassian.net/browse/CO-')) {
-                    error('The PR description must contain a link to the corresponding JIRA bug or story')
-                }
+
 
                 sh "mkdir -p $buildOutputFolder"
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -126,7 +126,7 @@ class TestTrainerInitOrFit:
     def max_duration(self):
         return Time(1, TimeUnit.EPOCH)
 
-    @pytest.mark.parametrize('train_subset_num_batches', [-1, 1])
+    @pytest.mark.parametrize('train_subset_num_batches', [pytest.param(-1, marks=pytest.mark.timeout(5)), 1])
     @pytest.mark.parametrize('compute_training_metrics', [True, False])
     def test_train_dataloader(
         self,


### PR DESCRIPTION
This PR requires that all (future) PRs include a JIRA link in the PR description.

Linking each PR to a JIRA issue will streamline release management. Specifically, it will help identify which commits should be cherry-picked in for each release based on the "fix version" field in Jira. In the future, we could write a script to automate this process. If we later added a standardized formatting for a release notes section in the PR description too, then we could also automate the release note generation.

For external contributors, we will need to manually create a Jira story for them, and add the link to the PR description, before they can merge. Tests should still run, however, without this link, since this check is performed last. Features and bug fixes completed by external contributors should still have a corresponding JIRA story, since these features should be included in release notes, too!

Closes https://mosaicml.atlassian.net/browse/CO-729