### PR TITLE
Fix hparams error

### DIFF
--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -86,10 +86,9 @@ def _initialize_dataloader(
 
         train_device_batch_size = batch_size // dist.get_world_size()
         if dataset_hparams.shuffle and subset_num_batches is not None and subset_num_batches != -1:
-            warnings.warn(
-                (f'SubsetNumBatchesWarning: When specifying `subset_num_batches` for the {dataloader_label} dataset, '
-                 f'dataset_hparams.shuffle should be set to False. '
-                 'Otherwise, each epoch may load a different subset of samples.'))
+            warnings.warn((f'SubsetNumBatchesWarning: When specifying `[train|eval]_subset_num_batches` for '
+                           f'the {dataloader_label} dataset, dataset_hparams.shuffle should be set to False. '
+                           'Otherwise, each epoch may load a different subset of samples.'))
         dataloader = dataset_hparams.initialize_object(train_device_batch_size, dataloader_hparams)
     return dataloader
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -85,7 +85,7 @@ def _initialize_dataloader(
             )
 
         train_device_batch_size = batch_size // dist.get_world_size()
-        if dataset_hparams.shuffle and subset_num_batches is not None:
+        if dataset_hparams.shuffle and subset_num_batches is not None and subset_num_batches != -1:
             warnings.warn(
                 (f'SubsetNumBatchesWarning: When specifying `subset_num_batches` for the {dataloader_label} dataset, '
                  f'dataset_hparams.shuffle should be set to False. '


### PR DESCRIPTION
Hparams by default instantiates `train_subset_num_batches` to -1. However, we only check if its not None when giving a warning 