### PR TITLE
Mid Epoch Resumption of Streaming Datasets

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -435,7 +435,7 @@ class State(Serializable):
                 dataloader_state = None
                 if self.dataloader is not None and hasattr(self.dataloader, 'state_dict'):
                     dataloader_state = self.dataloader.state_dict()  # type: ignore
-                    dataloader_state['sample_count'] = self.timestamp.batch_in_epoch
+                    dataloader_state['sample_count'] = self.timestamp.sample_in_epoch
                 # patch this value to be resilient to prefetching:
                 serialized_value = dataloader_state
                 continue

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -434,8 +434,7 @@ class State(Serializable):
             if attribute_name == 'dataloader_state':
                 dataloader_state = None
                 if self.dataloader is not None and hasattr(self.dataloader, 'state_dict'):
-                    # type: ignore
-                    dataloader_state = self.dataloader.state_dict()
+                    dataloader_state = self.dataloader.state_dict()  # type: ignore
                     dataloader_state['batch_count'] = self.timestamp.batch_in_epoch
                 # patch this value to be resilient to prefetching:
                 serialized_value = dataloader_state
@@ -498,8 +497,7 @@ class State(Serializable):
                 continue
             elif attribute_name == 'dataloader_state':
                 if self.dataloader is not None and hasattr(self.dataloader, 'load_state_dict'):
-                    # type: ignore
-                    self.dataloader.load_state_dict(state)
+                    self.dataloader.load_state_dict(state)  # type: ignore
                 continue
             state_field_value = getattr(self, attribute_name)
             if attribute_name in _STATE_DICT_SERIALIZED_ATTRIBUTES:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -435,7 +435,7 @@ class State(Serializable):
                 dataloader_state = None
                 if self.dataloader is not None and hasattr(self.dataloader, 'state_dict'):
                     dataloader_state = self.dataloader.state_dict()  # type: ignore
-                    dataloader_state['batch_count'] = self.timestamp.batch_in_epoch
+                    dataloader_state['sample_count'] = self.timestamp.batch_in_epoch
                 # patch this value to be resilient to prefetching:
                 serialized_value = dataloader_state
                 continue

--- a/composer/datasets/streaming/__init__.py
+++ b/composer/datasets/streaming/__init__.py
@@ -18,8 +18,6 @@ A brief list of improvements:
 * Dataset order is deterministic for a given value of ``world_size`` and ``num_workers``.
 * Dataset can resume mid epoch without needing to "spin" through previous values.
 * (TODO) Supports lazy random-access retrieval of samples (useful for local dataset inspection).
-* Shuffling is best-effort in epoch 1, and samples are made available for random acess as they are being downloaded.
-* (TODO) Shuffling is perfect, i.e. random access (per-worker), in all subsequent epochs.
 """
 
 from composer.datasets.streaming.dataset import StreamingDataset

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -162,8 +162,6 @@ class StreamingDataset(IterableDataset):
                     fp.write('')
                 pass
 
-        self.num_samples = np.sum(self.index.samples_per_shard[self._shard_shuffle_indices])
-
         # Load the index file containing the shard metadata
         # This file contains the shard and offset in bytes of each sample (for direct access).
         # Only local device 0 on each node downloads the index. All other devices wait.
@@ -195,6 +193,7 @@ class StreamingDataset(IterableDataset):
             N = self.index.num_shards
             self._shard_shuffle_indices = np.arange(N)[(np.arange(N) % num_nodes) == global_rank]
             self.index.relocate_samples(self._shard_shuffle_indices)
+        self.num_samples = np.sum(self.index.samples_per_shard[self._shard_shuffle_indices])
 
     def _parse_shuffle_buffer_size(self, shuffle_buffer_size_arg: str) -> np.int64:
         if shuffle_buffer_size_arg.endswith('prop'):

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -183,6 +183,7 @@ class StreamingDataset(IterableDataset):
         world = get_world()
         num_nodes = world.global_num_nodes
         global_rank = world.global_node
+        print("num nodes:", num_nodes, "global rank:", global_rank)
         if shuffle:
             cipher_key = 42  # initialize using an arbitrary cipher key
             self.shuffler = BlockCipherShuffler(cipher_key, self.index)
@@ -190,8 +191,10 @@ class StreamingDataset(IterableDataset):
             self.index.relocate_samples(self._shard_shuffle_indices)
         else:
             N = self.index.num_shards
-            self._shard_shuffle_indices = np.arange(N)[np.arange(N) % num_nodes == global_rank]
+            self._shard_shuffle_indices = np.arange(N)[(np.arange(N) % num_nodes) == global_rank]
             self.index.relocate_samples(self._shard_shuffle_indices)
+
+        print(self._shard_shuffle_indices)
 
     def _parse_shuffle_buffer_size(self, shuffle_buffer_size_arg: str) -> np.int64:
         if shuffle_buffer_size_arg.endswith('prop'):

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -257,7 +257,7 @@ class StreamingDataset(IterableDataset):
             current_shard_index = self.shuffler.get_shard_index(current_shard_id)
             current_shard_index -= current_shard_index % self._shuffle_buffer_size
 
-        shard_ids = self._shard_shuffle_indices[current_shard_index:]
+        shard_ids = self._shard_shuffle_indices[0:]
 
         for shard_id in shard_ids:
             basename = get_shard_basename(shard_id, compression_name=self.compression_scheme)

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -193,7 +193,7 @@ class StreamingDataset(IterableDataset):
         else:
             N = self.index.num_shards
             self._shard_shuffle_indices = np.arange(N)[(np.arange(N) % num_nodes) == global_rank]
-            if not self._shard_shuffle_indices:
+            if len(self._shard_shuffle_indices) == 0:
                 self._shard_shuffle_indices = np.array([0])
             self.index.relocate_samples(self._shard_shuffle_indices)
         self.num_samples = np.sum(self.index.samples_per_shard[self._shard_shuffle_indices])

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -181,9 +181,9 @@ class StreamingDataset(IterableDataset):
         self._sample_count = 0
         self._restored_sample_count = 0
         self._shuffle_buffer_size = self._parse_shuffle_buffer_size(shuffle_size)
-        world = get_world()
-        num_nodes = world.global_num_devices
-        global_rank = world.global_device
+        # world = get_world()
+        num_nodes = 8  # world.global_num_devices
+        global_rank = 0  # world.global_device
         if shuffle:
             cipher_key = 42  # initialize using an arbitrary cipher key
             self.shuffler = BlockCipherShuffler(cipher_key, self.index, num_nodes, global_rank,

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -181,9 +181,9 @@ class StreamingDataset(IterableDataset):
         self._sample_count = 0
         self._restored_sample_count = 0
         self._shuffle_buffer_size = self._parse_shuffle_buffer_size(shuffle_size)
-        # world = get_world()
-        num_nodes = 8  # world.global_num_devices
-        global_rank = 0  # world.global_device
+        world = get_world()
+        num_nodes = world.global_num_devices
+        global_rank = world.global_device
         if shuffle:
             cipher_key = 42  # initialize using an arbitrary cipher key
             self.shuffler = BlockCipherShuffler(cipher_key, self.index, num_nodes, global_rank,

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -344,9 +344,9 @@ class StreamingDataset(IterableDataset):
         sbs = int(self._shuffle_buffer_size)
         batch_size = 1 if self.batch_size is None else self.batch_size
         while self._sample_count < self.index.total_samples:
-            if self._sample_count < self._restored_sample_count:
-                self._sample_count += 1
-                yield None
+            # if self._sample_count < self._restored_sample_count:
+            #     self._sample_count += 1
+            #     yield None
             try:
                 idx = self.shuffler.shuffle_sample(self._sample_count, node_num_workers, rank, sbs, batch_size, self.num_samples) \
                     if self.shuffle else self._sample_count

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -182,7 +182,7 @@ class StreamingDataset(IterableDataset):
         self._shuffle_buffer_size = self._parse_shuffle_buffer_size(shuffle_size)
         world = get_world()
         num_nodes = world.global_num_nodes
-        global_rank = world.node_device
+        global_rank = world.global_node
         if shuffle:
             cipher_key = 42  # initialize using an arbitrary cipher key
             self.shuffler = BlockCipherShuffler(cipher_key, self.index)
@@ -212,7 +212,7 @@ class StreamingDataset(IterableDataset):
         self.shuffler = BlockCipherShuffler(cipher_key, self.index)
         world = get_world()
         num_nodes = world.global_num_nodes
-        global_rank = world.node_device
+        global_rank = world.global_node 
         self._shard_shuffle_indices = self.shuffler.shuffle_shards(num_nodes, global_rank)
         self.index.relocate_samples(self._shard_shuffle_indices)
 

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -134,7 +134,7 @@ class StreamingDataset(IterableDataset):
                  max_retries: int = 2,
                  timeout: float = 60,
                  batch_size: Optional[int] = None,
-                 shuffle_size: str = '0.50prop') -> None:
+                 shuffle_size: str = '2shards') -> None:
 
         self.remote = remote
         self.local = local
@@ -263,7 +263,7 @@ class StreamingDataset(IterableDataset):
             basename = get_shard_basename(shard_id, compression_name=self.compression_scheme)
             try:
                 self._download_file(basename, wait=(dist.get_local_rank() != 0))
-                print("downloaded", basename)
+                print('downloaded', basename)
             except Exception as e:
                 with self._lock:
                     self._download_status = _DownloadStatus.FAILED
@@ -353,4 +353,4 @@ class StreamingDataset(IterableDataset):
                     elif self._download_status == _DownloadStatus.DONE:
                         raise e
                 sleep(0.25)
-                print("file not found")
+                print('file not found')

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -359,6 +359,7 @@ class StreamingDataset(IterableDataset):
                         if not self.shuffle and self.index.sample_id_shards[
                                 self._sample_count] not in self._shard_shuffle_indices:
                             self._sample_count += 1
+                            print('skipping')
                             continue
                         raise e
                 sleep(0.25)

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -246,7 +246,7 @@ class StreamingDataset(IterableDataset):
             self._lock = Lock()
 
         world = get_world()
-        if world.node_device != 0:
+        if world.node_worker != 0:
             return
 
         with self._lock:

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -343,14 +343,13 @@ class StreamingDataset(IterableDataset):
         world = get_world()
         node_num_workers = world.node_num_workers
         rank = world.node_worker
-        sbs = int(self._shuffle_buffer_size)
         batch_size = 1 if self.batch_size is None else self.batch_size
         while self._sample_count < self.index.total_samples:
             # if self._sample_count < self._restored_sample_count:
             #     self._sample_count += 1
             #     yield None
             try:
-                idx = self.shuffler.shuffle_sample(self._sample_count, node_num_workers, rank, sbs, batch_size, self.num_samples) \
+                idx = self.shuffler.shuffle_sample(self._sample_count, node_num_workers, rank, batch_size, self.num_samples) \
                     if self.shuffle else self._sample_count
                 yield self[idx]
                 self._sample_count += 1

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -356,5 +356,9 @@ class StreamingDataset(IterableDataset):
                     if self._download_status == _DownloadStatus.FAILED:
                         raise self._download_exception
                     elif self._download_status == _DownloadStatus.DONE:
+                        if not self.shuffle and self.index.sample_id_shards[
+                                self._sample_count] not in self._shard_shuffle_indices:
+                            self._sample_count += 1
+                            continue
                         raise e
                 sleep(0.25)

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -263,6 +263,7 @@ class StreamingDataset(IterableDataset):
             basename = get_shard_basename(shard_id, compression_name=self.compression_scheme)
             try:
                 self._download_file(basename, wait=(dist.get_local_rank() != 0))
+                print("downloaded", basename)
             except Exception as e:
                 with self._lock:
                     self._download_status = _DownloadStatus.FAILED

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -272,7 +272,7 @@ class StreamingDataset(IterableDataset):
                 continue
             basename = get_shard_basename(shard_id, compression_name=self.compression_scheme)
             try:
-                self._download_file(basename, wait=(dist.get_local_rank() != 0))
+                self._download_file(basename, wait=False)
                 print('downloaded file')
                 with self._lock:
                     self._shards_downloaded += 1

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -334,12 +334,13 @@ class StreamingDataset(IterableDataset):
         node_num_workers = world.node_num_workers
         rank = world.node_worker
         sbs = int(self._shuffle_buffer_size)
+        batch_size = 1 if self.batch_size is None else self.batch_size
         while self._sample_count < self.index.total_samples:
             if self._sample_count < self._restored_sample_count:
                 self._sample_count += 1
                 yield None
             try:
-                idx = self.shuffler.shuffle_sample(self._sample_count, node_num_workers, rank, sbs) \
+                idx = self.shuffler.shuffle_sample(self._sample_count, node_num_workers, rank, sbs, batch_size) \
                     if self.shuffle else self._sample_count
                 yield self[idx]
                 self._sample_count += 1

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -242,11 +242,12 @@ class StreamingDataset(IterableDataset):
     def download(self) -> None:
         """Downloads everything in the correct order"""
 
-        if dist.get_local_rank() != 0:
-            return
-
         if not hasattr(self, '_lock'):
             self._lock = Lock()
+
+        world = get_world()
+        if world.node_device != 0:
+            return
 
         with self._lock:
             if self._download_status != _DownloadStatus.NOT_STARTED:

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -206,7 +206,10 @@ class StreamingDataset(IterableDataset):
 
     def load_state_dict(self, state):
         self._restored_sample_count = state['sample_count']
-        self.shuffler = BlockCipherShuffler(state['cipher_key'], self.index)
+        cipher_key = self.shuffler._cipher_key
+        if 'cipher_key' in state:
+            cipher_key = state['cipher_key']
+        self.shuffler = BlockCipherShuffler(cipher_key, self.index)
         world = get_world()
         num_nodes = world.global_num_nodes
         global_rank = dist.get_global_rank()

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -270,7 +270,9 @@ class StreamingDataset(IterableDataset):
             basename = get_shard_basename(shard_id, compression_name=self.compression_scheme)
             try:
                 self._download_file(basename, wait=False)
-                print('downloaded', basename)
+                if shard_id == 0:
+                    print("IT'S RIGHT HEEEERE")
+                print('downloaded', basename, ix)
             except Exception as e:
                 with self._lock:
                     self._download_status = _DownloadStatus.FAILED

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -331,7 +331,7 @@ class StreamingDataset(IterableDataset):
         """
         Thread(target=self.download, daemon=True).start()
         world = get_world()
-        num_workers = world.node_num_workers
+        node_num_workers = world.node_num_workers
         rank = world.node_worker
         sbs = int(self._shuffle_buffer_size)
         while self._sample_count < self.index.total_samples:
@@ -339,7 +339,7 @@ class StreamingDataset(IterableDataset):
                 self._sample_count += 1
                 yield None
             try:
-                idx = self.shuffler.shuffle_sample(self._sample_count, num_workers, rank, sbs) \
+                idx = self.shuffler.shuffle_sample(self._sample_count, node_num_workers, rank, sbs) \
                     if self.shuffle else self._sample_count
                 yield self[idx]
                 self._sample_count += 1

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -268,7 +268,9 @@ class StreamingDataset(IterableDataset):
         for _, shard_id in enumerate(shard_ids):
             basename = get_shard_basename(shard_id, compression_name=self.compression_scheme)
             try:
+                print('downloading file', basename)
                 self._download_file(basename, wait=(dist.get_local_rank() != 0))
+                print('downloaded file', basename)
             except Exception as e:
                 with self._lock:
                     self._download_status = _DownloadStatus.FAILED

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -353,3 +353,4 @@ class StreamingDataset(IterableDataset):
                     elif self._download_status == _DownloadStatus.DONE:
                         raise e
                 sleep(0.25)
+                print("file not found")

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -181,8 +181,8 @@ class StreamingDataset(IterableDataset):
         self._restored_sample_count = 0
         self._shuffle_buffer_size = self._parse_shuffle_buffer_size(shuffle_size)
         world = get_world()
-        num_nodes = world.global_num_devices
-        global_rank = world.global_device
+        num_nodes = world.global_num_nodes
+        global_rank = world.global_node
         print('num nodes:', num_nodes, 'global rank:', global_rank)
         if shuffle:
             cipher_key = 42  # initialize using an arbitrary cipher key
@@ -214,8 +214,8 @@ class StreamingDataset(IterableDataset):
             cipher_key = state['cipher_key']
         self.shuffler = BlockCipherShuffler(cipher_key, self.index)
         world = get_world()
-        num_nodes = world.global_num_devices
-        global_rank = world.global_device
+        num_nodes = world.global_num_nodes
+        global_rank = world.global_node
         self._shard_shuffle_indices = self.shuffler.shuffle_shards(num_nodes, global_rank)
         self.index.relocate_samples(self._shard_shuffle_indices)
 

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -242,6 +242,9 @@ class StreamingDataset(IterableDataset):
     def download(self) -> None:
         """Downloads everything in the correct order"""
 
+        if dist.get_local_rank() != 0:
+            return
+
         if not hasattr(self, '_lock'):
             self._lock = Lock()
 
@@ -273,7 +276,8 @@ class StreamingDataset(IterableDataset):
                     self._download_exception = e
 
         with self._lock:
-            self._download_status = _DownloadStatus.DONE
+            if dist.get_local_rank() == 0:
+                self._download_status = _DownloadStatus.DONE
 
     def __len__(self) -> int:
         """Get the length of the dataset.

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -344,9 +344,9 @@ class StreamingDataset(IterableDataset):
         sbs = int(self._shuffle_buffer_size)
         batch_size = 1 if self.batch_size is None else self.batch_size
         while self._sample_count < self.index.total_samples:
-            # if self._sample_count < self._restored_sample_count:
-            #     self._sample_count += 1
-            #     yield None
+            if self._sample_count < self._restored_sample_count:
+                self._sample_count += 1
+                yield None
             try:
                 idx = self.shuffler.shuffle_sample(self._sample_count, node_num_workers, rank, sbs, batch_size, self.num_samples) \
                     if self.shuffle else self._sample_count

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -174,6 +174,7 @@ class StreamingDataset(IterableDataset):
         self._lock: Lock
         self._next_epoch = 0
         self._download_status = _DownloadStatus.NOT_STARTED
+        self._shards_downloaded = 0
         self._download_exception: Exception
 
         self._shuffle_index = 0
@@ -273,6 +274,9 @@ class StreamingDataset(IterableDataset):
                 if shard_id == 0:
                     print("IT'S RIGHT HEEEERE")
                 print('downloaded', basename, ix)
+                with self._lock:
+                    self._shards_downloaded += 1
+                    print(self._shards_downloaded)
             except Exception as e:
                 with self._lock:
                     self._download_status = _DownloadStatus.FAILED
@@ -362,6 +366,6 @@ class StreamingDataset(IterableDataset):
                     if self._download_status == _DownloadStatus.FAILED:
                         raise self._download_exception
                     elif self._download_status == _DownloadStatus.DONE:
-                        raise e
+                        pass
                 sleep(0.25)
                 print('file not found')

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -263,6 +263,8 @@ class StreamingDataset(IterableDataset):
                 raise ValueError('shuffling is on but no seed was specified')
             current_shard_index = self.shuffler.get_shard_index(current_shard_id)
             current_shard_index -= current_shard_index % self._shuffle_buffer_size
+        if self.restored_sample_count == 0:
+            current_shard_index = 0
 
         shard_ids = self._shard_shuffle_indices[current_shard_index:]
 

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -247,6 +247,7 @@ class StreamingDataset(IterableDataset):
                 return
             self._download_status = _DownloadStatus.IN_PROGRESS
 
+        print(self.index.sample_shards)
         current_shard_id = self.index.sample_shards[self._restored_sample_count]
         current_shard_index = current_shard_id
 

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -328,6 +328,7 @@ class StreamingDataset(IterableDataset):
         size = None
 
         if not self.shuffle:
+            idx = idx % self.num_samples
             shard = self.index.unshuffled_index_to_shard[idx]
             offset = self.index.unshuffled_index_to_offset[idx]
             size = self.index.unshuffled_index_to_bytes[idx]
@@ -373,4 +374,4 @@ class StreamingDataset(IterableDataset):
                         raise self._download_exception
                     elif self._download_status == _DownloadStatus.DONE:
                         raise e
-                sleep(0.25)
+                sleep(0.05)

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -331,7 +331,8 @@ class StreamingDataset(IterableDataset):
         Returns:
             Iterator[Any]: Each sample.
         """
-        Thread(target=self.download, daemon=True).start()
+        self.download()
+        #Thread(target=self.download, daemon=True).start()
         world = get_world()
         node_num_workers = world.node_num_workers
         rank = world.node_worker

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -182,8 +182,8 @@ class StreamingDataset(IterableDataset):
         self._restored_sample_count = 0
         self._shuffle_buffer_size = self._parse_shuffle_buffer_size(shuffle_size)
         world = get_world()
-        num_nodes = world.global_num_nodes
-        global_rank = world.global_node
+        num_nodes = world.global_num_devices
+        global_rank = world.global_device
         if shuffle:
             cipher_key = 42  # initialize using an arbitrary cipher key
             self.shuffler = BlockCipherShuffler(cipher_key, self.index, num_nodes, global_rank,
@@ -339,7 +339,7 @@ class StreamingDataset(IterableDataset):
         """
         Thread(target=self.download, daemon=True).start()
         world = get_world()
-        node_num_workers = world.node_num_workers
+        node_num_workers = world.device_num_workers
         rank = world.node_worker
         batch_size = 1 if self.batch_size is None else self.batch_size
         while self._sample_count < self.index.total_samples:

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -263,6 +263,8 @@ class StreamingDataset(IterableDataset):
         shard_ids = self._shard_shuffle_indices[0:]
 
         for shard_id in shard_ids:
+            if dist.get_local_rank() != 0:
+                continue
             basename = get_shard_basename(shard_id, compression_name=self.compression_scheme)
             try:
                 self._download_file(basename, wait=(dist.get_local_rank() != 0))

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -212,7 +212,7 @@ class StreamingDataset(IterableDataset):
         self.shuffler = BlockCipherShuffler(cipher_key, self.index)
         world = get_world()
         num_nodes = world.global_num_nodes
-        global_rank = world.global_node 
+        global_rank = world.global_node
         self._shard_shuffle_indices = self.shuffler.shuffle_shards(num_nodes, global_rank)
         self.index.relocate_samples(self._shard_shuffle_indices)
 
@@ -337,9 +337,9 @@ class StreamingDataset(IterableDataset):
         sbs = int(self._shuffle_buffer_size)
         batch_size = 1 if self.batch_size is None else self.batch_size
         while self._sample_count < self.index.total_samples:
-            if self._sample_count < self._restored_sample_count:
-                self._sample_count += 1
-                yield None
+            # if self._sample_count < self._restored_sample_count:
+            #     self._sample_count += 1
+            #     yield None
             try:
                 idx = self.shuffler.shuffle_sample(self._sample_count, node_num_workers, rank, sbs, batch_size) \
                     if self.shuffle else self._sample_count

--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -143,6 +143,7 @@ class StreamingDataset(IterableDataset):
         self.max_retries = max_retries
         self.timeout = timeout
         self.batch_size = batch_size
+        self.world = get_world()
 
         self.compression_scheme = None
         if remote is not None:
@@ -181,9 +182,8 @@ class StreamingDataset(IterableDataset):
         self._sample_count = 0
         self._restored_sample_count = 0
         self._shuffle_buffer_size = self._parse_shuffle_buffer_size(shuffle_size)
-        world = get_world()
-        num_nodes = world.global_num_devices
-        global_rank = world.global_device
+        num_nodes = self.world.global_num_devices
+        global_rank = self.world.global_device
         if shuffle:
             cipher_key = 42  # initialize using an arbitrary cipher key
             self.shuffler = BlockCipherShuffler(cipher_key, self.index, num_nodes, global_rank,
@@ -212,9 +212,8 @@ class StreamingDataset(IterableDataset):
         cipher_key = self.shuffler._cipher_key
         if 'cipher_key' in state:
             cipher_key = state['cipher_key']
-        world = get_world()
-        num_nodes = world.global_num_nodes
-        global_rank = world.global_node
+        num_nodes = self.world.global_num_nodes
+        global_rank = self.world.global_node
         self.shuffler = BlockCipherShuffler(cipher_key, self.index, num_nodes, global_rank,
                                             int(self._shuffle_buffer_size))
         self._shard_shuffle_indices = self.shuffler.shuffle_indices
@@ -317,6 +316,8 @@ class StreamingDataset(IterableDataset):
             Any: The sample.
         """
         shard = self.index.sample_id_shards[idx]
+        if self.shuffle == False:
+            shard = (shard // self.world.global_num_devices) * self.world.global_num_devices + self.world.global_device
         offset = self.index.sample_shard_offsets[idx]
         size = self.index.bytes_per_sample[idx]
 

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -283,7 +283,6 @@ class StreamingDatasetIndex(object):
             sample_shard_offsets (NDArray[np.int64]): Intra-shard byte offset per sample.
         """
         samples_per_shard_shuffled = np.array([self.samples_per_shard[ix] for ix in self.shuffle_indices])
-        owned_shards = set(self.shuffle_indices)
         indices = self.shuffle_indices
 
         shard_ends = self.bytes_per_shard.cumsum()
@@ -294,8 +293,6 @@ class StreamingDatasetIndex(object):
         sample_shards = []
         shard_samples = []
         for shard, (num_samples, shard_begin) in enumerate(zip(self.samples_per_shard, shard_begins)):
-            if shard not in owned_shards:
-                continue
             sample_id_shards += [shard] * num_samples
             sample_shard_begins += [shard_begin] * num_samples
 

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -284,7 +284,7 @@ class StreamingDatasetIndex(object):
         """
         samples_per_shard_shuffled = np.array([self.samples_per_shard[ix] for ix in self.shuffle_indices])
         indices = self.shuffle_indices
-        owned_samples = set(self.shuffle_indices)
+        owned_shards = set(self.shuffle_indices)
 
         shard_ends = self.bytes_per_shard.cumsum()
         shard_begins = shard_ends - self.bytes_per_shard
@@ -306,7 +306,7 @@ class StreamingDatasetIndex(object):
         sample_shards = np.array(sample_shards, np.int64)
         shard_samples = np.array(shard_samples, np.int64)
 
-        mask = np.array([x in owned_samples for x in sample_id_shards])
+        mask = np.array([x in owned_shards for x in sample_id_shards])
 
         sample_ends = self.bytes_per_sample.astype(np.int64).cumsum()
         sample_begins = sample_ends - self.bytes_per_sample

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -169,12 +169,12 @@ class StreamingDatasetIndex(object):
 
         # Sample -> shard, byte offset within shard.
         self.shuffle_indices = shuffle_indices if shuffle_indices is not None else np.arange(self.num_shards)
-        self.sample_shards, self.sample_id_shards, self.sample_shard_offsets, self.shard_samples = self._locate_samples(
+        self.sample_shards, self.sample_id_shards, self.sample_shard_offsets, self.shard_samples, self.bytes_per_sample = self._locate_samples(
         )
 
     def relocate_samples(self, shuffle_indices: NDArray[np.int64]) -> None:
         self.shuffle_indices = shuffle_indices
-        self.sample_shards, self.sample_id_shards, self.sample_shard_offsets, self.shard_samples = self._locate_samples(
+        self.sample_shards, self.sample_id_shards, self.sample_shard_offsets, self.shard_samples, self.bytes_per_sample = self._locate_samples(
         )
 
     @classmethod
@@ -275,7 +275,9 @@ class StreamingDatasetIndex(object):
         data = self.dumps()
         fp.write(data)
 
-    def _locate_samples(self) -> Tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.int64], NDArray[np.int64]]:
+    def _locate_samples(
+            self
+    ) -> Tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.int64], NDArray[np.int64], NDArray[np.int64]]:
         """Precompute the shard and byte offset within the shard of every sample.
 
         Returns:
@@ -311,4 +313,5 @@ class StreamingDatasetIndex(object):
         sample_ends = self.bytes_per_sample.astype(np.int64).cumsum()
         sample_begins = sample_ends - self.bytes_per_sample
         sample_shard_offsets = sample_begins - sample_shard_begins
-        return sample_shards, sample_id_shards[mask], sample_shard_offsets[mask], shard_samples
+        return sample_shards, sample_id_shards[mask], sample_shard_offsets[mask], shard_samples, self.bytes_per_sample[
+            mask]

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -283,6 +283,7 @@ class StreamingDatasetIndex(object):
             sample_shard_offsets (NDArray[np.int64]): Intra-shard byte offset per sample.
         """
         samples_per_shard_shuffled = np.array([self.samples_per_shard[ix] for ix in self.shuffle_indices])
+        print(len(samples_per_shard_shuffled))
         indices = self.shuffle_indices
 
         shard_ends = self.bytes_per_shard.cumsum()

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -283,7 +283,6 @@ class StreamingDatasetIndex(object):
             sample_shard_offsets (NDArray[np.int64]): Intra-shard byte offset per sample.
         """
         samples_per_shard_shuffled = np.array([self.samples_per_shard[ix] for ix in self.shuffle_indices])
-        print(len(samples_per_shard_shuffled))
         indices = self.shuffle_indices
 
         shard_ends = self.bytes_per_shard.cumsum()

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -283,6 +283,7 @@ class StreamingDatasetIndex(object):
             sample_shard_offsets (NDArray[np.int64]): Intra-shard byte offset per sample.
         """
         samples_per_shard_shuffled = np.array([self.samples_per_shard[ix] for ix in self.shuffle_indices])
+        owned_shards = set(self.shuffle_indices)
         indices = self.shuffle_indices
 
         shard_ends = self.bytes_per_shard.cumsum()
@@ -293,6 +294,8 @@ class StreamingDatasetIndex(object):
         sample_shards = []
         shard_samples = []
         for shard, (num_samples, shard_begin) in enumerate(zip(self.samples_per_shard, shard_begins)):
+            if shard not in owned_shards:
+                continue
             sample_id_shards += [shard] * num_samples
             sample_shard_begins += [shard_begin] * num_samples
 

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -284,6 +284,7 @@ class StreamingDatasetIndex(object):
         """
         samples_per_shard_shuffled = np.array([self.samples_per_shard[ix] for ix in self.shuffle_indices])
         indices = self.shuffle_indices
+        owned_samples = set(self.shuffle_indices)
 
         shard_ends = self.bytes_per_shard.cumsum()
         shard_begins = shard_ends - self.bytes_per_shard
@@ -305,7 +306,9 @@ class StreamingDatasetIndex(object):
         sample_shards = np.array(sample_shards, np.int64)
         shard_samples = np.array(shard_samples, np.int64)
 
+        mask = np.array([x in owned_samples for x in sample_id_shards])
+
         sample_ends = self.bytes_per_sample.astype(np.int64).cumsum()
         sample_begins = sample_ends - self.bytes_per_sample
         sample_shard_offsets = sample_begins - sample_shard_begins
-        return sample_shards, sample_id_shards, sample_shard_offsets, shard_samples
+        return sample_shards, sample_id_shards[mask], sample_shard_offsets[mask], shard_samples

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -282,7 +282,7 @@ class StreamingDatasetIndex(object):
             sample_shards (NDArray[np.int64]): Shard per sample.
             sample_shard_offsets (NDArray[np.int64]): Intra-shard byte offset per sample.
         """
-        samples_per_shard_shuffled = self.samples_per_shard[self.shuffle_indices]
+        samples_per_shard_shuffled = np.array([self.samples_per_shard[ix] for ix in self.shuffle_indices])
         indices = self.shuffle_indices
 
         shard_ends = self.bytes_per_shard.cumsum()

--- a/composer/datasets/streaming/format.py
+++ b/composer/datasets/streaming/format.py
@@ -169,12 +169,12 @@ class StreamingDatasetIndex(object):
 
         # Sample -> shard, byte offset within shard.
         self.shuffle_indices = shuffle_indices if shuffle_indices is not None else np.arange(self.num_shards)
-        self.sample_shards, self.sample_id_shards, self.sample_shard_offsets, self.shard_samples, self.bytes_per_sample = self._locate_samples(
+        self.sample_shards, self.sample_id_shards, self.sample_shard_offsets, self.shard_samples = self._locate_samples(
         )
 
     def relocate_samples(self, shuffle_indices: NDArray[np.int64]) -> None:
         self.shuffle_indices = shuffle_indices
-        self.sample_shards, self.sample_id_shards, self.sample_shard_offsets, self.shard_samples, self.bytes_per_sample = self._locate_samples(
+        self.sample_shards, self.sample_id_shards, self.sample_shard_offsets, self.shard_samples = self._locate_samples(
         )
 
     @classmethod
@@ -275,9 +275,7 @@ class StreamingDatasetIndex(object):
         data = self.dumps()
         fp.write(data)
 
-    def _locate_samples(
-            self
-    ) -> Tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.int64], NDArray[np.int64], NDArray[np.int64]]:
+    def _locate_samples(self) -> Tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.int64], NDArray[np.int64]]:
         """Precompute the shard and byte offset within the shard of every sample.
 
         Returns:
@@ -286,7 +284,7 @@ class StreamingDatasetIndex(object):
         """
         samples_per_shard_shuffled = np.array([self.samples_per_shard[ix] for ix in self.shuffle_indices])
         indices = self.shuffle_indices
-        owned_shards = set(self.shuffle_indices)
+        # owned_shards = set(self.shuffle_indices)
 
         shard_ends = self.bytes_per_shard.cumsum()
         shard_begins = shard_ends - self.bytes_per_shard
@@ -308,10 +306,9 @@ class StreamingDatasetIndex(object):
         sample_shards = np.array(sample_shards, np.int64)
         shard_samples = np.array(shard_samples, np.int64)
 
-        mask = np.array([x in owned_shards for x in sample_id_shards])
+        # mask = np.array([x in owned_shards for x in sample_id_shards])
 
         sample_ends = self.bytes_per_sample.astype(np.int64).cumsum()
         sample_begins = sample_ends - self.bytes_per_sample
         sample_shard_offsets = sample_begins - sample_shard_begins
-        return sample_shards, sample_id_shards[mask], sample_shard_offsets[mask], shard_samples, self.bytes_per_sample[
-            mask]
+        return sample_shards, sample_id_shards, sample_shard_offsets, shard_samples

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -114,7 +114,7 @@ class BlockCipherShuffler:
         self.shuffle_indices = self.shuffle_shards(num_nodes, global_rank)
         self.shuffle_buffer_size = shuffle_buffer_size
         num_shards = len(self.index.samples_per_shard)
-        for shard_index, shard_id in enumerate(self.shuffle_indices):
+        for shard_index, _ in enumerate(self.shuffle_indices):
             if shard_index % shuffle_buffer_size != 0:
                 continue
 

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -113,6 +113,9 @@ class BlockCipherShuffler:
         self.group_relative_id_to_shard_offset = {}
         self.shuffle_indices = self.shuffle_shards(num_nodes, global_rank)
         self.shuffle_buffer_size = shuffle_buffer_size
+        self.num_nodes = num_nodes
+        self.rank = global_rank
+
         num_shards = len(self.index.samples_per_shard)
         for shard_index, _ in enumerate(self.shuffle_indices):
             if shard_index % shuffle_buffer_size != 0:
@@ -215,7 +218,7 @@ class BlockCipherShuffler:
             int: relative position in an epoch of shard
         """
         num_shards = len(self.index.samples_per_shard)
-        return decrypt(self._cipher_key, shard_id, num_shards)
+        return decrypt(self._cipher_key, shard_id, num_shards) // self.num_nodes
 
     def get_shard_id(self, shard_index: int) -> int:
         """Gets the ID (relative position in dataset) of a shard with a given index
@@ -227,4 +230,4 @@ class BlockCipherShuffler:
             int: relative position in an epoch of shard
         """
         num_shards = len(self.index.samples_per_shard)
-        return encrypt(self._cipher_key, shard_index, num_shards)
+        return encrypt(self._cipher_key, shard_index * self.num_nodes + self.rank, num_shards)

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -125,7 +125,8 @@ class BlockCipherShuffler:
             if (idx % num_nodes) == global_rank
         ])
 
-    def shuffle_sample(self, idx: int, num_workers: int, rank: int, shuffle_buffer_size: int, batch_size: int, num_samples: int) -> int:
+    def shuffle_sample(self, idx: int, num_workers: int, rank: int, shuffle_buffer_size: int, batch_size: int,
+                       num_samples: int) -> int:
         """
         Shuffles the samples as much as possible while maintaining the shuffle_buffer_size invariant of shards
         required on the disk at once.

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -125,7 +125,7 @@ class BlockCipherShuffler:
             if (idx % num_nodes) == global_rank
         ])
 
-    def shuffle_sample(self, idx: int, num_workers: int, rank: int, shuffle_buffer_size: int, batch_size: int) -> int:
+    def shuffle_sample(self, idx: int, num_workers: int, rank: int, shuffle_buffer_size: int, batch_size: int, num_samples: int) -> int:
         """
         Shuffles the samples as much as possible while maintaining the shuffle_buffer_size invariant of shards
         required on the disk at once.
@@ -142,6 +142,7 @@ class BlockCipherShuffler:
         if self._cipher_key is None:
             raise ValueError('shuffling is on but no seed was specified')
         idx = ((idx // batch_size) * num_workers + rank) * batch_size + (idx % batch_size)
+        idx = idx % num_samples
 
         ### at a high level, this function does the following things:
         ### 1. calculates the group of shards that need to be present on the disk at a time

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -125,7 +125,7 @@ class BlockCipherShuffler:
             if (idx % num_nodes) == global_rank
         ])
 
-    def shuffle_sample(self, idx: int, num_workers: int, rank: int, shuffle_buffer_size: int) -> int:
+    def shuffle_sample(self, idx: int, num_workers: int, rank: int, shuffle_buffer_size: int, batch_size: int) -> int:
         """
         Shuffles the samples as much as possible while maintaining the shuffle_buffer_size invariant of shards
         required on the disk at once.
@@ -141,7 +141,7 @@ class BlockCipherShuffler:
         """
         if self._cipher_key is None:
             raise ValueError('shuffling is on but no seed was specified')
-        idx = idx * num_workers + rank
+        idx = ((idx // batch_size) * num_workers + rank) * batch_size + (idx % batch_size)
 
         ### at a high level, this function does the following things:
         ### 1. calculates the group of shards that need to be present on the disk at a time

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -115,9 +115,9 @@ class BlockCipherShuffler:
         num_shards = len(self.index.samples_per_shard)
         for shard_index, shard_id in enumerate(self.shuffle_indices):
             if shard_id % shuffle_buffer_size != 0:
-                pass
+                continue
 
-            first_shard_group_index = shard_index - (shard_index % shuffle_buffer_size)
+            first_shard_group_index = shard_index
             last_shard_group_index = min(first_shard_group_index + shuffle_buffer_size, num_shards)
 
             relative_id_to_shard_index = []

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -160,9 +160,9 @@ class BlockCipherShuffler:
 
         # calculate the number of samples in the shard group
         samples_in_group = 0
-        for id in range(first_shard_group_index, last_shard_group_index):
-            idx = self.get_shard_index(id)
-            samples_in_group += self.index.samples_per_shard[idx]
+        for shard_idx in range(first_shard_group_index, last_shard_group_index):
+            group_shard_id = self.get_shard_id(shard_idx)
+            samples_in_group += self.index.samples_per_shard[group_shard_id]
 
         # calculate how far into our shard group the shuffled sample lies
         group_key = int(self._cipher_key + first_shard_group_index)
@@ -172,13 +172,14 @@ class BlockCipherShuffler:
         relative_id_to_shard_index = []
         relative_id_to_shard_offset = []
         for shard_member_index in np.arange(first_shard_group_index, last_shard_group_index):
-            shard_id = self.get_shard_id(shard_member_index)
-            relative_id_to_shard_index += [shard_member_index] * self.index.samples_per_shard[shard_id]
-            relative_id_to_shard_offset += list(range(self.index.samples_per_shard[shard_id]))
+            shard_member_id = self.get_shard_id(shard_member_index)
+            relative_id_to_shard_index += [shard_member_index] * self.index.samples_per_shard[shard_member_id]
+            relative_id_to_shard_offset += list(range(self.index.samples_per_shard[shard_member_id]))
 
         target_shard_index = relative_id_to_shard_index[group_relative_sample_id]
         target_shard_id = self.get_shard_id(target_shard_index)
         shard_offset = relative_id_to_shard_offset[group_relative_sample_id]
+        print(group_relative_sample_id)
         shard_base_offset = np.sum(self.index.samples_per_shard[:target_shard_id])
 
         return shard_base_offset + shard_offset

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -153,7 +153,7 @@ class BlockCipherShuffler:
 
         # calculate the index of the shard group
         num_shards = len(self.index.samples_per_shard)
-        shard_id, _ = self.index.sample_shards[idx]
+        shard_id = self.index.sample_shards[idx]
         shard_index = self.get_shard_index(shard_id)
         first_shard_group_index = shard_index - (shard_index % shuffle_buffer_size)
         last_shard_group_index = min(int(first_shard_group_index + shuffle_buffer_size), num_shards)

--- a/composer/datasets/streaming/shuffle.py
+++ b/composer/datasets/streaming/shuffle.py
@@ -115,7 +115,7 @@ class BlockCipherShuffler:
         self.shuffle_buffer_size = shuffle_buffer_size
         num_shards = len(self.index.samples_per_shard)
         for shard_index, shard_id in enumerate(self.shuffle_indices):
-            if shard_id % shuffle_buffer_size != 0:
+            if shard_index % shuffle_buffer_size != 0:
                 continue
 
             first_shard_group_index = shard_index

--- a/composer/models/timm/model.py
+++ b/composer/models/timm/model.py
@@ -52,7 +52,7 @@ def composer_timm(model_name: str,
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='timm', conda_package='timm>=0.5.4',
                                             conda_channel=None) from e
-    model = timm.create_model(model_name=model_name,
+    model = timm.create_model(model_name=model_name, # type: ignore
                               pretrained=pretrained,
                               num_classes=num_classes,
                               drop_rate=drop_rate,

--- a/composer/models/timm/timm_hparams.py
+++ b/composer/models/timm/timm_hparams.py
@@ -57,7 +57,7 @@ class TimmHparams(ModelHparams):
                 raise MissingConditionalImportError(extra_deps_group='timm',
                                                     conda_package='timm >=0.5.4',
                                                     conda_channel=None) from e
-            raise ValueError(f'model must be one of {timm.models.list_models()}')
+            raise ValueError(f'model must be one of {timm.models.list_models()}') # type: ignore
 
     def initialize_object(self):
         if self.model_name is None:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1511,7 +1511,10 @@ class Trainer:
 
             for batch_idx, self.state.batch in enumerate(self._iter_dataloader(TrainerMode.TRAIN)):
 
-                # if resuming, skip dataloader forward to the minibatch index
+                # if resuming, skip dataloader forward to the minibatch index or restore directly if supported
+                if hasattr(self.state.dataloader, 'restored_sample_count'):
+                    batch_idx += int(self.state.timestamp.batch_in_epoch)
+
                 if batch_idx < int(self.state.timestamp.batch_in_epoch):
                     # Restore the RNG state immediately before the next batch is yielded from the dataloader
                     if batch_idx + 1 == int(self.state.timestamp.batch_in_epoch) and self._rng_state is not None:

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -17,10 +17,10 @@ import sys
 import tempfile
 import warnings
 
-from composer.utils.misc import warning_on_one_line
 from composer.loggers import LogLevel
 from composer.trainer.trainer_hparams import TrainerHparams
 from composer.utils import dist
+from composer.utils.misc import warning_on_one_line
 
 
 def _main():

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -15,13 +15,17 @@ import logging
 import os
 import sys
 import tempfile
+import warnings
 
+from composer.utils.misc import warning_on_one_line
 from composer.loggers import LogLevel
 from composer.trainer.trainer_hparams import TrainerHparams
 from composer.utils import dist
 
 
 def _main():
+    warnings.formatwarning = warning_on_one_line
+
     global_rank = dist.get_global_rank()
 
     logging.basicConfig(

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -15,17 +15,13 @@ import logging
 import os
 import sys
 import tempfile
-import warnings
 
 from composer.loggers import LogLevel
 from composer.trainer.trainer_hparams import TrainerHparams
 from composer.utils import dist
-from composer.utils.misc import warning_on_one_line
 
 
 def _main():
-    warnings.formatwarning = warning_on_one_line
-
     global_rank = dist.get_global_rank()
 
     logging.basicConfig(

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -447,7 +447,9 @@ def test_cipher_shuffle(remote_local: Tuple[str, str]):
 
     for datum in dataset:
         if datum['uid'] in unique_set:
-            nominal_order = [dataset.shuffler.shuffle_sample(ix, 1, 0, 15, 1) for ix in range(len(dataset))]
+            nominal_order = [
+                dataset.shuffler.shuffle_sample(ix, 1, 0, 15, 1, num_samples) for ix in range(len(dataset))
+            ]
             raise ValueError(
                 f"Duplicate UID: {datum['uid']}, full order: {unique_set}, nominal order: {nominal_order}, shard order: {dataset._shard_shuffle_indices}, samples per shard: {dataset.index.samples_per_shard}"
             )

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -447,9 +447,7 @@ def test_cipher_shuffle(remote_local: Tuple[str, str]):
 
     for datum in dataset:
         if datum['uid'] in unique_set:
-            nominal_order = [
-                dataset.shuffler.shuffle_sample(ix, 1, 0, 15, 1, num_samples) for ix in range(len(dataset))
-            ]
+            nominal_order = [dataset.shuffler.shuffle_sample(ix, 1, 0, 1, num_samples) for ix in range(len(dataset))]
             raise ValueError(
                 f"Duplicate UID: {datum['uid']}, full order: {unique_set}, nominal order: {nominal_order}, shard order: {dataset._shard_shuffle_indices}, samples per shard: {dataset.index.samples_per_shard}"
             )

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -447,7 +447,7 @@ def test_cipher_shuffle(remote_local: Tuple[str, str]):
 
     for datum in dataset:
         if datum['uid'] in unique_set:
-            nominal_order = [dataset.shuffler.shuffle_sample(ix, 1, 0, 15) for ix in range(len(dataset))]
+            nominal_order = [dataset.shuffler.shuffle_sample(ix, 1, 0, 15, 1) for ix in range(len(dataset))]
             raise ValueError(
                 f"Duplicate UID: {datum['uid']}, full order: {unique_set}, nominal order: {nominal_order}, shard order: {dataset._shard_shuffle_indices}, samples per shard: {dataset.index.samples_per_shard}"
             )


### PR DESCRIPTION
Mid Epoch Resumption of Streaming Datasets

Uses a Feistel network to reproducibly and efficiently shuffle streaming datasets while constraining the maximum number of shards that must be present on the device at any given time.

![image](https://user-images.githubusercontent.com/19612401/184601873-ba60ce64-ba8f-4798-8dd3-78502cacee86.png)

Addresses: 
* CO-408 
* CO-580
* CO-548

Follows up on an issue diagnosed by CO-630

