### PR TITLE
add yahp deprecation warnings

### DIFF
--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -16,6 +16,7 @@ import torch
 import yahp as hp
 
 import composer
+from composer import utils
 from composer.algorithms.algorithm_hparams_registry import algorithm_registry
 from composer.callbacks.callback_hparams_registry import callback_registry
 from composer.core import Algorithm, Callback, DataSpec, Evaluator, Event, Precision, State, Time
@@ -385,7 +386,11 @@ class TrainerHparams(hp.Hparams):
     # Profiling
     profiler: Optional[Profiler] = hp.auto(Trainer, 'profiler')
 
+    def __post_init__(self):
+        utils.warn_yahp_deprecation()
+
     def validate(self):
+
         super().validate()
 
         if self.deepspeed_config is not None:

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Helper utilities."""
+import warnings
+
 from composer.utils.batch_helpers import batch_get, batch_set
 from composer.utils.checkpoint import load_checkpoint, save_checkpoint
 from composer.utils.collect_env import configure_excepthook, disable_env_report, enable_env_report, print_env
@@ -16,6 +18,14 @@ from composer.utils.object_store import (LibcloudObjectStore, ObjectStore, Objec
                                          SFTPObjectStore)
 from composer.utils.retrying import retry
 from composer.utils.string_enum import StringEnum
+
+
+def warn_yahp_deprecation():
+    warnings.warn(
+        'yahp-based workflows are deprecated and will be removed in a future release. Please'
+        'migrate to using other configuration managers and create the Trainer objects directly.'
+        'v0.10 will be the last release to support yahp.', DeprecationWarning)
+
 
 __all__ = [
     'ensure_tuple',

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -19,7 +19,7 @@ import warnings
 
 from composer.loggers import LogLevel
 from composer.trainer.trainer_hparams import TrainerHparams
-from composer.utils import dist
+from composer.utils import dist, warn_yahp_deprecation
 from composer.utils.misc import warning_on_one_line
 
 
@@ -34,6 +34,8 @@ def _main():
         # Including the PID and thread name to help with debugging dataloader workers and callbacks that spawn background
         # threads / processes
         format=f'%(asctime)s: rank{global_rank}[%(process)d][%(threadName)s]: %(levelname)s: %(name)s: %(message)s')
+
+    warn_yahp_deprecation()
 
     if len(sys.argv) == 1:
         sys.argv.append('--help')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ filterwarnings = [
     'ignore:Metric `SpearmanCorrcoef` will save all targets and predictions in the buffer:UserWarning:torchmetrics',
     # Ignore a UserWarning from torch 1.12 due to DeepSpeed's use of positional args
     'ignore:Positional args are being deprecated, use kwargs instead.*:UserWarning',
+    'ignore:yahp-based workflows are deprecated and will be removed:DeprecationWarning',
 ]
 
 # Coverage


### PR DESCRIPTION
This PR adds deprecation warnings whenever a user invokes:
* `run_composer_trainer.py` entrypoint
* `TrainerHparams` creation

There are many places in our codebase where we have hparams objects, but this should be sufficient to cover most use cases.