### PR TITLE
Remove hparams from test_ddp

### DIFF
--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -14,7 +14,6 @@ from composer import Callback, Event
 from composer.core import State
 from composer.datasets.synthetic import SyntheticBatchPairDataset
 from composer.loggers import Logger
-from composer.models.model_hparams import ModelHparams
 from composer.trainer.trainer import Trainer
 from composer.utils import dist
 from tests.common import SimpleModel
@@ -90,8 +89,7 @@ class CheckBatch0(Callback):
     pytest.param(1),
     pytest.param(2, marks=pytest.mark.world_size(2)),
 ])
-def test_ddp(device: str, world_size: int, dummy_model_hparams: ModelHparams, deepspeed: bool,
-             tmp_path: pathlib.Path) -> None:
+def test_ddp(device: str, world_size: int, deepspeed: bool, tmp_path: pathlib.Path) -> None:
     """test strategy for ddp: 1) Train a dummy model on two gps, for two epochs, using the tracked dataset. 2) The
     tracked dataset should record two -- and only two -- accesses for each sample -- one for each epoch If each sample
     is accessed more than this number of times, then the distributed sampler isn't working properly If each sample is

--- a/tests/trainer/test_ddp.py
+++ b/tests/trainer/test_ddp.py
@@ -1,25 +1,19 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-import collections.abc
 import os
 import pathlib
-from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import pytest
 import torch
 import torch.distributed
-import torch.utils.data
-import yahp as hp
+from torch.utils.data import DataLoader
 
 import composer.core.types as types
 from composer import Callback, Event
 from composer.core import State
-from composer.core.data_spec import DataSpec
-from composer.datasets.dataset_hparams import DataLoaderHparams, DatasetHparams
 from composer.datasets.synthetic import SyntheticBatchPairDataset
-from composer.datasets.synthetic_hparams import SyntheticHparamsMixin
 from composer.loggers import Logger
 from composer.models.model_hparams import ModelHparams
 from composer.trainer.trainer import Trainer
@@ -62,38 +56,6 @@ class TrackedDataset(types.Dataset):
 
     def __len__(self):
         return len(self.dataset)
-
-
-@dataclass
-class TrackedDatasetHparams(DatasetHparams, SyntheticHparamsMixin):
-    num_classes: Optional[int] = hp.optional('num_classes', default=None)
-    data_shape: Optional[List[int]] = hp.optional('data_shape', default=None)
-    tmp_path: Optional[str] = hp.optional('tmp_path', default=None)
-    is_train: bool = hp.optional('Whether to load the training data (the default) or validation data.', default=True)
-
-    def initialize_object(self, batch_size: int, dataloader_hparams: DataLoaderHparams):
-        assert self.num_classes is not None
-        assert self.data_shape is not None
-        assert self.tmp_path is not None
-        synthetic_dataset = SyntheticBatchPairDataset(
-            num_unique_samples_to_create=self.synthetic_num_unique_samples,
-            total_dataset_size=10_000,
-            data_shape=self.data_shape,
-            num_classes=self.num_classes,
-        )
-        drop_last = False
-        tracked_dataset = TrackedDataset(
-            tmp_path=pathlib.Path(self.tmp_path),
-            is_train=self.is_train,
-            synthetic_dataset=synthetic_dataset,
-        )
-        sampler = dist.get_sampler(tracked_dataset, drop_last=drop_last, shuffle=True)
-        return dataloader_hparams.initialize_object(
-            dataset=tracked_dataset,
-            batch_size=batch_size,
-            sampler=sampler,
-            drop_last=drop_last,
-        )
 
 
 class CheckBatch0(Callback):
@@ -143,44 +105,67 @@ def test_ddp(device: str, world_size: int, dummy_model_hparams: ModelHparams, de
     and 2) each ddp process is indeed getting different data.
     """
 
-    dummy_model_hparams.num_classes = 100
-    model = dummy_model_hparams.initialize_object()
-    assert isinstance(model, SimpleModel)
+    model = SimpleModel(num_classes=100)
 
-    dataloader_hparams = DataLoaderHparams(
+    train_batch_size = 10
+    train_subset_num_batches = 3
+
+    synthetic_dataset = SyntheticBatchPairDataset(
+        num_unique_samples_to_create=train_batch_size * train_subset_num_batches,
+        total_dataset_size=10_000,
+        data_shape=(model.num_features, 5, 5),
+        num_classes=model.num_classes,
+    )
+    train_dataset = TrackedDataset(
+        synthetic_dataset=synthetic_dataset,
+        is_train=True,
+        tmp_path=tmp_path,
+    )
+
+    train_dataloader = DataLoader(
+        dataset=train_dataset,
         num_workers=0,
         prefetch_factor=2,
         persistent_workers=False,
         pin_memory=False,
         timeout=0.0,
+        batch_size=train_batch_size // dist.get_world_size(),
+        sampler=dist.get_sampler(
+            train_dataset,
+            drop_last=False,
+            shuffle=True,
+        ),
     )
 
-    train_batch_size = 10
-    train_dataloader_batch_size = train_batch_size // dist.get_world_size()
-    train_subset_num_batches = 3
-    train_dataset_hparams = TrackedDatasetHparams(
-        synthetic_num_unique_samples=train_batch_size * train_subset_num_batches,
-        is_train=True,
-        data_shape=[model.num_features, 5, 5],
-        num_classes=model.num_classes,
-        tmp_path=str(tmp_path),
-    )
-    train_dataloader = train_dataset_hparams.initialize_object(train_dataloader_batch_size, dataloader_hparams)
     eval_batch_size = 10
     eval_subset_num_batches = 3
-    val_dataset_hparams = TrackedDatasetHparams(
-        synthetic_num_unique_samples=eval_batch_size * eval_subset_num_batches,
-        is_train=False,
-        data_shape=[model.num_features, 5, 5],
+
+    eval_dataset = SyntheticBatchPairDataset(
+        num_unique_samples_to_create=eval_batch_size * eval_subset_num_batches,
+        total_dataset_size=10_000,
+        data_shape=(model.num_features, 5, 5),
         num_classes=model.num_classes,
-        tmp_path=str(tmp_path),
     )
-    eval_dataloader_batch_size = eval_batch_size // dist.get_world_size()
-    val_dataloader = val_dataset_hparams.initialize_object(eval_dataloader_batch_size, dataloader_hparams)
+    eval_dataset = TrackedDataset(
+        synthetic_dataset=eval_dataset,
+        is_train=False,
+        tmp_path=tmp_path,
+    )
+
+    eval_dataloader = DataLoader(
+        dataset=eval_dataset,
+        batch_size=eval_batch_size // dist.get_world_size(),
+        sampler=dist.get_sampler(
+            eval_dataset,
+            drop_last=False,
+            shuffle=True,
+        ),
+    )
+
     max_epochs = 2
     trainer = Trainer(model=model,
                       train_dataloader=train_dataloader,
-                      eval_dataloader=val_dataloader,
+                      eval_dataloader=eval_dataloader,
                       device=device,
                       max_duration=f'{max_epochs}ep',
                       eval_interval='1ep',
@@ -189,20 +174,17 @@ def test_ddp(device: str, world_size: int, dummy_model_hparams: ModelHparams, de
                       deepspeed_config={} if deepspeed else None,
                       callbacks=[CheckBatch0(tmp_path)])
 
-    for evaluator in trainer.state.evaluators:
-        assert isinstance(evaluator.dataloader, DataSpec)
-        assert isinstance(evaluator.dataloader.dataloader, collections.abc.Sized)
     trainer.fit()
 
     expected_train_num_loads = max_epochs * train_batch_size * train_subset_num_batches
     #expected_val_num_loads = max_epochs * hparams.eval_batch_size * hparams.eval_subset_num_batches
     expected_val_num_loads = 0
-    for evaluator in trainer.state.evaluators:
+    for _ in trainer.state.evaluators:
         expected_val_num_loads += max_epochs * eval_batch_size * eval_subset_num_batches
 
     # adding hparams.eval_batch_size to account for the extra spin of the evaluator dataloaders
     # that is called to create a deterministic ordering for the sampler
-    for evaluator in trainer.state.evaluators:
+    for _ in trainer.state.evaluators:
         expected_val_num_loads += eval_batch_size
 
     actual_train_num_loads = 0

--- a/tests/utils/test_inference.py
+++ b/tests/utils/test_inference.py
@@ -55,7 +55,7 @@ def test_export_for_inference_torchscript(model_cls, sample_input):
         loaded_model.eval()
         loaded_model_out = loaded_model(sample_input)
 
-        torch.testing.assert_allclose(
+        torch.testing.assert_close(
             orig_out,
             loaded_model_out,
             msg=f'output mismatch with {save_format}',

--- a/tests/utils/test_inference.py
+++ b/tests/utils/test_inference.py
@@ -46,14 +46,20 @@ def test_export_for_inference_torchscript(model_cls, sample_input):
     save_format = 'torchscript'
     with tempfile.TemporaryDirectory() as tempdir:
         save_path = os.path.join(tempdir, f'model.pt')
-        inference.export_for_inference(model=model, save_format=save_format, save_path=save_path)
+        inference.export_for_inference(
+            model=model,
+            save_format=save_format,
+            save_path=save_path,
+        )
         loaded_model = torch.jit.load(save_path)
         loaded_model.eval()
         loaded_model_out = loaded_model(sample_input)
 
-        assert torch.allclose(
+        torch.testing.assert_allclose(
             orig_out,
-            loaded_model_out), f'mismatch in the original and exported for inference model outputs with {save_format}'
+            loaded_model_out,
+            msg=f'output mismatch with {save_format}',
+        )
 
 
 @pytest.mark.parametrize(
@@ -77,10 +83,12 @@ def test_export_for_inference_onnx(model_cls, sample_input):
     save_format = 'onnx'
     with tempfile.TemporaryDirectory() as tempdir:
         save_path = os.path.join(tempdir, f'model.{save_format}')
-        inference.export_for_inference(model=model,
-                                       save_format=save_format,
-                                       save_path=save_path,
-                                       sample_input=(sample_input,))
+        inference.export_for_inference(
+            model=model,
+            save_format=save_format,
+            save_path=save_path,
+            sample_input=(sample_input,),
+        )
         loaded_model = onnx.load(save_path)
         onnx.checker.check_model(loaded_model)
 
@@ -95,7 +103,8 @@ def test_export_for_inference_onnx(model_cls, sample_input):
             loaded_model_out[0],
             rtol=1e-4,  # lower tolerance for ONNX
             atol=1e-3,  # lower tolerance for ONNX
-            msg=f'mismatch in the original and exported for inference model outputs with {save_format}')
+            msg=f'output mismatch with {save_format}',
+        )
 
 
 @pytest.mark.parametrize(
@@ -139,10 +148,12 @@ def test_export_for_inference_onnx_ddp(model_cls, sample_input):
         with tempfile.TemporaryDirectory() as tempdir:
             save_path = os.path.join(str(tempdir), f'model.{save_format}')
             assert isinstance(state.model.module, nn.Module)
-            inference.export_for_inference(model=state.model.module,
-                                           save_format=save_format,
-                                           save_path=save_path,
-                                           sample_input=(sample_input,))
+            inference.export_for_inference(
+                model=state.model.module,
+                save_format=save_format,
+                save_path=save_path,
+                sample_input=(sample_input,),
+            )
 
             loaded_model = onnx.load(save_path)
             onnx.checker.check_model(loaded_model)
@@ -195,7 +206,11 @@ def test_export_for_inference_torchscript_ddp(model_cls, sample_input):
         with tempfile.TemporaryDirectory() as tempdir:
             save_path = os.path.join(str(tempdir), f'model.pt')
             assert isinstance(state.model.module, nn.Module)
-            inference.export_for_inference(model=state.model.module, save_format=save_format, save_path=save_path)
+            inference.export_for_inference(
+                model=state.model.module,
+                save_format=save_format,
+                save_path=save_path,
+            )
 
             loaded_model = torch.jit.load(save_path)
             loaded_model.eval()
@@ -219,25 +234,31 @@ def test_export_with_file_artifact_logger(model_cls, sample_input):
             save_path = os.path.join(tempdir, f'model.pt')
 
             # Construct the trainer and train
-            trainer = Trainer(model=model,
-                              train_dataloader=DataLoader(RandomImageDataset(shape=(3, 224, 224))),
-                              max_duration='1ba')
+            trainer = Trainer(
+                model=model,
+                train_dataloader=DataLoader(RandomImageDataset(shape=(3, 224, 224))),
+                max_duration='1ba',
+            )
             trainer.fit()
 
             mock_logger = Logger(state=trainer.state, destinations=[mock_obj_logger])
 
-            export_with_logger(model=model,
-                               save_format=save_format,
-                               save_path=save_path,
-                               sample_input=(sample_input,),
-                               logger=mock_logger)
+            export_with_logger(
+                model=model,
+                save_format=save_format,
+                save_path=save_path,
+                sample_input=(sample_input,),
+                logger=mock_logger,
+            )
 
             # Assert export_for_inference utility called with expected inputs
-            inference.export_for_inference.assert_called_once_with(model=model,
-                                                                   save_format=save_format,
-                                                                   save_path=ANY,
-                                                                   sample_input=ANY,
-                                                                   transforms=None)
+            inference.export_for_inference.assert_called_once_with(
+                model=model,
+                save_format=save_format,
+                save_path=ANY,
+                sample_input=ANY,
+                transforms=None,
+            )
 
 
 @pytest.mark.parametrize(
@@ -255,26 +276,35 @@ def test_export_with_other_logger(model_cls, sample_input):
             save_path = os.path.join(tempdir, f'model.pt')
 
             # Construct the trainer and train
-            trainer = Trainer(model=model,
-                              train_dataloader=DataLoader(RandomImageDataset(shape=(3, 224, 224))),
-                              max_duration='1ba')
+            trainer = Trainer(
+                model=model,
+                train_dataloader=DataLoader(RandomImageDataset(shape=(3, 224, 224))),
+                max_duration='1ba',
+            )
             trainer.fit()
 
-            mock_logger = Logger(state=trainer.state, destinations=[non_file_artifact_logger])
+            mock_logger = Logger(
+                state=trainer.state,
+                destinations=[non_file_artifact_logger],
+            )
 
-            export_with_logger(model=model,
-                               save_format=save_format,
-                               save_path=save_path,
-                               sample_input=(sample_input,),
-                               logger=mock_logger)
+            export_with_logger(
+                model=model,
+                save_format=save_format,
+                save_path=save_path,
+                sample_input=(sample_input,),
+                logger=mock_logger,
+            )
 
             # Assert export_for_inference utility called with expected inputs
-            inference.export_for_inference.assert_called_once_with(model=model,
-                                                                   save_format=save_format,
-                                                                   save_path=save_path,
-                                                                   save_object_store=None,
-                                                                   sample_input=ANY,
-                                                                   transforms=None)
+            inference.export_for_inference.assert_called_once_with(
+                model=model,
+                save_format=save_format,
+                save_path=save_path,
+                save_object_store=None,
+                sample_input=ANY,
+                transforms=None,
+            )
 
 
 class LinModel(nn.Module):
@@ -302,12 +332,18 @@ def test_dynamic_quantize(model_cls):
     save_format = 'torchscript'
     with tempfile.TemporaryDirectory() as tempdir:
         save_path_no_quantize = os.path.join(tempdir, f'model_no_quantize.pt')
-        inference.export_for_inference(model=model, save_format=save_format, save_path=save_path_no_quantize)
+        inference.export_for_inference(
+            model=model,
+            save_format=save_format,
+            save_path=save_path_no_quantize,
+        )
         save_path_quantize = os.path.join(tempdir, f'model_quantize.pt')
-        inference.export_for_inference(model=model,
-                                       save_format=save_format,
-                                       save_path=save_path_quantize,
-                                       transforms=[inference.quantize_dynamic])
+        inference.export_for_inference(
+            model=model,
+            save_format=save_format,
+            save_path=save_path_quantize,
+            transforms=[inference.quantize_dynamic],
+        )
         no_quantize_size = os.path.getsize(save_path_no_quantize)
         quantize_size = os.path.getsize(save_path_quantize)
         # Size different should be almost 4x

--- a/tests/utils/test_iter_helpers.py
+++ b/tests/utils/test_iter_helpers.py
@@ -38,4 +38,7 @@ def test_iter_to_stream():
     x = [b'1234', b'56789', b'abcd']
     iter1 = iter(x)
     iter2 = iter(x)
-    assert b''.join(iter1) == io.BufferedReader(IteratorFileStream(iter2), buffer_size=io.DEFAULT_BUFFER_SIZE).read()
+    assert b''.join(iter1) == io.BufferedReader(
+        IteratorFileStream(iter2),
+        buffer_size=io.DEFAULT_BUFFER_SIZE,
+    ).read()


### PR DESCRIPTION
This PR removes the usage of `yahp` in the DDP unit testing.

Coming along for the ride: some readability and stylistic fixes