### PR TITLE
Cleanup API Reference Titles

### DIFF
--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -1,6 +1,6 @@
 .. From https://github.com/sphinx-doc/sphinx/tree/4.x/sphinx/ext/autosummary/templates/autosummary/module.rst
 
-{{ fullname | escape | underline}}
+{{ name | escape | underline}}
 
 .. List the submodules
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -334,7 +334,7 @@ def add_module_summary_tables(
     attributes: List[Tuple[str, object]] = []
     if len(lines) == 0:
         # insert a stub docstring so it doesn't start with functions/exceptions/classes/attributes
-        lines.append(name)
+        lines.append(f'Module :mod:`~{name}`.')
 
     if what == 'module':
 


### PR DESCRIPTION
Cleanup the API Reference to only show the name, and not the fullname, in the title and default description.

Closes https://mosaicml.atlassian.net/browse/CO-786