### PR TITLE
Rework auto grad accum checks

### DIFF
--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -310,13 +310,13 @@ class SeqLengthWarmup(Algorithm):
 
             # This error/state.grad_accum handling mimics the logic in trainer._train_batch().
             except RuntimeError as e:
-                if state.adaptive_gradient_accumulation and _is_cuda_oom(e):
+                if state.auto_grad_accum and _is_cuda_oom(e):
                     log.debug((f"Rank {dist.get_global_rank()} OOM'd."))
                     found_cuda_oom = 1
                 else:
                     raise
 
-            if state.adaptive_gradient_accumulation:
+            if state.auto_grad_accum:
                 devicegpu = DeviceGPU()
                 # Propagate across all ranks if any rank hit CUDA OOM
                 found_cuda_oom = devicegpu.tensor_to_device(torch.tensor([found_cuda_oom], dtype=torch.uint8))

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -3,6 +3,7 @@
 
 """Core code for sequence length warmup."""
 
+import logging
 import textwrap
 from math import ceil
 from typing import Dict, Mapping, Optional
@@ -18,6 +19,8 @@ from composer.loggers import Logger
 from composer.models import HuggingFaceModel
 from composer.trainer.devices import DeviceGPU
 from composer.utils import dist, ensure_tuple
+
+log = logging.getLogger(__name__)
 
 __all__ = ['SeqLengthWarmup', 'set_batch_sequence_length']
 
@@ -271,14 +274,15 @@ class SeqLengthWarmup(Algorithm):
         # truncate all sequence-shaped tensors to the max sequence length
         batch_clone = {k: torch.clone(v) for k, v in state.batch.items()}
         device_batch_size = 0
-        device = None
         for k, v in batch_clone.items():
             if v.ndim < 2:
                 raise ValueError(f'Sequence Length Warmup requires that all tensors are sequence-shaped. '
                                  f'Tensor "{k}" has shape {v.shape}.')
             batch_clone[k] = v[:, :self.max_seq_length].contiguous()
             device_batch_size = v.shape[0]
-            device = v.device
+
+        # In-line to avoid circular dependency
+        from composer.trainer.trainer import _adjust_grad_accum, _is_cuda_oom
 
         # This loop tries to do a forward/backward pass using the current microbatch size.
         # If it hits an OOM error, it doubles `state.grad_accum` and tries again until
@@ -306,16 +310,13 @@ class SeqLengthWarmup(Algorithm):
 
             # This error/state.grad_accum handling mimics the logic in trainer._train_batch().
             except RuntimeError as e:
-                if 'CUDA out of memory' in str(e):
+                if state.adaptive_gradient_accumulation and _is_cuda_oom(e):
+                    log.debug((f"Rank {dist.get_global_rank()} OOM'd."))
                     found_cuda_oom = 1
                 else:
                     raise
 
-            # In-line to avoid circular dependency
-            from composer.trainer.trainer import _adjust_grad_accum
-
-            # Auto grad accum only supported on GPU
-            if device and device.type == 'gpu':
+            if state.adaptive_gradient_accumulation:
                 devicegpu = DeviceGPU()
                 # Propagate across all ranks if any rank hit CUDA OOM
                 found_cuda_oom = devicegpu.tensor_to_device(torch.tensor([found_cuda_oom], dtype=torch.uint8))

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -83,7 +83,7 @@ class State(Serializable):
             size for each device becomes ``microbatch_size = train_batch_size / (num_devices * grad_accum)``.
         eval_batch_split (int, optional): The mirror of grad_accum for eval. With this argument, micro batch
             size for each device becomes ``microbatch_size = eval_batch_size / (num_devices * eval_batch_split)``.
-        adaptive_gradient_accumulation (bool, optional): Whether automatic gradient accumulation is enabled.
+        auto_grad_accum (bool, optional): Whether automatic gradient accumulation is enabled.
         train_dataloader (types.DataLoader, optional): Dataloader used for training
         evaluators (Evalutor | Evaluators, optional): :class:`.Evaluator` used for evaluation.
         dataloader (types.DataLoader, optional): The active DataLoader.
@@ -236,7 +236,7 @@ class State(Serializable):
         # data configurations
         grad_accum: int = 1,
         eval_batch_split: int = 1,
-        adaptive_gradient_accumulation: bool = False,
+        auto_grad_accum: bool = False,
 
         # dataloaders
         train_dataloader: Optional[Iterable] = None,
@@ -269,7 +269,7 @@ class State(Serializable):
         self.run_name = run_name
         self.grad_accum = grad_accum
         self.eval_batch_split = eval_batch_split
-        self.adaptive_gradient_accumulation = adaptive_gradient_accumulation
+        self.auto_grad_accum = auto_grad_accum
         self._dataloader_len = None
         self._dataloader = None
         self._dataloader_label = None

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -83,6 +83,7 @@ class State(Serializable):
             size for each device becomes ``microbatch_size = train_batch_size / (num_devices * grad_accum)``.
         eval_batch_split (int, optional): The mirror of grad_accum for eval. With this argument, micro batch
             size for each device becomes ``microbatch_size = eval_batch_size / (num_devices * eval_batch_split)``.
+        adaptive_gradient_accumulation (bool, optional): Whether automatic gradient accumulation is enabled.
         train_dataloader (types.DataLoader, optional): Dataloader used for training
         evaluators (Evalutor | Evaluators, optional): :class:`.Evaluator` used for evaluation.
         dataloader (types.DataLoader, optional): The active DataLoader.
@@ -235,6 +236,7 @@ class State(Serializable):
         # data configurations
         grad_accum: int = 1,
         eval_batch_split: int = 1,
+        adaptive_gradient_accumulation: bool = False,
 
         # dataloaders
         train_dataloader: Optional[Iterable] = None,
@@ -267,6 +269,7 @@ class State(Serializable):
         self.run_name = run_name
         self.grad_accum = grad_accum
         self.eval_batch_split = eval_batch_split
+        self.adaptive_gradient_accumulation = adaptive_gradient_accumulation
         self._dataloader_len = None
         self._dataloader = None
         self._dataloader_label = None

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -871,15 +871,13 @@ class Trainer:
             optimizers = map_collection(optimizers, self._device.optimizer_to_device)
 
         # Grad Accum
-        self.adaptive_gradient_accumulation = _is_adaptive_grad_accum(grad_accum, device=self._device)
-        if self.adaptive_gradient_accumulation and profiler:
+        adaptive_gradient_accumulation = _is_adaptive_grad_accum(grad_accum, device=self._device)
+        if adaptive_gradient_accumulation and profiler:
             raise ValueError("`grad_accum='auto'` is not compatible with the profiler. It is recommended to run "
                              "a mini-run with `grad_accum='auto'` to identify the optimal grad_accum value and "
                              'then manually specify that in a second run with profiler.')
         grad_accum = _get_initial_grad_accum(grad_accum)
         eval_batch_split = 1
-        if self.adaptive_gradient_accumulation and isinstance(self._device, DeviceTPU):
-            raise NotImplementedError(f'grad_accum=auto not supported on TPUs.')
 
         # Grad Clip Norm
         if grad_clip_norm > 0:
@@ -904,16 +902,19 @@ class Trainer:
         log.info('Run name: %s', run_name)
 
         # Create the State
-        self.state = State(rank_zero_seed=rank_zero_seed,
-                           algorithms=algorithms,
-                           model=model,
-                           callbacks=callbacks,
-                           grad_accum=grad_accum,
-                           eval_batch_split=eval_batch_split,
-                           precision=precision,
-                           optimizers=optimizers,
-                           run_name=run_name,
-                           deepspeed_config=deepspeed_config)
+        self.state = State(
+            rank_zero_seed=rank_zero_seed,
+            algorithms=algorithms,
+            model=model,
+            callbacks=callbacks,
+            grad_accum=grad_accum,
+            adaptive_gradient_accumulation=adaptive_gradient_accumulation,
+            eval_batch_split=eval_batch_split,
+            precision=precision,
+            optimizers=optimizers,
+            run_name=run_name,
+            deepspeed_config=deepspeed_config,
+        )
 
         # Profiler
         if profiler is not None:
@@ -1436,8 +1437,8 @@ class Trainer:
 
         # Grad Accum
         if grad_accum is not None:
-            self.adaptive_gradient_accumulation = _is_adaptive_grad_accum(grad_accum, device=self._device)
-            if self.adaptive_gradient_accumulation and self.state.profiler:
+            self.state.adaptive_gradient_accumulation = _is_adaptive_grad_accum(grad_accum, device=self._device)
+            if self.state.adaptive_gradient_accumulation and self.state.profiler:
                 raise ValueError("`grad_accum='auto'` is not compatible with the profiler. It is recommended to run "
                                  "a mini-run with `grad_accum='auto'` to identify the optimal grad_accum value and "
                                  'then manually specify that in a second run with profiler.')
@@ -1734,13 +1735,12 @@ class Trainer:
                                     )
 
                 except RuntimeError as e:
-                    if self.adaptive_gradient_accumulation and _is_cuda_oom(e):
+                    if self.state.adaptive_gradient_accumulation and _is_cuda_oom(e):
                         log.debug((f"Rank {dist.get_global_rank()} OOM'd."))
                         found_cuda_oom = 1
                     else:
                         raise
-                # Auto eval batch split only supported on GPU
-                if self.adaptive_gradient_accumulation:
+                if self.state.adaptive_gradient_accumulation:
                     # Propagate across all ranks if any rank hit CUDA OOM
                     found_cuda_oom = self._device.tensor_to_device(torch.tensor([found_cuda_oom], dtype=torch.uint8))
                     dist.all_reduce(found_cuda_oom, reduce_operation='MAX')
@@ -1813,14 +1813,13 @@ class Trainer:
                                 else:
                                     optimizer.step()
             except RuntimeError as e:
-                if self.adaptive_gradient_accumulation and _is_cuda_oom(e):
+                if self.state.adaptive_gradient_accumulation and _is_cuda_oom(e):
                     log.debug((f"Rank {dist.get_global_rank()} OOM'd."))
                     found_cuda_oom = 1
                 else:
                     raise
 
-            # Auto grad accum only supported on GPU
-            if self.adaptive_gradient_accumulation:
+            if self.state.adaptive_gradient_accumulation:
                 # Propagate across all ranks if any rank hit CUDA OOM
                 found_cuda_oom = self._device.tensor_to_device(torch.tensor([found_cuda_oom], dtype=torch.uint8))
                 dist.all_reduce(found_cuda_oom, reduce_operation='MAX')
@@ -2385,13 +2384,12 @@ class Trainer:
                                         )
 
                     except RuntimeError as e:
-                        if self.adaptive_gradient_accumulation and _is_cuda_oom(e):
+                        if self.state.adaptive_gradient_accumulation and _is_cuda_oom(e):
                             log.debug((f"Rank {dist.get_global_rank()} OOM'd."))
                             found_cuda_oom = 1
                         else:
                             raise
-                    # Auto eval batch split only supported on GPU
-                    if self.adaptive_gradient_accumulation:
+                    if self.state.adaptive_gradient_accumulation:
                         # Propagate across all ranks if any rank hit CUDA OOM
                         found_cuda_oom = self._device.tensor_to_device(torch.tensor([found_cuda_oom],
                                                                                     dtype=torch.uint8))

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1740,7 +1740,7 @@ class Trainer:
                     else:
                         raise
                 # Auto eval batch split only supported on GPU
-                if isinstance(self._device, DeviceGPU):
+                if self.adaptive_gradient_accumulation:
                     # Propagate across all ranks if any rank hit CUDA OOM
                     found_cuda_oom = self._device.tensor_to_device(torch.tensor([found_cuda_oom], dtype=torch.uint8))
                     dist.all_reduce(found_cuda_oom, reduce_operation='MAX')
@@ -1820,7 +1820,7 @@ class Trainer:
                     raise
 
             # Auto grad accum only supported on GPU
-            if isinstance(self._device, DeviceGPU):
+            if self.adaptive_gradient_accumulation:
                 # Propagate across all ranks if any rank hit CUDA OOM
                 found_cuda_oom = self._device.tensor_to_device(torch.tensor([found_cuda_oom], dtype=torch.uint8))
                 dist.all_reduce(found_cuda_oom, reduce_operation='MAX')
@@ -2391,7 +2391,7 @@ class Trainer:
                         else:
                             raise
                     # Auto eval batch split only supported on GPU
-                    if isinstance(self._device, DeviceGPU):
+                    if self.adaptive_gradient_accumulation:
                         # Propagate across all ranks if any rank hit CUDA OOM
                         found_cuda_oom = self._device.tensor_to_device(torch.tensor([found_cuda_oom],
                                                                                     dtype=torch.uint8))

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -141,7 +141,7 @@ def _set_evaluator_interval_and_subset_num_batches(
             evaluator.eval_interval = eval_interval
 
 
-def _is_adaptive_grad_accum(grad_accum: Union[int, str], device: Device):
+def _is_auto_grad_accum(grad_accum: Union[int, str], device: Device):
     if grad_accum == 'auto':
         warnings.warn(("Setting `grad_accum='auto'` is an experimental feature which may cause "
                        'uncaught Cuda Out of Memory errors. In this case, please manually '
@@ -871,7 +871,7 @@ class Trainer:
             optimizers = map_collection(optimizers, self._device.optimizer_to_device)
 
         # Grad Accum
-        auto_grad_accum = _is_adaptive_grad_accum(grad_accum, device=self._device)
+        auto_grad_accum = _is_auto_grad_accum(grad_accum, device=self._device)
         if auto_grad_accum and profiler:
             raise ValueError("`grad_accum='auto'` is not compatible with the profiler. It is recommended to run "
                              "a mini-run with `grad_accum='auto'` to identify the optimal grad_accum value and "
@@ -1437,7 +1437,7 @@ class Trainer:
 
         # Grad Accum
         if grad_accum is not None:
-            self.state.auto_grad_accum = _is_adaptive_grad_accum(grad_accum, device=self._device)
+            self.state.auto_grad_accum = _is_auto_grad_accum(grad_accum, device=self._device)
             if self.state.auto_grad_accum and self.state.profiler:
                 raise ValueError("`grad_accum='auto'` is not compatible with the profiler. It is recommended to run "
                                  "a mini-run with `grad_accum='auto'` to identify the optimal grad_accum value and "


### PR DESCRIPTION
As is, this would silently skip certain things (eg metrics calculation) for non-CPU / non-GPU devices. It would catch OOM and then just... return. We should be checking device type at top.

Note: I am assuming AGA doesn't work on TPU and disabling, but @hanlint  feel free to change if you think it should work / is something you've tested

Update: Also moved aga check to state so seq length warmup does this properly