### PR TITLE
current metrics docs

### DIFF
--- a/docs/source/trainer/using_the_trainer.rst
+++ b/docs/source/trainer/using_the_trainer.rst
@@ -78,9 +78,14 @@ objects.
 
     trainer.fit()
 
+When training is complete, metrics can be accessed from the trainer state.
+
+.. code:: python
+
+    print(trainer.state.current_metrics)
+
 In the background, we automatically add the :class:`.ProgressBarLogger` to log
 training progress to the console.
-
 
 A few tips and tricks for using our Trainer:
 


### PR DESCRIPTION
added a line about getting current eval metrics from the trainer after training.

stopgap for CO-756. Metrics can also be accessed from the composermodel, but i believe this is the most logical way to access them.