### PR TITLE
Remove `pytest-timeout`

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -46,7 +46,7 @@ pLintTimeout = '1800' // timeout to run lint + doctests, in seconds
 // Conda settings
 dependenciesChanged = false // Whether meta.yaml or setup.py have changed, (if so, rebuild conda)
 condaCpuLimit = '4'
-condaMemLimit = '20Gi' // memory limit for ram and ephemeral storage
+condaMemLimit = '30Gi' // memory limit for ram and ephemeral storage
 condaBuildDockerImage = 'continuumio/anaconda-pkg-build:2022.02.09-amd64'  // Docker image for conda builds
 condaTimeout = '7200' // timeout for conda builds, in seconds
 

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -46,7 +46,7 @@ pLintTimeout = '1800' // timeout to run lint + doctests, in seconds
 // Conda settings
 dependenciesChanged = false // Whether meta.yaml or setup.py have changed, (if so, rebuild conda)
 condaCpuLimit = '4'
-condaMemLimit = '30Gi' // memory limit for ram and ephemeral storage
+condaMemLimit = '20Gi' // memory limit for ram and ephemeral storage
 condaBuildDockerImage = 'continuumio/anaconda-pkg-build:2022.02.09-amd64'  // Docker image for conda builds
 condaTimeout = '7200' // timeout for conda builds, in seconds
 

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -42,13 +42,11 @@ COMMON_ARGS="-v -m '$MARKERS' --s3_bucket '$S3_BUCKET' --sftp_uri '$SFTP_URI'"
 # Run pytest with coverage, and store the junit output
 make test \
     PYTEST="coverage run -m pytest" \
-    DURATION=all \
     EXTRA_ARGS="--codeblocks --junitxml ${BUILD_DIR}/build${BUILD_NUMBER}_nproc0.junit.xml $COMMON_ARGS"
 
 RANK_ARG='\$${RANK}' # escape RANK from the makefile and the makefile shell command
 make test-dist \
     PYTEST="coverage run -m pytest" \
-    DURATION=all \
     WORLD_SIZE=2 \
     EXTRA_LAUNCHER_ARGS="--stdout ${BUILD_DIR}/build${BUILD_NUMBER}_nproc2_rank{rank}.stdout.txt \
         --stderr ${BUILD_DIR}/build${BUILD_NUMBER}_nproc2_rank{rank}.stderr.txt" \

--- a/.ci/test_lint_doctests.py
+++ b/.ci/test_lint_doctests.py
@@ -32,7 +32,6 @@ def check_output(proc: subprocess.CompletedProcess):
     raise RuntimeError(error_msg)
 
 
-@pytest.mark.timeout(0)
 def test_run_pre_commit_hooks():
     composer_root = os.path.join(os.path.dirname(__file__), '..')
     check_output(
@@ -44,7 +43,6 @@ def test_run_pre_commit_hooks():
         ))
 
 
-@pytest.mark.timeout(0)
 def test_run_doctests():
     docs_folder = pathlib.Path(os.path.dirname(__file__)) / '..' / 'docs'
     api_reference_folder = docs_folder / 'source' / 'api_reference'
@@ -56,7 +54,6 @@ def test_run_doctests():
     check_output(subprocess.run(['make', 'doctest'], cwd=docs_folder, capture_output=True, text=True))
 
 
-@pytest.mark.timeout(30)
 def test_docker_build_matrix():
     """Test that the docker build matrix is up to date."""
     docker_folder = pathlib.Path(os.path.dirname(__file__)) / '..' / 'docker'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ git checkout -b cool-new-feature
 
 ## Configuring README Code Snippets
 
-Composer uses [pytest-codeblocks](https://github.com/nschloe/pytest-codeblocks) to test all example code snippets. The pytest-codeblocks repository explains how to annotate code snippets, which supports most `pytest` configurations. For example, if a test requires model training, the GPU mark (`<!--pytest.mark.skip-->`) and timeout mark (`<!--pytest.mark.timeout(15)-->`) should be applied.
+Composer uses [pytest-codeblocks](https://github.com/nschloe/pytest-codeblocks) to test all example code snippets. The pytest-codeblocks repository explains how to annotate code snippets, which supports most `pytest` configurations. For example, if a test requires model training, the GPU mark (`<!--pytest.mark.skip-->`) should be applied.
 
 ## Running Tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # several pytest settings
-DURATION ?= all  # pytest duration, one of short, long or all
 WORLD_SIZE ?= 1  # world size for launcher tests
 MASTER_PORT ?= 26000 # port for distributed tests
 PYTHON ?= python3  # Python command
@@ -7,9 +6,6 @@ PYTEST ?= pytest  # Pytest command
 PYRIGHT ?= pyright  # Pyright command. Pyright must be installed seperately -- e.g. `node install -g pyright`
 EXTRA_ARGS ?=  # extra arguments for pytest
 EXTRA_LAUNCHER_ARGS ?= # extra arguments for the composer cli launcher
-
-# Force append the duration flag to extra args
-override EXTRA_ARGS += --duration $(DURATION)
 
 test:
 	$(PYTHON) -m $(PYTEST) $(EXTRA_ARGS)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ For the best experience and the most efficient possible training, we recommend u
 
 <!-- begin_example_2 --->
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(30)-->
 <!--pytest.mark.filterwarnings(r'ignore:Some targets have less than 1 total probability:UserWarning')-->
 <!--
 ```python

--- a/composer/algorithms/alibi/README.md
+++ b/composer/algorithms/alibi/README.md
@@ -53,7 +53,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from tests.fixtures.synthetic_hf_state import make_dataset_configs, synthetic_hf_state_maker

--- a/composer/algorithms/augmix/README.md
+++ b/composer/algorithms/augmix/README.md
@@ -64,7 +64,6 @@ dataset = VisionDataset(data_path, transform=composed)
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/blurpool/README.md
+++ b/composer/algorithms/blurpool/README.md
@@ -51,7 +51,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/channels_last/README.md
+++ b/composer/algorithms/channels_last/README.md
@@ -40,7 +40,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/colout/README.md
+++ b/composer/algorithms/colout/README.md
@@ -54,7 +54,6 @@ dataset = VisionDataset("data_path", transform=composed)
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/cutmix/README.md
+++ b/composer/algorithms/cutmix/README.md
@@ -40,7 +40,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/cutout/README.md
+++ b/composer/algorithms/cutout/README.md
@@ -43,7 +43,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/ema/README.md
+++ b/composer/algorithms/ema/README.md
@@ -34,7 +34,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/factorize/README.md
+++ b/composer/algorithms/factorize/README.md
@@ -54,7 +54,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/fused_layernorm/README.md
+++ b/composer/algorithms/fused_layernorm/README.md
@@ -38,7 +38,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from tests.fixtures.synthetic_hf_state import make_dataset_configs, synthetic_hf_state_maker

--- a/composer/algorithms/gated_linear_units/README.md
+++ b/composer/algorithms/gated_linear_units/README.md
@@ -39,7 +39,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from tests.fixtures.synthetic_hf_state import make_dataset_configs, synthetic_hf_state_maker

--- a/composer/algorithms/ghost_batchnorm/README.md
+++ b/composer/algorithms/ghost_batchnorm/README.md
@@ -49,7 +49,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/gradient_clipping/README.md
+++ b/composer/algorithms/gradient_clipping/README.md
@@ -109,7 +109,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/label_smoothing/README.md
+++ b/composer/algorithms/label_smoothing/README.md
@@ -42,7 +42,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/layer_freezing/README.md
+++ b/composer/algorithms/layer_freezing/README.md
@@ -49,7 +49,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/mixup/README.md
+++ b/composer/algorithms/mixup/README.md
@@ -66,7 +66,6 @@ def training_loop(model, train_loader):
 Here we run `mixup` using index labels and interpolate the loss (a trick when using cross entropy)
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader
@@ -99,7 +98,6 @@ trainer.fit()
 Here we run `mixup` using dense/one-hot labels and interpolate the labels (general case).
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/progressive_resizing/README.md
+++ b/composer/algorithms/progressive_resizing/README.md
@@ -62,7 +62,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/randaugment/README.md
+++ b/composer/algorithms/randaugment/README.md
@@ -57,7 +57,6 @@ dataset = VisionDataset(data_path, transform=composed)
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/seq_length_warmup/README.md
+++ b/composer/algorithms/seq_length_warmup/README.md
@@ -42,7 +42,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(30)-->
 <!--
 ```python
 from tests.fixtures.synthetic_hf_state import make_dataset_configs, synthetic_hf_state_maker

--- a/composer/algorithms/squeeze_excite/README.md
+++ b/composer/algorithms/squeeze_excite/README.md
@@ -46,7 +46,6 @@ def training_loop(model, train_loader):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/stochastic_depth/README.md
+++ b/composer/algorithms/stochastic_depth/README.md
@@ -11,7 +11,6 @@
 ### Functional Interface
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader
@@ -64,7 +63,6 @@ for epoch in range(1):
 ### Composer Trainer
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -82,7 +82,8 @@ class _ProgressBar:
                 self.pbar.refresh()
             # Create a newline that will not be erased by leave=False. This allows for the finished pbar to be cached in the terminal
             # This emulates `leave=True` without progress bar jumping
-            print('', file=self.file, flush=True)
+            if not self.file.closed:
+                print('', file=self.file, flush=True)
             self.pbar.close()
 
     def state_dict(self) -> Dict[str, Any]:

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -116,7 +116,8 @@ class TensorboardLogger(LoggerDestination):
         if self.rank_zero_only and dist.get_global_rank() != 0:
             return
 
-        assert self.writer is not None
+        if self.writer is None:
+            return
         # Skip if no writes occurred since last flush.
         if not self.writer.file_writer:
             return
@@ -134,3 +135,8 @@ class TensorboardLogger(LoggerDestination):
 
         # Close writer, which creates new log file.
         self.writer.close()
+
+    def close(self, state: State, logger: Logger) -> None:
+        del state  # unused
+        self._flush(logger)
+        self.writer = None

--- a/docs/source/notes/numerics.md
+++ b/docs/source/notes/numerics.md
@@ -15,7 +15,6 @@ When using the {class}`~.Trainer`, the number format can be selected by specifyi
 initialization. In the example below, we are training on a `gpu` device using [Automatic Mixed Precision](amp) (`amp`):
 
 <!--pytest.mark.gpu-->
-<!--pytest.mark.timeout(15)-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/meta.yaml
+++ b/meta.yaml
@@ -56,7 +56,6 @@ test:
     - ipython >=8.4.0,<9
     - ipykernel ==6.13.1,<7
     - jupyter >=1.0.0,<2
-    - pytest-timeout >=2.1.0,<3
     - testbook >=0.4.2,<0.5
     # Including all run_constrained requirements in the test requirements, so those tests will not be import-skipped
     - pip # Required for dependencies not available on conda
@@ -86,8 +85,8 @@ test:
   commands:
     # deepspeed, codeblocks, and mock-ssh-server are not available on conda, and timm has a conda version conflict
     - pip install 'deepspeed>=0.5.5' 'timm>=0.5.4' 'pytest_codeblocks==0.16.1' 'mock-ssh-server>=0.9.1,<1'
-    - make test DURATION=all EXTRA_ARGS="-v -m 'not gpu and not vision and not daily and not remote'"
-    - make test-dist DURATION=all WORLD_SIZE=2 EXTRA_ARGS="-v -m 'not gpu and not vision and not daily and not remote'"
+    - make test EXTRA_ARGS="-v -m 'not gpu and not vision and not daily and not remote'"
+    - make test-dist WORLD_SIZE=2 EXTRA_ARGS="-v -m 'not gpu and not vision and not daily and not remote'"
 
 about:
   home: https://www.mosaicml.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,6 @@ reportUnusedCoroutine = "error"
 # By default, do not run gpu, vision, notebook, or daily tests
 addopts = "--codeblocks --strict-markers -m 'not gpu and not vision and not daily and not remote'"
 
-# by default, tests should be fast.
-# for slower tests, use @pytest.mark.timeout with a higher timeout (specified in seconds)
-timeout = 2
 markers = [
     # !!!!!!!!!!!IMPORTANT!!!!!!!!!: when updating the markers, also make sure to update .ci/Jenkinsfile and meta.yaml
     # Tests that require a world_size of two should be annotated with `@pytest.mark.world_size(2)`.
@@ -113,7 +110,6 @@ filterwarnings = [
     # Ignore a UserWarning from torch 1.12 due to DeepSpeed's use of positional args
     'ignore:Positional args are being deprecated, use kwargs instead.*:UserWarning',
 ]
-timeout_func_only = true  # exclude fixtures from the timeout
 
 # Coverage
 [tool.coverage.run]

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,6 @@ extra_deps['dev'] = [
     'ipykernel==6.9.2',
     'jupyter==1.0.0',
     'yamllint==1.26.3',
-    'pytest-timeout==2.1.0',
     'recommonmark==0.7.1',
     'sphinx==4.4.0',
     'pre-commit>=2.18.1,<3',

--- a/tests/algorithms/algorithm_settings.py
+++ b/tests/algorithms/algorithm_settings.py
@@ -214,9 +214,6 @@ def get_algs_with_marks():
         if alg_cls in (Alibi, GatedLinearUnits, SeqLengthWarmup):
             pytest.importorskip('transformers')
 
-        if _settings[alg_cls] is simple_bert_settings:
-            marks.append(pytest.mark.timeout(15))  # bert settings require the model to be downloaded from the HF hub
-
         if alg_cls == SWA:
             # TODO(matthew): Fix
             marks.append(

--- a/tests/algorithms/test_algorithm_resumption.py
+++ b/tests/algorithms/test_algorithm_resumption.py
@@ -15,7 +15,6 @@ from tests.algorithms.algorithm_settings import get_alg_dataloader, get_alg_kwar
 from tests.common import deep_compare
 
 
-@pytest.mark.timeout(30)
 @pytest.mark.gpu
 @pytest.mark.parametrize('alg_cls', get_algs_with_marks())
 def test_algorithm_resumption(

--- a/tests/algorithms/test_algorithms_train.py
+++ b/tests/algorithms/test_algorithms_train.py
@@ -10,7 +10,6 @@ from composer.algorithms.layer_freezing.layer_freezing import LayerFreezing
 from tests.algorithms.algorithm_settings import get_alg_dataloader, get_alg_kwargs, get_alg_model, get_algs_with_marks
 
 
-@pytest.mark.timeout(5)
 @pytest.mark.gpu
 @pytest.mark.parametrize('alg_cls', get_algs_with_marks())
 def test_algorithm_trains(alg_cls: Type[Algorithm]):

--- a/tests/algorithms/test_blurpool_layers.py
+++ b/tests/algorithms/test_blurpool_layers.py
@@ -19,7 +19,6 @@ def generate_pool_args():
 
 
 @pytest.mark.parametrize('pool_args', generate_pool_args())
-@pytest.mark.timeout(5)
 def test_blurmaxpool_shapes(pool_args):
     n, c, sz, stride, kernel_size = pool_args
 

--- a/tests/algorithms/test_stochastic_depth.py
+++ b/tests/algorithms/test_stochastic_depth.py
@@ -156,7 +156,6 @@ class TestStochasticDepthDropRate:
     @pytest.mark.parametrize('drop_rate', [0.0, 0.5, 1.0])
     @pytest.mark.parametrize('drop_distribution', ['uniform', 'linear'])
     @pytest.mark.parametrize('drop_warmup', ['0.1dur'])
-    @pytest.mark.timeout(5)
     def test_drop_rate_warmup(self, algorithm: StochasticDepth, step: int, state: State):
         old_drop_rates = []
         self.get_drop_rate_list(state.model, drop_rates=old_drop_rates)

--- a/tests/algorithms/test_torch_export.py
+++ b/tests/algorithms/test_torch_export.py
@@ -65,7 +65,6 @@ def get_surgery_method(alg_cls: Type[Algorithm]) -> Callable:
     raise ValueError(f'Unknown algorithm class {alg_cls}')
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('alg_cls', torchscript_algs_with_marks)
 def test_surgery_torchscript_train(input: Any, alg_cls: Type[Algorithm]):
     """Tests torchscript model in train mode."""
@@ -87,7 +86,6 @@ def test_surgery_torchscript_train(input: Any, alg_cls: Type[Algorithm]):
     torch.testing.assert_close(scripted_func(input), model(input))  # type: ignore (third-party)
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('alg_cls', torchscript_algs_with_marks)
 def test_surgery_torchscript_eval(input: Any, alg_cls: Type[Algorithm]):
     """Tests torchscript model in eval mode."""
@@ -111,7 +109,6 @@ def test_surgery_torchscript_eval(input: Any, alg_cls: Type[Algorithm]):
 # <--- torch.fx export --->
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('alg_cls', torchscript_algs_with_marks)
 def test_surgery_torchfx_eval(
     input: Any,
@@ -139,7 +136,6 @@ def test_surgery_torchfx_eval(
 # <--- onnx export --->
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('alg_cls', torchscript_algs_with_marks)
 @pytest.mark.filterwarnings(
     r'ignore:Converting a tensor to a Python .* might cause the trace to be incorrect:torch.jit._trace.TracerWarning')

--- a/tests/algorithms/test_torch_export.py
+++ b/tests/algorithms/test_torch_export.py
@@ -146,8 +146,9 @@ def test_surgery_onnx(
 ):
     """Tests onnx export and runtime"""
     pytest.importorskip('onnx')
-    import onnx  # type: ignore
-    import onnxruntime as ort  # type: ignore
+    pytest.importorskip('onnxruntime')
+    import onnx
+    import onnxruntime as ort
 
     surgery_method = get_surgery_method(alg_cls)
 

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -13,7 +13,7 @@ from composer import Callback
 from composer.callbacks import EarlyStopper, ImageVisualizer, MemoryMonitor, SpeedMonitor, ThresholdStopper
 from composer.callbacks.callback_hparams_registry import callback_registry
 from composer.callbacks.mlperf import MLPerfCallback
-from composer.loggers import FileLogger, ObjectStoreLogger, TensorboardLogger, WandBLogger
+from composer.loggers import ObjectStoreLogger, TensorboardLogger, WandBLogger
 from composer.loggers.logger_destination import LoggerDestination
 from composer.loggers.logger_hparams_registry import ObjectStoreLoggerHparams, logger_registry
 from composer.loggers.progress_bar_logger import ProgressBarLogger
@@ -101,7 +101,6 @@ _callback_marks: Dict[Union[Type[Callback], Type[hp.Hparams]], List[pytest.MarkD
         pytest.mark.filterwarnings(
             r'ignore:The memory monitor only works on CUDA devices, but the model is on cpu:UserWarning')
     ],
-    FileLogger: [pytest.mark.timeout(30)],  # Jenkins can have slow disks
     MLPerfCallback: [pytest.mark.skipif(not _MLPERF_INSTALLED, reason='MLPerf is optional')],
     WandBLogger: [
         pytest.mark.filterwarnings(r'ignore:unclosed file:ResourceWarning'),

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -127,14 +127,12 @@ class TestCallbackTrains:
             profiler=Profiler(schedule=lambda _: ProfilerAction.SKIP, trace_handlers=[]),
         )
 
-    @pytest.mark.timeout(30)
     def test_trains(self, cb_cls: Type[Callback], grad_accum: int):
         cb_kwargs = get_cb_kwargs(cb_cls)
         cb = cb_cls(**cb_kwargs)
         trainer = self._get_trainer(cb, grad_accum)
         trainer.fit()
 
-    @pytest.mark.timeout(30)
     def test_trains_multiple_calls(self, cb_cls: Type[Callback], grad_accum: int):
         """
         Tests that training with multiple fits complete.

--- a/tests/callbacks/test_early_stopper.py
+++ b/tests/callbacks/test_early_stopper.py
@@ -16,7 +16,6 @@ from tests.metrics import MetricSetterCallback
 
 
 @device('cpu', 'gpu')
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('metric_sequence', [[0.1, 0.2, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.2, 1.3], [0.1, 0.2]])
 @pytest.mark.parametrize('unit', [TimeUnit.EPOCH, TimeUnit.BATCH])
 def test_early_stopper(metric_sequence: List[float], unit: TimeUnit, device: str):

--- a/tests/callbacks/test_image_visualizer.py
+++ b/tests/callbacks/test_image_visualizer.py
@@ -35,6 +35,7 @@ def test_image_visualizer(interval: str):
         eval_dataloader=DataLoader(RandomImageDataset()),
         max_duration='1ep',
     )
+    pytest.xfail('This test segfaults. See https://mosaicml.atlassian.net/browse/CO-776')
     trainer.fit()
     num_train_steps = int(trainer.state.timestamp.batch)
     num_train_tables = len(in_memory_logger.data['Images/Train'])

--- a/tests/callbacks/test_image_visualizer.py
+++ b/tests/callbacks/test_image_visualizer.py
@@ -19,7 +19,6 @@ except ImportError:
     _WANDB_INSTALLED = False
 
 
-@pytest.mark.timeout(15.0)
 @pytest.mark.skipif(not _WANDB_INSTALLED, reason='Wandb is optional')
 @pytest.mark.parametrize('interval', ['9ba', '90ba'])
 def test_image_visualizer(interval: str):

--- a/tests/callbacks/test_mlperf_callback.py
+++ b/tests/callbacks/test_mlperf_callback.py
@@ -58,7 +58,6 @@ class TestMLPerfCallbackEvents:
 
         return state
 
-    @pytest.mark.timeout(5)
     def test_eval_start(self, mlperf_callback, mock_state):
         mlperf_callback.eval_start(mock_state, Mock())
 
@@ -68,7 +67,6 @@ class TestMLPerfCallbackEvents:
 
         assert mlperf_callback.mllogger.logs == [{'key': 'eval_start', 'value': None, 'metadata': {'epoch_num': 1}}]
 
-    @pytest.mark.timeout(5)
     def test_eval_end(self, mlperf_callback, mock_state):
         mlperf_callback.eval_end(mock_state, Mock())
 
@@ -92,7 +90,6 @@ class TestMLPerfCallbackEvents:
 class TestWithMLPerfChecker:
     """Ensures that the logs created by the MLPerfCallback pass the official package checker."""
 
-    @pytest.mark.timeout(15)
     def test_mlperf_callback_passes(self, tmp_path, monkeypatch, world_size, device):
 
         def mock_accuracy(self, state: State):
@@ -108,7 +105,6 @@ class TestWithMLPerfChecker:
         if rank_zero():
             self.run_mlperf_checker(tmp_path, monkeypatch)
 
-    @pytest.mark.timeout(15)
     def test_mlperf_callback_fails(self, tmp_path, monkeypatch, world_size, device):
 
         def mock_accuracy(self, state: State):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -17,7 +17,6 @@ import composer
     [sys.executable, '-m', 'composer.cli', '--version'],
     [sys.executable, '-m', 'composer.cli.launcher', '--version'],
 ])
-@pytest.mark.timeout(5)  # spawning a subprocess is slow
 def test_cli_version(args: List[str]):
     version_str = subprocess.check_output(args, text=True)
     assert version_str == f'composer {composer.__version__}\n'

--- a/tests/datasets/test_dataset_registry.py
+++ b/tests/datasets/test_dataset_registry.py
@@ -79,7 +79,6 @@ default_required_fields: Dict[Type[DatasetHparams], Callable[[], DatasetHparams]
 }
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('dataset_name', dataset_registry.keys())
 def test_dataset(dataset_name: str, dummy_dataloader_hparams: DataLoaderHparams) -> None:
     hparams_cls = dataset_registry[dataset_name]

--- a/tests/datasets/test_ffcv_utils.py
+++ b/tests/datasets/test_ffcv_utils.py
@@ -11,7 +11,6 @@ from composer.datasets.synthetic import SyntheticDataLabelType, SyntheticPILData
 
 
 @pytest.mark.vision
-@pytest.mark.timeout(15)
 def test_write_ffcv_dataset(tmp_path: pathlib.Path):
     dataset = SyntheticPILDataset(total_dataset_size=1,
                                   num_classes=1,

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -58,7 +58,6 @@ def write_synthetic_streaming_dataset(dirname: str,
         writer.write_samples(samples=samples)
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('num_samples', [100, 10000])
 @pytest.mark.parametrize('shard_size_limit', [1 << 8, 1 << 16, 1 << 24])
 def test_writer(remote_local: Tuple[str, str], num_samples: int, shard_size_limit: int) -> None:
@@ -80,7 +79,6 @@ def test_writer(remote_local: Tuple[str, str], num_samples: int, shard_size_limi
     assert len(files) == expected_num_files, f'Files written ({len(files)}) != expected ({expected_num_files}).'
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('batch_size', [None, 1, 2])
 @pytest.mark.parametrize('remote_arg', ['none', 'same', 'different'])
 @pytest.mark.parametrize('shuffle', [False, True])
@@ -134,7 +132,6 @@ def test_reader(remote_local: Tuple[str, str], batch_size: int, remote_arg: str,
     assert len(dataset) == num_samples, f'Got dataset length={len(dataset)} samples, expected {num_samples}'
 
 
-@pytest.mark.timeout(3)
 @pytest.mark.parametrize(
     'missing_file',
     [
@@ -163,7 +160,6 @@ def test_reader_download_fail(remote_local: Tuple[str, str], missing_file: str):
         print(f'Successfully raised error: {e}')
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('created_ago', [0.5, 3])
 @pytest.mark.parametrize('timeout', [1])
 def test_reader_after_crash(remote_local: Tuple[str, str], created_ago: float, timeout: float) -> None:
@@ -218,7 +214,6 @@ def test_reader_getitem(remote_local: Tuple[str, str], share_remote_local: bool)
 
 
 @pytest.mark.daily()
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('batch_size', [1, 2, 5])
 @pytest.mark.parametrize('drop_last', [False, True])
 @pytest.mark.parametrize('num_workers', [1, 2, 3])
@@ -296,7 +291,6 @@ def test_dataloader_single_device(remote_local: Tuple[str, str], batch_size: int
 
 
 @pytest.mark.daily()
-@pytest.mark.timeout(10)
 @pytest.mark.world_size(2)
 @pytest.mark.parametrize('batch_size', [4])
 @pytest.mark.parametrize('drop_last', [False, True])
@@ -409,7 +403,6 @@ def check_for_diff_files(dir: dircmp):
         check_for_diff_files(subdir)
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize('compression', [None, 'gz', 'gz:5'])
 def test_compression(compressed_remote_local: Tuple[str, str, str], compression: Optional[str]):
     num_samples = 31

--- a/tests/datasets/test_streaming_remote.py
+++ b/tests/datasets/test_streaming_remote.py
@@ -124,7 +124,6 @@ def test_upload_streaming_dataset(tmp_path: pathlib.Path, s3_bucket: str):
 
 
 @pytest.mark.remote()
-@pytest.mark.timeout(0)
 @pytest.mark.filterwarnings(r'ignore::pytest.PytestUnraisableExceptionWarning')
 @pytest.mark.parametrize('name', [
     'ade20k',
@@ -165,7 +164,6 @@ def test_streaming_remote_dataset(tmp_path: pathlib.Path, name: str, split: str)
 
 
 @pytest.mark.remote()
-@pytest.mark.timeout(0)
 @pytest.mark.filterwarnings(r'ignore::pytest.PytestUnraisableExceptionWarning')
 @pytest.mark.parametrize('name', [
     'ade20k',

--- a/tests/loggers/test_file_logger.py
+++ b/tests/loggers/test_file_logger.py
@@ -27,7 +27,6 @@ class FileArtifactLoggerTracker(LoggerDestination):
 
 
 @pytest.mark.parametrize('log_level', [LogLevel.EPOCH, LogLevel.BATCH])
-@pytest.mark.timeout(30)
 def test_file_logger(dummy_state: State, log_level: LogLevel, tmp_path: pathlib.Path):
     log_file_name = os.path.join(tmp_path, 'output.log')
     log_destination = FileLogger(
@@ -102,7 +101,6 @@ def test_file_logger(dummy_state: State, log_level: LogLevel, tmp_path: pathlib.
             dummy_state.timestamp.epoch) + int(dummy_state.timestamp.epoch) + 1
 
 
-@pytest.mark.timeout(15)  # disk can be slow on Jenkins
 def test_file_logger_capture_stdout_stderr(dummy_state: State, tmp_path: pathlib.Path):
     log_file_name = os.path.join(tmp_path, 'output.log')
     log_destination = FileLogger(filename=log_file_name,

--- a/tests/loggers/test_object_store_logger.py
+++ b/tests/loggers/test_object_store_logger.py
@@ -152,12 +152,10 @@ def test_object_store_logger(tmp_path: pathlib.Path, dummy_state: State):
     object_store_test_helper(tmp_path=tmp_path, dummy_state=dummy_state, use_procs=False)
 
 
-@pytest.mark.timeout(15)
 def test_object_store_logger_use_procs(tmp_path: pathlib.Path, dummy_state: State):
     object_store_test_helper(tmp_path=tmp_path, dummy_state=dummy_state, use_procs=True)
 
 
-@pytest.mark.timeout(15)
 @pytest.mark.filterwarnings(r'ignore:((.|\n)*)FileExistsError((.|\n)*):pytest.PytestUnhandledThreadExceptionWarning')
 @pytest.mark.parametrize('overwrite_delay', [True, False])
 def test_object_store_logger_no_overwrite(tmp_path: pathlib.Path, dummy_state: State, overwrite_delay: bool):
@@ -167,12 +165,10 @@ def test_object_store_logger_no_overwrite(tmp_path: pathlib.Path, dummy_state: S
                              overwrite_delay=overwrite_delay)
 
 
-@pytest.mark.timeout(5)
 def test_object_store_logger_should_log_artifact_filter(tmp_path: pathlib.Path, dummy_state: State):
     object_store_test_helper(tmp_path=tmp_path, dummy_state=dummy_state, should_filter=True)
 
 
-@pytest.mark.timeout(30)  # long timeout as this test spawns many subprocesses
 @pytest.mark.parametrize('use_procs', [True, False])
 def test_race_with_overwrite(tmp_path: pathlib.Path, use_procs: bool, dummy_state: State):
     # Test a race condition with the object store logger where multiple files with the same name are logged in rapid succession
@@ -218,7 +214,6 @@ def test_race_with_overwrite(tmp_path: pathlib.Path, use_procs: bool, dummy_stat
         assert f.read() == str(num_files - 1)
 
 
-@pytest.mark.timeout(5)
 @pytest.mark.filterwarnings(r'ignore:Exception in thread:pytest.PytestUnhandledThreadExceptionWarning')
 def test_close_on_failure(tmp_path: pathlib.Path, dummy_state: State):
     """Test that .close() and .post_close() does not hang even when a worker crashes."""

--- a/tests/loggers/test_progress_bar_logger.py
+++ b/tests/loggers/test_progress_bar_logger.py
@@ -24,7 +24,6 @@ from tests.common import RandomClassificationDataset, SimpleModel
      Time.from_timestring('100sp'),
      Time.from_timestring('5ba')],
 )
-@pytest.mark.timeout(10)
 def test_progress_bar_logger(max_duration: Time[int], monkeypatch: MonkeyPatch, world_size: int):
 
     mock_tqdms_train = []

--- a/tests/loggers/test_wandb_logger.py
+++ b/tests/loggers/test_wandb_logger.py
@@ -54,7 +54,6 @@ def test_logged_data_is_json_serializable(callback_cls: Type[Callback]):
 @pytest.mark.world_size(2)
 @pytest.mark.parametrize('rank_zero_only', [True, False])
 @pytest.mark.remote
-@pytest.mark.timeout(60)
 def test_wandb_artifacts(rank_zero_only: bool, tmp_path: pathlib.Path, dummy_state: State):
     """Test that artifacts logged on rank zero are accessible by all ranks."""
     pytest.importorskip('wandb', reason='wandb is optional')

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -5,7 +5,6 @@ import pytest
 import torch
 
 
-@pytest.mark.timeout(30)
 def test_hf_model_forward():
     pytest.importorskip('transformers')
     import transformers

--- a/tests/models/test_model_yamls.py
+++ b/tests/models/test_model_yamls.py
@@ -25,7 +25,6 @@ def walk_model_yamls():
     return yamls
 
 
-@pytest.mark.timeout(40)
 @pytest.mark.parametrize('hparams_file', walk_model_yamls())
 class TestHparamsCreate:
 

--- a/tests/profiler/test_json_trace_handler.py
+++ b/tests/profiler/test_json_trace_handler.py
@@ -16,7 +16,6 @@ from tests.common import RandomClassificationDataset, SimpleModel
 
 
 # This test shouldn't run with the Torch profiler enabled, not providing a model or data can cause a seg fault
-@pytest.mark.timeout(30)
 @pytest.mark.filterwarnings(
     r'ignore:The profiler is enabled\. Using the profiler adds additional overhead when training\.:UserWarning')
 def test_json_trace_profiler_handler(tmp_path: pathlib.Path):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -241,7 +241,6 @@ def check_output(proc: subprocess.CompletedProcess):
     raise RuntimeError(error_msg)
 
 
-@pytest.mark.timeout(30)
 @pytest.mark.parametrize('exception', [True, False])
 def test_engine_closes_on_atexit(exception: bool):
     # Running this test via a subprocess, as atexit() must trigger

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -76,7 +76,6 @@ def modify_cell_source(tb: TestbookNotebookClient, notebook_name: str, cell_sour
     return cell_source
 
 
-@pytest.mark.timeout(120)
 @pytest.mark.parametrize('notebook', [_to_pytest_param(notebook) for notebook in NOTEBOOKS])
 @device('cpu', 'gpu')
 @pytest.mark.daily

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -37,7 +37,6 @@ def run_and_measure_memory(precision: Precision) -> int:
 
 
 @pytest.mark.gpu
-@pytest.mark.timeout(5)
 @pytest.mark.parametrize('precision', [Precision.AMP, Precision.BF16])
 def test_precision_memory(precision: Precision):
     if version.parse(torch.__version__) < version.parse('1.10'):

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -147,7 +147,6 @@ def get_two_epoch_composer_hparams(composer_trainer_hparams: TrainerHparams, che
     return composer_trainer_hparams
 
 
-@pytest.mark.timeout(5)
 @pytest.mark.parametrize(
     'remove_field_paths,filter_params',
     [
@@ -227,7 +226,6 @@ def test_ignore_params(remove_field_paths: List[List[str]], filter_params: List[
     assert base_dict == new_dict
 
 
-@pytest.mark.timeout(90)
 @device('cpu', 'gpu')
 def test_load_weights(
     device: str,
@@ -278,7 +276,6 @@ def test_load_weights(
     )
 
 
-@pytest.mark.timeout(90)
 @device('cpu', 'gpu')
 @pytest.mark.parametrize('use_object_store,delete_local_checkpoint', [
     pytest.param(False, False),
@@ -364,7 +361,6 @@ def test_autoresume(
     assert trainer.state.run_name == second_trainer.state.run_name
 
 
-@pytest.mark.timeout(90)
 @device('cpu', 'gpu')
 def test_different_run_names(
     device: Device,
@@ -402,7 +398,6 @@ def test_different_run_names(
     assert trainer_a.state.run_name != trainer_b.state.run_name
 
 
-@pytest.mark.timeout(90)
 @device('cpu', 'gpu')
 @pytest.mark.parametrize('save_overwrite', [
     True,
@@ -461,7 +456,6 @@ def test_save_overwrite(
     trainer.fit(duration='1ba')
 
 
-@pytest.mark.timeout(90)
 def test_checkpoint_with_object_store_logger(
     composer_trainer_hparams: TrainerHparams,
     tmp_path: pathlib.Path,
@@ -552,7 +546,6 @@ def test_checkpoint_with_object_store_logger(
     )
 
 
-@pytest.mark.timeout(180)
 @pytest.mark.parametrize('world_size', [
     pytest.param(1),
     pytest.param(2, marks=pytest.mark.world_size(2)),

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -120,7 +120,6 @@ class CheckBatch0(Callback):
             )
 
 
-@pytest.mark.timeout(90)
 @pytest.mark.parametrize('device,deepspeed', [
     pytest.param('cpu', False, id='cpu'),
     pytest.param('gpu', False, id='gpu', marks=pytest.mark.gpu),

--- a/tests/trainer/test_ddp_sync_strategy.py
+++ b/tests/trainer/test_ddp_sync_strategy.py
@@ -39,7 +39,6 @@ class MinimalConditionalModel(nn.Module):
         return (output - target) * (output - target)
 
 
-@pytest.mark.timeout(90)
 @pytest.mark.parametrize('ddp_sync_strategy,expected_grads', [
     pytest.param('single_auto_sync', ([-1, None, None], [-1, -1.5, None], [-1, -1.5, None]), id='single_auto_sync'),
     pytest.param('multi_auto_sync', ([-1.5, None, None], [-1.5, -1.5, None], [-1.5, -1.5, None]), id='multi_auto_sync'),

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -518,7 +518,6 @@ class TestTrainerInitOrFit:
         # Assert that the states are equivalent
         assert_state_equivalent(init_trainer.state, algo_trainer.state)
 
-    @pytest.mark.timeout(5.0)
     def test_dataloader_active_iterator_error(self, model: ComposerModel):
         dataloader = DataLoader(
             dataset=RandomClassificationDataset(),
@@ -564,7 +563,6 @@ class TestTrainerInitOrFit:
 
         assert trainer.state.timestamp.get(max_duration.unit) == 2 * max_duration
 
-    @pytest.mark.timeout(10)
     @pytest.mark.parametrize('eval_interval', ['1ba', '1ep'])
     def test_eval_is_excluded_from_wct_tracking(
         self,
@@ -783,7 +781,6 @@ class TestTrainerInitOrFit:
 
 @world_size(1, 2)
 @device('cpu', 'gpu', 'gpu-amp', precision=True)
-@pytest.mark.timeout(15)  # higher timeout since each model is trained twice
 class TestTrainerEquivalence():
 
     default_threshold = {'atol': 0, 'rtol': 0}
@@ -958,7 +955,6 @@ class TestTrainerEvents():
 
 
 @pytest.mark.vision
-@pytest.mark.timeout(30)
 class TestFFCVDataloaders:
 
     train_file = None

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -96,7 +96,6 @@ def test_trainer_eval_timestamp():
     True,
     False,
 ])
-@pytest.mark.timeout(15)
 def test_eval_at_fit_end(eval_at_fit_end: bool):
     """Test the `eval_subset_num_batches` and `eval_interval` works when specified on init."""
 

--- a/tests/utils/object_store/test_object_store_hparams.py
+++ b/tests/utils/object_store/test_object_store_hparams.py
@@ -15,7 +15,6 @@ from tests.utils.object_store.object_store_settings import (get_object_store_ctx
 
 
 @pytest.mark.parametrize('constructor', object_store_hparams)
-@pytest.mark.timeout(5)
 def test_object_store_hparams_is_constructable(
     constructor: Type[ObjectStoreHparams],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/utils/object_store/test_s3_object_store.py
+++ b/tests/utils/object_store/test_s3_object_store.py
@@ -17,7 +17,6 @@ def _worker(bucket: str, tmp_path: pathlib.Path, tid: int):
         object_store.download_object('this_key_should_not_exist', filename=tmp_path / str(tid) / 'dummy_file')
 
 
-@pytest.mark.timeout(15)
 # This test requires properly configured aws credentials; otherwise the s3 client would hit a NoCredentialsError
 # when constructing the Session, which occurs before the bug this test checks
 @pytest.mark.remote

--- a/tests/utils/test_fx_utils.py
+++ b/tests/utils/test_fx_utils.py
@@ -163,7 +163,6 @@ def test_fuse_parallel_linears(model_cls, before_count, after_count):
 @pytest.mark.filterwarnings(
     r'ignore:Attempted to insert a call_module Node with no underlying reference in the owning GraphModule!.*:UserWarning'
 )
-@pytest.mark.timeout(15)
 def test_stochastic_depth(model_cls, block_count):
     model = model_cls()
     traced = symbolic_trace(model)

--- a/tests/utils/test_inference.py
+++ b/tests/utils/test_inference.py
@@ -15,7 +15,6 @@ from composer.models import composer_resnet
 from composer.utils import export_for_inference
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     'model_cls, sample_input',
     [
@@ -41,7 +40,6 @@ def test_export_for_inference_torchscript(model_cls, sample_input):
             loaded_model_out), f'mismatch in the original and exported for inference model outputs with {target_format}'
 
 
-@pytest.mark.timeout(10)
 @pytest.mark.parametrize(
     'model_cls, sample_input',
     [

--- a/tests/utils/test_inference.py
+++ b/tests/utils/test_inference.py
@@ -48,6 +48,7 @@ def test_export_for_inference_torchscript(model_cls, sample_input):
 )
 def test_export_for_inference_onnx(model_cls, sample_input):
     pytest.importorskip('onnx')
+    pytest.importorskip('onnxruntime')
     import onnx  # type: ignore
     import onnxruntime as ort  # type: ignore
 


### PR DESCRIPTION
This PR removes `pytest-timeout`, all timeout markers from tests, and the `--duration` flag from running pytest.

The original intent of adding pytest-timeout was to a) incentivise tests to be fast, b) prevent stalled tests from hogging up system resources, and c) provide a heuristic that could be used to split in parallelize tests in the future. However, it has accomplished none of these goals.

a) Slow-running tests have just been giving longer timeouts to get it to pass ci/cd. Instead, slow-running tests should either be moved to run only on the daily build (i.e. `@pytest.mark.daily`), or be made faster.

b) If a test is stalling due to a distributed error, pytest-timeout doesn't help at all, since Composer will hang on a distributed barrier. Because of inconsistent CI/CD hardware that caused tests to sporadically exceed the timeout, we probably have used _more_ CI/CD minutes re-running failed builds due to timeout failures compared to the amount of CI/CD time the timeout has saved. Instead, we should rely on the `pytestTimeout` variable in the Jenkinsfile -- this controls how long the k8s pod will run before dying, and it is not affected by `torch.dist` calls that could freeze the python process. It is set to 30 minutes right now, which is relatively short.

c) For when we want to split and parallelize tests, the `junitxml` reports already include the amount of time each test case took. So, we can split tests based on their historical execution time, rather than requiring an upper-bound be specified in the codebase.

Closes https://mosaicml.atlassian.net/browse/CO-769