### PR TITLE
Update Eval API

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2140,14 +2140,10 @@ class Trainer:
         return outputs
 
     def eval(
-        self,
-        eval_dataloader: Optional[Union[Iterable, DataSpec, Evaluator, Sequence[Evaluator]]] = None,
-        subset_num_batches: int = -1,
-        **kwargs,  # catch deprecated arguments
-        # dataloader: Optional[Any] = None,
-        # dataloader_label: Optional[Any] = None,
-        # metrics: Optional[Any] = None,
-        # log_level: Optional[Any] = None,
+            self,
+            eval_dataloader: Optional[Union[Iterable, DataSpec, Evaluator, Sequence[Evaluator]]] = None,
+            subset_num_batches: int = -1,
+            **kwargs,  # catch deprecated arguments
     ):
         """Run evaluation loop.
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2143,11 +2143,11 @@ class Trainer:
         self,
         eval_dataloader: Optional[Union[Iterable, DataSpec, Evaluator, Sequence[Evaluator]]] = None,
         subset_num_batches: int = -1,
-        # deprecated arguments below
-        dataloader: Optional[Any] = None,
-        dataloader_label: Optional[Any] = None,
-        metrics: Optional[Any] = None,
-        log_level: Optional[Any] = None,
+        **kwargs,  # catch deprecated arguments
+        # dataloader: Optional[Any] = None,
+        # dataloader_label: Optional[Any] = None,
+        # metrics: Optional[Any] = None,
+        # log_level: Optional[Any] = None,
     ):
         """Run evaluation loop.
 
@@ -2230,16 +2230,15 @@ class Trainer:
                 ``eval_dataloader`` provided to the trainer init().
             subset_num_batches (int, optional): Evaluate on this many batches. Default to ``-1`` (the entire
                 dataloader. Can also be provided in the trainer init()as ``eval_subset_num_batches``.
-            dataloader: Removed, do not use.
-            dataloader_label: Removed, do not use.
-            metrics: Removed, do not use.
-            log_level: Removed, do not use.
 
         """
-        if any([dataloader, dataloader_label, metrics]):
+        if any([k in kwargs for k in ['dataloader', 'dataloader_label', 'metrics', 'log_level']]):
             raise ValueError('eval() API has changed, please migrate to the new API, or'
                              'for backwards compatibility, call _eval_loop() instead'
                              'with the same arguments.')
+        if kwargs:
+            arg = next(iter(kwargs.keys()))
+            raise TypeError(f'eval() got an unexpected keyword argument \'{arg}\'')
 
         if eval_dataloader is not None:
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2159,13 +2159,17 @@ class Trainer:
         return outputs
 
     def eval(
-            self,
-            eval_dataloader: Optional[Union[Iterable, DataSpec, Evaluator, Sequence[Evaluator]]] = None,
-            eval_subset_num_batches: int = -1,
-            log_level: Union[str, LogLevel] = LogLevel.FIT,
-            dataloader: Optional[Any] = None  # deprecated
+        self,
+        eval_dataloader: Optional[Union[Iterable, DataSpec, Evaluator, Sequence[Evaluator]]] = None,
+        eval_subset_num_batches: int = -1,
+        log_level: Union[str, LogLevel] = LogLevel.FIT,
+        # deprecated arguments below
+        dataloader: Optional[Any] = None,
+        dataloader_label: Optional[Any] = None,
+        metrics: Optional[Any] = None,
+        subset_num_batches: Optional[Any] = None,
     ):
-        if dataloader is not None:
+        if not all([dataloader, dataloader_label, metrics, subset_num_batches]):
             raise ValueError('eval() API has changed, please migrate to the new API, or'
                              'for backwards compatibility, call eval_loop() instead'
                              'with the same arguments.')

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2215,7 +2215,7 @@ class Trainer:
             )
 
         The metrics used are defined in your model's ``get_metrics()`` method. For more information,
-        see :doc:`/evaluation`.
+        see :doc:`/trainer/evaluation`.
 
         .. note::
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -810,7 +810,7 @@ class EvalHparams(hp.Hparams):
             'eval_dataloader': eval_dataloader,
             'subset_num_batches': self.subset_num_batches,
             'dataloader': None,
-            'dataloader_label': Optional[Any],
+            'dataloader_label': None,
             'metrics': None,
             'log_level': None,
         }

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -9,13 +9,11 @@ import dataclasses
 import datetime
 import logging
 import os
-import re
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 import torch
 import yahp as hp
-from torchmetrics import Metric
 
 import composer
 from composer.algorithms.algorithm_hparams_registry import algorithm_registry
@@ -751,10 +749,12 @@ class EvalKwargs(TypedDict):
 
     :meta private:
     """
-    dataloader: Union[Iterable, DataSpec, dict]
-    dataloader_label: str
-    metrics: Dict[str, Metric]
+    eval_dataloader: Optional[Union[Iterable, DataSpec, Evaluator, Sequence[Evaluator]]]
     subset_num_batches: int
+    dataloader: Optional[Any]
+    dataloader_label: Optional[Any]
+    metrics: Optional[Any]
+    log_level: Optional[Any]
 
 
 @dataclasses.dataclass
@@ -776,17 +776,12 @@ class EvalHparams(hp.Hparams):
     hparams_registry = {
         'dataset': dataset_registry,
     }
-    dataset: DatasetHparams = hp.required(doc='Validation dataset hparams')
-    batch_size: int = hp.required(doc='batch size to use for each evaluation step')
-    dataloader_label: str = hp.auto(Trainer.eval, 'dataloader_label')
-    subset_num_batches: int = hp.auto(Trainer.eval, 'subset_num_batches')
-    metric_names: Optional[List[str]] = hp.optional(
-        doc=
-        ('Name of the metrics for the evaluator. Can be a torchmetrics name or the '
-         'class name of a metric returned by model.get_metrics(). If None (the default), uses all metrics in the model'
-        ),
-        default=None,
-    )
+
+    # Evaluation
+    dataset: Optional[DatasetHparams] = hp.optional(doc='Validation dataset hparams', default=None)
+    evaluators: Optional[List[EvaluatorHparams]] = hp.optional(doc='Evaluators', default=None)
+    batch_size: Optional[int] = hp.optional(doc='batch size to use for each evaluation step', default=None)
+    subset_num_batches: Optional[int] = hp.optional(doc='eval for this number of batches', default=None)
 
     def initialize_object(self, model: ComposerModel, dataloader_hparams: DataLoaderHparams) -> EvalKwargs:
         """Construct a kwargs dictionary that can be unpacked and passed into :meth:`.Trainer.eval`.
@@ -798,43 +793,26 @@ class EvalHparams(hp.Hparams):
         Returns:
             EvalKwargs: A kwargs dictionary that can be unpacked and passed into :meth:`.Trainer.eval`.
         """
-        # Dataloader
-        dataloader = _initialize_dataloader(
-            dataset_hparams=self.dataset,
-            dataloader_label=self.dataloader_label,
-            batch_size=self.batch_size,
-            subset_num_batches=self.subset_num_batches,
+        if self.subset_num_batches is None:
+            self.subset_num_batches = -1
+
+        # Eval dataloader
+        eval_dataloader = _initialize_eval_dataloader(
+            model=model,
+            eval_dataset_hparams=self.dataset,
+            evaluators=self.evaluators,
+            eval_batch_size=self.batch_size,
+            eval_subset_num_batches=self.subset_num_batches,
             dataloader_hparams=dataloader_hparams,
         )
-        assert dataloader is not None, 'The dataloader is a required argument'
-
-        # Metrics
-
-        # Get and copy all the model's associated evaluation metrics
-        model_metrics = model.get_metrics(is_train=False)
-
-        # Use all the metrics from the model if no metric_names are specified
-        if self.metric_names is None:
-            metrics = model_metrics
-        else:
-            metrics = {}
-            for metric_name in self.metric_names:
-                for k in model_metrics.keys():
-                    matches = re.match(f'.*{metric_name}.*', k, re.IGNORECASE)
-                    if matches:
-                        metrics[k] = model_metrics[k]
-                    else:
-                        raise RuntimeError((f'No metric found with the name {metric_name}. Check if this '
-                                            'metric is compatible/listed in your model metrics. '))
-            if len(metrics) == 0:
-                raise RuntimeError(('No metrics compatible with your model were added to this evaluator. '
-                                    'Check that the metrics you specified are compatible/listed in your model.'))
 
         return {
-            'dataloader': dataloader,
-            'dataloader_label': self.dataloader_label,
-            'metrics': metrics,
+            'eval_dataloader': eval_dataloader,
             'subset_num_batches': self.subset_num_batches,
+            'dataloader': None,
+            'dataloader_label': Optional[Any],
+            'metrics': None,
+            'log_level': None,
         }
 
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -751,10 +751,6 @@ class EvalKwargs(TypedDict):
     """
     eval_dataloader: Optional[Union[Iterable, DataSpec, Evaluator, Sequence[Evaluator]]]
     subset_num_batches: int
-    dataloader: Optional[Any]
-    dataloader_label: Optional[Any]
-    metrics: Optional[Any]
-    log_level: Optional[Any]
 
 
 @dataclasses.dataclass
@@ -809,10 +805,6 @@ class EvalHparams(hp.Hparams):
         return {
             'eval_dataloader': eval_dataloader,
             'subset_num_batches': self.subset_num_batches,
-            'dataloader': None,
-            'dataloader_label': None,
-            'metrics': None,
-            'log_level': None,
         }
 
 

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -53,9 +53,7 @@ def eval_run_and_measure_memory(precision: Precision) -> int:
     trainer = hparams.initialize_object()
     torch.cuda.empty_cache()
     torch.cuda.reset_peak_memory_stats()
-    trainer.eval(dataloader=trainer.state.evaluators[0].dataloader,
-                 dataloader_label='eval',
-                 metrics=trainer.state.eval_metrics[trainer.state.evaluators[0].label])
+    trainer.eval()
     return torch.cuda.max_memory_allocated()
 
 

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -43,13 +43,29 @@ def test_eval_call():
     assert trainer.state.eval_metrics['eval']['Accuracy'].compute() != 0.0
 
 
+def test_eval_deprecation_error():
+    # Construct the trainer
+    trainer = Trainer(model=SimpleModel(),)
+
+    with pytest.raises(ValueError):
+        trainer.eval(
+            dataloader=DataLoader(dataset=RandomClassificationDataset()),
+            dataloader_label='test',
+            metrics=Accuracy(),
+        )
+
+
 def test_trainer_eval_loop():
     # Construct the trainer
     trainer = Trainer(model=SimpleModel())
 
     # Evaluate the model
     eval_dataloader = DataLoader(dataset=RandomClassificationDataset())
-    trainer._eval_loop(dataloader=eval_dataloader, dataloader_label='eval', metrics={'Accuracy': Accuracy()})
+    trainer._eval_loop(
+        dataloader=eval_dataloader,
+        dataloader_label='eval',
+        metrics={'Accuracy': Accuracy()},
+    )
 
     # Assert that there is some accuracy
     assert trainer.state.eval_metrics['eval']['Accuracy'].compute() != 0.0
@@ -120,7 +136,10 @@ def test_eval_at_fit_end(eval_at_fit_end: bool):
         metric_names=['Accuracy'],
     )
 
-    evaluator.eval_interval = evaluate_periodically(eval_interval=eval_interval, eval_at_fit_end=eval_at_fit_end)
+    evaluator.eval_interval = evaluate_periodically(
+        eval_interval=eval_interval,
+        eval_at_fit_end=eval_at_fit_end,
+    )
 
     trainer = Trainer(
         model=SimpleModel(),

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -49,7 +49,7 @@ def test_trainer_eval_loop():
 
     # Evaluate the model
     eval_dataloader = DataLoader(dataset=RandomClassificationDataset())
-    trainer.eval_loop(dataloader=eval_dataloader, dataloader_label='eval', metrics={'Accuracy': Accuracy()})
+    trainer._eval_loop(dataloader=eval_dataloader, dataloader_label='eval', metrics={'Accuracy': Accuracy()})
 
     # Assert that there is some accuracy
     assert trainer.state.eval_metrics['eval']['Accuracy'].compute() != 0.0
@@ -66,8 +66,8 @@ def test_trainer_eval_subset_num_batches():
     # Evaluate the model
     eval_dataloader = DataLoader(dataset=RandomClassificationDataset())
     trainer.eval(
-        dataloader=eval_dataloader,
-        eval_subset_num_batches=1,
+        eval_dataloader=eval_dataloader,
+        subset_num_batches=1,
     )
 
     # Ensure that just one batch was evaluated
@@ -85,7 +85,7 @@ def test_trainer_eval_timestamp():
 
     # Evaluate the model
     eval_dataloader = DataLoader(dataset=RandomClassificationDataset())
-    trainer.eval(dataloader=eval_dataloader)
+    trainer.eval(eval_dataloader=eval_dataloader)
 
     # Ensure that the eval timestamp matches the number of evaluation events
     assert event_counter_callback.event_to_num_calls[Event.EVAL_BATCH_START] == trainer.state.eval_timestamp.batch
@@ -97,7 +97,7 @@ def test_trainer_eval_timestamp():
     event_counter_callback.event_to_num_calls = {k: 0 for k in event_counter_callback.event_to_num_calls}
 
     # Eval again
-    trainer.eval(dataloader=eval_dataloader)
+    trainer.eval(eval_dataloader=eval_dataloader)
     # Validate the same invariants
     assert event_counter_callback.event_to_num_calls[Event.EVAL_BATCH_START] == trainer.state.eval_timestamp.batch
     assert trainer.state.eval_timestamp.batch == trainer.state.eval_timestamp.batch_in_epoch

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -91,6 +91,7 @@ def test_trainer_eval_subset_num_batches():
     assert event_counter_callback.event_to_num_calls[Event.EVAL_BATCH_START] == 1
 
 
+@pytest.mark.filterwarnings(r'ignore:eval_dataloader label:UserWarning')
 def test_trainer_eval_timestamp():
     # Construct the trainer
     event_counter_callback = EventCounterCallback()

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -55,6 +55,14 @@ def test_eval_deprecation_error():
         )
 
 
+def test_eval_type_error():
+    # Construct the trainer
+    trainer = Trainer(model=SimpleModel(),)
+
+    with pytest.raises(TypeError):
+        trainer.eval(unknown_kwarg=None,)
+
+
 def test_trainer_eval_loop():
     # Construct the trainer
     trainer = Trainer(model=SimpleModel())


### PR DESCRIPTION
Based on discussions in #1429 , it's clear that our Eval API should be updated to be consistent with the Trainer API, eg.
```
trainer = Trainer(
    eval_dataloader=...
)
trainer.eval()
```
or
```
trainer = Trainer(
    ...
)

trainer.eval(
    eval_dataloader=...
)
```

Instead, currently the `eval` API is fairly constrained to evaluating a single dataloader/metric, and also requires re-passing in the metrics, even though they have already been defined by the user in the `model`. This PR implements the new Evaluation API.

Todo:
- [x] update docstrings / docs
- [x] update tests
