### PR TITLE
Dynamic quantization + minor improvements in inference APIs

### DIFF
--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -9,7 +9,7 @@ from composer.utils.file_helpers import (create_symlink_file, ensure_folder_has_
                                          ensure_folder_is_empty, format_name_with_dist, format_name_with_dist_and_time,
                                          get_file, is_tar)
 from composer.utils.import_helpers import MissingConditionalImportError, import_object
-from composer.utils.inference import export_for_inference, export_with_logger
+from composer.utils.inference import export_for_inference, export_with_logger, quantize_dynamic
 from composer.utils.iter_helpers import IteratorFileStream, ensure_tuple, map_collection
 from composer.utils.misc import is_model_deepspeed, is_notebook
 from composer.utils.object_store import (LibcloudObjectStore, ObjectStore, ObjectStoreTransientError, S3ObjectStore,
@@ -39,6 +39,7 @@ __all__ = [
     'ensure_folder_has_no_conflicting_files',
     'export_for_inference',
     'export_with_logger',
+    'quantize_dynamic',
     'format_name_with_dist',
     'format_name_with_dist_and_time',
     'is_tar',

--- a/composer/utils/inference.py
+++ b/composer/utils/inference.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+import functools
 import logging
 import os
 import tempfile
@@ -29,9 +30,20 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-__all__ = ['export_for_inference', 'ExportFormat', 'export_with_logger']
+__all__ = ['export_for_inference', 'ExportFormat', 'export_with_logger', 'quantize_dynamic']
 
 Transform = Callable[[nn.Module], nn.Module]
+
+# This is the most common way to use dynamic quantization.
+#  Example:
+#    from composer.utils import quantize_dynamic
+#    export_for_inference(
+#        ...
+#        transforms = [quantize_dynamic],
+#        ...
+#    )
+#  A user can always redefine it with extra options. This also serves as an example of what to pass to transforms.
+quantize_dynamic = functools.partial(torch.quantization.quantize_dynamic, qconfig_spec={torch.nn.Linear})
 
 
 class ExportFormat(StringEnum):
@@ -148,19 +160,20 @@ def export_for_inference(
             export_model = None
             try:
                 export_model = torch.jit.script(model)
-            except Exception as e:
-                log.warning(
-                    'Scripting with torch.jit.script failed with the following exception. Trying torch.jit.trace!',
-                    exc_info=True)
+            except Exception:
                 if sample_input is not None:
+                    log.warning('Scripting with torch.jit.script failed. Trying torch.jit.trace!',)
                     export_model = torch.jit.trace(model, sample_input)
                 else:
-                    raise RuntimeError(
-                        'Scripting with torch.jit.script failed and sample inputs are not provided for tracing with torch.jit.trace'
-                    ) from e
+                    log.warning(
+                        'Scripting with torch.jit.script failed and sample inputs are not provided for tracing '
+                        'with torch.jit.trace',
+                        exc_info=True)
 
             if export_model is not None:
                 torch.jit.save(export_model, local_save_path)
+            else:
+                raise RuntimeError('Scritping and tracing failed! No model is getting exported.')
 
         if save_format == ExportFormat.ONNX:
             if sample_input is None:


### PR DESCRIPTION
Adds 

1. Helper wrapper for dynamic quantization 
2. If scripting fails, we were printing an exception stack trace but still continuing with tracing. Fix this. 
3. Add a test for dynamic quantization. 

closes https://mosaicml.atlassian.net/browse/CO-798

Test:
python -m pytest -k "test_dynamic_quantize" -s