### PR TITLE
Upgrade WandB version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ extra_deps['deepspeed'] = [
 ]
 
 extra_deps['wandb'] = [
-    'wandb>=0.12.17,<0.13',
+    'wandb>=0.13.2,<0.14',
 ]
 
 extra_deps['tensorboard'] = [


### PR DESCRIPTION
On our custom GLUE entrypoint, we use multiprocessing to manage fine-tuning in parallel.

However, because our spawned processes cannot spawn further processes, we get this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/wandb/sdk/wandb_init.py", line 1043, in init
    run = wi.init()
  File "/usr/local/lib/python3.9/dist-packages/wandb/sdk/wandb_init.py", line 556, in init
    backend.ensure_launched()
  File "/usr/local/lib/python3.9/dist-packages/wandb/sdk/backend/backend.py", line 220, in ensure_launched
    self.wandb_process.start()
  File "/usr/lib/python3.9/multiprocessing/process.py", line 118, in start
    assert not _current_process._config.get('daemon'), \
AssertionError: daemonic processes are not allowed to have children
```

There are two potential solutions to this error:

Encourage WandB to use threads instead of processes by changing an environmental variable (`export WANDB_START_METHOD=thread`). They do not recommend this solution.

WandB actually has a solution v0.13 that uses a “[WandB service](https://docs.wandb.ai/guides/track/advanced/distributed-training#wandb-service)” by default, which is what they recommend.

I can implement #1, but it seems like we will need to upgrade WandB version at some point, so by doing the upgrade, we should be able to kill two birds with one stone.

Are there any reasons not to upgrade? Do we see a potential performance degradation?

Closes CO-968.