### PR TITLE
Squelch Engine debug logs

### DIFF
--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -37,6 +37,7 @@ These orderings are enforced by algorithm passes. The default passes registered 
     * The design of :class:`.Engine` is subject to change in future releases
       to accommodate more complexity as we investigate composition of algorithms.
 
+To generate verbose debug logs for the engine, set the environment variable ``ENGINE_DEBUG=1``.
 
 Trace
 ~~~~~
@@ -65,6 +66,7 @@ from __future__ import annotations
 import atexit
 import contextlib
 import logging
+import os
 import weakref
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -424,7 +426,8 @@ class Engine():
 
         timestamp += f'[event={event.name}]'
 
-        log.debug(f'{timestamp}: {msg}')
+        if os.environ.get('ENGINE_DEBUG', None):
+            log.debug(f'{timestamp}: {msg}')
 
     def close(self) -> None:
         """Shutdown the engine.

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -226,11 +226,18 @@ def test_engine_closes_on_atexit(exception: bool):
         check_output(proc)
 
 
-def test_logging(caplog: pytest.LogCaptureFixture, dummy_state: State, dummy_logger: Logger):
+def test_logging(
+    caplog: pytest.LogCaptureFixture,
+    dummy_state: State,
+    dummy_logger: Logger,
+    monkeypatch: pytest.MonkeyPatch,
+):
     """Test that engine logs statements as expected"""
     caplog.set_level(logging.DEBUG, logger=Engine.__module__)
     # Include a callback, since most logging happens around callback events
     dummy_state.callbacks = [EventCounterCallback()]
+
+    monkeypatch.setenv('ENGINE_DEBUG', '1')
     engine = Engine(dummy_state, dummy_logger)
     engine.run_event('INIT')
     engine.close()


### PR DESCRIPTION
The engine currently emits extremely verbose debug logs. `pytest` errors invoke debug logging levels, which ends up polluting the pytest output even when engine errors were not the issue.

Instead, this PR hides the debug log behind an `ENGINE_DEBUG` environment variable, which can be set if specialized debugging of the engine is required. This is consistent with our frameworks that use envvars to control specific debugging modes.