### PR TITLE
Add informative error for infer batch size issues

### DIFF
--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -194,6 +194,11 @@ class DataSpec:
         if isinstance(batch, (list, tuple)):
             for tensors in batch:
                 for t in ensure_tuple(tensors):
+                    if not hasattr(t, 'shape'):
+                        raise ValueError('Unable to determine the batch size, batch contains'
+                                         f'an element of type {type(t)}, which does not have a'
+                                         'shape. Please use a DataSpec and provide a'
+                                         '`get_num_samples_in_batch(your_batch) -> int` method.')
                     dim0_sizes.append(t.shape[0])
         elif isinstance(batch, dict):
             dim0_sizes = [t.shape[0] for t in batch.values()]

--- a/tests/trainer/test_dataspec.py
+++ b/tests/trainer/test_dataspec.py
@@ -27,6 +27,7 @@ class TestDefaultGetNumSamples:
         (torch.rand(N, 8), torch.rand(N, 64)),  # tuple
         [torch.rand(N, 8), torch.rand(N, 64)],  # list
         torch.rand(N, 8),  # tensor
+        torch.rand(N, 8, 4, 2),  # 4-dim tensor
     ])
     # yapf: enable
     def test_num_samples_infer(self, batch: Any, dataspec: DataSpec):

--- a/tests/trainer/test_dataspec.py
+++ b/tests/trainer/test_dataspec.py
@@ -1,0 +1,47 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import pytest
+import torch
+from torch.utils.data import DataLoader
+
+from composer.core.data_spec import DataSpec
+from tests.common import RandomClassificationDataset
+
+N = 128
+
+
+class TestDefaultGetNumSamples:
+
+    @pytest.fixture
+    def dataspec(self):
+        dataloader = DataLoader(RandomClassificationDataset())
+        return DataSpec(dataloader=dataloader)
+
+    # yapf: disable
+    @pytest.mark.parametrize('batch', [
+        {'a': torch.rand(N, 8), 'b': torch.rand(N, 64)},  # dict
+        [{'a': torch.rand(N, 8)}, {'c': torch.rand(N, 64)}],  # list of dict
+        (torch.rand(N, 8), torch.rand(N, 64)),  # tuple
+        [torch.rand(N, 8), torch.rand(N, 64)],  # list
+        torch.rand(N, 8),  # tensor
+    ])
+    # yapf: enable
+    def test_num_samples_infer(self, batch: Any, dataspec: DataSpec):
+        assert dataspec._default_get_num_samples_in_batch(batch) == N
+
+    def test_batch_dict_mismatch(self, dataspec: DataSpec):
+        N = 128
+        batch = {'a': torch.rand(N, 8), 'b': torch.rand(N * 2, 64)}
+
+        with pytest.raises(NotImplementedError, match='multiple Tensors'):
+            dataspec._default_get_num_samples_in_batch(batch)
+
+    def test_unable_to_infer(self, dataspec: DataSpec):
+        N = 128
+        batch = [torch.rand(N, 8), 'I am a string.']
+
+        with pytest.raises(ValueError, match='Unable to determine'):
+            dataspec._default_get_num_samples_in_batch(batch)


### PR DESCRIPTION
This PR:
* adds an informative error if the batch yielded by the dataloader has a non-Tensor element (e.g. cannot retrieve the shape)
* improves test coverage of the `_default_num_samples_in_batch` function.