### PR TITLE
[Hot fix] Remove compression from Bert example

### DIFF
--- a/composer/yamls/models/bert-base.yaml
+++ b/composer/yamls/models/bert-base.yaml
@@ -8,7 +8,7 @@ model:
 # Train the model on the English C4 corpus
 train_dataset:
   streaming_c4:
-    remote: s3://allenai-c4/mds/1-gz/
+    remote: s3://allenai-c4/mds/1/
     local: /tmp/mds-cache/mds-c4/
     split: train
     shuffle: true
@@ -32,7 +32,7 @@ evaluators:
     label: bert_pre_training
     eval_dataset:
       streaming_c4:
-        remote: s3://allenai-c4/mds/1-gz/
+        remote: s3://allenai-c4/mds/1/
         local: /tmp/mds-cache/mds-c4/
         split: val
         shuffle: false


### PR DESCRIPTION
* Using compressed version of the C4 streaming dataset is causing regression failures
* Pointing the example to the un-compressed version for v0.8.1
* Fixes CO-763