### PR TITLE
Help users reduce `ProgressBarLogger` print frequency

### DIFF
--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -158,12 +158,9 @@ class ProgressBarLogger(LoggerDestination):
         log_to_console = log_to_console if (log_to_console is not None) else (not progress_bar)
         console_log_level = LogLevel(console_log_level)
 
-        def _should_log(state: State, log_level: LogLevel):
-            return (log_to_console and ((log_level < console_log_level) or  #type: ignore
-                                        ((console_log_level == LogLevel.BATCH) and
-                                         (state.timestamp.batch.value % console_log_every_n_batches == 0))))
-
-        self.should_log = _should_log
+        self.should_log = lambda state, log_level: (log_to_console and (
+            (log_level < console_log_level) or ((console_log_level == LogLevel.BATCH) and
+                                                (state.timestamp.batch.value % console_log_every_n_batches == 0))))
 
         # set the stream
         if isinstance(stream, str):

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -165,7 +165,7 @@ class ProgressBarLogger(LoggerDestination):
         if log_to_console:
             # set should_log to a Callable[[State, LogLevel], bool]
             self.should_log = lambda state, ll: (ll < console_log_level) or (
-                console_log_level == LogLevel.BATCH and state.timestamp.batch % console_log_every_n_batches == 0)
+                (console_log_level == LogLevel.BATCH) and (state.timestamp.batch % console_log_every_n_batches == 0))
         else:
             # never log to console
             self.should_log = lambda state, ll: False

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -409,8 +409,8 @@ class Trainer:
 
             The default behavior (when set to ``None``) only prints logging statements when ``progress_bar`` is ``False``.
 
-        console_log_level (LogLevel | str | (State, LogLevel) -> bool, optional): The maximum log level which
-            should be printed to the console. (default: :attr:`.LogLevel.EPOCH`)
+        console_log_level (str | int | LogLevel): The maximum log level which
+            should be printed to the console. (default: :attr:`.LogLevel.BATCH`)
 
             It can either be :class:`.LogLevel`, a string corresponding to a :class:`.LogLevel`, or a callable
             that takes the training :class:`.State` and the :class:`.LogLevel` and returns a boolean of whether this
@@ -418,7 +418,9 @@ class Trainer:
 
             This parameter has no effect if ``log_to_console`` is ``False``, or is unspecified and ``progres_bar`` is
             ``True``.
+        console_log_every_n_batches (int, optional): Limit console logging to every N batches to reduce verbosity. (default: ``1``)
 
+            This parameter only has an effect if ``log_level`` is ``LogLevel.BATCH``.
         console_stream (TextIO | str, optional): The stream to write to. If a string, it can either be
             ``'stdout'`` or ``'stderr'``. (default: :attr:`sys.stderr`)
         load_path (str, optional):  The path format string to an existing checkpoint file.
@@ -695,7 +697,8 @@ class Trainer:
         run_name: Optional[str] = None,
         progress_bar: bool = True,
         log_to_console: Optional[bool] = None,
-        console_log_level: Union[LogLevel, str, Callable[[State, LogLevel], bool]] = LogLevel.EPOCH,
+        console_log_level: Union[str, int, LogLevel] = LogLevel.BATCH,
+        console_log_every_n_batches: int = 1,
         console_stream: Union[str, TextIO] = 'stderr',
 
         # Load Checkpoint
@@ -851,6 +854,7 @@ class Trainer:
                     progress_bar=progress_bar,
                     log_to_console=log_to_console,
                     console_log_level=console_log_level,
+                    console_log_every_n_batches=console_log_every_n_batches,
                     stream=console_stream,
                 ))
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -212,7 +212,8 @@ class TrainerHparams(hp.Hparams):
         run_name (str, optional): See :class:`.Trainer`.
         progress_bar (bool, optional): See :class:`.Trainer`.
         log_to_console (bool, optional): See :class:`.Trainer`.
-        console_log_level (bool, optional): See :class:`.Trainer`.
+        console_log_level (str | int | LogLevel, optional): See :class:`.Trainer`.
+        console_log_every_n_batches (int, optional): See :class:`.Trainer`.
         console_stream (bool, optional): See :class:`.Trainer`.
         python_log_level (str): The Python log level to use for log statements in the :mod:`composer`
             module. (default: ``INFO``)
@@ -320,7 +321,8 @@ class TrainerHparams(hp.Hparams):
     run_name: Optional[str] = hp.auto(Trainer, 'run_name')
     progress_bar: bool = hp.auto(Trainer, 'progress_bar')
     log_to_console: Optional[bool] = hp.auto(Trainer, 'log_to_console')
-    console_log_level: LogLevel = hp.auto(Trainer, 'console_log_level')
+    console_log_level: Union[str, int, LogLevel] = hp.auto(Trainer, 'console_log_level')
+    console_log_every_n_batches: int = hp.auto(Trainer, 'console_log_every_n_batches')
     console_stream: str = hp.auto(Trainer, 'console_stream')
     python_log_level: str = hp.optional(doc='Python loglevel to use composer', default='INFO')
 
@@ -510,6 +512,7 @@ class TrainerHparams(hp.Hparams):
             progress_bar=self.progress_bar,
             log_to_console=self.log_to_console,
             console_log_level=self.console_log_level,
+            console_log_every_n_batches=self.console_log_every_n_batches,
             console_stream=self.console_stream,
 
             # Checkpoint Loading

--- a/composer/yamls/models/bert-base.yaml
+++ b/composer/yamls/models/bert-base.yaml
@@ -75,10 +75,9 @@ grad_accum: auto # Use automatic gradient accumulation to avoid OOMs
 save_folder: bert_checkpoints # The directory to save checkpoints to
 save_interval: 3500ba # Save checkpoints every 3500 batches
 
-loggers:
-  progress_bar: {} # Add a TQDM progress bar
-  # Optional, some nice default parameters for object store checkpointing. Uncomment this if you want to checkpoint to cloud.
-  # object_store:
-  #  object_store_hparams:
-  #    s3:
-  #      bucket: mosaicml-internal-checkpoints-bert
+# Optional, some nice default parameters for object store checkpointing. Uncomment this if you want to checkpoint to cloud.
+# loggers:
+# object_store:
+#  object_store_hparams:
+#    s3:
+#      bucket: mosaicml-internal-checkpoints-bert

--- a/composer/yamls/recipes/resnet50_medium.yaml
+++ b/composer/yamls/recipes/resnet50_medium.yaml
@@ -39,10 +39,6 @@ device:
   gpu: {}
 eval_batch_size: 2048
 eval_interval: 1
-loggers:
-  progress_bar:
-    console_log_level: EPOCH
-    stream: stderr
 model:
   resnet:
     initializers:

--- a/composer/yamls/recipes/resnet50_mild.yaml
+++ b/composer/yamls/recipes/resnet50_mild.yaml
@@ -32,10 +32,6 @@ device:
   gpu: {}
 eval_batch_size: 2048
 eval_interval: 1
-loggers:
-  progress_bar:
-    console_log_level: EPOCH
-    stream: stderr
 model:
   resnet:
     initializers:

--- a/composer/yamls/recipes/resnet50_spicy.yaml
+++ b/composer/yamls/recipes/resnet50_spicy.yaml
@@ -53,10 +53,6 @@ dataloader:
 device:
   gpu: {}
 eval_batch_size: 2048
-loggers:
-  progress_bar:
-    console_log_level: EPOCH
-    stream: stderr
 model:
   resnet:
     groups: 1


### PR DESCRIPTION
Making this a draft PR in case I'm biting off more than I can chew... 

### This PR does the folllowing:

* Simplify typing of `console_log_level: Union[str, int, LogLevel]` because it seems pretty unlikely someone will build a whole Callable requiring imports of LogLevel and State
   * this also better matches the name of the variable
   * and matches the signature of other LoggerDestinations like `InMemoryLogger.log_level`
* Set default to `LogLevel.BATCH` which I'm pretty sure makes more sense
* Add `console_log_every_n_batches: int = 1` to allow users to easily scale down the frequency
* update some YAMLs to remove references to `progress_bar` which is now added by default in the `Trainer`

### Questions from Abhi:

* I see that the ProgressBarLogger is sort of added automatically to the Trainer, but then I also see all the `ProgressBarLogger` args passed in as well :( I wonder if that's a good practice or whether it would make more sense to just have `trainer.progress_bar_logger: bool = True` which instantiates a good default `ProgressBarLogger`, but then if you want to do anything custom, you ought to just construct the object yourself... It makes me sad to see 4-5 `ProgressBarLogger` specific args littering the trainer signature.

relevant code snippet from `trainer.py` 
```python
loggers = list(ensure_tuple(loggers))
        if any(isinstance(x, ProgressBarLogger) for x in loggers):
            warnings.warn(
                DeprecationWarning(
                    (f'Specifying the {ProgressBarLogger.__name__} via `loggers` is deprecated. Instead, '
                     'please specify `progress_bar`, `log_to_console`, `log_level`, and `stream` arguments when '
                     'constructing the trainer. If specified, these arguments will be ignored, as the '
                     f'{ProgressBarLogger.__name__} was already created.')))
```

* Is `log_every_n_batches` useful enough that it should be made global, or something that each LoggerDestination implements? I know we've had some debate before and I have a light preference for per-logger args, because in the cloud setting, I probably want super fine detailed logs going to WandB, but I want my console to be relatively sparse, maybe logging every 1000 batches.