### PR TITLE
Cleaner API reference part 1: references with minimal import paths

### DIFF
--- a/composer/algorithms/__init__.py
+++ b/composer/algorithms/__init__.py
@@ -34,7 +34,7 @@ For example, a simple algorithm that shortens training:
         def apply(self, state: State, event: Event, logger: Logger):
             state.max_duration /= 2  # cut training time in half
 
-For more information about events, see :class:`~composer.core.event.Event`.
+For more information about events, see :class:`.Event`.
 """
 
 from composer.algorithms.alibi import Alibi

--- a/composer/algorithms/__init__.py
+++ b/composer/algorithms/__init__.py
@@ -3,21 +3,20 @@
 
 """Efficiency methods for training.
 
-Examples include :class:`~composer.algorithms.label_smoothing.LabelSmoothing`
-and adding :class:`~composer.algorithms.squeeze_excite.SqueezeExcite` blocks,
+Examples include :class:`.LabelSmoothing` and adding :class:`.SqueezeExcite` blocks,
 among many others.
 
 Algorithms are implemented in both a standalone functional form (see :mod:`composer.functional`)
 and as subclasses of :class:`Algorithm` for integration in the Composer :class:`Trainer`.
 The former are easier to integrate piecemeal into an existing codebase.
 The latter are easier to compose together, since they all have the same public interface
-and work automatically with the Composer :py:class:`~composer.trainer.Trainer`.
+and work automatically with the Composer :py:class:`.Trainer`.
 
 For ease of composability, algorithms in our Trainer are based on the two-way callbacks concept from
 `Howard et al, 2020 <https://arxiv.org/abs/2002.04688>`_. Each algorithm implements two methods:
 
 * :meth:`Algorithm.match`: returns ``True`` if the algorithm should be run given the current
-  :class:`State` and :class:`~composer.core.event.Event`.
+  :class:`State` and :class:`.Event`.
 * :meth:`Algorithm.apply`: performs an in-place modification of the given
   :class:`State`
 

--- a/composer/algorithms/alibi/alibi.py
+++ b/composer/algorithms/alibi/alibi.py
@@ -121,7 +121,7 @@ class Alibi(Algorithm):
 
     This algorithm runs on :attr:`.Event.INIT` to modify the model
     before the model has been moved to accelerators. It also runs on
-    :attr:`~composer.core.event.Event.AFTER_DATALOADER` to modify the shape of a batch of
+    :attr:`.Event.AFTER_DATALOADER` to modify the shape of a batch of
     data after the model and data have been moved to accelerators.
 
     See the :doc:`Method Card </method_cards/alibi>` for more details.

--- a/composer/algorithms/alibi/alibi.py
+++ b/composer/algorithms/alibi/alibi.py
@@ -119,7 +119,7 @@ class Alibi(Algorithm):
     extrapolation capability by training with shorter sequence lengths,
     which reduces the memory and computation load.
 
-    This algorithm runs on :attr:`~composer.core.event.Event.INIT` to modify the model
+    This algorithm runs on :attr:`.Event.INIT` to modify the model
     before the model has been moved to accelerators. It also runs on
     :attr:`~composer.core.event.Event.AFTER_DATALOADER` to modify the shape of a batch of
     data after the model and data have been moved to accelerators.

--- a/composer/algorithms/augmix/augmix.py
+++ b/composer/algorithms/augmix/augmix.py
@@ -37,7 +37,7 @@ def augmix_image(img: ImgT,
     This function works on a single image or batch of images. See :class:`.AugMix` and
     the :doc:`Method Card </method_cards/augmix>` for details. This function only acts on a
     single image (or batch) per call and is unlikely to be used in a training loop.
-    Use :class:`~composer.algorithms.augmix.augmix.AugmentAndMixTransform` to use AugMix as
+    Use :class:`.AugmentAndMixTransform` to use AugMix as
     part of a :class:`torchvision.datasets.VisionDataset`\'s ``transform``.
 
     Example:

--- a/composer/algorithms/augmix/augmix.py
+++ b/composer/algorithms/augmix/augmix.py
@@ -174,7 +174,7 @@ class AugMix(Algorithm):
     ``Dirichlet(alpha, alpha, ...)`` distribution. The coefficient for mixing the combined augmented image and the
     original image is drawn from a ``Beta(alpha, alpha)`` distribution, using the same ``alpha``.
 
-    This algorithm runs on on :attr:`~composer.core.event.Event.FIT_START` to insert a dataset transformation.
+    This algorithm runs on on :attr:`.Event.FIT_START` to insert a dataset transformation.
     It is a no-op if this algorithm already applied itself on the :attr:`State.train_dataloader.dataset`.
 
     See the :doc:`Method Card </method_cards/augmix>` for more details.

--- a/composer/algorithms/blurpool/blurpool.py
+++ b/composer/algorithms/blurpool/blurpool.py
@@ -85,7 +85,7 @@ class BlurPool(Algorithm):
     """`BlurPool <http://proceedings.mlr.press/v97/zhang19a.html>`_ adds anti-aliasing filters to convolutional layers.
 
     This algorithm increases accuracy and invariance to small shifts in the input. It runs on
-    :attr:`~composer.core.event.Event.INIT`.
+    :attr:`.Event.INIT`.
 
     Args:
         replace_convs (bool): replace strided :class:`torch.nn.Conv2d` modules with

--- a/composer/algorithms/blurpool/blurpool_layers.py
+++ b/composer/algorithms/blurpool/blurpool_layers.py
@@ -96,7 +96,7 @@ def blurmax_pool2d(input: torch.Tensor,
     ``kernel_size``, then applies an anti-aliasing filter to smooth the maxes,
     and only then pools according to ``stride``.
 
-    See also: :func:`~blur_2d`.
+    See also: :func:`.blur_2d`.
 
     Args:
         input (torch.Tensor): A 4d tensor of shape NCHW
@@ -150,7 +150,7 @@ class BlurMaxPool2d(nn.Module):
     See the associated `paper <http://proceedings.mlr.press/v97/zhang19a.html>`_
     for more details, experimental results, etc.
 
-    See :func:`~blurmax_pool2d` for details.
+    See :func:`.blurmax_pool2d` for details.
     """
 
     # based on https://pytorch.org/docs/stable/_modules/torch/nn/modules/pooling.html#MaxPool2d # noqa
@@ -215,7 +215,7 @@ class BlurConv2d(nn.Module):
     See the associated `paper <http://proceedings.mlr.press/v97/zhang19a.html>`_
     for more details, experimental results, etc.
 
-    See also: :func:`~blur_2d`.
+    See also: :func:`.blur_2d`.
     """
 
     # based partially on https://pytorch.org/docs/stable/_modules/torch/nn/modules/conv.html#Conv2d
@@ -295,7 +295,7 @@ class BlurConv2d(nn.Module):
 
 
 class BlurPool2d(nn.Module):
-    """This module just calls :func:`~blur_2d` in ``forward`` using the provided arguments."""
+    """This module just calls :func:`.blur_2d` in ``forward`` using the provided arguments."""
 
     def __init__(self, stride: _size_2_t = 2, padding: _size_2_t = 1) -> None:
         super(BlurPool2d, self).__init__()

--- a/composer/algorithms/channels_last/channels_last.py
+++ b/composer/algorithms/channels_last/channels_last.py
@@ -34,7 +34,7 @@ class ChannelsLast(Algorithm):
     """Changes the memory format of the model to `torch.channels_last <https://\\
     pytorch.org/tutorials/intermediate/memory_format_tutorial.html>`_. This usually improves GPU utilization.
 
-    Runs on :attr:`~composer.core.event.Event.INIT``, so it can set the memory format before the model is DDP wrapped.
+    Runs on :attr:`.Event.INIT``, so it can set the memory format before the model is DDP wrapped.
     Has no hyperparameters.
 
     Example:

--- a/composer/algorithms/colout/colout.py
+++ b/composer/algorithms/colout/colout.py
@@ -160,7 +160,7 @@ class ColOut(Algorithm):
     rows/columns dropped isn't too large, this does not significantly alter the content of the image, but reduces its
     size and provides extra variability.
 
-    If ``batch`` is True (the default), then this algorithm runs on :attr:`~composer.core.event.Event.AFTER_DATALOADER`
+    If ``batch`` is True (the default), then this algorithm runs on :attr:`.Event.AFTER_DATALOADER`
     to modify the batch.
 
     Otherwise, if ``batch=False`` (the default), this algorithm runs on :attr:`.Event.INIT` to insert

--- a/composer/algorithms/colout/colout.py
+++ b/composer/algorithms/colout/colout.py
@@ -163,7 +163,7 @@ class ColOut(Algorithm):
     If ``batch`` is True (the default), then this algorithm runs on :attr:`~composer.core.event.Event.AFTER_DATALOADER`
     to modify the batch.
 
-    Otherwise, if ``batch=False`` (the default), this algorithm runs on :attr:`~composer.core.event.Event.INIT` to insert
+    Otherwise, if ``batch=False`` (the default), this algorithm runs on :attr:`.Event.INIT` to insert
     a dataset transformation. It is a no-op if this algorithm already applied itself on the :attr:`State.train_dataloader.dataset`.
 
     See the :doc:`Method Card </method_cards/colout>` for more details.

--- a/composer/algorithms/factorize/factorize.py
+++ b/composer/algorithms/factorize/factorize.py
@@ -117,7 +117,7 @@ class Factorize(Algorithm):
     and :class:`.FactorizedLinear` for more information about the factorized modules
     used to replace the original modules.
 
-    Runs on :attr:`~composer.core.event.Event.INIT`.
+    Runs on :attr:`.Event.INIT`.
 
     Args:
         factorize_convs (bool): whether to try factorizing :class:`torch.nn.Conv2d` modules.

--- a/composer/algorithms/factorize/factorize_modules.py
+++ b/composer/algorithms/factorize/factorize_modules.py
@@ -178,7 +178,7 @@ class _FactorizedModule(nn.Module, abc.ABC):
 
     @abc.abstractmethod
     def solution_for_rank(self, input: torch.Tensor, rank: int) -> LowRankSolution:
-        """Returns a solution that :meth:`~apply_solution` can use to update the module's level of factorization.
+        """Returns a solution that :meth:`.apply_solution` can use to update the module's level of factorization.
 
         This is seperate from :meth:`set_rank` so that one can generate and assess
         many possible solutions for a given module before choosing one.
@@ -209,7 +209,7 @@ class _FactorizedModule(nn.Module, abc.ABC):
             solution (LowRankSolution): An object encapsulating the new
                 parameters to be used and their associated mean squared error on
                 the input for which they were optimized. Can be obtained using
-                :meth:`~solution_for_rank`.
+                :meth:`.solution_for_rank`.
         """
         ...
 
@@ -257,7 +257,7 @@ class FactorizedConv2d(_FactorizedModule):
             to reduce the number of multiply-add operations. In this regime,
             factorization is both slower and less expressive than a
             non-factorized operation. Setting
-            ``latent_features`` to  :meth:`~max_allowed_latent_channels`
+            ``latent_features`` to  :meth:`.max_allowed_latent_channels`
             or a smaller value is sufficient to avoid this.
     """
 
@@ -399,7 +399,7 @@ class FactorizedLinear(_FactorizedModule):
             factorization is both slower and less expressive than a
             non-factorized operation. Setting
             ``latent_features < min(in_features, out_features) / 2`` or
-            using :meth:`~max_allowed_latent_features` is sufficient to avoid
+            using :meth:`.max_allowed_latent_features` is sufficient to avoid
             this.
     """
 

--- a/composer/algorithms/gated_linear_units/gated_linear_units.py
+++ b/composer/algorithms/gated_linear_units/gated_linear_units.py
@@ -126,7 +126,7 @@ class GatedLinearUnits(Algorithm):
     """Replaces all instances of Linear layers in the feed-forward subnetwork with a `Gated Linear Unit <https://arxiv.org/abs/2002.05202>`_.
     The Gated Linear Units provide a more expressive form for the same number of parameters, and a slight degredation to throughput.
 
-    Runs on :attr:`~composer.core.event.Event.INIT`, so it can swap the Linear layers in the FFN for GLUs before the model is DDP wrapped.
+    Runs on :attr:`.Event.INIT`, so it can swap the Linear layers in the FFN for GLUs before the model is DDP wrapped.
 
     Args:
         act_fn (Callable[[torch.Tensor], torch.Tensor], optional): Optionally, the activation function to use. If ``None``, the algorithm will

--- a/composer/algorithms/ghost_batchnorm/ghost_batchnorm.py
+++ b/composer/algorithms/ghost_batchnorm/ghost_batchnorm.py
@@ -70,7 +70,7 @@ class GhostBatchNorm(Algorithm):
     running batch normalization on each chunk separately. ``dim=0`` is assumed to
     be the sample axis.
 
-    Runs on :attr:`~composer.core.event.Event.INIT`.
+    Runs on :attr:`.Event.INIT`.
 
     Args:
         ghost_batch_size (int, optional): size of sub-batches to normalize over. Default: ``32``.

--- a/composer/algorithms/layer_freezing/layer_freezing.py
+++ b/composer/algorithms/layer_freezing/layer_freezing.py
@@ -95,7 +95,7 @@ class LayerFreezing(Algorithm):
     `FreezeOut <https://arxiv.org/abs/1706.04983>`_ and
     `Freeze Training <https://arxiv.org/abs/1706.05806>`_.
 
-    Runs on :attr:`~composer.core.event.Event.EPOCH_END`.
+    Runs on :attr:`.Event.EPOCH_END`.
 
     Example:
          .. testcode::

--- a/composer/algorithms/no_op_model/__init__.py
+++ b/composer/algorithms/no_op_model/__init__.py
@@ -4,7 +4,7 @@
 """Replaces model with a dummy model of type :class:`NoOpModelClass`.
 
 The algorithm runs on :attr:`Event.INIT`. It replaces the model in the state with
-a :class:`~composer.algorithms.no_op_model.no_op_model.NoOpModelClass` and then updates the parameters in the optimizer
+a :class:`.NoOpModelClass` and then updates the parameters in the optimizer
 through module surgery.
 
 A dummy model can helpful for profiling the dataloader by eliminating the work

--- a/composer/algorithms/randaugment/randaugment.py
+++ b/composer/algorithms/randaugment/randaugment.py
@@ -125,7 +125,7 @@ class RandAugment(Algorithm):
     """Randomly applies a sequence of image data augmentations to an image.
 
     This algorithm (`Cubuk et al, 2019 <https://arxiv.org/abs/1909.13719>`_) runs on
-    :attr:`~composer.core.event.Event.INIT` to insert a dataset
+    :attr:`.Event.INIT` to insert a dataset
     transformation. It is a no-op if this algorithm already applied itself on the
     :attr:`.State.train_dataloader.dataset`.
 

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -114,7 +114,7 @@ class SAM(Algorithm):
     by wrapping an existing optimizer with a :class:`.SAMOptimizer`. SAM can improve model generalization
     and provide robustness to label noise.
 
-    Runs on :attr:`~composer.core.event.Event.INIT`.
+    Runs on :attr:`.Event.INIT`.
 
     Args:
         rho (float, optional): The neighborhood size parameter of SAM. Must be greater than 0.

--- a/composer/algorithms/selective_backprop/__init__.py
+++ b/composer/algorithms/selective_backprop/__init__.py
@@ -5,7 +5,7 @@
 individual training examples, and only computes weight gradients over the pruned subset, reducing iteration time and
 speeding up training.
 
-The algorithm runs on :attr:`~composer.core.event.Event.INIT` and :attr:`~composer.core.event.Event.AFTER_DATLOADER`.
+The algorithm runs on :attr:`.Event.INIT` and :attr:`~composer.core.event.Event.AFTER_DATLOADER`.
 On Event.INIT, it gets the loss function before the model is wrapped. On Event.AFTER_DATALOADER, it applies selective
 backprop if the time is between ``self.start`` and ``self.end``.
 

--- a/composer/algorithms/selective_backprop/__init__.py
+++ b/composer/algorithms/selective_backprop/__init__.py
@@ -5,7 +5,7 @@
 individual training examples, and only computes weight gradients over the pruned subset, reducing iteration time and
 speeding up training.
 
-The algorithm runs on :attr:`.Event.INIT` and :attr:`~composer.core.event.Event.AFTER_DATLOADER`.
+The algorithm runs on :attr:`.Event.INIT` and :attr:`.Event.AFTER_DATLOADER`.
 On Event.INIT, it gets the loss function before the model is wrapped. On Event.AFTER_DATALOADER, it applies selective
 backprop if the time is between ``self.start`` and ``self.end``.
 

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -160,7 +160,7 @@ class SeqLengthWarmup(Algorithm):
     Tensors are either truncated (``truncate=True``) or reshaped to
     create new examples from the extra tokens (``truncate=False``).
 
-    This algorithm runs on :attr:`~composer.core.event.Event.AFTER_DATALOADER` to modify
+    This algorithm runs on :attr:`.Event.AFTER_DATALOADER` to modify
     the sequence length of a batch of data after the model and data have been moved to
     accelerators.
 

--- a/composer/algorithms/squeeze_excite/squeeze_excite.py
+++ b/composer/algorithms/squeeze_excite/squeeze_excite.py
@@ -128,7 +128,7 @@ class SqueezeExcite(Algorithm):
     """Adds Squeeze-and-Excitation blocks (`Hu et al, 2019 <https://arxiv.org/abs/1709.01507>`_) after the
     :class:`torch.nn.Conv2d` modules in a neural network.
 
-    Runs on :attr:`~composer.core.event.Event.INIT`. See :class:`SqueezeExcite2d` for more information.
+    Runs on :attr:`.Event.INIT`. See :class:`SqueezeExcite2d` for more information.
 
     Args:
         latent_channels (float, optional): Dimensionality of the hidden layer within the added

--- a/composer/algorithms/stochastic_depth/stochastic_depth.py
+++ b/composer/algorithms/stochastic_depth/stochastic_depth.py
@@ -108,7 +108,7 @@ class StochasticDepth(Algorithm):
     implementation used for EfficientNet in the
     `Tensorflow/TPU repo <https://github.com/tensorflow/tpu>`_.
 
-    Runs on :attr:`~composer.core.event.Event.INIT`, as well as
+    Runs on :attr:`.Event.INIT`, as well as
     :attr:`~composer.core.event.Event.BATCH_START` if ``drop_warmup > 0``.
 
     .. note::

--- a/composer/algorithms/stochastic_depth/stochastic_depth.py
+++ b/composer/algorithms/stochastic_depth/stochastic_depth.py
@@ -109,7 +109,7 @@ class StochasticDepth(Algorithm):
     `Tensorflow/TPU repo <https://github.com/tensorflow/tpu>`_.
 
     Runs on :attr:`.Event.INIT`, as well as
-    :attr:`~composer.core.event.Event.BATCH_START` if ``drop_warmup > 0``.
+    :attr:`.Event.BATCH_START` if ``drop_warmup > 0``.
 
     .. note::
 

--- a/composer/callbacks/memory_monitor.py
+++ b/composer/callbacks/memory_monitor.py
@@ -38,7 +38,7 @@ class MemoryMonitor(Callback):
             ...     callbacks=[MemoryMonitor()],
             ... )
 
-    The memory statistics are logged by the :class:`~composer.loggers.logger.Logger` to the following keys as
+    The memory statistics are logged by the :class:`.Logger` to the following keys as
     described below.
 
     +--------------------------+-------------------------------------------------------------+

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -39,7 +39,7 @@ class SpeedMonitor(Callback):
             ...     callbacks=[SpeedMonitor(window_size=100)],
             ... )
 
-    The training throughput is logged by the :class:`~composer.loggers.logger.Logger` to the following keys as
+    The training throughput is logged by the :class:`.Logger` to the following keys as
     described below.
 
     +----------------------------------+-------------------------------------------------------------+

--- a/composer/loggers/file_logger.py
+++ b/composer/loggers/file_logger.py
@@ -250,7 +250,7 @@ class FileLogger(LoggerDestination):  # noqa: D101
 
         .. note::
 
-            If the ``write`` occurs before the :attr:`~composer.core.event.Event.INIT` event,
+            If the ``write`` occurs before the :attr:`.Event.INIT` event,
             the write will be enqueued, as the file is not yet open.
 
         Args:

--- a/composer/loggers/file_logger.py
+++ b/composer/loggers/file_logger.py
@@ -85,7 +85,7 @@ class FileLogger(LoggerDestination):  # noqa: D101
             The logfile will be periodically logged (according to the ``flush_interval``) as a file artifact.
             The artifact name will be determined by this format string.
 
-            .. seealso:: :meth:`~composer.loggers.logger.Logger.log_file_artifact` for file artifact logging.
+            .. seealso:: :meth:`.Logger.log_file_artifact` for file artifact logging.
 
             The same format variables for ``filename`` are available. Setting this parameter to ``None``
             (the default) will use the same format string as ``filename``. It is sometimes helpful to deviate

--- a/composer/loggers/logger.py
+++ b/composer/loggers/logger.py
@@ -53,7 +53,7 @@ class LogLevel(IntEnum):
 class Logger:
     """An interface to record training data.
 
-    The :class:`~composer.trainer.trainer.Trainer`, instances of :class:`~composer.core.callback.Callback`, and
+    The :class:`.Trainer`, instances of :class:`~composer.core.callback.Callback`, and
     instances of :class:`~composer.core.algorithm.Algorithm` invoke the logger to record data such as
     the epoch, training loss, and custom metrics as provided by individual callbacks and algorithms.
     This class does not store any data itself; instead, it routes all data to the ``destinations``.

--- a/composer/loggers/logger.py
+++ b/composer/loggers/logger.py
@@ -53,7 +53,7 @@ class LogLevel(IntEnum):
 class Logger:
     """An interface to record training data.
 
-    The :class:`.Trainer`, instances of :class:`~composer.core.callback.Callback`, and
+    The :class:`.Trainer`, instances of :class:`.Callback`, and
     instances of :class:`~composer.core.algorithm.Algorithm` invoke the logger to record data such as
     the epoch, training loss, and custom metrics as provided by individual callbacks and algorithms.
     This class does not store any data itself; instead, it routes all data to the ``destinations``.

--- a/composer/loggers/logger_destination.py
+++ b/composer/loggers/logger_destination.py
@@ -20,8 +20,8 @@ class LoggerDestination(Callback, ABC):
     """Base class for logger destination.
 
     As this class extends :class:`~.callback.Callback`, logger destinations can run on any training loop
-    :class:`~composer.core.event.Event`. For example, it may be helpful to run on
-    :attr:`~composer.core.event.Event.EPOCH_END` to perform any flushing at the end of every epoch.
+    :class:`.Event`. For example, it may be helpful to run on
+    :attr:`.Event.EPOCH_END` to perform any flushing at the end of every epoch.
 
     Example:
         .. doctest::
@@ -51,7 +51,7 @@ class LoggerDestination(Callback, ABC):
 
             *   Use background thread(s) or process(s) to read from this queue to perform any I/O.
             *   Batch the data together and flush periodically on events, such as
-                :attr:`~composer.core.event.Event.BATCH_END` or :attr:`~composer.core.event.Event.EPOCH_END`.
+                :attr:`.Event.BATCH_END` or :attr:`.Event.EPOCH_END`.
 
                 .. seealso:: :class:`~composer.loggers.file_logger.FileLogger` as an example.
 

--- a/composer/loggers/logger_destination.py
+++ b/composer/loggers/logger_destination.py
@@ -76,7 +76,7 @@ class LoggerDestination(Callback, ABC):
 
         Subclasses should implement this method to store logged files (e.g. copy it to another folder or upload it to
         an object store), then it should implement this method. However, not all loggers need to implement this method.
-        For example, the :class:`~composer.loggers.tqdm_logger.TQDMLogger` does not implement this method, as it cannot
+        For example, the :class:`.TQDMLogger` does not implement this method, as it cannot
         handle file artifacts.
 
         .. note::

--- a/composer/loggers/logger_hparams_registry.py
+++ b/composer/loggers/logger_hparams_registry.py
@@ -39,7 +39,7 @@ class ObjectStoreLoggerHparams(hp.Hparams):
         should_log_artifact (str, optional): The path to a filter function which returns whether an artifact should be
             logged. The path should be of the format ``path.to.module:filter_function_name``.
 
-            The function should take (:class:`~composer.core.state.State`, :class:`.LogLevel`, ``<artifact name>``).
+            The function should take (:class:`~composer.core.State`, :class:`.LogLevel`, ``<artifact name>``).
             The artifact name will be a string. The function should return a boolean indicating whether the artifact
             should be logged.
 

--- a/composer/loggers/logger_hparams_registry.py
+++ b/composer/loggers/logger_hparams_registry.py
@@ -46,10 +46,10 @@ class ObjectStoreLoggerHparams(hp.Hparams):
             .. seealso: :func:`composer.utils.import_helpers.import_object`
 
             Setting this parameter to ``None`` (the default) will log all artifacts.
-        object_name (str, optional): See :class:`~composer.loggers.object_store_logger.ObjectStoreLogger`.
-        num_concurrent_uploads (int, optional): See :class:`~composer.loggers.object_store_logger.ObjectStoreLogger`.
-        upload_staging_folder (str, optional): See :class:`~composer.loggers.object_store_logger.ObjectStoreLogger`.
-        use_procs (bool, optional): See :class:`~composer.loggers.object_store_logger.ObjectStoreLogger`.
+        object_name (str, optional): See :class:`.ObjectStoreLogger`.
+        num_concurrent_uploads (int, optional): See :class:`.ObjectStoreLogger`.
+        upload_staging_folder (str, optional): See :class:`.ObjectStoreLogger`.
+        use_procs (bool, optional): See :class:`.ObjectStoreLogger`.
     """
 
     hparams_registry = {

--- a/composer/loggers/object_store_logger.py
+++ b/composer/loggers/object_store_logger.py
@@ -43,7 +43,7 @@ def _build_object_store(object_store_cls: Type[ObjectStore], object_store_kwargs
 class ObjectStoreLogger(LoggerDestination):
     r"""Logger destination that uploads artifacts to an object store.
 
-    This logger destination handles calls to :meth:`~composer.loggers.logger.Logger.file_artifact`
+    This logger destination handles calls to :meth:`.Logger.file_artifact`
     and uploads files to :class:`.ObjectStore`, such as AWS S3 or Google Cloud Storage. To minimize the training
     loop performance hit, it supports background uploads.
 

--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -54,7 +54,7 @@ class ComposerModel(torch.nn.Module, abc.ABC):
 
     Attributes:
         logger (Optional[Logger]): The training :class:`.Logger`.
-            The trainer sets the :class:`.Logger` on the:attr:`~composer.core.event.Event.INIT` event.
+            The trainer sets the :class:`.Logger` on the:attr:`.Event.INIT` event.
     """
 
     def __init__(self) -> None:

--- a/composer/models/unet/unet_hparams.py
+++ b/composer/models/unet/unet_hparams.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """`YAHP <https://docs.mosaicml.com/projects/yahp/en/stable/README.html>`_ interface for
-:class:`.UNet`."""
+:class:`~composer.models.unet.unet.UNet`."""
 
 from dataclasses import dataclass
 
@@ -14,7 +14,7 @@ __all__ = ['UnetHparams']
 @dataclass
 class UnetHparams(ModelHparams):
     """`YAHP <https://docs.mosaicml.com/projects/yahp/en/stable/README.html>`_ interface for
-    :class:`.UNet`.
+    :class:`~composer.models.unet.unet.UNet`.
 
     Args:
         num_classes (int, optional): The number of classes. Needed for classification tasks. Default: ``3``.

--- a/composer/models/unet/unet_hparams.py
+++ b/composer/models/unet/unet_hparams.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """`YAHP <https://docs.mosaicml.com/projects/yahp/en/stable/README.html>`_ interface for
-:class:`~composer.models.unet.unet.UNet`."""
+:class:`.UNet`."""
 
 from dataclasses import dataclass
 
@@ -14,7 +14,7 @@ __all__ = ['UnetHparams']
 @dataclass
 class UnetHparams(ModelHparams):
     """`YAHP <https://docs.mosaicml.com/projects/yahp/en/stable/README.html>`_ interface for
-    :class:`~composer.models.unet.unet.UNet`.
+    :class:`.UNet`.
 
     Args:
         num_classes (int, optional): The number of classes. Needed for classification tasks. Default: ``3``.

--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -83,7 +83,7 @@ class ComposerScheduler(Protocol):
 
     The constructions of ``ten_epoch_decay_scheduler`` in each of the examples above are equivalent. Note that neither
     scheduler uses the ``scale_schedule_ratio`` parameter. As long as this parameter is not used when initializing
-    :class:`~composer.trainer.trainer.Trainer`, it is not required that any schedulers implement that parameter.
+    :class:`.Trainer`, it is not required that any schedulers implement that parameter.
 
     .. automethod:: __call__
     """

--- a/composer/profiler/json_trace_handler.py
+++ b/composer/profiler/json_trace_handler.py
@@ -79,7 +79,7 @@ class JSONTraceHandler(TraceHandler):  # noqa: D101
             Whenever a trace file is saved, it is also logged as a file artifact according to this format string.
             The same format variables as for ``filename`` are available.
 
-            .. seealso:: :meth:`~composer.loggers.logger.Logger.file_artifact` for file artifact logging.
+            .. seealso:: :meth:`.Logger.file_artifact` for file artifact logging.
 
             Leading slashes (``'/'``) will be stripped.
 
@@ -125,7 +125,7 @@ class JSONTraceHandler(TraceHandler):  # noqa: D101
             are removed first. Set to ``-1`` to keep all traces locally. (default: ``-1``)
 
             Traces will be removed after they have been logged as a file artifact. For example, when this handler
-            is used in conjunction with the :class:`~composer.loggers.object_store_logger.ObjectStoreLogger`, set this
+            is used in conjunction with the :class:`.ObjectStoreLogger`, set this
             parameter to ``0`` to immediately delete traces from the local disk after they have been uploaded to
             the object store.
 

--- a/composer/profiler/marker.py
+++ b/composer/profiler/marker.py
@@ -20,7 +20,7 @@ __all__ = ['Marker']
 class Marker:
     """Profiler Marker.
 
-    Used by the :class:`~composer.core.engine.Engine` to measure the duration of :class:`.Event` during training.
+    Used by the :class:`.Engine` to measure the duration of :class:`.Event` during training.
 
     .. note::
 

--- a/composer/profiler/marker.py
+++ b/composer/profiler/marker.py
@@ -20,7 +20,7 @@ __all__ = ['Marker']
 class Marker:
     """Profiler Marker.
 
-    Used by the :class:`~composer.core.engine.Engine` to measure the duration of :class:`~composer.core.event.Event` during training.
+    Used by the :class:`~composer.core.engine.Engine` to measure the duration of :class:`.Event` during training.
 
     .. note::
 

--- a/composer/profiler/profiler.py
+++ b/composer/profiler/profiler.py
@@ -151,7 +151,7 @@ class Profiler:
 
         .. note::
 
-            The :class:`~composer.trainer.trainer.Trainer` automatically invokes this method.
+            The :class:`.Trainer` automatically invokes this method.
 
         Args:
             state (State): The training state.

--- a/composer/profiler/profiler_schedule.py
+++ b/composer/profiler/profiler_schedule.py
@@ -21,7 +21,7 @@ def cyclic_schedule(
     """Profiler schedule function for a cyclic profiling window.
 
     This function returns a schedule function that uses a cyclic profiling window. The resulting function can be
-    passed as the ``prof_schedule`` argument to the :class:`~composer.trainer.trainer.Trainer`.
+    passed as the ``prof_schedule`` argument to the :class:`.Trainer`.
 
     The cyclic window skips the first ``skip_first`` batches in every epoch. Then, it performs a cycle of
     skipping ``wait`` batches, warming up for ``warmup`` batches, and recording ``active`` batches.
@@ -39,7 +39,7 @@ def cyclic_schedule(
             Defaults to ``1``.
 
     Returns:
-        (State -> ProfilerAction): A ``prof_schedule`` for the :class:`~composer.trainer.trainer.Trainer`.
+        (State -> ProfilerAction): A ``prof_schedule`` for the :class:`.Trainer`.
     """
 
     def schedule(state: State):

--- a/composer/profiler/system_profiler.py
+++ b/composer/profiler/system_profiler.py
@@ -26,11 +26,11 @@ class SystemProfiler(Callback):
 
     .. note::
 
-        The Composer :class:`~composer.trainer.trainer.Trainer` automatically creates an instance of this
+        The Composer :class:`.Trainer` automatically creates an instance of this
         :class:`.SystemProfiler` callback whenever any of the System Profiler arguments (``sys_prof_cpu``,
         ``sys_prof_memory``, ``sys_prof_disk``, or ``sys_prof_net``) are enabled.
 
-        When using the Composer :class:`~composer.trainer.trainer.Trainer`, one does not need to directly create an
+        When using the Composer :class:`.Trainer`, one does not need to directly create an
         instance of this :class:`.SystemProfiler` callback.
 
     Args:

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -32,12 +32,12 @@ class TorchProfiler(Callback):  # noqa: D101
 
     .. note::
 
-        The Composer :class:`~composer.trainer.trainer.Trainer` automatically creates an instance of this
+        The Composer :class:`.Trainer` automatically creates an instance of this
         :class:`.TorchProfiler` callback whenever any of the PyTorch Profiler arguments
         (``torch_prof_record_shapes``, ``torch_prof_profile_memory``, ``torch_prof_with_stack``, or
         ``torch_prof_with_flops``) are enabled.
 
-        When using the Composer :class:`~composer.trainer.trainer.Trainer`, one does not need to directly create an
+        When using the Composer :class:`.Trainer`, one does not need to directly create an
         instance of this :class:`.TorchProfiler` callback.
 
 

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -100,7 +100,7 @@ class TorchProfiler(Callback):  # noqa: D101
             Whenever a trace file is saved, it is also logged as a file artifact according to this format string.
             The same format variables as for ``filename`` are available.
 
-            .. seealso:: :meth:`~composer.loggers.logger.Logger.file_artifact` for file artifact logging.
+            .. seealso:: :meth:`.Logger.file_artifact` for file artifact logging.
 
             Leading slashes (``'/'``) will be stripped.
 
@@ -124,7 +124,7 @@ class TorchProfiler(Callback):  # noqa: D101
             traces are not deleted from artifact stores.
 
             It can be useful to set this parameter to ``0`` when using an artifact logger such as the
-            :class:`~composer.loggers.object_store_logger.ObjectStoreLogger`. This combination will minimize local
+            :class:`.ObjectStoreLogger`. This combination will minimize local
             disk usage by deleting trace files immediately after they have been uploaded to the object store.
 
     Attributes:

--- a/composer/profiler/trace_handler.py
+++ b/composer/profiler/trace_handler.py
@@ -21,7 +21,7 @@ class TraceHandler(Callback, abc.ABC):
     Subclasses should implement :meth:`process_duration_event`, :meth:`process_instant_event`,
     :meth:`process_counter_event`, and :meth:`process_chrome_json_trace_file` to record trace events.
 
-    Since :class:`TraceHandler` subclasses :class:`~composer.core.callback.Callback`, a trace handler can run on any
+    Since :class:`TraceHandler` subclasses :class:`.Callback`, a trace handler can run on any
     :class:`.Event` (such as on :attr:`.Event.INIT` to open files or on :attr:`.Event.BATCH_END` to periodically dump
     data to files) and use :meth:`.Callback.close` to perform any cleanup.
     """

--- a/composer/trainer/_deepspeed.py
+++ b/composer/trainer/_deepspeed.py
@@ -119,7 +119,7 @@ def _parse_deepspeed_config(
 
     Returns:
         Dict[str, Any]: The DeepSpeed config updated with values from the arguments passed to the
-            :class:`~composer.trainer.trainer.Trainer`.
+            :class:`.Trainer`.
 
     Raises:
         ValueError: If any of the values in the DeepSpeed config conflict with arguments passed

--- a/composer/trainer/ddp.py
+++ b/composer/trainer/ddp.py
@@ -53,7 +53,7 @@ def ddp_sync_context(state: State, is_final_microbatch: bool, sync_strategy: Uni
     """A context manager for handling the :class:`DDPSyncStrategy`.
 
     Args:
-        state (State): The state of the :class:`~composer.trainer.trainer.Trainer`.
+        state (State): The state of the :class:`.Trainer`.
         is_final_microbatch (bool): Whether or not the context is being used during the final
             microbatch of the gradient accumulation steps.
         sync_strategy (str | DDPSyncStrategy): The ddp sync strategy to use. If a string

--- a/composer/trainer/devices/__init__.py
+++ b/composer/trainer/devices/__init__.py
@@ -3,7 +3,7 @@
 
 """Module for devices on which models run.
 
-Used by :class:`~composer.trainer.trainer.Trainer` in order to train on different devices such as GPU and CPU.
+Used by :class:`.Trainer` in order to train on different devices such as GPU and CPU.
 """
 
 from composer.trainer.devices.device import Device as Device

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -574,7 +574,7 @@ class Trainer:
             are removed first. Set to ``-1`` to keep all checkpoints locally. (default: ``-1``)
 
             Checkpoints will be removed after they have been logged as a file artifact. For example, when this callback
-            is used in conjunction with the :class:`~composer.loggers.object_store_logger.ObjectStoreLogger`, set this
+            is used in conjunction with the :class:`.ObjectStoreLogger`, set this
             parameter to ``0`` to immediately delete checkpoints from the local disk after they have been uploaded to
             the object store.
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -1,7 +1,7 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The :class:`~yahp.hparams.Hparams` used to construct the :class:`~composer.trainer.trainer.Trainer`."""
+"""The :class:`~yahp.hparams.Hparams` used to construct the :class:`.Trainer`."""
 
 from __future__ import annotations
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -231,17 +231,17 @@ class TrainerHparams(hp.Hparams):
         load_progress_bar (bool, optional): See :class:`.Trainer`.
         load_ignore_keys (List[str] | (Dict) -> None, optional): See :class:`.Trainer`.
 
-        save_folder (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
-        save_filename (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
-        save_artifact_name (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
+        save_folder (str, optional): See :class:`.CheckpointSaver`.
+        save_filename (str, optional): See :class:`.CheckpointSaver`.
+        save_artifact_name (str, optional): See :class:`.CheckpointSaver`.
         save_latest_filename (str, optional): See
-            :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
-        save_latest_artifact_name (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
-        save_overwrite (str, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
-        save_weights_only (bool, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
+            :class:`.CheckpointSaver`.
+        save_latest_artifact_name (str, optional): See :class:`.CheckpointSaver`.
+        save_overwrite (str, optional): See :class:`.CheckpointSaver`.
+        save_weights_only (bool, optional): See :class:`.CheckpointSaver`.
         save_interval (str, optional): See
             :class:`~composer.callbacks.callback_hparams.CheckpointSaverHparams`.
-        save_num_checkpoints_to_keep (int, optional): See :class:`~composer.callbacks.checkpoint_saver.CheckpointSaver`.
+        save_num_checkpoints_to_keep (int, optional): See :class:`.CheckpointSaver`.
         autoresume (bool, optional): See :class:`.Trainer`.
 
         deepspeed_config (Dict[str, JSON], optional): If set to a dict will be used for as the DeepSpeed

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -113,7 +113,7 @@ def load_checkpoint(
             Then, ``path`` should be set to ``my_model/ep1-rank{rank}.tar``, and all ranks will load the
             correct state.
 
-        state (State): The :class:`~composer.core.state.State` to load the checkpoint into.
+        state (State): The :class:`~composer.core.State` to load the checkpoint into.
         object_store (Union[ObjectStore, LoggerDestination], optional): If the ``path`` is in an object store
             (i.e. AWS S3 or Google Cloud Storage), an instance of
             :class:`~.ObjectStore` or :class:`~.LoggerDestination` which will be used

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -133,7 +133,7 @@ FORMAT_NAME_WITH_DIST_TABLE = """
 | Variable               | Description                                           |
 +========================+=======================================================+
 | ``{run_name}``         | The name of the training run. See                     |
-|                        | :attr:`.Logger.run_name`.     |
+|                        | :attr:`.Logger.run_name`.                             |
 +------------------------+-------------------------------------------------------+
 | ``{rank}``             | The global rank, as returned by                       |
 |                        | :func:`~composer.utils.dist.get_global_rank`.         |
@@ -195,7 +195,7 @@ FORMAT_NAME_WITH_DIST_AND_TIME_TABLE = """
 | Variable                   | Description                                                |
 +============================+============================================================+
 | ``{run_name}``             | The name of the training run. See                          |
-|                            | :attr:`.Logger.run_name`.          |
+|                            | :attr:`.Logger.run_name`.                                  |
 +----------------------------+------------------------------------------------------------+
 | ``{rank}``                 | The global rank, as returned by                            |
 |                            | :func:`~composer.utils.dist.get_global_rank`.              |

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -133,7 +133,7 @@ FORMAT_NAME_WITH_DIST_TABLE = """
 | Variable               | Description                                           |
 +========================+=======================================================+
 | ``{run_name}``         | The name of the training run. See                     |
-|                        | :attr:`~composer.loggers.logger.Logger.run_name`.     |
+|                        | :attr:`.Logger.run_name`.     |
 +------------------------+-------------------------------------------------------+
 | ``{rank}``             | The global rank, as returned by                       |
 |                        | :func:`~composer.utils.dist.get_global_rank`.         |
@@ -195,7 +195,7 @@ FORMAT_NAME_WITH_DIST_AND_TIME_TABLE = """
 | Variable                   | Description                                                |
 +============================+============================================================+
 | ``{run_name}``             | The name of the training run. See                          |
-|                            | :attr:`~composer.loggers.logger.Logger.run_name`.          |
+|                            | :attr:`.Logger.run_name`.          |
 +----------------------------+------------------------------------------------------------+
 | ``{rank}``                 | The global rank, as returned by                            |
 |                            | :func:`~composer.utils.dist.get_global_rank`.              |

--- a/composer/utils/reproducibility.py
+++ b/composer/utils/reproducibility.py
@@ -81,7 +81,7 @@ def configure_deterministic_mode():
 
     .. note::
 
-        When using the :class:`~composer.trainer.trainer.Trainer`, you can use the ``deterministic_mode`` flag
+        When using the :class:`.Trainer`, you can use the ``deterministic_mode`` flag
         instead of invoking this function directly.
         For example:
 
@@ -140,7 +140,7 @@ def seed_all(seed: int):
 
     .. note::
 
-        When using the :class:`~composer.trainer.trainer.Trainer`, you can use the ``seed`` parameter
+        When using the :class:`.Trainer`, you can use the ``seed`` parameter
         instead of invoking this function directly.
         For example:
 

--- a/docs/source/composer_model.rst
+++ b/docs/source/composer_model.rst
@@ -190,7 +190,7 @@ Integrations
 TIMM
 ~~~~
 
-Integrate with your favorite `TIMM`_ models with our :func:`.composer_timm` class.
+Integrate with your favorite `TIMM`_ models with our :func:`.composer_timm` function.
 
 .. code:: python
 

--- a/docs/source/getting_started/welcome_tour.rst
+++ b/docs/source/getting_started/welcome_tour.rst
@@ -170,7 +170,7 @@ Putting all the pieces together, our trainer looks something like this:
         engine.run_event("epoch_end")
 
 That's it! Mixup will automatically run on ``"after_dataloader"`` and ``"after_loss"``. And thanks to all of the events being present in the training loop, we can easily start using new algorithms as well!
-For more information on events, state, and engines, check out :class:`~composer.core.event.Event`,
+For more information on events, state, and engines, check out :class:`.Event`,
 :class:`~composer.core.State`, and :class:`~composer.core.engine.Engine`.
 
 For advanced experimentation, we recommend using the Composer :doc:`Trainer<../trainer/using_the_trainer>`.

--- a/docs/source/getting_started/welcome_tour.rst
+++ b/docs/source/getting_started/welcome_tour.rst
@@ -178,3 +178,4 @@ The trainer not only takes care of all the state management and event callbacks 
 but also adds advanced features like hyperparameter management, gradient accumulation, and closure support.
 
 .. _Howard et al, 2020: https://arxiv.org/abs/2002.04688
+

--- a/docs/source/getting_started/welcome_tour.rst
+++ b/docs/source/getting_started/welcome_tour.rst
@@ -171,7 +171,7 @@ Putting all the pieces together, our trainer looks something like this:
 
 That's it! Mixup will automatically run on ``"after_dataloader"`` and ``"after_loss"``. And thanks to all of the events being present in the training loop, we can easily start using new algorithms as well!
 For more information on events, state, and engines, check out :class:`.Event`,
-:class:`~composer.core.State`, and :class:`~composer.core.engine.Engine`.
+:class:`~composer.core.State`, and :class:`.Engine`.
 
 For advanced experimentation, we recommend using the Composer :doc:`Trainer<../trainer/using_the_trainer>`.
 The trainer not only takes care of all the state management and event callbacks from above,

--- a/docs/source/getting_started/welcome_tour.rst
+++ b/docs/source/getting_started/welcome_tour.rst
@@ -178,4 +178,3 @@ The trainer not only takes care of all the state management and event callbacks 
 but also adds advanced features like hyperparameter management, gradient accumulation, and closure support.
 
 .. _Howard et al, 2020: https://arxiv.org/abs/2002.04688
-

--- a/docs/source/getting_started/welcome_tour.rst
+++ b/docs/source/getting_started/welcome_tour.rst
@@ -171,7 +171,7 @@ Putting all the pieces together, our trainer looks something like this:
 
 That's it! Mixup will automatically run on ``"after_dataloader"`` and ``"after_loss"``. And thanks to all of the events being present in the training loop, we can easily start using new algorithms as well!
 For more information on events, state, and engines, check out :class:`~composer.core.event.Event`,
-:class:`~composer.core.state.State`, and :class:`~composer.core.engine.Engine`.
+:class:`~composer.core.State`, and :class:`~composer.core.engine.Engine`.
 
 For advanced experimentation, we recommend using the Composer :doc:`Trainer<../trainer/using_the_trainer>`.
 The trainer not only takes care of all the state management and event callbacks from above,

--- a/docs/source/trainer/logging.rst
+++ b/docs/source/trainer/logging.rst
@@ -53,7 +53,7 @@ Available Loggers
 Automatically Logged Data
 -------------------------
 
-The :class:`~composer.trainer.trainer.Trainer` automatically logs the following data:
+The :class:`.Trainer` automatically logs the following data:
 
 -  ``trainer/algorithms``: a list of specified algorithm names.
 -  ``epoch``: the current epoch.

--- a/docs/source/trainer/using_the_trainer.rst
+++ b/docs/source/trainer/using_the_trainer.rst
@@ -486,7 +486,7 @@ gradient accumulation, Composer initially sets ``grad_accum=1``. During the trai
 if a Cuda Out of Memory Exception is encountered, indicating the current batch size is too
 large for the hardware, Composer catches this exception and continues training after doubling
 ``grad_accum``. As a secondary benefit, automatic gradient accumulation is able to dynamically
-adjust throughout the training process. For example, when using ``ProgressiveResizing``, input
+adjust throughout the training process. For example, when using :class:`.ProgressiveResizing`, input
 size increases throughout training. Composer automatically increases ``grad_accum`` only when
 required, such as when a Cuda OOM is encountered due to larger images, allowing for faster
 training at the start until image sizes are scaled up. Note that this feature is experimental

--- a/examples/glue/nlp_trainer_hparams.py
+++ b/examples/glue/nlp_trainer_hparams.py
@@ -1,7 +1,7 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The :class:`~yahp.hparams.Hparams` used to construct the :class:`~composer.trainer.trainer.Trainer`."""
+"""The :class:`~yahp.hparams.Hparams` used to construct the :class:`.Trainer`."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
To address [CO-789](https://mosaicml.atlassian.net/browse/CO-789) (showing preferred import paths in the docs rather than private ones), we need to change our internal references to not break when the paths change. E.g., we need to replace 
```rst
:class:`~composer.algorithms.blurpool.blurpool.BlurPool`
```
with 
```rst
:class:`.BlurPool`
```
so that, when we have the docs just show `composer.algorithms.BlurPool`, the reference still works.

This PR touches a lot of files but is 90% just the result of `sed` commands, with a little bit of manual correction for isolated cases. Also I fixed a typo in [docs/source/composer_model.rst](https://github.com/mosaicml/composer/pull/1385/files#diff-fd86e5afd002ce9ef1291de49c2a22b77e6e303e582a8452753ad5135661c22f) and a missing reference in [docs/source/trainer/using_the_trainer.rst](https://github.com/mosaicml/composer/pull/1385/files#diff-5f973a074ae8beaa91023affdd5e757f71702611ae61005cbdff5c8ce090cf49).
