### PR TITLE
Fixed remote path in streaming dataloader facesynthetics jupyter notebook

### DIFF
--- a/examples/streaming_dataloader_facesynthetics.ipynb
+++ b/examples/streaming_dataloader_facesynthetics.ipynb
@@ -310,8 +310,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "remote_train = out_train if upload_train_location is not None else upload_train_location # replace this with your URL for cloud streaming\n",
-    "remote_test  = out_test if upload_test_location is not None else upload_test_location"
+    "remote_train = out_train if upload_train_location is None else upload_train_location # replace this with your URL for cloud streaming\n",
+    "remote_test  = out_test if upload_test_location is None else upload_test_location"
    ]
   },
   {


### PR DESCRIPTION
## Description
- Running the notebook as it is in google colab throws `ValueError('In the absence of local dataset, path to remote dataset must be provided')`. This is because the existing notebook does not stream the data from a cloud instead using the local dataset. Hence, it requires a minor change for variable `remote_train` and `remote_test` when using the local data.
- Full Traceback is as below:

```
---------------------------------------------------------------------------

ValueError                                Traceback (most recent call last)

[/usr/local/lib/python3.7/dist-packages/composer/datasets/streaming/download.py](https://localhost:8080/#) in download_or_wait(remote, local, wait, max_retries, timeout)
    150             else:
--> 151                 dispatch_download(remote, local)
    152             break

7 frames

ValueError: In the absence of local dataset, path to remote dataset must be provided


The above exception was the direct cause of the following exception:

RuntimeError                              Traceback (most recent call last)

[/usr/local/lib/python3.7/dist-packages/composer/datasets/streaming/download.py](https://localhost:8080/#) in download_or_wait(remote, local, wait, max_retries, timeout)
    158             continue
    159     if len(error_msgs) > max_retries:
--> 160         raise RuntimeError(f'Failed to download {remote} -> {local}. Got errors:\n{error_msgs}') from last_error

RuntimeError: Failed to download None -> ./local/train/index.mds. Got errors:
[ValueError('In the absence of local dataset, path to remote dataset must be provided'), ValueError('In the absence of local dataset, path to remote dataset must be provided'), ValueError('In the absence of local dataset, path to remote dataset must be provided')]
``` 
- After the change in this PR, I am able to train the model.