### PR TITLE
Add a `return_outputs` flag to `predict()`

### DIFF
--- a/tests/trainer/test_predict.py
+++ b/tests/trainer/test_predict.py
@@ -1,10 +1,15 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import pathlib
+
 import pytest
+import torch
 from torch.utils.data import DataLoader
 
-from composer.core.event import Event
+from composer.core import Callback, Event, State
+from composer.loggers import Logger, LogLevel
 from composer.trainer.trainer import Trainer
 from tests.common import EventCounterCallback, RandomClassificationDataset, SimpleModel
 
@@ -26,6 +31,21 @@ def _assert_predict_events_called_expected_number_of_times(
     for event, expected in event_to_num_expected_invocations.items():
         actual = event_counter.event_to_num_calls[event]
         assert expected == actual, f'Event {event} expected to be called {expected} times, but instead it was called {actual} times'
+
+
+class PredictionSaver(Callback):
+
+    def __init__(self, folder: str):
+        self.folder = folder
+        os.makedirs(self.folder, exist_ok=True)
+
+    def predict_batch_end(self, state: State, logger: Logger) -> None:
+        name = f'batch_{int(state.predict_timestamp.batch)}.pt'
+        filepath = os.path.join(self.folder, name)
+        torch.save(state.outputs, filepath)
+
+        # Also log the outputs as an artifact
+        logger.file_artifact(LogLevel.BATCH, artifact_name=name, file_path=filepath)
 
 
 class TestTrainerPredict():
@@ -82,3 +102,30 @@ class TestTrainerPredict():
         assert event_counter_callback.event_to_num_calls[
             Event.PREDICT_BATCH_START] == trainer.state.predict_timestamp.batch
         assert trainer.state.predict_timestamp.batch == trainer.state.predict_timestamp.batch_in_epoch
+
+    @pytest.mark.parametrize('return_outputs', [True, False])
+    @pytest.mark.parametrize('device', ['cpu', pytest.param('gpu', marks=pytest.mark.gpu)])
+    def test_return_outputs(self, return_outputs: bool, tmp_path: pathlib.Path, device: str):
+        # Construct the trainer
+        folder = str(tmp_path / 'prediction_outputs')
+        prediction_saver_callback = PredictionSaver(folder)
+        trainer = Trainer(
+            model=SimpleModel(),
+            device=device,
+            callbacks=[prediction_saver_callback],
+        )
+
+        # Predict on the model
+        predict_dataloader = DataLoader(dataset=RandomClassificationDataset())
+        outputs = trainer.predict(predict_dataloader, subset_num_batches=1, return_outputs=return_outputs)
+
+        if return_outputs:
+            assert len(outputs) > 0
+        else:
+            assert len(outputs) == 0
+
+        for output in outputs:
+            assert output.device.type == 'cpu'
+
+        loaded_output = torch.load(os.path.join(folder, 'batch_1.pt'), map_location='cpu')
+        assert loaded_output.shape == (1, 2)


### PR DESCRIPTION
This PR adds a `return_outputs` flag to `predict()`, which when set, will move all batch outputs to cpu and accumulate them in a python list when running `predict()`.

Closes https://mosaicml.atlassian.net/browse/CO-765