### PR TITLE
Improved comments and improved test code

### DIFF
--- a/composer/datasets/streaming/download.py
+++ b/composer/datasets/streaming/download.py
@@ -37,7 +37,7 @@ def get_object_store(remote: str) -> ObjectStore:
     elif remote.startswith('sftp://'):
         return _get_sftp_object_store(remote)
     else:
-        raise ValueError('unsupported upload scheme')
+        raise ValueError('unsupported download scheme')
 
 
 def _get_s3_object_store(remote: str) -> S3ObjectStore:
@@ -60,9 +60,6 @@ def _get_sftp_object_store(remote: str) -> SFTPObjectStore:
         key_filename=key_filename,
     )
     return object_store
-
-
-__all__ = ['download_or_wait']
 
 
 def download_from_local(remote: str, local: str) -> None:

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -19,8 +19,8 @@ from composer.utils import dist
 
 @pytest.fixture
 def remote_local(tmp_path: pathlib.Path) -> Tuple[str, str]:
-    remote = tmp_path / 'remote'
-    local = tmp_path / 'local'
+    remote = tmp_path.joinpath('remote')
+    local = tmp_path.joinpath('local')
     remote.mkdir()
     local.mkdir()
     return str(remote), str(local)
@@ -28,9 +28,9 @@ def remote_local(tmp_path: pathlib.Path) -> Tuple[str, str]:
 
 @pytest.fixture
 def compressed_remote_local(tmp_path: pathlib.Path) -> Tuple[str, str, str]:
-    compressed = tmp_path / 'compressed'
-    remote = tmp_path / 'remote'
-    local = tmp_path / 'local'
+    compressed = tmp_path.joinpath('compressed')
+    remote = tmp_path.joinpath('remote')
+    local = tmp_path.joinpath('local')
     list(x.mkdir() for x in [compressed, remote, local])
     return tuple(str(x) for x in [compressed, remote, local])
 


### PR DESCRIPTION
## Description
- Improved the code comments and removed redundant `__all__` from `composer/datasets/streaming/download.py`.
- Update the test code with `joinpath()` API rather than using `/` for robustness

## Linting
`pre-commit run`
```
PASSED
``` 

## Testing
`pytest tests/algorithms/test_torch_export.py`
```
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/karan/Projects/doc_composer, configfile: pyproject.toml
plugins: pytest_codeblocks-0.16.1, httpserver-1.0.5
collected 137 items / 104 deselected / 33 selected

tests/datasets/test_streaming.py .............................x...                                                                                                  [100%]

============================================================== 32 passed, 104 deselected, 1 xfailed in 9.68s ==============================================================


```