### PR TITLE
Update DeepLabv3 pretrained weight interface to work with PyTorch 1.12

### DIFF
--- a/composer/models/deeplabv3/README.md
+++ b/composer/models/deeplabv3/README.md
@@ -11,8 +11,7 @@ from composer.models import composer_deeplabv3
 
 model = composer_deeplabv3(num_classes=150,
                            backbone_arch="resnet101",
-                           is_backbone_pretrained=True,
-                           backbone_url="https://download.pytorch.org/models/resnet101-cd907fc2.pth",
+                           backbone_weights="IMAGENET1K_V2",
                            sync_bn=False
 )
 ```
@@ -54,8 +53,7 @@ model:
       - kaiming_normal
       - bn_ones
     num_classes: 150
-    backbone_arch: resnet101
-    is_backbone_pretrained: true
+    backbone_weights: IMAGENET1K_V1
     use_plus: true
     sync_bn: true
 optimizer:
@@ -88,11 +86,10 @@ model:
       - bn_ones
     num_classes: 150
     backbone_arch: resnet101
-    is_backbone_pretrained: true
     use_plus: true
     sync_bn: true
     # New Pytorch pretrained weights
-    backbone_url: https://download.pytorch.org/models/resnet101-cd907fc2.pth
+    backbone_weights: IMAGENET1K_V2
 optimizer:
   decoupled_sgdw:
     lr: 0.01

--- a/composer/models/deeplabv3/deeplabv3_hparams.py
+++ b/composer/models/deeplabv3/deeplabv3_hparams.py
@@ -4,6 +4,7 @@
 """`YAHP <https://docs.mosaicml.com/projects/yahp/en/stable/README.html>`_ interface for :func:`.composer_deeplabv3`."""
 
 from dataclasses import dataclass
+from typing import Optional
 
 import yahp as hp
 
@@ -21,10 +22,8 @@ class DeepLabV3Hparams(ModelHparams):
         num_classes (int): Number of classes in the segmentation task.
         backbone_arch (str, optional): The architecture to use for the backbone. Must be either
             [``'resnet50'``, ``'resnet101'``]. Default: ``'resnet101'``.
-        is_backbone_pretrained (bool, optional): If ``True``, use pretrained weights for the backbone.
-            Default: ``True``.
-        backbone_url (str, optional): Url used to download model weights. If empty, the PyTorch url will be used.
-            Default: ``''``.
+        backbone_weights (str, optional): If specified, the PyTorch pre-trained weights to load for the backbone.
+            Currently, only ['IMAGENET1K_V1', 'IMAGENET1K_V2'] are supported. Default: ``None``.
         use_plus (bool, optional): If ``True``, use DeepLabv3+ head instead of DeepLabv3. Default: ``True``.
         sync_bn (bool, optional): If ``True``, replace all BatchNorm layers with SyncBatchNorm layers.
             Default: ``True``.
@@ -34,9 +33,8 @@ class DeepLabV3Hparams(ModelHparams):
 
     backbone_arch: str = hp.optional("The backbone architecture to use. Must be either ['resnet50', resnet101'].",
                                      default='resnet101')
-    is_backbone_pretrained: bool = hp.optional('If true, use pre-trained weights for backbone.', default=True)
-    backbone_url: str = hp.optional(
-        "Url to download model weights from. If blank (default), will download from PyTorch's url.", default='')
+    backbone_weights: Optional[str] = hp.optional(
+        'If specified, the PyTorch pre-trained weights to load for the backbone. Default is ``None``.', default=None)
     use_plus: bool = hp.optional('If true (default), use DeepLabv3+ head instead of DeepLabv3.', default=True)
     sync_bn: bool = hp.optional('If true, use SyncBatchNorm to sync batch norm statistics across GPUs.', default=True)
     ignore_index: int = hp.optional('Class label to ignore when calculating the loss and other metrics.', default=-1)
@@ -67,8 +65,7 @@ class DeepLabV3Hparams(ModelHparams):
 
         return composer_deeplabv3(num_classes=self.num_classes,
                                   backbone_arch=self.backbone_arch,
-                                  is_backbone_pretrained=self.is_backbone_pretrained,
-                                  backbone_url=self.backbone_url,
+                                  backbone_weights=self.backbone_weights,
                                   use_plus=self.use_plus,
                                   sync_bn=self.sync_bn,
                                   ignore_index=self.ignore_index,

--- a/composer/models/deeplabv3/model.py
+++ b/composer/models/deeplabv3/model.py
@@ -144,10 +144,10 @@ def deeplabv3(num_classes: int,
             initializer_fn = Initializer(initializer).get_initializer()
 
             # Only apply initialization to classifier head if pre-trained weights are used
-            if not backbone_weights is None:
-                model.classifier.apply(initializer_fn)
-            else:
+            if backbone_weights is None:
                 model.apply(initializer_fn)
+            else:
+                model.classifier.apply(initializer_fn)
 
     if sync_bn:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)

--- a/composer/models/deeplabv3/model.py
+++ b/composer/models/deeplabv3/model.py
@@ -95,7 +95,7 @@ def deeplabv3(num_classes: int,
                                                   replace_stride_with_dilation=[False, True, True])
     else:
         backbone = getattr(resnet, backbone_arch)(weights=backbone_weights,
-                                                  replace_stride_with_dilations=[False, True, True])
+                                                  replace_stride_with_dilation=[False, True, True])
 
     # specify which layers to extract activations from
     return_layers = {'layer1': 'layer1', 'layer4': 'layer4'} if use_plus else {'layer4': 'layer4'}

--- a/composer/models/deeplabv3/model.py
+++ b/composer/models/deeplabv3/model.py
@@ -144,7 +144,7 @@ def deeplabv3(num_classes: int,
             initializer_fn = Initializer(initializer).get_initializer()
 
             # Only apply initialization to classifier head if pre-trained weights are used
-            if backbone_weights is None:
+            if not backbone_weights is None:
                 model.classifier.apply(initializer_fn)
             else:
                 model.apply(initializer_fn)

--- a/composer/models/deeplabv3/model.py
+++ b/composer/models/deeplabv3/model.py
@@ -5,10 +5,12 @@
 
 import functools
 import textwrap
-from typing import Sequence
+from typing import Optional, Sequence
 
 import torch
 import torch.nn.functional as F
+import torchvision
+from packaging import version
 from torchmetrics import MetricCollection
 from torchvision.models import _utils, resnet
 
@@ -41,8 +43,7 @@ class SimpleSegmentationModel(torch.nn.Module):
 
 def deeplabv3(num_classes: int,
               backbone_arch: str = 'resnet101',
-              is_backbone_pretrained: bool = True,
-              backbone_url: str = '',
+              backbone_weights: Optional[str] = None,
               sync_bn: bool = True,
               use_plus: bool = True,
               initializers: Sequence[Initializer] = ()):
@@ -50,14 +51,15 @@ def deeplabv3(num_classes: int,
 
     Args:
         num_classes (int): Number of classes in the segmentation task.
-        backbone_arch (str, optional): The architecture to use for the backbone. Must be either [``'resnet50'``, ``'resnet101'``].
-            Default: ``'resnet101'``.
-        is_backbone_pretrained (bool, optional): If ``True``, use pretrained weights for the backbone. Default: ``True``.
-        backbone_url (str, optional): Url used to download model weights. If empty, the PyTorch url will be used.
-            Default: ``''``.
-        sync_bn (bool, optional): If ``True``, replace all BatchNorm layers with SyncBatchNorm layers. Default: ``True``.
+        backbone_arch (str, optional): The architecture to use for the backbone. Must be either
+            [``'resnet50'``, ``'resnet101'``]. Default: ``'resnet101'``.
+        backbone_weights (str, optional): If specified, the PyTorch pre-trained weights to load for the backbone.
+            Currently, only ['IMAGENET1K_V1', 'IMAGENET1K_V2'] are supported. Default: ``None``.
+        sync_bn (bool, optional): If ``True``, replace all BatchNorm layers with SyncBatchNorm layers.
+            Default: ``True``.
         use_plus (bool, optional): If ``True``, use DeepLabv3+ head instead of DeepLabv3. Default: ``True``.
-        initializers (Sequence[Initializer], optional): Initializers for the model. ``[]`` for no initialization. Default: ``()``.
+        initializers (Sequence[Initializer], optional): Initializers for the model. ``()`` for no initialization.
+            Default: ``()``.
 
     Returns:
         deeplabv3: A DeepLabV3 :class:`torch.nn.Module`.
@@ -68,7 +70,7 @@ def deeplabv3(num_classes: int,
 
         from composer.models.deeplabv3.deeplabv3 import deeplabv3
 
-        pytorch_model = deeplabv3(num_classes=150, backbone_arch='resnet101', is_backbone_pretrained=False)
+        pytorch_model = deeplabv3(num_classes=150, backbone_arch='resnet101', backbone_weights=None)
     """
 
     # check that the specified architecture is in the resnet module
@@ -76,10 +78,24 @@ def deeplabv3(num_classes: int,
         raise ValueError(f'backbone_arch must be part of the torchvision resnet module, got value: {backbone_arch}')
 
     # change the model weight url if specified
-    if backbone_url:
-        resnet.model_urls[backbone_arch] = backbone_url
-    backbone = getattr(resnet, backbone_arch)(pretrained=is_backbone_pretrained,
-                                              replace_stride_with_dilation=[False, True, True])
+    if version.parse(torchvision.__version__) < version.parse('0.13.0'):
+        pretrained = False
+        if backbone_weights:
+            pretrained = True
+            if backbone_weights == 'IMAGENET1K_V1':
+                resnet.model_urls[backbone_arch] = 'https://download.pytorch.org/models/resnet101-63fe2227.pth'
+            elif backbone_weights == 'IMAGENET1K_V2':
+                resnet.model_urls[backbone_arch] = 'https://download.pytorch.org/models/resnet101-cd907fc2.pth'
+            else:
+                ValueError(
+                    textwrap.dedent(f"""\
+                        `backbone_weights` must be either "IMAGENET1K_V1" or "IMAGENET1K_V2"
+                        if torchvision.__version__ < 0.13.0. `backbone_weights` was {backbone_weights}."""))
+        backbone = getattr(resnet, backbone_arch)(pretrained=pretrained,
+                                                  replace_stride_with_dilation=[False, True, True])
+    else:
+        backbone = getattr(resnet, backbone_arch)(weights=backbone_weights,
+                                                  replace_stride_with_dilations=[False, True, True])
 
     # specify which layers to extract activations from
     return_layers = {'layer1': 'layer1', 'layer4': 'layer4'} if use_plus else {'layer4': 'layer4'}
@@ -128,7 +144,7 @@ def deeplabv3(num_classes: int,
             initializer_fn = Initializer(initializer).get_initializer()
 
             # Only apply initialization to classifier head if pre-trained weights are used
-            if is_backbone_pretrained:
+            if backbone_weights is None:
                 model.classifier.apply(initializer_fn)
             else:
                 model.apply(initializer_fn)
@@ -141,8 +157,7 @@ def deeplabv3(num_classes: int,
 
 def composer_deeplabv3(num_classes: int,
                        backbone_arch: str = 'resnet101',
-                       is_backbone_pretrained: bool = True,
-                       backbone_url: str = '',
+                       backbone_weights: Optional[str] = None,
                        sync_bn: bool = True,
                        use_plus: bool = True,
                        ignore_index: int = -1,
@@ -159,10 +174,8 @@ def composer_deeplabv3(num_classes: int,
         num_classes (int): Number of classes in the segmentation task.
         backbone_arch (str, optional): The architecture to use for the backbone. Must be either
             [``'resnet50'``, ``'resnet101'``]. Default: ``'resnet101'``.
-        is_backbone_pretrained (bool, optional): If ``True``, use pretrained weights for the backbone.
-            Default: ``True``.
-        backbone_url (str, optional): Url used to download model weights. If empty, the PyTorch url will be used.
-            Default: ``''``.
+        backbone_weights (str, optional): If specified, the PyTorch pre-trained weights to load for the backbone.
+            Currently, only ['IMAGENET1K_V1', 'IMAGENET1K_V2'] are supported. Default: ``None``.
         sync_bn (bool, optional): If ``True``, replace all BatchNorm layers with SyncBatchNorm layers.
             Default: ``True``.
         use_plus (bool, optional): If ``True``, use DeepLabv3+ head instead of DeepLabv3. Default: ``True``.
@@ -182,12 +195,11 @@ def composer_deeplabv3(num_classes: int,
 
         from composer.models import composer_deeplabv3
 
-        model = composer_deeplabv3(num_classes=150, backbone_arch='resnet101', is_backbone_pretrained=False)
+        model = composer_deeplabv3(num_classes=150, backbone_arch='resnet101', backbone_weights=None)
     """
 
     model = deeplabv3(backbone_arch=backbone_arch,
-                      is_backbone_pretrained=is_backbone_pretrained,
-                      backbone_url=backbone_url,
+                      backbone_weights=backbone_weights,
                       use_plus=use_plus,
                       num_classes=num_classes,
                       sync_bn=sync_bn,

--- a/composer/yamls/models/deeplabv3_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_ade20k_optimized.yaml
@@ -31,8 +31,7 @@ model:
       - bn_ones
     num_classes: 150
     backbone_arch: resnet101
-    is_backbone_pretrained: true
-    backbone_url: https://download.pytorch.org/models/resnet101-cd907fc2.pth
+    backbone_weights: IMAGENET1K_V2
     use_plus: true
     sync_bn: false
 max_duration: 128ep

--- a/composer/yamls/models/deeplabv3_ade20k_unoptimized.yaml
+++ b/composer/yamls/models/deeplabv3_ade20k_unoptimized.yaml
@@ -32,8 +32,7 @@ model:
       - bn_ones
     num_classes: 150
     backbone_arch: resnet101
-    is_backbone_pretrained: true
-    backbone_url: https://download.pytorch.org/models/resnet101-cd907fc2.pth
+    backbone_weights: IMAGENET1K_V1
     use_plus: true
     sync_bn: true
 max_duration: 127ep

--- a/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
@@ -37,8 +37,7 @@ model:
       - bn_ones
     num_classes: 150
     backbone_arch: resnet101
-    is_backbone_pretrained: true
-    backbone_url: https://download.pytorch.org/models/resnet101-cd907fc2.pth
+    backbone_weights: IMAGENET1K_V2
     use_plus: true
     sync_bn: false
 max_duration: 128ep

--- a/examples/streaming_dataloader_facesynthetics.ipynb
+++ b/examples/streaming_dataloader_facesynthetics.ipynb
@@ -352,7 +352,7 @@
     "    model = composer_deeplabv3(\n",
     "        num_classes=num_classes, \n",
     "        backbone_arch='resnet101', \n",
-    "        is_backbone_pretrained=True,\n",
+    "        backbone_weights='IMAGENET1K_V2',\n",
     "        sync_bn=False)\n",
     "    optimizer = DecoupledAdamW(model.parameters(), lr=1e-3)\n",
     "    \n",

--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -135,7 +135,7 @@ def configure_model_hparams_for_synthetic(model_hparams: ModelHparams) -> None:
 
     # configure DeepLabV3 models for synthetic testing
     if isinstance(model_hparams, DeepLabV3Hparams):
-        model_hparams.is_backbone_pretrained = False  # prevent downloading pretrained weights during test
+        model_hparams.backbone_weights = None  # prevent downloading pretrained weights during test
         model_hparams.sync_bn = False  # sync_bn throws an error when run on CPU
 
 

--- a/tests/models/test_model_registry.py
+++ b/tests/models/test_model_registry.py
@@ -31,7 +31,7 @@ def test_model_registry(model_name, request):
         model_hparams.model_name = 'resnet50'
 
     if model_name == 'deeplabv3':
-        model_hparams.is_backbone_pretrained = False
+        model_hparams.backbone_weights = None
 
     if model_name == 'timm':
         model_hparams.model_name = 'resnet18'


### PR DESCRIPTION
This is supposed to be similar to the ResNet PR here: https://github.com/mosaicml/composer/pull/1262. 

The `is_backbone_pretrained` and `backbone_url` are replaced in favor of `backbone_weights` which uses PyTorch's new multiple weights API. When torchvision is below 0.13, the respective urls for `IMAGENET1K_V1` and `IMAGENET1K_V2` are hardcoded.

For the future, we need a better interface to be able to use arbitrary pre-trained weights i.e. be able to use weights locally or ones stored in the cloud. I just wanted to get a quick fix to use PyTorch 1.12, but will create a jira for this feature