### PR TITLE
Auto Grad Accum Cache Clearing

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1707,6 +1707,14 @@ class Trainer:
                         RuntimeWarning('CUDA out of memory detected. Gradient Accumulation '
                                        f'increased from {original_grad_accum} -> {self.state.grad_accum}, '
                                        'and the batch will be retrained.'))
+                    # Empty cache if on GPU, which will help reduce fragmentation
+                    if type(self._device) == DeviceGPU:
+                        def compute_memory_fragmentation():
+                            snapshot = torch.cuda.memory_snapshot()
+                            return sum(b['allocated_size'] for b in snapshot) / sum(b['total_size'] for b in snapshot)
+                        print("\n!!", compute_memory_fragmentation())
+                        torch.cuda.empty_cache()
+                        print("!!", compute_memory_fragmentation(), '\n')
             # Otherwise, log grad_accum and return calculated loss
             else:
                 # Synchronize new batch compute time

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1708,13 +1708,8 @@ class Trainer:
                                        f'increased from {original_grad_accum} -> {self.state.grad_accum}, '
                                        'and the batch will be retrained.'))
                     # Empty cache if on GPU, which will help reduce fragmentation
-                    if type(self._device) == DeviceGPU:
-                        def compute_memory_fragmentation():
-                            snapshot = torch.cuda.memory_snapshot()
-                            return sum(b['allocated_size'] for b in snapshot) / sum(b['total_size'] for b in snapshot)
-                        print("\n!!", compute_memory_fragmentation())
+                    if isinstance(self._device, DeviceGPU):
                         torch.cuda.empty_cache()
-                        print("!!", compute_memory_fragmentation(), '\n')
             # Otherwise, log grad_accum and return calculated loss
             else:
                 # Synchronize new batch compute time


### PR DESCRIPTION
Adds cache clearing to auto grad accum, which should help reduce the fragmentation issues people have been seeing. Used a [simple function](https://github.com/pytorch/pytorch/issues/29554) which approximates fragmentation. Picture below shows fragmentation dropping as we call cache clear
```
def compute_memory_fragmentation():
                            snapshot = torch.cuda.memory_snapshot()
                            return sum(b['allocated_size'] for b in snapshot) / sum(b['total_size'] for b in snapshot)
```
<img width="290" alt="image" src="https://user-images.githubusercontent.com/17102158/183484303-719d81da-b6f0-498a-b793-06f0a309e7a0.png">
