### PR TITLE
Fix compression file remote download exception handling.

### DIFF
--- a/composer/datasets/streaming/dataset.py
+++ b/composer/datasets/streaming/dataset.py
@@ -149,8 +149,9 @@ class StreamingDataset(IterableDataset):
                     self.compression_scheme = compression_scheme if compression_scheme != '' else None
                     if remote == local and self.compression_scheme is not None:
                         raise DatasetCompressionException('cannot decompress when remote == local')
-
-            except FileNotFoundError:
+            except DatasetCompressionException:
+                raise
+            except:
                 compression_local = os.path.join(self.local, get_compression_scheme_basename() + '.old')
                 with open(compression_local, 'x') as fp:
                     fp.write('')


### PR DESCRIPTION
This fixes issue CO-1071

The problem is that we were expecting the wrong exception (for when the dataset is on localdisk), but actually each cloud backend will throw its own exception for the missing file.