### PR TITLE
[xs] Build the Composer Docker Image only on `dev` branch merges

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -325,8 +325,8 @@ stage('Build') {
         if (isComposerImage && buildArgs['COMPOSER_INSTALL_COMMAND'] == 'mosaicml[all]GIT_COMMIT') {
             // If this is a composer image and it is the 'GIT_COMMIT' entry in the matrix
             // then build and publish the image on the staging repo
-            if (!isMergeCommit) {
-                // Skip composer images except on merge commits -- it's slow!
+            if (!shouldPushToDestinations) {
+                // Skip composer images except on merge commits on the dev branch -- it's slow!
                 return
             }
             String stagingTagName = "mosaicml/composer_staging:${gitCommitHash[0..6]}"


### PR DESCRIPTION
The composer dockerimage should only be built when merging into dev (or on a pr that does that); it should not be built on release branches, as the correct composer version is not yet published on pypi (and the build will thus fail!)

Closes https://mosaicml.atlassian.net/browse/CO-761