### PR TITLE
[inference] Update export_for_inference notebook with new APIs

### DIFF
--- a/composer/utils/inference.py
+++ b/composer/utils/inference.py
@@ -228,7 +228,7 @@ def export_with_logger(
             export_for_inference(model=model,
                                  save_format=save_format,
                                  save_path=temp_local_save_path,
-                                 sample_input=(sample_input,),
+                                 sample_input=sample_input,
                                  transforms=transforms)
             logger.file_artifact(log_level=LogLevel.FIT, artifact_name=save_path, file_path=temp_local_save_path)
     else:
@@ -236,5 +236,5 @@ def export_with_logger(
                              save_format=save_format,
                              save_path=save_path,
                              save_object_store=save_object_store,
-                             sample_input=(sample_input,),
+                             sample_input=sample_input,
                              transforms=transforms)

--- a/examples/exporting_for_inference.ipynb
+++ b/examples/exporting_for_inference.ipynb
@@ -7,22 +7,7 @@
    "source": [
     "# 🥡 Exporting for Inference\n",
     "\n",
-    "Composer models are also `torch.nn.Module`, and thus can be exported like any other PyTorch module. In this tutorial, we walk through how to export your models into various common formats: [ONNX](https://onnx.ai/), [TorchScript](https://pytorch.org/docs/stable/jit.html), and [torch.fx](https://pytorch.org/docs/stable/fx.html). For more detailed options and configuration settings, please consult the linked documentation.\n",
-    "\n",
-    "## Algorithm compatibility\n",
-    "Some of our algorithms alter the model architecture in ways that may render them incompatible with some of the export procedures above. For example, BlurPool replaces some instances of `Conv2d` with `BlurConv2d` layers which are not compatible with `torch.fx` as they have data-dependant control flow. \n",
-    "\n",
-    "The following table shows which algorithms are compatible with which export formats for inference.\n",
-    "\n",
-    "|                        | torchscript | torch.fx | ONNX |\n",
-    "|------------------------|-------------|----------|------|\n",
-    "| apply_blurpool         | &check;           |          | &check;    |\n",
-    "| apply_factorization    |             | &check;        | &check;    |\n",
-    "| apply_ghost_batchnorm  | &check;           |          | &check;    |\n",
-    "| apply_squeeze_excite   | &check;           | &check;        | &check;    |\n",
-    "| apply_stochastic_depth | &check;           | &check;        | &check;    |\n",
-    "| apply_channels_last    | &check;           | &check;        | &check;    |\n",
-    "\n"
+    "Composer provides model export support for inference using a dedicated export API and a callback. In this tutorial, we walk through how to export your models into various common formats: [ONNX](https://onnx.ai/), [TorchScript](https://pytorch.org/docs/stable/jit.html) using the dedicated export API as well as Composer's callback mechanism. For more detailed options and configuration settings, please consult the linked documentation. In addition, if for any reason, above methods of exporting are not sufficient for your use case Composer models can be exported like any other PyTorch module since Composer models are also `torch.nn.Module`. "
    ]
   },
   {
@@ -47,18 +32,17 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4de762c7",
+   "id": "c3ccf56d",
    "metadata": {},
    "source": [
     "## Create the model\n",
-    "\n",
-    "First, we create the model we'd like to export, which in this case is based on a ResNet-50 from torchvision, but with our SqueezeExcite algorithm applied, which adds SqueezeExcite modules after certain `Conv2d` layers."
+    "First, we create the model we’d like to export, which in this case is based on a ResNet-50 from torchvision, but with our SqueezeExcite algorithm applied, which adds SqueezeExcite modules after certain Conv2d layers."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6197713c",
+   "id": "bbde37e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,20 +59,260 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f4bd162",
+   "id": "87cc6bc6",
    "metadata": {},
    "source": [
-    "Printing the model shows the new `Bottleneck` layers:"
+    "## Torchscript Export using standalone API\n",
+    "Torchscript creates models from PyTorch code that can be saved and also optimized for deployment, and is the tooling is native to pytorch. \n",
+    "\n",
+    "The *ComposerClassifier*’s forward method takes as input a pair of tensors (input, label), so we create a dummy tensors to run the model."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b876784",
+   "id": "02603737",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(model)"
+    "import torch\n",
+    "\n",
+    "input = (torch.rand(4, 3, 224, 224), torch.Tensor())\n",
+    "\n",
+    "output = model(input)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5668ffed",
+   "metadata": {},
+   "source": [
+    "Now we run export using our standalone export API. Composer also supports exporting to an object store such as S3. Please checkout [full documentation](https://docs.mosaicml.com/en/stable/api_reference/composer.utils.inference.html) for `export_for_inference` API for help on using an object store."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e654bff1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import tempfile\n",
+    "from composer.utils import export_for_inference\n",
+    "\n",
+    "save_format = 'torchscript'\n",
+    "working_dir = tempfile.TemporaryDirectory()\n",
+    "model_save_path = os.path.join(working_dir.name, 'model.pt')\n",
+    "\n",
+    "export_for_inference(model=model, \n",
+    "                     save_format=save_format, \n",
+    "                     save_path=model_save_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33d5a8ec",
+   "metadata": {},
+   "source": [
+    "Let us check to make sure that the model exists in our working directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07519d35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(os.listdir(path=working_dir.name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eda90bdf",
+   "metadata": {},
+   "source": [
+    "Let us reload the saved model and run inference on it. We also compare the results with the previously computed results on the same input to make sure .  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8726defb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scripted_model = torch.jit.load(model_save_path)\n",
+    "scripted_model.eval()\n",
+    "scripted_output = scripted_model(input)\n",
+    "print(torch.allclose(output, scripted_output))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e154ac3d",
+   "metadata": {},
+   "source": [
+    "## Export using a callback\n",
+    "\n",
+    "Composer trainer also allows you to specify a export callback that automatically exports at the end of training. Since we will be training a model for a few epochs, we first create a dataloader with synthetic dataset for this tutorial. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5141e6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from composer.datasets.synthetic import SyntheticBatchPairDataset\n",
+    "from torch.utils.data import DataLoader\n",
+    "\n",
+    "dataset = SyntheticBatchPairDataset(total_dataset_size=8, data_shape=(3, 224, 224), num_classes=1000)\n",
+    "dataloader = DataLoader(dataset=dataset, batch_size=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4de762c7",
+   "metadata": {},
+   "source": [
+    "## Create the model\n",
+    "\n",
+    "We create the model we are training, which in this case is based on ResNet-50 from torchvision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6197713c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from torchvision.models import resnet\n",
+    "from composer.models import ComposerClassifier\n",
+    "\n",
+    "model = ComposerClassifier(module=resnet.resnet50())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2b15fb6",
+   "metadata": {},
+   "source": [
+    "## Create export callback\n",
+    "Now we create a callback that is used by the trainer to export model for inference. Since we already saw torchscript export using Composer's standalone export API, for this section, we are using `onnx` as export format to showcase both capabilties. However, both torchscript and onnx are supported with both ways of exporting. In either case, you can just change `save_format` `'onnx'` or `'torchscript'` to export in your desired format. [ONNX](https://onnx.ai/) is a popular model format that can then be consumed by many third-party tools (e.g. TensorRT, OpenVINO) to optimize the model for specific hardware devices. \n",
+    "\n",
+    "Note: ONNX does not have a prebuild wheel for Mac M1/M2 chips yet, so is not pip installable. Skip this section if you are running on a Mac laptop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24b649ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import composer.functional as cf\n",
+    "from composer.callbacks import ExportForInferenceCallback\n",
+    "# change to 'torchscript' for exporting to torchscript format \n",
+    "save_format = 'onnx'\n",
+    "model_save_path = os.path.join(working_dir.name, 'model1.onnx')\n",
+    "export_callback = ExportForInferenceCallback(save_format=save_format, save_path=model_save_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5408fbe1",
+   "metadata": {},
+   "source": [
+    "## Run Training\n",
+    "Now we construct the trainer using this callback. The model is exported at the end of the training. In the later part of this tutorail we show model exporting from a checkpoint, so we also supply trainer `save_folder` and `save_interval` to save some checkpoints. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "220d936b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from composer import Trainer\n",
+    "from composer.algorithms import SqueezeExcite\n",
+    "\n",
+    "optimizer = torch.optim.SGD(model.parameters(), lr=0.01)\n",
+    "scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=5)\n",
+    "\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    train_dataloader=dataloader,\n",
+    "    optimizers=optimizer,\n",
+    "    schedulers=scheduler,\n",
+    "    save_folder=working_dir.name,\n",
+    "    algorithms=[SqueezeExcite()],\n",
+    "    callbacks=[export_callback],\n",
+    "    max_duration='2ep',\n",
+    "    save_interval='1ep')\n",
+    "trainer.fit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c06abf1f",
+   "metadata": {},
+   "source": [
+    "Let us list the content of the `working_dir` to check if the checkpoints and exported model is available. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3b38073",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(os.listdir(path=working_dir.name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "beb2f655",
+   "metadata": {},
+   "source": [
+    "## Alternative way of exporting with `trainer.export_for_inference`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3612cdae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_save_path = os.path.join(working_dir.name, 'model2.onnx')\n",
+    "\n",
+    "trainer.export_for_inference(save_format='onnx', save_path=model_save_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55470cc5",
+   "metadata": {},
+   "source": [
+    "Let us list the content of the `working_dir` to see if this exported model is available. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ac1ef9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(os.listdir(path=working_dir.name))"
    ]
   },
   {
@@ -96,11 +320,7 @@
    "id": "8517a2d2",
    "metadata": {},
    "source": [
-    "## ONNX\n",
-    "\n",
-    "[ONNX](https://onnx.ai/) is a popular model format that can then be consumed by many third-party tools (e.g. TensorRT, OpenVINO) to optimize the model for specific hardware devices. \n",
-    "\n",
-    "Note: ONNX does not have a prebuild wheel for Mac M1/M2 chips yet, so is not pip installable. Skip this section if you are running on a Mac laptop."
+    "## Load and run exported ONNX model"
    ]
   },
   {
@@ -112,52 +332,6 @@
    "source": [
     "%pip install onnx\n",
     "%pip install onnxruntime"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5dd2d584",
-   "metadata": {},
-   "source": [
-    "The `ComposerClassifier`'s forward method takes as input a pair of tensors `(input, label)`, so we create a dummy tensor sizes for the ONNX export:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c0f787ff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "\n",
-    "input = (torch.rand(4, 3, 112, 112), torch.Tensor())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "041e1c76",
-   "metadata": {},
-   "source": [
-    "Then we are ready to run the export with:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f98d7d10",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "torch.onnx.export(\n",
-    "    model=model,\n",
-    "    args=(input,),\n",
-    "    f='model.onnx',\n",
-    "    input_names=['input'],\n",
-    "    output_names=['output'],\n",
-    ")"
    ]
   },
   {
@@ -177,7 +351,7 @@
    "source": [
     "import onnx\n",
     "\n",
-    "onnx_model = onnx.load('model.onnx')\n",
+    "onnx_model = onnx.load(model_save_path)\n",
     "onnx.checker.check_model(onnx_model)"
    ]
   },
@@ -200,12 +374,10 @@
     "import numpy as np\n",
     "\n",
     "# run inference\n",
-    "ort_session = ort.InferenceSession('model.onnx')\n",
+    "ort_session = ort.InferenceSession(model_save_path)\n",
     "outputs = ort_session.run(\n",
     "    None,\n",
-    "    {'input': input[0].numpy()},\n",
-    ")\n",
-    "\n",
+    "    {'input': input[0].numpy()})\n",
     "print(f\"The predicted classes are {np.argmax(outputs[0], axis=1)}\")"
    ]
   },
@@ -219,66 +391,88 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c172d596",
+   "id": "84137136",
    "metadata": {},
    "source": [
-    "## Torchscript\n",
+    "## Exporting from an existing checkpoint\n",
     "\n",
-    "Torchscript creates models from PyTorch code that can be saved and also optimized for deployment, and is the tooling is native to pytorch. The below command "
+    "In this part of the tutorial, we will look at exporting a model from a previously created checkpoint that is stored locally. Composer also supports exporting from a checkpoint stored in an object store such as S3. Please checkout [full documentation](https://docs.mosaicml.com/en/stable/api_reference/composer.utils.inference.html) for `export_for_inference` API for using an object store. \n",
+    "\n",
+    "Some of our algorithms alter the model architecture. For example, [SqueezeExcite](https://docs.mosaicml.com/en/stable/method_cards/squeeze_excite.html) adds a channel-wise attention operator in CNNs and modifies model architecure. Therefore, we need to provide a function that takes the mode and applies the algorithm before we can load the model weights from a checkpoint. Functional form of SqueezeExcite does exactly that and we pass that as surgery_algs to the `export_for_inference` API. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de7564a3",
+   "id": "13d51ca4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import torch\n",
-    "import numpy as np\n",
+    "from composer.utils import export_for_inference\n",
+    "# We call it model2.onnx to make it different from our previous export\n",
+    "model_save_path = os.path.join(working_dir.name, 'model2.onnx')\n",
+    "checkpoint_path = os.path.join(working_dir.name, 'ep2-ba4-rank0.pt')\n",
     "\n",
-    "input = (torch.rand(4, 3, 112, 112), torch.Tensor())\n",
+    "model = ComposerClassifier(module=resnet.resnet50())\n",
     "\n",
-    "scripted_model = torch.jit.script(model)\n",
-    "scripted_model.eval()"
+    "export_for_inference(model=model, \n",
+    "                     save_format=save_format, \n",
+    "                     save_path=model_save_path, \n",
+    "                     sample_input=(input,),\n",
+    "                     surgery_algs=[cf.apply_squeeze_excite],\n",
+    "                     load_path=checkpoint_path)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cab1e98c",
+   "id": "5b1aab7a",
    "metadata": {},
    "source": [
-    "We can then run inference by passing in our input:"
+    "Let us list the content of the working_dir to check if the newly exported model is available."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4cf7a53",
+   "id": "e28fd1d1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "output = scripted_model(input)\n",
-    "output.shape\n",
-    "print(f\"The predicted classes are {torch.argmax(output, dim=1)}\")"
+    "print(os.listdir(path=working_dir.name))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d7eb9ea2",
+   "id": "e02a7a9d",
    "metadata": {},
    "source": [
-    "The compiled model can also be saved using `torch.jit`:"
+    "Make sure the model loaded from a checkpoint produces the same results as before"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90dddfc3",
+   "id": "8fea266b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "torch.jit.save(scripted_model, 'scripted_model.pt')"
+    "ort_session = ort.InferenceSession(model_save_path)\n",
+    "new_outputs = ort_session.run(\n",
+    "    None,\n",
+    "    {'input': input[0].numpy()},\n",
+    ")\n",
+    "print(np.allclose(outputs[0], new_outputs[0], atol=1e-07))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7a48014",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up working directory\n",
+    "working_dir.cleanup()"
    ]
   },
   {
@@ -346,6 +540,26 @@
    "metadata": {},
    "source": [
     "`torch.fx` is powerful, but one of the key limitations of this method is that it does not support dynamic control flow (e.g. `if` statements or loop that are data-dependant). Therefore, some algorithms, such as BlurPool, are currently not supported. We have ongoing work to bring `torch.fx` support to all our algorithms."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d58df1b",
+   "metadata": {},
+   "source": [
+    "## Algorithm compatibility\n",
+    "Some of our algorithms alter the model architecture in ways that may render them incompatible with some of the export procedures above. For example, BlurPool replaces some instances of `Conv2d` with `BlurConv2d` layers which are not compatible with `torch.fx` as they have data-dependant control flow. \n",
+    "\n",
+    "The following table shows which algorithms are compatible with which export formats for inference.\n",
+    "\n",
+    "|                        | torchscript | torch.fx | ONNX |\n",
+    "|------------------------|-------------|----------|------|\n",
+    "| apply_blurpool         | &check;           |          | &check;    |\n",
+    "| apply_factorization    |             | &check;        | &check;    |\n",
+    "| apply_ghost_batchnorm  | &check;           |          | &check;    |\n",
+    "| apply_squeeze_excite   | &check;           | &check;        | &check;    |\n",
+    "| apply_stochastic_depth | &check;           | &check;        | &check;    |\n",
+    "| apply_channels_last    | &check;           | &check;        | &check;    |"
    ]
   }
  ],


### PR DESCRIPTION
Showcase the use of new exportForInference callback and functional API in the export_for_inference notebook. 

Couple of issues I see:

1) ~~We don't specifically showcase torchscript export. Should we?~~ 
2) Torch.fx part is just dangling at the bottom. Should we keep it or remove?