### PR TITLE
Update DWD optimizers

### DIFF
--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import List, Tuple
+from typing import Iterable, List, Tuple, Union
 
 import torch
 from torch.optim import SGD, AdamW
-from torch.optim.optimizer import _params_t, required  # type: ignore
+from torch.optim.optimizer import required  # type: ignore
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class DecoupledSGDW(SGD):
     """
 
     def __init__(self,
-                 params: _params_t,
+                 params: Union[Iterable[torch.Tensor], Iterable[dict]],
                  lr: float = required,
                  momentum: float = 0,
                  dampening: float = 0,
@@ -173,7 +173,7 @@ class DecoupledAdamW(AdamW):
     """
 
     def __init__(self,
-                 params: _params_t,
+                 params: Union[Iterable[torch.Tensor], Iterable[dict]],
                  lr: float = 1e-3,
                  betas: Tuple[float, float] = (0.9, 0.95),
                  eps: float = 1e-8,

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -55,8 +55,8 @@ class DecoupledSGDW(SGD):
                  nesterov: bool = False):
         if weight_decay >= 1e-3:
             log.warning(
-                f'You are using a high value of `weight_decay={weight_decay}` for the `DecoupledSGDW` optimizer. Are you sure you want to do this?'
-                f'Your model\'s weights will be multiplied by {1.0 - weight_decay} on every step.')
+                f'You are using a high value of `weight_decay={weight_decay}` for the `DecoupledSGDW` optimizer. Are you sure you want to do this? '
+                f'Your model\'s weights will be multiplied by {1.0 - weight_decay} on every step!')
         super().__init__(params=params,
                          lr=lr,
                          momentum=momentum,
@@ -195,8 +195,8 @@ class DecoupledAdamW(AdamW):
                  amsgrad: bool = False):
         if weight_decay >= 1e-3:
             log.warning(
-                f'You are using a high value of `weight_decay={weight_decay}` for the `DecoupledAdamW` optimizer. Are you sure you want to do this?'
-                f'Your model\'s weights will be multiplied by {1.0 - weight_decay} on every step.')
+                f'You are using a high value of `weight_decay={weight_decay}` for the `DecoupledAdamW` optimizer. Are you sure you want to do this? '
+                f'Your model\'s weights will be multiplied by {1.0 - weight_decay} on every step!')
         super().__init__(params=params, lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, amsgrad=amsgrad)
         for group in self.param_groups:
             group['initial_lr'] = group['lr']

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -179,7 +179,7 @@ class DecoupledAdamW(AdamW):
                  eps: float = 1e-8,
                  weight_decay: float = 1e-5,
                  amsgrad: bool = False):
-        super(DecoupledAdamW, self).__init__(params=params,
+        super().__init__(params=params,
                                              lr=lr,
                                              betas=betas,
                                              eps=eps,

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -34,7 +34,7 @@ class DecoupledSGDW(SGD):
 
     Args:
         params (list): List of parameters to optimize or dicts defining parameter groups.
-        lr (float, required): Learning rate.
+        lr (float): Learning rate.
         momentum (int, optional): Momentum factor. Default: ``0``.
         dampening (int, optional): Dampening factor applied to the momentum. Default: ``0``.
         weight_decay (int, optional): Decoupled weight decay factor. Default: ``0``.

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -171,7 +171,7 @@ class DecoupledAdamW(AdamW):
     * The default for ``weight_decay`` is changed from ``1e-2`` -> ``1e-5`` because in `DecoupledAdamW`, the weight decay is decoupled and no longer scaled by the `lr=1e-3`.
     * The default for ``betas`` is changed from ``(0.9, 0.999)`` to ``(0.9, 0.95)`` to reflect community best-practices for the beta2 hyperparameter.
 
-    The standard `AdamW <https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html#torch.optim.AdamW>`_
+    Why use this optimizer? The standard `AdamW <https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html#torch.optim.AdamW>`_
     optimizer explicitly couples the weight decay term with the learning rate. This ties the
     optimal value of :attr:`weight_decay` to :attr:`lr` and can also hurt generalization in practice. For more details on
     why decoupling might be desirable, see `Decoupled Weight Decay Regularization <https://arxiv.org/abs/1711.05101>`_.


### PR DESCRIPTION
This PR fixes #1334 and does the following:

* fix bug when `lr=0`
* Fix some typings
* Update `DecoupledAdamW` default values for `weight_decay` and `betas` to be safer

@ravi-mosaicml I'm wondering if I should also go through all the docstrings and clean them up? I see some inconsistent formatting like `weight_decay (float, optional)` and wonder if it should be `weight_decay (Optional[float])`. Let me know what you suggest!