### PR TITLE
Fix logging of hparams to object stores

### DIFF
--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -12,6 +12,7 @@ Example that trains MNIST with label smoothing:
 """
 
 import logging
+import os
 import sys
 import tempfile
 import warnings
@@ -57,8 +58,10 @@ def _main():
 
     # Only log the config once, since it should be the same on all ranks.
     if dist.get_global_rank() == 0:
-        with tempfile.NamedTemporaryFile(mode='x+') as f:
-            f.write(hparams.to_yaml())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            hparams_name = os.path.join(tmpdir, 'hparams.yaml')
+            with open(hparams_name, 'w+') as f:
+                f.write(hparams.to_yaml())
             trainer.logger.file_artifact(
                 LogLevel.FIT,
                 artifact_name=f'{trainer.state.run_name}/hparams.yaml',


### PR DESCRIPTION
Fix the logging of hparams to object stores in the `examples/run_composer_trainer.py`. It was likely that the file was not being flushed before uploading, causing an empty file to be uploaded. To fix, switched to using a TemporaryDirectory, and creating a file within the tmpdir that can be properly closed before uploading.

Example of the fix: https://wandb.ai/mosaic-ml/ravi-composer-examples/runs/uexuga9v/files/config.yaml

Closes https://mosaicml.atlassian.net/browse/CO-687