### PR TITLE
Add save fine-tune model to HuggingFace example

### DIFF
--- a/examples/huggingface_models.ipynb
+++ b/examples/huggingface_models.ipynb
@@ -286,6 +286,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Save Fine-Tuned Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, to save the fine-tuned model parameters we call PyTorch `save` method and pass it the model's `state_dict`: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.save(trainer.state.model.state_dict(), 'model.pt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Conclusion"
    ]
   },


### PR DESCRIPTION
HuggingFace example did not include a demonstration of saving the fine-tuned PyTorch model parameters.
This commit addresses this and adds saving of the model parameters.
Tested on Colab with `%pip install "mosaicml[nlp] @ git+https://github.com/mosaicml/composer@dev"`, ran successfully.