### PR TITLE
Fix SAM loss

### DIFF
--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -90,7 +90,7 @@ class SAMOptimizer(torch.optim.Optimizer):
             loss = closure(ddp_sync=False)  # type: ignore
             if loss:
                 self.first_step()  # Compute e(w) and set weights to (w + (e(w)) separately per-GPU
-                loss_dict = {} # Dummy loss dict to ignore loss logging from w + e(w)
+                loss_dict = {}  # Dummy loss dict to ignore loss logging from w + e(w)
                 if closure(loss_dict=loss_dict):  # Compute gradient at (w + e(w))
                     self.second_step()  # Reset weights to (w) and step base optimizer
                 else:

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -90,7 +90,7 @@ class SAMOptimizer(torch.optim.Optimizer):
             loss = closure(ddp_sync=False)  # type: ignore
             if loss:
                 self.first_step()  # Compute e(w) and set weights to (w + (e(w)) separately per-GPU
-                if closure(total_loss_dict={}):  # Compute gradient at (w + e(w))
+                if closure(log_losses=False):  # Compute gradient at (w + e(w))
                     self.second_step()  # Reset weights to (w) and step base optimizer
                 else:
                     self.sub_e_w()  # If second forward-backward closure fails, reset weights to (w)

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -90,7 +90,8 @@ class SAMOptimizer(torch.optim.Optimizer):
             loss = closure(ddp_sync=False)  # type: ignore
             if loss:
                 self.first_step()  # Compute e(w) and set weights to (w + (e(w)) separately per-GPU
-                if closure():  # Compute gradient at (w + e(w))
+                loss_dict = {} # Dummy loss dict to ignore loss logging from w + e(w)
+                if closure(loss_dict=loss_dict):  # Compute gradient at (w + e(w))
                     self.second_step()  # Reset weights to (w) and step base optimizer
                 else:
                     self.sub_e_w()  # If second forward-backward closure fails, reset weights to (w)

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -90,7 +90,7 @@ class SAMOptimizer(torch.optim.Optimizer):
             loss = closure(ddp_sync=False)  # type: ignore
             if loss:
                 self.first_step()  # Compute e(w) and set weights to (w + (e(w)) separately per-GPU
-                if closure(log_losses=False):  # Compute gradient at (w + e(w))
+                if closure():  # Compute gradient at (w + e(w))
                     self.second_step()  # Reset weights to (w) and step base optimizer
                 else:
                     self.sub_e_w()  # If second forward-backward closure fails, reset weights to (w)

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -91,7 +91,7 @@ class SAMOptimizer(torch.optim.Optimizer):
             if loss:
                 self.first_step()  # Compute e(w) and set weights to (w + (e(w)) separately per-GPU
                 loss_dict = {}  # Dummy loss dict to ignore loss logging from w + e(w)
-                if closure(loss_dict=loss_dict):  # Compute gradient at (w + e(w))
+                if closure(loss_dict=loss_dict):  # type: ignore Compute gradient at (w + e(w))
                     self.second_step()  # Reset weights to (w) and step base optimizer
                 else:
                     self.sub_e_w()  # If second forward-backward closure fails, reset weights to (w)

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -90,7 +90,7 @@ class SAMOptimizer(torch.optim.Optimizer):
             loss = closure(ddp_sync=False)  # type: ignore
             if loss:
                 self.first_step()  # Compute e(w) and set weights to (w + (e(w)) separately per-GPU
-                if closure():  # Compute gradient at (w + e(w))
+                if closure(total_loss_dict={}):  # Compute gradient at (w + e(w))
                     self.second_step()  # Reset weights to (w) and step base optimizer
                 else:
                     self.sub_e_w()  # If second forward-backward closure fails, reset weights to (w)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1795,8 +1795,8 @@ class Trainer:
                 if self._use_closures():
                     for optimizer in self.state.optimizers:
                         if use_grad_scaling:
-                            def _wrapper_train_microbatches(**kwargs):
-                                return self._train_microbatches(microbatches, total_loss_dict, **kwargs)
+                            def _wrapper_train_microbatches(loss_dict=total_loss_dict, **kwargs):
+                                return self._train_microbatches(microbatches, loss_dict, **kwargs)
                             self.state.scaler.step(optimizer, closure=_wrapper_train_microbatches)
                         else:
                             optimizer.step(closure=lambda **kwargs: self._train_microbatches(

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1796,12 +1796,9 @@ class Trainer:
                     for optimizer in self.state.optimizers:
                         if use_grad_scaling:
 
-                            def _train_microbatches_wrapper(**kwargs):
-                                # if 'total_loss_dict' not in kwargs:
-                                #     kwargs['total_loss_dict'] = total_loss_dict
-                                if 'total_loss_dict' in kwargs:
-                                    del kwargs['total_loss_dict']
-                                self._train_microbatches(microbatches, total_loss_dict, **kwargs)
+                            def _train_microbatches_wrapper(log_losses=True, **kwargs):
+                                loss_dict = total_loss_dict if log_losses else {'loss/train/total': self._device.tensor_to_device(torch.zeros(size=(1,)))}
+                                self._train_microbatches(microbatches, loss_dict, **kwargs)
 
                             self.state.scaler.step(optimizer, closure=_train_microbatches_wrapper)
                         else:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1795,10 +1795,9 @@ class Trainer:
                 if self._use_closures():
                     for optimizer in self.state.optimizers:
                         if use_grad_scaling:
-
-                            self.state.scaler.step(optimizer,
-                                                   closure=lambda **kwargs: self._train_microbatches(
-                                                    microbatches, total_loss_dict, **kwargs))
+                            def dummy_fn(kwargs): 
+                                return self._train_microbatches(microbatches, total_loss_dict, **kwargs)
+                            self.state.scaler.step(optimizer, closure=dummy_fn)
                         else:
                             optimizer.step(closure=lambda **kwargs: self._train_microbatches(
                                 microbatches, total_loss_dict, **kwargs).item())

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1795,9 +1795,9 @@ class Trainer:
                 if self._use_closures():
                     for optimizer in self.state.optimizers:
                         if use_grad_scaling:
-                            def dummy_fn(kwargs): 
+                            def _wrapper_train_microbatches(**kwargs):
                                 return self._train_microbatches(microbatches, total_loss_dict, **kwargs)
-                            self.state.scaler.step(optimizer, closure=dummy_fn)
+                            self.state.scaler.step(optimizer, closure=_wrapper_train_microbatches)
                         else:
                             optimizer.step(closure=lambda **kwargs: self._train_microbatches(
                                 microbatches, total_loss_dict, **kwargs).item())

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1797,7 +1797,8 @@ class Trainer:
                         if use_grad_scaling:
 
                             def _train_microbatches_wrapper(**kwargs):
-                                kwargs.setdefault('total_loss_dict', total_loss_dict)
+                                if 'total_loss_dict' not in kwargs:
+                                    kwargs['total_loss_dict'] = total_loss_dict
                                 self._train_microbatches(microbatches, **kwargs)
 
                             self.state.scaler.step(optimizer, closure=_train_microbatches_wrapper)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1796,10 +1796,9 @@ class Trainer:
                     for optimizer in self.state.optimizers:
                         if use_grad_scaling:
 
-                            def _train_microbatches_wrapper(**kwargs):
-                                self._train_microbatches(microbatches, total_loss_dict, **kwargs)
-
-                            self.state.scaler.step(optimizer, closure=_train_microbatches_wrapper)
+                            self.state.scaler.step(optimizer,
+                                                   closure=lambda **kwargs: self._train_microbatches(
+                                                    microbatches, total_loss_dict, **kwargs))
                         else:
                             optimizer.step(closure=lambda **kwargs: self._train_microbatches(
                                 microbatches, total_loss_dict, **kwargs).item())

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1798,8 +1798,10 @@ class Trainer:
 
                             def _train_microbatches_wrapper(**kwargs):
                                 # if 'total_loss_dict' not in kwargs:
-                                kwargs['total_loss_dict'] = total_loss_dict
-                                self._train_microbatches(microbatches, **kwargs)
+                                #     kwargs['total_loss_dict'] = total_loss_dict
+                                if 'total_loss_dict' in kwargs:
+                                    del kwargs['total_loss_dict']
+                                self._train_microbatches(microbatches, total_loss_dict, **kwargs)
 
                             self.state.scaler.step(optimizer, closure=_train_microbatches_wrapper)
                         else:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1795,9 +1795,9 @@ class Trainer:
                 if self._use_closures():
                     for optimizer in self.state.optimizers:
                         if use_grad_scaling:
-                            def _wrapper_train_microbatches(loss_dict=total_loss_dict, **kwargs):
-                                return self._train_microbatches(microbatches, loss_dict, **kwargs)
-                            self.state.scaler.step(optimizer, closure=_wrapper_train_microbatches)
+                            self.state.scaler.step(optimizer,
+                                                   closure=lambda loss_dict=total_loss_dict, **kwargs: self.
+                                                   _train_microbatches(microbatches, loss_dict, **kwargs))
                         else:
                             optimizer.step(closure=lambda **kwargs: self._train_microbatches(
                                 microbatches, total_loss_dict, **kwargs).item())

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1797,8 +1797,8 @@ class Trainer:
                         if use_grad_scaling:
 
                             def _train_microbatches_wrapper(**kwargs):
-                                if 'total_loss_dict' not in kwargs:
-                                    kwargs['total_loss_dict'] = total_loss_dict
+                                # if 'total_loss_dict' not in kwargs:
+                                kwargs['total_loss_dict'] = total_loss_dict
                                 self._train_microbatches(microbatches, **kwargs)
 
                             self.state.scaler.step(optimizer, closure=_train_microbatches_wrapper)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1795,9 +1795,12 @@ class Trainer:
                 if self._use_closures():
                     for optimizer in self.state.optimizers:
                         if use_grad_scaling:
-                            self.state.scaler.step(optimizer,
-                                                   closure=lambda **kwargs: self._train_microbatches(
-                                                       microbatches, total_loss_dict, **kwargs))
+
+                            def _train_microbatches_wrapper(**kwargs):
+                                kwargs.setdefault('total_loss_dict', total_loss_dict)
+                                self._train_microbatches(microbatches, **kwargs)
+
+                            self.state.scaler.step(optimizer, closure=_train_microbatches_wrapper)
                         else:
                             optimizer.step(closure=lambda **kwargs: self._train_microbatches(
                                 microbatches, total_loss_dict, **kwargs).item())

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1796,9 +1796,8 @@ class Trainer:
                     for optimizer in self.state.optimizers:
                         if use_grad_scaling:
 
-                            def _train_microbatches_wrapper(log_losses=True, **kwargs):
-                                loss_dict = total_loss_dict if log_losses else {'loss/train/total': self._device.tensor_to_device(torch.zeros(size=(1,)))}
-                                self._train_microbatches(microbatches, loss_dict, **kwargs)
+                            def _train_microbatches_wrapper(**kwargs):
+                                self._train_microbatches(microbatches, total_loss_dict, **kwargs)
 
                             self.state.scaler.step(optimizer, closure=_train_microbatches_wrapper)
                         else:


### PR DESCRIPTION
Fixes spikes in loss logs from SAM (yellow line) where every SAM pass has 2x the loss logged. Loss should not be computed from the second pass. Bug was introduced [here](https://github.com/mosaicml/composer/commit/8f0d7601eb5a29773f36a5b1aed9c9d8273f94ae) when loss became computed by passing by reference
<img width="446" alt="image" src="https://user-images.githubusercontent.com/17102158/189540297-1046e17c-621f-480f-82a6-e521eb123115.png">
