### PR TITLE
Clean up docs Makefile

### DIFF
--- a/.ci/test_lint_doctests.py
+++ b/.ci/test_lint_doctests.py
@@ -45,9 +45,6 @@ def test_run_pre_commit_hooks():
 
 def test_run_doctests():
     docs_folder = pathlib.Path(os.path.dirname(__file__)) / '..' / 'docs'
-    api_reference_folder = docs_folder / 'source' / 'api_reference'
-    # Remove the `api_reference` folder, which isn't automatically removed via `make clean`
-    shutil.rmtree(api_reference_folder, ignore_errors=True)
     check_output(subprocess.run(['make', 'clean'], cwd=docs_folder, capture_output=True, text=True))
     # Must build the html first to ensure that doctests in .. autosummary:: generated pages are included
     check_output(subprocess.run(['make', 'html'], cwd=docs_folder, capture_output=True, text=True))

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -409,7 +409,6 @@ In one terminal, run:
 source path/to/composer_venv/bin/activate  # activate your composer virtual env
 cd composer/docs  # cd to the docs folder insde your composer clone
 make clean
-rm -rf source/api_reference  # make clean doesn't remove this folder
 make html
 ```
 
@@ -477,7 +476,6 @@ Assuming you already have a development install of Composer (see these [instruct
 source path/to/composer_venv/bin/activate  # activate your composer virtual env
 cd composer/docs  # cd to the docs folder insde your composer clone
 make clean
-rm -rf source/api_reference  # make clean doesn't remove this folder
 make html  # the html build must be completed first to ensure all doctests are identified
 make doctest 2>/dev/null # For more verbosity, do not direct stderr to /dev/null
 ```

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W --keep-going -Q
+SPHINXOPTS    ?= -W --keep-going -q
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W --keep-going -q
+SPHINXOPTS    ?= -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
@@ -12,11 +12,14 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+doctest:
+	@$(SPHINXBUILD) -M doctest "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) -q $(O)
+
 clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf $(SOURCEDIR)/api_reference
 
-.PHONY: help Makefile clean
+.PHONY: help Makefile clean doctest
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -W --keep-going
+SPHINXOPTS    ?= -W --keep-going -Q
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
@@ -12,7 +12,11 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+clean:
+	rm -rf $(BUILDDIR)/*
+	rm -rf $(SOURCEDIR)/api_reference
+
+.PHONY: help Makefile clean
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
This PR:
* add `-q` flag, so only warnings and failures are shown
* add `clean` command that will automatically remove `source/api_reference`
* adjust docs accordingly
* adjust jenkins accordingly