### PR TITLE
Update HF example with read of model eval accuracy

### DIFF
--- a/examples/huggingface_models.ipynb
+++ b/examples/huggingface_models.ipynb
@@ -235,7 +235,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our model reaches almost 86% accuracy with only 100 iterations of training! Let's visualize a few samples from the validation set to see how our model performs."
+    "To check the training's validation accuracy, we read the `Trainer` object `state.current_metrics['eval']` "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer.state.current_metrics['eval']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our model reaches ~86% accuracy with only 150 iterations of training! \n",
+    "Let's visualize a few samples from the validation set to see how our model performs."
    ]
   },
   {


### PR DESCRIPTION
The HF fine-tune example is missing an actual read of the model eval accuracy after fine-tuning.
This change adds the code that shows how to read the eval metrics.