### PR TITLE
Use eval context

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1570,15 +1570,12 @@ class Trainer:
             reproducibility.load_rng_state(self._rng_state)
             self._rng_state = None
 
-        # Flag if the epoch finished early, so it can be tracked whether to run the epoch end events
+        self.state.model.train()
         finished_epoch_early = False
-
         last_wct = datetime.datetime.now()
 
         while self.state.timestamp < self.state.max_duration:
             try:
-                self.state.model.train()
-
                 if int(self.state.timestamp.batch_in_epoch) == 0:
                     self.engine.run_event(Event.EPOCH_START)
                     self.logger.log_metrics({'epoch': int(self.state.timestamp.epoch)})
@@ -1603,8 +1600,6 @@ class Trainer:
 
                     if self.deepspeed_enabled:
                         self.state.batch = _fix_batch_precision_for_deepspeed(self.state.batch, self.state.precision)
-
-                    self.state.model.train()
 
                     self.engine.run_event(Event.AFTER_DATALOADER)
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -45,7 +45,7 @@ from composer.trainer._scaler import ClosureGradScaler
 from composer.trainer.ddp import DDPSyncStrategy, ddp_sync_context, prepare_ddp_module
 from composer.trainer.devices import Device, DeviceCPU, DeviceGPU, DeviceMPS, DeviceTPU
 from composer.utils import (ObjectStore, checkpoint, dist, ensure_tuple, format_name_with_dist, is_model_deepspeed,
-                            map_collection, reproducibility)
+                            map_collection, model_eval_mode, reproducibility)
 from composer.utils.file_helpers import get_file
 from composer.utils.import_helpers import MissingConditionalImportError
 from composer.utils.inference import ExportFormat, Transform, export_with_logger
@@ -1713,8 +1713,7 @@ class Trainer:
         assert self._train_data_spec is not None, 'The train data spec should be set on __init__ or fit()'
         assert self.state.train_metrics is not None, 'The train metrics should be set on __init__ or fit()'
 
-        self.state.model.eval()
-        with torch.no_grad():
+        with torch.no_grad(), model_eval_mode(self.state.model):
             # Retry until we successfully complete evaluation
             while True:
                 found_cuda_oom = 0  # int since bool BOR not supported on all torch.distributed backends
@@ -2063,10 +2062,6 @@ class Trainer:
         else:
             data_spec = DataSpec(dataloader)
 
-        # Put the model into evaluation mode, but be able to restore it to training mode afterwards
-        restore_model_train = self.state.model.training
-        self.state.model.eval()
-
         # Bind the dataloader to the state, but be able to restore the previous dataloader afterwards
         original_dataloader = self.state.dataloader
         original_dataloader_label = self.state.dataloader_label
@@ -2082,7 +2077,7 @@ class Trainer:
         outputs = []
         cpu_device = DeviceCPU()
 
-        with torch.no_grad():
+        with torch.no_grad(), model_eval_mode(self.state.model):
 
             self.engine.run_event(Event.PREDICT_START)
 
@@ -2130,10 +2125,6 @@ class Trainer:
                 self.engine.run_event(Event.PREDICT_BATCH_END)
 
             self.engine.run_event(Event.PREDICT_END)
-
-        # Restore training mode
-        if restore_model_train:
-            self.state.model.train()
 
         # Restore the dataloader
         self.state.set_dataloader(original_dataloader, original_dataloader_label)
@@ -2302,8 +2293,6 @@ class Trainer:
                 ``len(eval_dataloader)``, or ``eval_dataloader`` is an :class:`.Evaluator` (which is via
                 ``Evaluator(subset_num_batches=...)``.)
         """
-        restore_model_train = self.state.model.training
-
         if subset_num_batches is None:
             subset_num_batches = -1
 
@@ -2325,8 +2314,7 @@ class Trainer:
 
         last_wct = datetime.datetime.now()
 
-        self.state.model.eval()
-        with torch.no_grad():
+        with torch.no_grad(), model_eval_mode(self.state.model):
             self.state.set_dataloader(data_spec.dataloader, dataloader_label, subset_num_batches)
             assert self.state.dataloader is not None, 'dataloader is set'
 
@@ -2446,9 +2434,6 @@ class Trainer:
             self._compute_and_log_metrics(dataloader_label=dataloader_label, metrics=metrics)
 
             self.engine.run_event(Event.EVAL_END)
-
-        if restore_model_train:
-            self.state.model.train()
 
         self.state.set_dataloader(original_dataloader, original_dataloader_label)
         if original_num_batches is not None:

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -13,7 +13,7 @@ from composer.utils.file_helpers import (create_symlink_file, ensure_folder_has_
 from composer.utils.import_helpers import MissingConditionalImportError, import_object
 from composer.utils.inference import export_for_inference, export_with_logger, quantize_dynamic
 from composer.utils.iter_helpers import IteratorFileStream, ensure_tuple, map_collection
-from composer.utils.misc import is_model_deepspeed, is_notebook
+from composer.utils.misc import is_model_deepspeed, is_notebook, model_eval_mode
 from composer.utils.object_store import (LibcloudObjectStore, ObjectStore, ObjectStoreTransientError, S3ObjectStore,
                                          SFTPObjectStore)
 from composer.utils.retrying import retry
@@ -60,4 +60,5 @@ __all__ = [
     'enable_env_report',
     'print_env',
     'retry',
+    'model_eval_mode',
 ]

--- a/composer/utils/inference.py
+++ b/composer/utils/inference.py
@@ -21,7 +21,7 @@ import torch.nn as nn
 from composer.utils import dist
 from composer.utils.checkpoint import download_checkpoint
 from composer.utils.iter_helpers import ensure_tuple
-from composer.utils.misc import is_model_ddp, is_model_deepspeed
+from composer.utils.misc import is_model_ddp, is_model_deepspeed, model_eval_mode
 from composer.utils.object_store import ObjectStore
 from composer.utils.string_enum import StringEnum
 
@@ -143,54 +143,54 @@ def export_for_inference(
             if len(unexpected_keys) > 0:
                 log.warning(f"Found these unexpected keys in the checkpoint: {', '.join(unexpected_keys)}")
 
-    model.eval()
-    # Apply transformations (i.e., inference optimizations) in the given order
-    for transform in ensure_tuple(transforms):
-        model = transform(model)
+    with model_eval_mode(model):
+        # Apply transformations (i.e., inference optimizations) in the given order
+        for transform in ensure_tuple(transforms):
+            model = transform(model)
 
-    is_remote_store = save_object_store is not None
-    tempdir_ctx = tempfile.TemporaryDirectory() if is_remote_store else contextlib.nullcontext(None)
-    with tempdir_ctx as tempdir:
-        if is_remote_store:
-            local_save_path = os.path.join(str(tempdir), 'model.export')
-        else:
-            local_save_path = save_path
-
-        if save_format == ExportFormat.TORCHSCRIPT:
-            export_model = None
-            try:
-                export_model = torch.jit.script(model)
-            except Exception:
-                if sample_input is not None:
-                    log.warning('Scripting with torch.jit.script failed. Trying torch.jit.trace!',)
-                    export_model = torch.jit.trace(model, sample_input)
-                else:
-                    log.warning(
-                        'Scripting with torch.jit.script failed and sample inputs are not provided for tracing '
-                        'with torch.jit.trace',
-                        exc_info=True)
-
-            if export_model is not None:
-                torch.jit.save(export_model, local_save_path)
+        is_remote_store = save_object_store is not None
+        tempdir_ctx = tempfile.TemporaryDirectory() if is_remote_store else contextlib.nullcontext(None)
+        with tempdir_ctx as tempdir:
+            if is_remote_store:
+                local_save_path = os.path.join(str(tempdir), 'model.export')
             else:
-                raise RuntimeError('Scritping and tracing failed! No model is getting exported.')
+                local_save_path = save_path
 
-        if save_format == ExportFormat.ONNX:
-            if sample_input is None:
-                raise ValueError(f'sample_input argument is required for onnx export')
-            sample_input = ensure_tuple(sample_input)
+            if save_format == ExportFormat.TORCHSCRIPT:
+                export_model = None
+                try:
+                    export_model = torch.jit.script(model)
+                except Exception:
+                    if sample_input is not None:
+                        log.warning('Scripting with torch.jit.script failed. Trying torch.jit.trace!',)
+                        export_model = torch.jit.trace(model, sample_input)
+                    else:
+                        log.warning(
+                            'Scripting with torch.jit.script failed and sample inputs are not provided for tracing '
+                            'with torch.jit.trace',
+                            exc_info=True)
 
-            torch.onnx.export(
-                model,
-                sample_input,
-                local_save_path,
-                input_names=['input'],
-                output_names=['output'],
-            )
+                if export_model is not None:
+                    torch.jit.save(export_model, local_save_path)
+                else:
+                    raise RuntimeError('Scritping and tracing failed! No model is getting exported.')
 
-        # upload if required.
-        if is_remote_store:
-            save_object_store.upload_object(save_path, local_save_path)
+            if save_format == ExportFormat.ONNX:
+                if sample_input is None:
+                    raise ValueError(f'sample_input argument is required for onnx export')
+                sample_input = ensure_tuple(sample_input)
+
+                torch.onnx.export(
+                    model,
+                    sample_input,
+                    local_save_path,
+                    input_names=['input'],
+                    output_names=['output'],
+                )
+
+            # upload if required.
+            if is_remote_store:
+                save_object_store.upload_object(save_path, local_save_path)
 
 
 def export_with_logger(

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -4,12 +4,13 @@
 """Miscellaneous Helpers."""
 
 import socket
+from contextlib import contextmanager
 from typing import Type
 
 import torch
 from torch.nn.parallel import DistributedDataParallel
 
-__all__ = ['is_model_deepspeed', 'is_notebook', 'warning_on_one_line', 'get_free_tcp_port']
+__all__ = ['is_model_deepspeed', 'is_notebook', 'warning_on_one_line', 'get_free_tcp_port', 'model_eval_mode']
 
 
 def is_model_deepspeed(model: torch.nn.Module) -> bool:
@@ -50,3 +51,14 @@ def get_free_tcp_port() -> int:
     _, port = tcp.getsockname()
     tcp.close()
     return port
+
+
+@contextmanager
+def model_eval_mode(model: torch.nn.Module):
+    """Set model.eval() for context duration, restoring model status at end."""
+    is_training = model.training
+    try:
+        model.eval()
+        yield
+    finally:
+        model.train(mode=is_training)


### PR DESCRIPTION
Fixes dev regressions. These were caused by the model being in eval mode for all but the first microbatch.

Now, we set train mode only once (at start of training) and all eval happens within a context which automatically cleans up eval mode.

Regression runs verifying fix: https://wandb.ai/mosaic-ml/mihir-metrics-debug?workspace=user-mihirmosaic (pre-metrics vs. fix-medium)