### PR TITLE
Raise ValueError for Profiler + Auto Grad Accum

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -141,8 +141,12 @@ def _set_evaluator_interval_and_subset_num_batches(
             evaluator.eval_interval = eval_interval
 
 
-def _is_adaptive_grad_accum(grad_accum: Union[int, str], device: Device):
+def _is_adaptive_grad_accum(grad_accum: Union[int, str], device: Device, profiler: Optional[Profiler]):
     if grad_accum == 'auto':
+        if profiler:
+            raise ValueError("`grad_accum='auto' is not compatible with the profiler. It is recommended to run "
+                             "a mini-run with `grad_accum='auto'` to identify the optimal grad_accum value and "
+                             'then manually specify that in a second run with profiler.')
         warnings.warn(("Setting `grad_accum='auto'` is an experimental feature which may cause "
                        'uncaught Cuda Out of Memory errors. In this case, please manually '
                        'set grad_accum explicitly to an integer instead. '))
@@ -871,7 +875,9 @@ class Trainer:
             optimizers = map_collection(optimizers, self._device.optimizer_to_device)
 
         # Grad Accum
-        self.adaptive_gradient_accumulation = _is_adaptive_grad_accum(grad_accum, device=self._device)
+        self.adaptive_gradient_accumulation = _is_adaptive_grad_accum(grad_accum,
+                                                                      device=self._device,
+                                                                      profiler=profiler)
         grad_accum = _get_initial_grad_accum(grad_accum)
         eval_batch_split = 1
         if self.adaptive_gradient_accumulation and isinstance(self._device, DeviceTPU):
@@ -1432,7 +1438,9 @@ class Trainer:
 
         # Grad Accum
         if grad_accum is not None:
-            self.adaptive_gradient_accumulation = _is_adaptive_grad_accum(grad_accum, device=self._device)
+            self.adaptive_gradient_accumulation = _is_adaptive_grad_accum(grad_accum,
+                                                                          device=self._device,
+                                                                          profiler=self.state.profiler)
             self.state.grad_accum = _get_initial_grad_accum(grad_accum)
 
         # Precision

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -142,7 +142,6 @@ def _set_evaluator_interval_and_subset_num_batches(
 
 
 def _is_adaptive_grad_accum(grad_accum: Union[int, str], device: Device):
-    """Checks if `grad_accum='auto'` and if its compatible with current run configurations."""
     if grad_accum == 'auto':
         warnings.warn(("Setting `grad_accum='auto'` is an experimental feature which may cause "
                        'uncaught Cuda Out of Memory errors. In this case, please manually '

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -142,9 +142,10 @@ def _set_evaluator_interval_and_subset_num_batches(
 
 
 def _is_adaptive_grad_accum(grad_accum: Union[int, str], device: Device, profiler: Optional[Profiler]):
+    """Checks if `grad_accum='auto'` and if its compatible with current run configurations."""
     if grad_accum == 'auto':
         if profiler:
-            raise ValueError("`grad_accum='auto' is not compatible with the profiler. It is recommended to run "
+            raise ValueError("`grad_accum='auto'` is not compatible with the profiler. It is recommended to run "
                              "a mini-run with `grad_accum='auto'` to identify the optimal grad_accum value and "
                              'then manually specify that in a second run with profiler.')
         warnings.warn(("Setting `grad_accum='auto'` is an experimental feature which may cause "


### PR DESCRIPTION
As title. It's very complicated to support profiler and auto grad accum since profiler requires all "close" events, eg `AFTER_X`, run. This is hard to do and not worth it right now.