### PR TITLE
Update evaluate_periodically() when eval interval is of type Duration

### DIFF
--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -85,7 +85,7 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
                         last_batch_seen = state.timestamp.batch
                         return True
             elif state.max_duration.unit == TimeUnit.TOKEN and event == Event.BATCH_END:
-                raise ValueError(f'Evaluation interval of type `dur` is not support yet for max_duration as `tok`')
+                raise ValueError(f'Evaluation interval of type `dur` is not supported yet for max_duration as `tok`')
         return False
 
     return should_eval

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -75,23 +75,8 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
                     state.max_duration.value * eval_interval.value) == 0 and event == Event.BATCH_END:
                 last_batch_seen = state.timestamp.batch
                 return True
-            elif (state.max_duration.unit == TimeUnit.SAMPLE or
-                  state.max_duration.unit == TimeUnit.TOKEN) and event == Event.BATCH_END:
-                # Scenarios:
-                # (1) If the last global sample in a current batch is evenly divisible (zero remainder) by a evaluation interval duration
-                # during each evaluation cycle.
-                # E.g.: If batch_size = 2, max_duration.value = 50, eval_interval = 0.2
-                #       then, last sample in a batch: 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22,......., 50
-                #       eval interval duration (theoretically): 10, 20, 30, 40, 50
-                #       eval interval duration (practically):   10, 20, 30, 40, 50
-                # (2) If the last global sample in a current batch is NOT evenly divisible (zero remainder) by a evaluation interval duration
-                # during each evaluation cycle, then it performs evaluation during first batch of next evaluation cycle.
-                # E.g.: If batch_size = 2, max_duration.value = 50, eval_interval = 0.1
-                #       then, last sample in a batch: 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22,......., 50
-                #       eval interval duration (theoretically): 5, 10, 15, 20, 25, 30, 35, 40, 45, 50
-                #       eval interval duration (practically):   6, 10, 16, 20, 26, 30, 36, 40, 46, 50
-                # Logic: It should perform evaluation if the co-efficient of last global sample in a current batch by evaluation interval
-                #        duration does not match with last global sample in a previous batch by evaluation interval duration.
+            elif state.max_duration.unit == TimeUnit.SAMPLE and event == Event.BATCH_END:
+                # If last sample in batch is not evenly divisible by eval_interval, perform evaluation in next batch
                 if int(state.timestamp.batch) > 0:
                     samples_in_a_batch = int(state.timestamp.sample) // int(state.timestamp.batch)
                     if int(state.timestamp.sample) // math.ceil(state.max_duration.value * eval_interval) != int(
@@ -99,6 +84,8 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
                                 state.max_duration.value * eval_interval):
                         last_batch_seen = state.timestamp.batch
                         return True
+            elif state.max_duration.unit == TimeUnit.TOKEN and event == Event.BATCH_END:
+                raise ValueError(f'Evaluation interval of type `dur` is not support yet for max_duration as `tok`')
         return False
 
     return should_eval

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -15,7 +15,6 @@ from composer.core.data_spec import DataSpec, ensure_data_spec
 from composer.core.event import Event
 from composer.core.state import State
 from composer.core.time import Time, TimeUnit
-from composer.trainer import Trainer
 
 __all__ = ['Evaluator', 'evaluate_periodically', 'ensure_evaluator']
 
@@ -64,8 +63,8 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
 
         if eval_interval.unit == TimeUnit.DURATION:
             if state.max_duration is None:
-                raise ValueError(f'max_duration  is a required argument and must be specified when constructing the '
-                                 f'{Trainer.__name__} or when calling {Trainer.__name__}.{Trainer.fit.__name__}()')
+                raise ValueError(f'`max_duration` is a required argument and must be specified when constructing the '
+                                 f'`Trainer()` or `duration` when calling `Trainer.fit()`')
             if state.dataloader_len is None:
                 raise RuntimeError(
                     f'Evaluation interval of type `dur` or {TimeUnit.DURATION} requires the dataloader to be sized.')

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -42,7 +42,7 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
     last_batch_seen = -1
 
     def should_eval(state: State, event: Event):
-        # `TimeUnit.Duration` value is a floating value and ranges from `[0.0, 1.0)`
+        # `TimeUnit.Duration` value is a float from `[0.0, 1.0)`
         if not eval_interval.unit == TimeUnit.DURATION and int(eval_interval) <= 0:
             return False
         nonlocal last_batch_seen  # required to use the last_batch_seen from the outer function scope
@@ -62,9 +62,7 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
             return True
 
         if eval_interval.unit == TimeUnit.DURATION:
-            if state.max_duration is None:
-                raise ValueError(f'`max_duration` is a required argument and must be specified when constructing the '
-                                 f'`Trainer()` or `duration` when calling `Trainer.fit()`')
+            assert state.max_duration is not None, 'max_duration should not be None'
             if state.dataloader_len is None:
                 raise RuntimeError(
                     f'Evaluation interval of type `dur` or {TimeUnit.DURATION} requires the dataloader to be sized.')

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -77,36 +77,30 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
                     state.max_duration.value * eval_interval.value) == 0 and event == Event.BATCH_END:
                 last_batch_seen = state.timestamp.batch
                 return True
-            elif state.max_duration.unit == TimeUnit.SAMPLE and event == Event.BATCH_END:
-                # If the last global sample in a current batch is evenly divisible (zero remainder) by a evaluation interval duration
+            elif (state.max_duration.unit == TimeUnit.SAMPLE or
+                  state.max_duration.unit == TimeUnit.TOKEN) and event == Event.BATCH_END:
+                # Scenarios:
+                # (1) If the last global sample in a current batch is evenly divisible (zero remainder) by a evaluation interval duration
                 # during each evaluation cycle.
                 # E.g.: If batch_size = 2, max_duration.value = 50, eval_interval = 0.2
-                #       then, last sample in a batch: 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, ....... , 50
+                #       then, last sample in a batch: 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22,......., 50
                 #       eval interval duration (theoretically): 10, 20, 30, 40, 50
                 #       eval interval duration (practically):   10, 20, 30, 40, 50
-                if int(state.timestamp.sample) % math.ceil(state.max_duration.value * eval_interval.value) == 0:
-                    last_batch_seen = state.timestamp.batch
-                    return True
-                # If the last global sample in a current batch is NOT evenly divisible (zero remainder) by a evaluation interval duration
+                # (2) If the last global sample in a current batch is NOT evenly divisible (zero remainder) by a evaluation interval duration
                 # during each evaluation cycle, then it performs evaluation during first batch of next evaluation cycle.
-                # Logic: It should perform evaluation if the co-efficient of last global sample in a current batch by evaluation interval
-                #        duration does not match with last global sample in a previous batch by evaluation interval duration.
                 # E.g.: If batch_size = 2, max_duration.value = 50, eval_interval = 0.1
-                #       then, last sample in a batch: 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, ....... , 50
+                #       then, last sample in a batch: 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22,......., 50
                 #       eval interval duration (theoretically): 5, 10, 15, 20, 25, 30, 35, 40, 45, 50
                 #       eval interval duration (practically):   6, 10, 16, 20, 26, 30, 36, 40, 46, 50
-                elif int(state.timestamp.batch) != 0:
+                # Logic: It should perform evaluation if the co-efficient of last global sample in a current batch by evaluation interval
+                #        duration does not match with last global sample in a previous batch by evaluation interval duration.
+                if int(state.timestamp.batch) > 0:
                     samples_in_a_batch = int(state.timestamp.sample) // int(state.timestamp.batch)
                     if int(state.timestamp.sample) // math.ceil(state.max_duration.value * eval_interval) != int(
                             state.timestamp.sample - samples_in_a_batch) // math.ceil(
                                 state.max_duration.value * eval_interval):
                         last_batch_seen = state.timestamp.batch
                         return True
-            elif state.max_duration.unit == TimeUnit.TOKEN and int(state.timestamp.token) % math.ceil(
-                    state.max_duration.value * eval_interval.value) == 0 and event == Event.BATCH_END:
-                last_batch_seen = state.timestamp.batch
-                return True
-
         return False
 
     return should_eval

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -125,23 +125,20 @@ def test_trainer_eval_timestamp():
     assert trainer.state.eval_timestamp.batch == trainer.state.eval_timestamp.batch_in_epoch
 
 
-@pytest.mark.parametrize(
-    ('eval_interval', 'max_duration', 'eval_at_fit_end', 'expected_eval_start_calls',
-     'expected_eval_batch_start_calls'),
-    [
-        (1, '5ep', True, 4, 4),
-        (Time(2, TimeUnit.EPOCH), '8ep', False, 4, 4),
-        (Time(100, TimeUnit.BATCH), '8ep', False, 4, 4),
-        (Time(0.25, TimeUnit.DURATION), '4ep', False, 4, 4),
-        ('1ep', '4ep', True, 3, 3),
-        ('50ba', '4ep', False, 4, 4),
-        ('50ba', '100ba', False, 2, 2),
-        ('0.35dur', '4ep', True, 2, 2),
-        ('0.01dur', '1000ba', False, 100, 100),
-        ('0.10dur', '700sp', True, 9, 9),
-        ('0.05dur', '700sp', False, 20, 20),
-        # ('0.25dur', '1000tok', True, 3, 3),
-    ])
+@pytest.mark.parametrize(('eval_interval', 'max_duration', 'eval_at_fit_end', 'expected_eval_start_calls',
+                          'expected_eval_batch_start_calls'), [
+                              (1, '5ep', True, 4, 4),
+                              (Time(2, TimeUnit.EPOCH), '8ep', False, 4, 4),
+                              (Time(100, TimeUnit.BATCH), '8ep', False, 4, 4),
+                              (Time(0.25, TimeUnit.DURATION), '4ep', False, 4, 4),
+                              ('1ep', '4ep', True, 3, 3),
+                              ('50ba', '4ep', False, 4, 4),
+                              ('50ba', '100ba', False, 2, 2),
+                              ('0.35dur', '4ep', True, 2, 2),
+                              ('0.01dur', '1000ba', False, 100, 100),
+                              ('0.10dur', '700sp', True, 9, 9),
+                              ('0.05dur', '700sp', False, 20, 20),
+                          ])
 def test_eval_at_fit_end(eval_interval: Union[str, Time, int], max_duration: str, eval_at_fit_end: bool,
                          expected_eval_start_calls: int, expected_eval_batch_start_calls: int):
     """Test the `eval_subset_num_batches` and `eval_interval` works when specified on init."""

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -125,17 +125,30 @@ def test_trainer_eval_timestamp():
     assert trainer.state.eval_timestamp.batch == trainer.state.eval_timestamp.batch_in_epoch
 
 
-@pytest.mark.parametrize('eval_at_fit_end', [
-    True,
-    False,
-])
-def test_eval_at_fit_end(eval_at_fit_end: bool):
+@pytest.mark.parametrize(
+    ('eval_interval', 'max_duration', 'eval_at_fit_end', 'expected_eval_start_calls',
+     'expected_eval_batch_start_calls'),
+    [
+        (1, '5ep', True, 4, 4),
+        (Time(2, TimeUnit.EPOCH), '8ep', False, 4, 4),
+        (Time(100, TimeUnit.BATCH), '8ep', False, 8, 8),
+        (Time(0.25, TimeUnit.DURATION), '4ep', False, 4, 4),
+        ('1ep', '4ep', True, 3, 3),
+        ('50ba', '4ep', False, 8, 8),
+        ('50ba', '100ba', False, 2, 2),
+        ('0.35dur', '4ep', True, 2, 2),
+        ('0.01dur', '1000ba', False, 100, 100),
+        ('0.10dur', '650sp', True, 9, 9),
+        # ('0.25dur', '1000tok', True, 3, 3),
+    ])
+def test_eval_at_fit_end(eval_interval: Union[str, Time, int], max_duration: str, eval_at_fit_end: bool,
+                         expected_eval_start_calls: int, expected_eval_batch_start_calls: int):
     """Test the `eval_subset_num_batches` and `eval_interval` works when specified on init."""
 
     # Construct the trainer
     train_dataloader = DataLoader(dataset=RandomClassificationDataset())
     event_counter_callback = EventCounterCallback()
-    eval_interval = '2ep'
+    eval_interval = eval_interval
     evaluator = Evaluator(
         label='eval',
         dataloader=DataLoader(dataset=RandomClassificationDataset()),
@@ -152,15 +165,12 @@ def test_eval_at_fit_end(eval_at_fit_end: bool):
         train_dataloader=train_dataloader,
         eval_dataloader=evaluator,
         eval_subset_num_batches=1,
-        max_duration='3ep',
+        max_duration=max_duration,
         callbacks=[event_counter_callback],
     )
 
     # Train (should evaluate once)
     trainer.fit()
-
-    expected_eval_start_calls = 1
-    expected_eval_batch_start_calls = 1
 
     # depending on eval_at_fit_end, ensure the appropriate amount of calls are invoked
     if eval_at_fit_end:

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -131,14 +131,15 @@ def test_trainer_eval_timestamp():
     [
         (1, '5ep', True, 4, 4),
         (Time(2, TimeUnit.EPOCH), '8ep', False, 4, 4),
-        (Time(100, TimeUnit.BATCH), '8ep', False, 8, 8),
+        (Time(100, TimeUnit.BATCH), '8ep', False, 4, 4),
         (Time(0.25, TimeUnit.DURATION), '4ep', False, 4, 4),
         ('1ep', '4ep', True, 3, 3),
-        ('50ba', '4ep', False, 8, 8),
+        ('50ba', '4ep', False, 4, 4),
         ('50ba', '100ba', False, 2, 2),
         ('0.35dur', '4ep', True, 2, 2),
         ('0.01dur', '1000ba', False, 100, 100),
-        ('0.10dur', '650sp', True, 9, 9),
+        ('0.10dur', '700sp', True, 9, 9),
+        ('0.05dur', '700sp', False, 20, 20),
         # ('0.25dur', '1000tok', True, 3, 3),
     ])
 def test_eval_at_fit_end(eval_interval: Union[str, Time, int], max_duration: str, eval_at_fit_end: bool,
@@ -146,7 +147,7 @@ def test_eval_at_fit_end(eval_interval: Union[str, Time, int], max_duration: str
     """Test the `eval_subset_num_batches` and `eval_interval` works when specified on init."""
 
     # Construct the trainer
-    train_dataloader = DataLoader(dataset=RandomClassificationDataset())
+    train_dataloader = DataLoader(dataset=RandomClassificationDataset(), batch_size=2)
     event_counter_callback = EventCounterCallback()
     eval_interval = eval_interval
     evaluator = Evaluator(


### PR DESCRIPTION
## Description
- User can now pass the `'<*>dur'` or `Time(<value>, TimeUnit.DURATION)` as `eval_interval` during training.
- For example, `eval_interval` as `0.1dur` with `max_duration` as `20ep` (20 Epochs) means that evaluation would get executed at every 2 epochs with total of 10 evaluations during the whole training process.
- There are multiple ways where user can define a combination of `eval_interval` and `max_duration`.

| No.  | eval_interval                 | max_duration | Description                              |
| ---- | ----------------------------- | ------------ | ---------------------------------------- |
| 1    | '0.1dur'                      | '50ep'       | Perform evaluation at every 5 epochs     |
| 2    | '0.05dur'                     | '1000ba'     | Perform evaluation at every 50 batches   |
| 3    | '0.2dur'                      | '6000sp'     | Perform evaluation at every 1200 samples |
| 4    | '0.1dur'                      | '10000tok'   | Perform evaluation at every 1000 tokens  |
| 5    | Time(0.25, TimeUnit.DURATION) | '40ep'       | Perform evaluation at every 10 epochs    |

## Testing
# Unit test
- Added a unit test to test the functionality for the above usecase except the 4th.
- [TODO] Add a unittest for NLP workloads (when `max_duration` is `'<val>tok'`)

# Integration Test
- Ran the MNIST example to different `max_duration` usecase such as `'<value>ep'`, `'<value>ba'`, and `'<value>sp'`
1. `max_duration: 10ep`,  `eval_interval: 0.2dur`, and `train_batch_size: 2048`
    1. Evaluation has been called 5 times as expected which is at epoch 1, 3, 5, 7, 9 (epoch number starts with 0)
    ```
    [epoch=1][batch=29/10]: metrics/eval/CrossEntropy: 0.1552
    [epoch=1][batch=29/10]: metrics/eval/Accuracy: 0.9490
    ....
    [epoch=3][batch=29/10]: metrics/eval/CrossEntropy: 0.0755
    [epoch=3][batch=29/10]: metrics/eval/Accuracy: 0.9770
    ....
    [epoch=5][batch=29/10]: metrics/eval/CrossEntropy: 0.0604
    [epoch=5][batch=29/10]: metrics/eval/Accuracy: 0.9806
    ....
    [epoch=7][batch=29/10]: metrics/eval/CrossEntropy: 0.0540
    [epoch=7][batch=29/10]: metrics/eval/Accuracy: 0.9828
    ....
    [epoch=9][batch=29/10]: metrics/eval/CrossEntropy: 0.0531
    [epoch=9][batch=29/10]: metrics/eval/Accuracy: 0.9831
    ``` 
2. `max_duration: 100ba`,  `eval_interval: 0.1dur`, and `train_batch_size: 2048`
    1.  Evaluation has been called 10 times as expected which is at batch 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
    ```
    [batch=10/100]: metrics/eval/CrossEntropy: 2.1561
    [batch=10/100]: metrics/eval/Accuracy: 0.3948
    ....
    [batch=20/100]: metrics/eval/CrossEntropy: 1.0348
    [batch=20/100]: metrics/eval/Accuracy: 0.7864
    ....
    [batch=30/100]: metrics/eval/CrossEntropy: 0.5125
    [batch=30/100]: metrics/eval/Accuracy: 0.9109
    ....
    [batch=40/100]: metrics/eval/CrossEntropy: 0.2912
    [batch=40/100]: metrics/eval/Accuracy: 0.9279
    ....
    <output curtailed>
    ....
    [batch=100/100]: metrics/eval/CrossEntropy: 0.1161
    [batch=100/100]: metrics/eval/Accuracy: 0.9644
    ```
3. `max_duration: 60000sp`,  `eval_interval: 0.10dur`, and `train_batch_size: 2048`
    1. Evaluation has been called 10 times as expected which is at samples 6144, 12288, 18432, 24576, 30720, 36864, 43008, 49152, 55296, 61440.
    ```
    [sample=6144/60000]: metrics/eval/CrossEntropy: 2.3010
    [sample=6144/60000]: metrics/eval/Accuracy: 0.1135
    ....
    [sample=12288/60000]: metrics/eval/CrossEntropy: 2.2809
    [sample=12288/60000]: metrics/eval/Accuracy: 0.1451
    ....
    [sample=18432/60000]: metrics/eval/CrossEntropy: 2.2158
    [sample=18432/60000]: metrics/eval/Accuracy: 0.2579
    ....
    [sample=24576/60000]: metrics/eval/CrossEntropy: 2.0613
    [sample=24576/60000]: metrics/eval/Accuracy: 0.5095
    ....
    <output curtailed>
    ....
    [sample=61440/60000]: metrics/eval/CrossEntropy: 1.0423
    [sample=61440/60000]: metrics/eval/Accuracy: 0.8067
    ```

## Upcoming
As part of next PR
- Add a support when `eval_interval` is `dur` and max_duration is `tok`. 
- Add a unittest for the same
Tracking Jira for the same [CO-1084](https://mosaicml.atlassian.net/browse/CO-1084)