### PR TITLE
Add Event.BEFORE_DATALOADER

### DIFF
--- a/composer/core/callback.py
+++ b/composer/core/callback.py
@@ -125,8 +125,8 @@ class Callback(Serializable, abc.ABC):
         del state, logger  # unused
         pass
 
-    def batch_start(self, state: State, logger: Logger) -> None:
-        """Called on the :attr:`.Event.BATCH_START` event.
+    def before_dataloader(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.BEFORE_DATALOADER` event.
 
         Args:
             state (State): The training state.
@@ -137,6 +137,16 @@ class Callback(Serializable, abc.ABC):
 
     def after_dataloader(self, state: State, logger: Logger) -> None:
         """Called on the :attr:`.Event.AFTER_DATALOADER` event.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+        """
+        del state, logger  # unused
+        pass
+
+    def batch_start(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.BATCH_START` event.
 
         Args:
             state (State): The training state.

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -216,7 +216,7 @@ class Engine():
         if self.state.profiler is not None:
             name = f'event/{event.canonical_name}'
             if (event.is_before_event or event.is_after_event):
-                # if not part of an event pair (e.g. init or after dataloader), then don't record an event here
+                # if not part of an event pair (e.g. init), then don't record an event here
                 if event in _ALWAYS_RECORD_EVENTS:
                     actions = [ProfilerAction.ACTIVE, ProfilerAction.WARMUP, ProfilerAction.SKIP]
                 else:

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -243,6 +243,42 @@ class Engine():
 
         return traces
 
+    def run_marker_only_event(
+        self,
+        event: Union[Event, str],
+    ) -> None:
+        """Runs the marker for an event if the profiler is enabled.
+
+        This is primarily used to complete the dataloader marker at the end of the dataloader. In
+        this scenario, the dataloader marker has started from Event.BEFORE_DATALOADER, but 
+        Event.AFTER_DATALOADER cannot be called as no batch was yielded from the dataloader.
+        
+        Args:
+            event (Event | str): The current :class:`.Event`. It can be the enum member values or a
+                string with the event value.
+        """
+        duration_marker = None
+        event = Event(event)
+
+        if self._is_closed:
+            raise RuntimeError(('The engine was already closed and therefore cannot be used again. '
+                                'To fix, please create a new Engine (or Trainer)'))
+
+        if self.state.profiler is not None:
+            name = f'event/{event.canonical_name}'
+            if (event.is_before_event or event.is_after_event):
+                # if not part of an event pair (e.g. init), then don't record an event here
+                if event in _ALWAYS_RECORD_EVENTS:
+                    actions = [ProfilerAction.ACTIVE, ProfilerAction.WARMUP, ProfilerAction.SKIP]
+                else:
+                    actions = [ProfilerAction.ACTIVE, ProfilerAction.WARMUP]
+                duration_marker = self.state.profiler.marker(name, actions=actions)
+
+        if event.is_after_event and duration_marker is not None:
+            duration_marker.finish()
+        if event.is_before_event and duration_marker is not None:
+            duration_marker.start()
+
     def register_pass(self, algorithm_pass: passes.AlgorithmPass, index: int = -1):
         """Registers an algorithm pass with the Engine.
 

--- a/composer/core/event.py
+++ b/composer/core/event.py
@@ -21,7 +21,11 @@ class Event(StringEnum):
         # <FIT_START>
         for epoch in range(NUM_EPOCHS):
             # <EPOCH_START>
-            for batch in dataloader:
+            while True:
+                # <BEFORE_DATALOADER>
+                batch = next(dataloader)
+                if batch is None:
+                    break
                 # <AFTER_DATALOADER>
 
                 # <BATCH_START>
@@ -85,6 +89,7 @@ class Event(StringEnum):
         FIT_START: Invoked at the beginning of each call to :meth:`.Trainer.fit`. Dataset transformations typically
             occur here.
         EPOCH_START: Start of an epoch.
+        BEFORE_DATALOADER: Immediately before the dataloader is called.
         AFTER_DATALOADER: Immediately after the dataloader is called.  Typically used for on-GPU dataloader transforms.
         BATCH_START: Start of a batch.
         BEFORE_TRAIN_BATCH: Before the forward-loss-backward computation for a training batch. When using gradient
@@ -128,6 +133,7 @@ class Event(StringEnum):
 
     EPOCH_START = 'epoch_start'
 
+    BEFORE_DATALOADER = 'before_dataloader'
     AFTER_DATALOADER = 'after_dataloader'
 
     BATCH_START = 'batch_start'
@@ -218,10 +224,10 @@ class Event(StringEnum):
         return self.value.startswith('eval')
 
 
-_BEFORE_EVENTS = (Event.FIT_START, Event.EPOCH_START, Event.BATCH_START, Event.BEFORE_TRAIN_BATCH, Event.BEFORE_FORWARD,
-                  Event.BEFORE_LOSS, Event.BEFORE_BACKWARD, Event.EVAL_START, Event.EVAL_BATCH_START,
-                  Event.EVAL_BEFORE_FORWARD, Event.PREDICT_START, Event.PREDICT_BATCH_START,
-                  Event.PREDICT_BEFORE_FORWARD)
-_AFTER_EVENTS = (Event.EPOCH_END, Event.BATCH_END, Event.AFTER_TRAIN_BATCH, Event.AFTER_FORWARD, Event.AFTER_LOSS,
-                 Event.AFTER_BACKWARD, Event.EVAL_END, Event.EVAL_BATCH_END, Event.EVAL_AFTER_FORWARD, Event.FIT_END,
-                 Event.PREDICT_END, Event.PREDICT_BATCH_END, Event.PREDICT_AFTER_FORWARD)
+_BEFORE_EVENTS = (Event.FIT_START, Event.EPOCH_START, Event.BEFORE_DATALOADER, Event.BATCH_START,
+                  Event.BEFORE_TRAIN_BATCH, Event.BEFORE_FORWARD, Event.BEFORE_LOSS, Event.BEFORE_BACKWARD,
+                  Event.EVAL_START, Event.EVAL_BATCH_START, Event.EVAL_BEFORE_FORWARD, Event.PREDICT_START,
+                  Event.PREDICT_BATCH_START, Event.PREDICT_BEFORE_FORWARD)
+_AFTER_EVENTS = (Event.EPOCH_END, Event.BATCH_END, Event.AFTER_DATALOADER, Event.AFTER_TRAIN_BATCH, Event.AFTER_FORWARD,
+                 Event.AFTER_LOSS, Event.AFTER_BACKWARD, Event.EVAL_END, Event.EVAL_BATCH_END, Event.EVAL_AFTER_FORWARD,
+                 Event.FIT_END, Event.PREDICT_END, Event.PREDICT_BATCH_END, Event.PREDICT_AFTER_FORWARD)

--- a/composer/core/types.py
+++ b/composer/core/types.py
@@ -44,6 +44,7 @@ class TrainerMode(StringEnum):
     EVAL = 'eval'
     PREDICT = 'predict'
 
+
 class MemoryFormat(StringEnum):
     """Enum class to represent different memory formats.
 

--- a/composer/core/types.py
+++ b/composer/core/types.py
@@ -32,6 +32,18 @@ PyTorchScheduler = torch.optim.lr_scheduler._LRScheduler
 JSON = Union[str, float, int, None, List['JSON'], Dict[str, 'JSON']]
 
 
+class TrainerMode(StringEnum):
+    """Enum to represent which mode the Trainer is in.
+
+    Attributes:
+        TRAIN: In training mode.
+        EVAL: In evaluation mode.
+        PREDICT: In predict mode.
+    """
+    TRAIN = 'train'
+    EVAL = 'eval'
+    PREDICT = 'predict'
+
 class MemoryFormat(StringEnum):
     """Enum class to represent different memory formats.
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2157,6 +2157,7 @@ class Trainer:
                 self.engine.run_event(Event.BEFORE_DATALOADER)
                 batch = next(dataloader_iter)
             except StopIteration:
+                self.engine.run_marker_only_event(Event.AFTER_DATALOADER)
                 break
             yield batch
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2145,9 +2145,6 @@ class Trainer:
         This method yields up to :attr:`.State.dataloader_len`` batches from the dataloader. In addition, if the
         profiler is enabled, the dataloader latency recorded via the :class:`.Marker` API.
         """
-        marker = None
-        if self.state.profiler is not None:
-            marker = self.state.profiler.marker(f'dataloader/{self.state.dataloader_label}', categories=['dataloader'])
         assert self.state.dataloader is not None, 'the dataloader should be set before calling this method'
 
         if self.state.dataloader_len is None:
@@ -2156,15 +2153,11 @@ class Trainer:
             dataloader_iter = itertools.islice(self.state.dataloader, int(self.state.dataloader_len))
 
         while True:
-            if marker is not None:
-                marker.start()
             try:
+                self.engine.run_event(Event.BEFORE_DATALOADER)
                 batch = next(dataloader_iter)
             except StopIteration:
                 break
-            finally:
-                if marker is not None:
-                    marker.finish()
             yield batch
 
     def _use_closures(self) -> bool:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2144,7 +2144,7 @@ class Trainer:
 
         This method yields up to :attr:`.State.dataloader_len`` batches from the dataloader. In addition, if the
         profiler is enabled, the dataloader latency recorded via the :class:`.Marker` API.
-        
+
         Args:
             trainer_mode (TrainerMode): Specifies which mode the trainer is in.
         """

--- a/docs/source/getting_started/welcome_tour.rst
+++ b/docs/source/getting_started/welcome_tour.rst
@@ -68,7 +68,12 @@ We could add events to our training loop as follows:
     # <FIT_START>
     for epoch in range(NUM_EPOCHS):
         # <EPOCH_START>
-        for inputs, targets in dataloader:
+        while True:
+            # <BEFORE_DATALOADER>
+            batch = next(dataloader)
+            if batch is None:
+                break
+            inputs, targets = batch
             # <AFTER_DATALOADER>
 
             # <BATCH_START>


### PR DESCRIPTION
Currently, the only point in which `Profiler` adds a marker outside the engine is for dataloader yields. This is messy agent wise because accessing dataloader yield times (for checking if we're dataloader bottlenecked) requires monkeypatching `Profiler`. 

In order to simplify the control plane, we've now added `Event.BEFORE_DATALOADER`. The engine should have enough entry points to control the entire flow without relying on anything else, and this new event helps complete that.

More broadly, `Profiler` is really just a wrapper around inserting callbacks. We should refactor away `Profiler` into callbacks so each trace handler can have its own schedule. This is a broader redesign though that's lower priority since it's mostly to clean up Composer internals as opposed to user-facing changes.