### PR TITLE
Enforce FusedLayerNorm is ordered last

### DIFF
--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -321,7 +321,7 @@ class Engine():
         Returns:
             Sequence[Algorithm]: Modified sequence of algorithms.
         """
-        from composer.algorithms import CutMix, MixUp, SelectiveBackprop, StochasticDepth, FusedLayerNorm
+        from composer.algorithms import CutMix, FusedLayerNorm, MixUp, SelectiveBackprop, StochasticDepth
 
         # Move selective backprop to the beginning while maintaining order of other algorithms
         algorithms = sorted(algorithms_to_run,

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -321,11 +321,14 @@ class Engine():
         Returns:
             Sequence[Algorithm]: Modified sequence of algorithms.
         """
-        from composer.algorithms import CutMix, MixUp, SelectiveBackprop, StochasticDepth
+        from composer.algorithms import CutMix, MixUp, SelectiveBackprop, StochasticDepth, FusedLayerNorm
 
         # Move selective backprop to the beginning while maintaining order of other algorithms
         algorithms = sorted(algorithms_to_run,
                             key=lambda x: not isinstance(x, SelectiveBackprop) and not isinstance(x, StochasticDepth))
+
+        # Move fused layernorm to the end while maintaining order of other algorithms (FLN only does surgery on leaf modules)
+        algorithms = sorted(algorithms_to_run, key=lambda x: isinstance(x, FusedLayerNorm))
 
         # Check for multiple algorithms that try to interpolate the loss at the same time
         interpolation_settings = [a.interpolate_loss for a in algorithms if isinstance(a, (CutMix, MixUp))]

--- a/tests/callbacks/test_image_visualizer.py
+++ b/tests/callbacks/test_image_visualizer.py
@@ -19,6 +19,7 @@ except ImportError:
     _WANDB_INSTALLED = False
 
 
+@pytest.mark.timeout(15.0)
 @pytest.mark.skipif(not _WANDB_INSTALLED, reason='Wandb is optional')
 @pytest.mark.parametrize('interval', ['9ba', '90ba'])
 def test_image_visualizer(interval: str):


### PR DESCRIPTION
Adds a single line of logic into `composer.core.engine` so that `FusedLayerNorm` is last in the algorithm execution order.

This will ensure that any `torch.nn.LayerNorm` modules which are added by other model surgery algorithms are caught by `FusedLayerNorm` and converted into the fused versions.

As a motivating use case, when `GatedLinearUnits` and `FusedLayerNorm` are used together on a BERT model, having `GatedLinearUnits` perform surgery last will result in a model that is roughly 50/50 fused and unfused layernorm instances.