### PR TITLE
Fix `get_file_artifact` in the WandBLogger to work on all ranks

### DIFF
--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -526,6 +526,7 @@ class TrainerHparams(hp.Hparams):
             save_filename=self.save_filename,
             save_latest_filename=self.save_latest_filename,
             save_artifact_name=self.save_artifact_name,
+            save_latest_artifact_name=self.save_latest_artifact_name,
             save_interval=self.save_interval,
             save_weights_only=self.save_weights_only,
             save_num_checkpoints_to_keep=self.save_num_checkpoints_to_keep,

--- a/tests/fixtures/new_fixtures.py
+++ b/tests/fixtures/new_fixtures.py
@@ -3,6 +3,7 @@
 
 """These fixtures are shared globally across the test suite."""
 import datetime
+import os
 import shutil
 
 import pytest
@@ -37,8 +38,13 @@ def empty_logger(minimal_state: State) -> Logger:
 
 
 @pytest.fixture(autouse=True)
-def disable_wandb(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv('WANDB_MODE', 'disabled')
+def disable_wandb(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest):
+    monkeypatch.setenv('WANDB_START_METHOD', 'thread')
+    if request.node.get_closest_marker('remote') is None:
+        monkeypatch.setenv('WANDB_MODE', 'disabled')
+    else:
+        if not os.environ.get('WANDB_PROJECT'):
+            monkeypatch.setenv('WANDB_PROJECT', 'pytest')
 
 
 @pytest.fixture(autouse=True)

--- a/tests/loggers/test_wandb_logger.py
+++ b/tests/loggers/test_wandb_logger.py
@@ -1,16 +1,24 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import json
+import pathlib
+import uuid
 from typing import Type
 
 import pytest
 import torch
 from torch.utils.data import DataLoader
 
+from composer.core import Engine, Event
 from composer.core.callback import Callback
+from composer.core.state import State
 from composer.loggers import InMemoryLogger
+from composer.loggers.logger import Logger, LogLevel
+from composer.loggers.wandb_logger import WandBLogger
 from composer.trainer import Trainer
+from composer.utils import dist, retry
 from tests.callbacks.callback_settings import get_cb_kwargs, get_cbs_and_marks
 from tests.common import RandomClassificationDataset, SimpleModel
 
@@ -41,3 +49,56 @@ def test_logged_data_is_json_serializable(callback_cls: Type[Callback]):
             if isinstance(data, (WBValue, torch.Tensor)):
                 continue
             json.dumps(data)
+
+
+@pytest.mark.world_size(2)
+@pytest.mark.parametrize('rank_zero_only', [True, False])
+@pytest.mark.remote
+@pytest.mark.timeout(60)
+def test_wandb_artifacts(rank_zero_only: bool, tmp_path: pathlib.Path, dummy_state: State):
+    """Test that artifacts logged on rank zero are accessible by all ranks."""
+    # Create the logger
+    ctx = pytest.warns(
+        UserWarning, match='`rank_zero_only` should be set to False.') if rank_zero_only else contextlib.nullcontext()
+    with ctx:
+        wandb_logger = WandBLogger(
+            rank_zero_only=rank_zero_only,
+            log_artifacts=True,
+        )
+    dummy_state.callbacks.append(wandb_logger)
+    logger = Logger(dummy_state, [wandb_logger])
+    engine = Engine(dummy_state, logger)
+    engine.run_event(Event.INIT)
+
+    # Distribute the artifact name from rank 0 to all ranks
+    artifact_name = 'test-artifact-' + str(uuid.uuid4())
+    artifact_name_list = [artifact_name]
+    dist.broadcast_object_list(artifact_name_list)
+    artifact_name = artifact_name_list[0]
+
+    if dist.get_global_rank() == 0:
+        # Create a dummy artifact
+        dummy_artifact_path = tmp_path / 'artifact.txt'
+        with open(dummy_artifact_path, 'w+') as f:
+            f.write('hello!')
+
+        # Log an artifact if rank zero
+        logger.file_artifact(
+            log_level=LogLevel.FIT,
+            file_path=dummy_artifact_path,
+            artifact_name=artifact_name,
+        )
+
+    # Wait for rank 0 queue the file upload
+    dist.barrier()
+
+    # Attempt to retrieve the artifact on all ranks
+    downloaded_artifact_path = tmp_path / 'downloaded_artifact'
+
+    @retry(FileNotFoundError, num_attempts=6)  # 6 attempts is ~2^(6-1) seconds max wait
+    def _validate_artifact():
+        wandb_logger.get_file_artifact(artifact_name, str(downloaded_artifact_path))
+        with open(downloaded_artifact_path, 'r') as f:
+            assert f.read() == 'hello!'
+
+    _validate_artifact()

--- a/tests/loggers/test_wandb_logger.py
+++ b/tests/loggers/test_wandb_logger.py
@@ -57,6 +57,7 @@ def test_logged_data_is_json_serializable(callback_cls: Type[Callback]):
 @pytest.mark.timeout(60)
 def test_wandb_artifacts(rank_zero_only: bool, tmp_path: pathlib.Path, dummy_state: State):
     """Test that artifacts logged on rank zero are accessible by all ranks."""
+    pytest.importorskip('wandb', reason='wandb is optional')
     # Create the logger
     ctx = pytest.warns(
         UserWarning, match='`rank_zero_only` should be set to False.') if rank_zero_only else contextlib.nullcontext()


### PR DESCRIPTION
Fix`get_file_artifact` to work on all ranks, not just the rank zero even if `rank_zero_only=True`

This allows for resuming from checkpoints stored in WandB in multi-node settings, even if `rank_zero_only=True`.

Added a `@pytest.mark.remote` test to verify the fix. Verified that this test passed locally.

Closes https://mosaicml.atlassian.net/browse/CO-640