### PR TITLE
Checkpointing Interface Refactor Part I: Renaming Arguments

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -109,7 +109,7 @@ class CheckpointSaver(Callback):  # noqa: D101
         ...     CheckpointSaver(
         ...         checkpoint_save_path='{{run_name}}/checkpoints',
         ...         checkpoint_filename="ep{{epoch}}-ba{{batch}}-rank{{rank}}",
-        ...         latest_filename="latest-rank{{rank}}",
+        ...         latest_checkpoint_filename="latest-rank{{rank}}",
         ...         checkpoint_save_interval="1ep",
         ...         weights_only=False,
         ...     )
@@ -188,10 +188,10 @@ class CheckpointSaver(Callback):  # noqa: D101
             Leading slashes (``'/'``) will be stripped.
 
             To disable logging trace files as file artifacts, set this parameter to ``None``.
-        latest_filename (str, optional): A format string for a symlink which points to the last saved checkpoint.
+        latest_checkpoint_filename (str, optional): A format string for a symlink which points to the last saved checkpoint.
             Default: ``'latest-rank{{rank}}.pt'``.
 
-            Symlinks will be created approximately at ``{{checkpoint_save_path}}/{{latest_filename.format(...)}}``.
+            Symlinks will be created approximately at ``{{checkpoint_save_path}}/{{latest_checkpoint_filename.format(...)}}``.
 
             The same format variables as for ``name`` are available.
 
@@ -202,7 +202,7 @@ class CheckpointSaver(Callback):  # noqa: D101
             *   The :attr:`~.State.run_name` is 'awesome-training-run'
             *   The default ``checkpoint_save_path='{{run_name}}/checkpoints'`` is used.
             *   The default ``name='ep{{epoch}}-ba{{batch}}-rank{{rank}}'`` is used.
-            *   The default ``latest_filename='latest-rank{{rank}}'`` is used.
+            *   The default ``latest_checkpoint_filename='latest-rank{{rank}}'`` is used.
             *   The current epoch count is ``1``.
             *   The current batch count is ``42``.
 
@@ -228,7 +228,7 @@ class CheckpointSaver(Callback):  # noqa: D101
             Default: ``'{{run_name}}/checkpoints/latest-rank{{rank}}"``.
 
             Whenever a new checkpoint is saved, a symlink artifact is created or updated to point to the latest checkpoint's ``artifact_name``.
-            The artifact name will be determined by this format string. This parameter has no effect if ``latest_filename`` or ``artifact_name`` is ``None``.
+            The artifact name will be determined by this format string. This parameter has no effect if ``latest_checkpoint_filename`` or ``artifact_name`` is ``None``.
 
             .. seealso:: :doc:`Artifact Logging</trainer/artifact_logging>` for notes for file artifact logging.
 
@@ -292,7 +292,7 @@ class CheckpointSaver(Callback):  # noqa: D101
         checkpoint_save_path: str = '{run_name}/checkpoints',
         checkpoint_filename: str = 'ep{epoch}-ba{batch}-rank{rank}.pt',
         artifact_name: Optional[str] = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}',
-        latest_filename: Optional[str] = 'latest-rank{rank}.pt',
+        latest_checkpoint_filename: Optional[str] = 'latest-rank{rank}.pt',
         latest_artifact_name: Optional[str] = '{run_name}/checkpoints/latest-rank{rank}',
         checkpoint_save_interval: Union[Time, str, int, Callable[[State, Event], bool]] = '1ep',
         *,
@@ -307,7 +307,7 @@ class CheckpointSaver(Callback):  # noqa: D101
         self.checkpoint_save_path = checkpoint_save_path
 
         self.checkpoint_filename = PartialFilePath(checkpoint_filename.lstrip('/'), checkpoint_save_path)
-        self.latest_filename = PartialFilePath(latest_filename.lstrip('/'), checkpoint_save_path) if latest_filename else None
+        self.latest_checkpoint_filename = PartialFilePath(latest_checkpoint_filename.lstrip('/'), checkpoint_save_path) if latest_checkpoint_filename else None
 
         self.artifact_name = PartialFilePath(artifact_name) if artifact_name else None
         self.latest_artifact_name = PartialFilePath(latest_artifact_name) if latest_artifact_name else None
@@ -378,8 +378,8 @@ class CheckpointSaver(Callback):  # noqa: D101
         if not saved_path:  # not all ranks save
             return
 
-        if self.latest_filename is not None:
-            symlink = self.latest_filename.format(state, is_deepspeed)
+        if self.latest_checkpoint_filename is not None:
+            symlink = self.latest_checkpoint_filename.format(state, is_deepspeed)
             os.makedirs(os.path.dirname(symlink), exist_ok=True)
             try:
                 os.remove(symlink)

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -108,7 +108,7 @@ class CheckpointSaver(Callback):  # noqa: D101
         >>> trainer = Trainer(..., callbacks=[
         ...     CheckpointSaver(
         ...         checkpoint_save_path='{{run_name}}/checkpoints',
-        ...         filename="ep{{epoch}}-ba{{batch}}-rank{{rank}}",
+        ...         checkpoint_filename="ep{{epoch}}-ba{{batch}}-rank{{rank}}",
         ...         latest_filename="latest-rank{{rank}}",
         ...         checkpoint_save_interval="1ep",
         ...         weights_only=False,
@@ -128,10 +128,10 @@ class CheckpointSaver(Callback):  # noqa: D101
                 When training with multiple devices (i.e. GPUs), ensure that ``'{{rank}}'`` appears in the format.
                 Otherwise, multiple processes may attempt to write to the same file.
 
-        filename (str, optional): A format string describing how to name checkpoints.
+        checkpoint_filename (str, optional): A format string describing how to name checkpoints.
             Default: ``'ep{{epoch}}-ba{{batch}}-rank{{rank}}.pt'``.
 
-            Checkpoints will be saved approximately to ``{{checkpoint_save_path}}/{{filename.format(...)}}``.
+            Checkpoints will be saved approximately to ``{{checkpoint_save_path}}/{{checkpoint_filename.format(...)}}``.
 
             The following format variables are available:
 
@@ -144,7 +144,7 @@ class CheckpointSaver(Callback):  # noqa: D101
 
                 *   When using DeepSpeed, each rank will save a checkpoint file in tarball format. DeepSpeed
                     requires tarball format, as it saves model and optimizer states in separate files.
-                    Ensure that ``'{{rank}}'`` appears within the ``filename``. Otherwise, multiple ranks
+                    Ensure that ``'{{rank}}'`` appears within the ``checkpoint_filename``. Otherwise, multiple ranks
                     may attempt to write to the same file(s), leading to corrupted checkpoints. If no tarball file
                     extension is specified, ``'.tar'`` will be used.
 
@@ -183,7 +183,7 @@ class CheckpointSaver(Callback):  # noqa: D101
 
             .. seealso:: :doc:`Artifact Logging</trainer/artifact_logging>` for notes for file artifact logging.
 
-            The same format variables for ``filename`` are available.
+            The same format variables for ``checkpoint_filename`` are available.
 
             Leading slashes (``'/'``) will be stripped.
 
@@ -232,7 +232,7 @@ class CheckpointSaver(Callback):  # noqa: D101
 
             .. seealso:: :doc:`Artifact Logging</trainer/artifact_logging>` for notes for file artifact logging.
 
-            The same format variables for ``filename`` are available.
+            The same format variables for ``checkpoint_filename`` are available.
 
             Leading slashes (``'/'``) will be stripped.
 
@@ -290,7 +290,7 @@ class CheckpointSaver(Callback):  # noqa: D101
     def __init__(
         self,
         checkpoint_save_path: str = '{run_name}/checkpoints',
-        filename: str = 'ep{epoch}-ba{batch}-rank{rank}.pt',
+        checkpoint_filename: str = 'ep{epoch}-ba{batch}-rank{rank}.pt',
         artifact_name: Optional[str] = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}',
         latest_filename: Optional[str] = 'latest-rank{rank}.pt',
         latest_artifact_name: Optional[str] = '{run_name}/checkpoints/latest-rank{rank}',
@@ -306,7 +306,7 @@ class CheckpointSaver(Callback):  # noqa: D101
 
         self.checkpoint_save_path = checkpoint_save_path
 
-        self.filename = PartialFilePath(filename.lstrip('/'), checkpoint_save_path)
+        self.checkpoint_filename = PartialFilePath(checkpoint_filename.lstrip('/'), checkpoint_save_path)
         self.latest_filename = PartialFilePath(latest_filename.lstrip('/'), checkpoint_save_path) if latest_filename else None
 
         self.artifact_name = PartialFilePath(artifact_name) if artifact_name else None
@@ -326,7 +326,7 @@ class CheckpointSaver(Callback):  # noqa: D101
             # checks that checkpoint_save_path contains no files with a timestamp after the current timestamp,
             # which has potential for future conflicts.
             checkpoint_save_path = format_name_with_dist(self.checkpoint_save_path, state.run_name)
-            ensure_folder_has_no_conflicting_files(checkpoint_save_path, self.filename.filename, state.timestamp)
+            ensure_folder_has_no_conflicting_files(checkpoint_save_path, self.checkpoint_filename.filename, state.timestamp)
 
         dist.barrier()  # holds all ranks until checkpoint_save_path check is done
 
@@ -363,15 +363,15 @@ class CheckpointSaver(Callback):  # noqa: D101
     def _save_checkpoint(self, state: State, logger: Logger, log_level: LogLevel):
         is_deepspeed = is_model_deepspeed(state.model)
 
-        if is_deepspeed and '{rank}' not in self.filename.filename:
-            raise ValueError(f'Save filename {self.filename.filename} must have {{rank}} for deepspeed.')
+        if is_deepspeed and '{rank}' not in self.checkpoint_filename.filename:
+            raise ValueError(f'Save checkpoint_filename {self.checkpoint_filename.filename} must have {{rank}} for deepspeed.')
 
         # save the checkpoint to the filename
-        filename = self.filename.format(state, is_deepspeed)
+        checkpoint_filename = self.checkpoint_filename.format(state, is_deepspeed)
 
         saved_path = checkpoint.save_checkpoint(
             state=state,
-            filename=filename,
+            filename=checkpoint_filename,
             weights_only=self.weights_only,
         )
 
@@ -385,7 +385,7 @@ class CheckpointSaver(Callback):  # noqa: D101
                 os.remove(symlink)
             except FileNotFoundError:
                 pass
-            os.symlink(os.path.relpath(filename, os.path.dirname(symlink)), symlink)
+            os.symlink(os.path.relpath(checkpoint_filename, os.path.dirname(symlink)), symlink)
 
         # if artifact name provided, upload the checkpoint
         if self.artifact_name is not None:
@@ -396,7 +396,7 @@ class CheckpointSaver(Callback):  # noqa: D101
 
             logger.file_artifact(log_level=log_level,
                                  artifact_name=artifact_name,
-                                 file_path=filename,
+                                 file_path=checkpoint_filename,
                                  overwrite=self.overwrite)
 
             if self.latest_artifact_name is not None:
@@ -416,7 +416,7 @@ class CheckpointSaver(Callback):  # noqa: D101
                         overwrite=True,
                     )
 
-        self.saved_checkpoints.append(filename)
+        self.saved_checkpoints.append(checkpoint_filename)
 
         if self.num_checkpoints_to_keep >= 0:
             self._rotate_checkpoints()

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -307,7 +307,8 @@ class CheckpointSaver(Callback):  # noqa: D101
         self.checkpoint_save_path = checkpoint_save_path
 
         self.checkpoint_filename = PartialFilePath(checkpoint_filename.lstrip('/'), checkpoint_save_path)
-        self.latest_checkpoint_filename = PartialFilePath(latest_checkpoint_filename.lstrip('/'), checkpoint_save_path) if latest_checkpoint_filename else None
+        self.latest_checkpoint_filename = PartialFilePath(latest_checkpoint_filename.lstrip('/'),
+                                                          checkpoint_save_path) if latest_checkpoint_filename else None
 
         self.artifact_name = PartialFilePath(artifact_name) if artifact_name else None
         self.latest_artifact_name = PartialFilePath(latest_artifact_name) if latest_artifact_name else None
@@ -326,7 +327,8 @@ class CheckpointSaver(Callback):  # noqa: D101
             # checks that checkpoint_save_path contains no files with a timestamp after the current timestamp,
             # which has potential for future conflicts.
             checkpoint_save_path = format_name_with_dist(self.checkpoint_save_path, state.run_name)
-            ensure_folder_has_no_conflicting_files(checkpoint_save_path, self.checkpoint_filename.filename, state.timestamp)
+            ensure_folder_has_no_conflicting_files(checkpoint_save_path, self.checkpoint_filename.filename,
+                                                   state.timestamp)
 
         dist.barrier()  # holds all ranks until checkpoint_save_path check is done
 
@@ -364,7 +366,8 @@ class CheckpointSaver(Callback):  # noqa: D101
         is_deepspeed = is_model_deepspeed(state.model)
 
         if is_deepspeed and '{rank}' not in self.checkpoint_filename.filename:
-            raise ValueError(f'Save checkpoint_filename {self.checkpoint_filename.filename} must have {{rank}} for deepspeed.')
+            raise ValueError(
+                f'Save checkpoint_filename {self.checkpoint_filename.filename} must have {{rank}} for deepspeed.')
 
         # save the checkpoint to the filename
         checkpoint_filename = self.checkpoint_filename.format(state, is_deepspeed)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -333,7 +333,7 @@ class Trainer:
             eval_interval="1ep",
             checkpoint_save_path="checkpoints",
             save_filename="ep{epoch}.pt",
-            save_interval="1ep",
+            checkpoint_save_interval="1ep",
             save_overwrite=True,
         )
 
@@ -633,7 +633,7 @@ class Trainer:
             This parameter has no effect if ``checkpoint_save_path`` is None. (default: ``False``)
 
             .. seealso:: :class:`~.CheckpointSaver`
-        save_interval (Time | str | int | (State, Event) -> bool): A :class:`Time`, time-string, integer (in epochs),
+        checkpoint_save_interval (Time | str | int | (State, Event) -> bool): A :class:`Time`, time-string, integer (in epochs),
             or a function that takes (state, event) and returns a boolean whether a checkpoint should be saved.
             This parameter has no effect if ``checkpoint_save_path`` is ``None``. (default: ``'1ep'``)
 
@@ -786,7 +786,7 @@ class Trainer:
         save_latest_filename: Optional[str] = 'latest-rank{rank}.pt',
         save_latest_artifact_name: Optional[str] = '{run_name}/checkpoints/latest-rank{rank}',
         save_overwrite: bool = False,
-        save_interval: Union[str, int, Time, Callable[[State, Event], bool]] = '1ep',
+        checkpoint_save_interval: Union[str, int, Time, Callable[[State, Event], bool]] = '1ep',
         save_weights_only: bool = False,
         save_num_checkpoints_to_keep: int = -1,
 
@@ -956,7 +956,7 @@ class Trainer:
                 latest_artifact_name=save_latest_artifact_name,
                 overwrite=save_overwrite,
                 weights_only=save_weights_only,
-                save_interval=save_interval,
+                checkpoint_save_interval=checkpoint_save_interval,
                 num_checkpoints_to_keep=save_num_checkpoints_to_keep,
             )
             self.state.callbacks.append(self._checkpoint_saver)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -949,7 +949,7 @@ class Trainer:
         self._checkpoint_saver = None
         if checkpoint_save_path is not None:
             self._checkpoint_saver = CheckpointSaver(
-                folder=checkpoint_save_path,
+                checkpoint_save_path=checkpoint_save_path,
                 filename=save_filename,
                 artifact_name=save_artifact_name,
                 latest_filename=save_latest_filename,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -642,7 +642,7 @@ class Trainer:
             state. This parameter has no effect if ``checkpoint_save_path`` is ``None``. (default: ``False``)
 
             .. seealso:: :class:`~.CheckpointSaver`
-        save_num_checkpoints_to_keep (int, optional): The number of checkpoints to keep locally. The oldest checkpoints
+        num_checkpoints_to_keep (int, optional): The number of checkpoints to keep locally. The oldest checkpoints
             are removed first. Set to ``-1`` to keep all checkpoints locally. (default: ``-1``)
 
             Checkpoints will be removed after they have been logged as a file artifact. For example, when this callback
@@ -788,7 +788,7 @@ class Trainer:
         save_overwrite: bool = False,
         checkpoint_save_interval: Union[str, int, Time, Callable[[State, Event], bool]] = '1ep',
         save_weights_only: bool = False,
-        save_num_checkpoints_to_keep: int = -1,
+        num_checkpoints_to_keep: int = -1,
 
         # Graceful Resumption
         autoresume: bool = False,
@@ -957,7 +957,7 @@ class Trainer:
                 overwrite=save_overwrite,
                 weights_only=save_weights_only,
                 checkpoint_save_interval=checkpoint_save_interval,
-                num_checkpoints_to_keep=save_num_checkpoints_to_keep,
+                num_checkpoints_to_keep=num_checkpoints_to_keep,
             )
             self.state.callbacks.append(self._checkpoint_saver)
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -950,7 +950,7 @@ class Trainer:
         if checkpoint_save_path is not None:
             self._checkpoint_saver = CheckpointSaver(
                 checkpoint_save_path=checkpoint_save_path,
-                filename=save_filename,
+                checkpoint_filename=save_filename,
                 artifact_name=save_artifact_name,
                 latest_filename=save_latest_filename,
                 latest_artifact_name=save_latest_artifact_name,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -952,7 +952,7 @@ class Trainer:
                 checkpoint_save_path=checkpoint_save_path,
                 checkpoint_filename=save_filename,
                 artifact_name=save_artifact_name,
-                latest_filename=save_latest_filename,
+                latest_checkpoint_filename=save_latest_filename,
                 latest_artifact_name=save_latest_artifact_name,
                 overwrite=save_overwrite,
                 weights_only=save_weights_only,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -331,7 +331,7 @@ class Trainer:
             schedulers=scheduler,
             device="cpu",
             eval_interval="1ep",
-            save_folder="checkpoints",
+            checkpoint_save_path="checkpoints",
             save_filename="ep{epoch}.pt",
             save_interval="1ep",
             save_overwrite=True,
@@ -598,7 +598,7 @@ class Trainer:
 
             (default: ``None``)
 
-        save_folder (str, optional): Format string for the folder where checkpoints are saved.
+        checkpoint_save_path (str, optional): Format string for the folder where checkpoints are saved.
             If ``None``, checkpoints will not be saved. (default: ``None``)
 
             .. seealso:: :class:`~.CheckpointSaver`
@@ -609,37 +609,37 @@ class Trainer:
                 at different intervals), leave this parameter as ``None``, and instead pass
                 instance(s) of :class:`~.CheckpointSaver` directly as ``callbacks``.
         save_filename (str, optional): A format string describing how to name checkpoints.
-            This parameter has no effect if ``save_folder`` is ``None``.
+            This parameter has no effect if ``checkpoint_save_path`` is ``None``.
             (default: ``"ep{epoch}-ba{batch}-rank{rank}.pt"``)
 
             .. seealso:: :class:`~.CheckpointSaver`
         save_artifact_name (str, optional): A format string describing how to name checkpoints in loggers.
-            This parameter has no effect if ``save_folder`` is ``None``.
+            This parameter has no effect if ``checkpoint_save_path`` is ``None``.
             (default: ``"{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}"``)
 
             .. seealso:: :class:`~.CheckpointSaver` and :doc:`Artifact Logging</trainer/artifact_logging>` notes.
         save_latest_filename (str, optional): A format string for the name of a symlink
-            (relative to ``save_folder``) that points to the last saved checkpoint.
-            This parameter has no effect if ``save_folder`` is ``None``.
+            (relative to ``checkpoint_save_path``) that points to the last saved checkpoint.
+            This parameter has no effect if ``checkpoint_save_path`` is ``None``.
             To disable symlinking, set this to ``None``. (default: ``"latest-rank{rank}.pt"``)
 
             .. seealso:: :class:`~.CheckpointSaver`
         save_latest_artifact_name (str, optional): A format string describing how to name symlinks in loggers.
-            This parameter has no effect if ``save_folder``, ``save_latest_filename``, or ``save_artifact_name`` are ``None``.
+            This parameter has no effect if ``checkpoint_save_path``, ``save_latest_filename``, or ``save_artifact_name`` are ``None``.
             To disable symlinking in logger, set this or ``save_latest_filename`` to ``None``. (default: ``"{run_name}/checkpoints/latest-rank{rank}"``)
 
             .. seealso:: :class:`~.CheckpointSaver` and :doc:`Artifact Logging</trainer/artifact_logging>` notes.
         save_overwrite (bool, optional): Whether existing checkpoints should be overridden.
-            This parameter has no effect if ``save_folder`` is None. (default: ``False``)
+            This parameter has no effect if ``checkpoint_save_path`` is None. (default: ``False``)
 
             .. seealso:: :class:`~.CheckpointSaver`
         save_interval (Time | str | int | (State, Event) -> bool): A :class:`Time`, time-string, integer (in epochs),
             or a function that takes (state, event) and returns a boolean whether a checkpoint should be saved.
-            This parameter has no effect if ``save_folder`` is ``None``. (default: ``'1ep'``)
+            This parameter has no effect if ``checkpoint_save_path`` is ``None``. (default: ``'1ep'``)
 
             .. seealso:: :class:`~.CheckpointSaver`
         save_weights_only (bool, optional): Whether to save only the model weights instead of the entire training
-            state. This parameter has no effect if ``save_folder`` is ``None``. (default: ``False``)
+            state. This parameter has no effect if ``checkpoint_save_path`` is ``None``. (default: ``False``)
 
             .. seealso:: :class:`~.CheckpointSaver`
         save_num_checkpoints_to_keep (int, optional): The number of checkpoints to keep locally. The oldest checkpoints
@@ -654,10 +654,10 @@ class Trainer:
             artifact stores.
         autoresume (bool, optional): Whether or not to enable autoresume, which allows for stopping and resuming
             training. This allows use of spot instances, as the training run is now fault tolerant.  This parameter
-            requires ``save_folder`` and ``run_name`` to be specified and ``save_overwrite`` to be ``False``.
+            requires ``checkpoint_save_path`` and ``run_name`` to be specified and ``save_overwrite`` to be ``False``.
             (default: ``False``)
 
-            When enabled, the save_folder is checked for checkpoints of the format ``"{save_folder}/{save_latest_filename}"``,
+            When enabled, the checkpoint_save_path is checked for checkpoints of the format ``"{checkpoint_save_path}/{save_latest_filename}"``,
             which are loaded to continue training. If no local checkpoints are found, each logger is checked for potential
             checkpoints named ``save_latest_artifact_name``. Finally, if no logged checkpoints are found, ``load_path`` is
             used to load a checkpoint if specified. This should only occur at the start of a run using autoresume.
@@ -780,7 +780,7 @@ class Trainer:
         load_ignore_keys: Optional[Union[List[str], Callable[[Dict], None]]] = None,
 
         # Save Checkpoint
-        save_folder: Optional[str] = None,
+        checkpoint_save_path: Optional[str] = None,
         save_filename: str = 'ep{epoch}-ba{batch}-rank{rank}.pt',
         save_artifact_name: str = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}',
         save_latest_filename: Optional[str] = 'latest-rank{rank}.pt',
@@ -947,9 +947,9 @@ class Trainer:
 
         # Checkpoint Saving
         self._checkpoint_saver = None
-        if save_folder is not None:
+        if checkpoint_save_path is not None:
             self._checkpoint_saver = CheckpointSaver(
-                folder=save_folder,
+                folder=checkpoint_save_path,
                 filename=save_filename,
                 artifact_name=save_artifact_name,
                 latest_filename=save_latest_filename,
@@ -1087,12 +1087,12 @@ class Trainer:
         # If autoresume is enabled, first check for existing checkpoints to load
         if autoresume:
             log.info('Searching for a previous checkpoint to autoresume')
-            if save_folder is None:
-                raise ValueError('The `save_folder` must be specified when autoresume is enabled.')
+            if checkpoint_save_path is None:
+                raise ValueError('The `checkpoint_save_path` must be specified when autoresume is enabled.')
             if save_overwrite:
                 raise ValueError(
                     'The flag `save_overwrite` must be False when autoresume is enabled as autoresume always loads the '
-                    'latest existing checkpoint in `save_folder`.')
+                    'latest existing checkpoint in `checkpoint_save_path`.')
             if save_latest_filename is None:
                 raise ValueError(
                     'The `save_latest_filename` must be specified so autoresume knows where to load checkpoints from.')
@@ -1104,7 +1104,7 @@ class Trainer:
                     'The `run_name` must be specified when using autoresume so Event.INIT is run with the correct run name.'
                 )
             autoresume_checkpoint_path = self._get_autoresume_checkpoint(
-                save_folder=save_folder,
+                checkpoint_save_path=checkpoint_save_path,
                 save_latest_filename=save_latest_filename,
                 save_latest_artifact_name=save_latest_artifact_name,
                 loggers=loggers,
@@ -1169,7 +1169,7 @@ class Trainer:
 
     def _get_autoresume_checkpoint(
         self,
-        save_folder: str,
+        checkpoint_save_path: str,
         save_latest_filename: str,
         save_latest_artifact_name: str,
         loggers: Sequence[LoggerDestination],
@@ -1177,22 +1177,22 @@ class Trainer:
     ):
         """Determines the load path when using autoresume.
 
-        First, check the ``save_folder`` for the latest checkpoint.
+        First, check the ``checkpoint_save_path`` for the latest checkpoint.
         If no latest checkpoint is found locally, then check each logger for the latest checkpoint, and download
-        it to the ``save_folder``.
+        it to the ``checkpoint_save_path``.
 
         Returns:
             Optional[str]: The path to the latest checkpoint, if found, otherwise None.
         """
         save_latest_filename = format_name_with_dist(save_latest_filename, self.state.run_name)
-        save_folder = format_name_with_dist(save_folder, self.state.run_name)
+        checkpoint_save_path = format_name_with_dist(checkpoint_save_path, self.state.run_name)
         save_latest_artifact_name = format_name_with_dist(save_latest_artifact_name, self.state.run_name)
-        latest_checkpoint_path = os.path.join(save_folder, save_latest_filename)
+        latest_checkpoint_path = os.path.join(checkpoint_save_path, save_latest_filename)
 
         # If latest checkpoint is not saved locally, try to fetch from loggers
         if not os.path.exists(latest_checkpoint_path):
             # Make save folder in case it doesn't exist so latest checkpoint can be downloaded
-            os.makedirs(save_folder, exist_ok=True)
+            os.makedirs(checkpoint_save_path, exist_ok=True)
             for logger in loggers:
                 try:
                     # Fetch from logger. If it succeeds, stop trying the rest of the loggers

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -242,7 +242,7 @@ class TrainerHparams(hp.Hparams):
         load_progress_bar (bool, optional): See :class:`.Trainer`.
         load_ignore_keys (List[str] | (Dict) -> None, optional): See :class:`.Trainer`.
 
-        save_folder (str, optional): See :class:`.CheckpointSaver`.
+        checkpoint_save_path (str, optional): See :class:`.CheckpointSaver`.
         save_filename (str, optional): See :class:`.CheckpointSaver`.
         save_artifact_name (str, optional): See :class:`.CheckpointSaver`.
         save_latest_filename (str, optional): See
@@ -352,7 +352,7 @@ class TrainerHparams(hp.Hparams):
     load_progress_bar: bool = hp.auto(Trainer, 'load_progress_bar')
 
     # Save Checkpoint
-    save_folder: Optional[str] = hp.auto(Trainer, 'save_folder')
+    checkpoint_save_path: Optional[str] = hp.auto(Trainer, 'checkpoint_save_path')
     save_filename: str = hp.auto(Trainer, 'save_filename')
     save_artifact_name: str = hp.auto(Trainer, 'save_artifact_name')
     save_latest_filename: str = hp.auto(Trainer, 'save_latest_filename')
@@ -557,7 +557,7 @@ class TrainerHparams(hp.Hparams):
             load_ignore_keys=self.load_ignore_keys,
 
             # Checkpoint Saving
-            save_folder=self.save_folder,
+            checkpoint_save_path=self.checkpoint_save_path,
             save_overwrite=self.save_overwrite,
             save_filename=self.save_filename,
             save_latest_filename=self.save_latest_filename,

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -252,7 +252,7 @@ class TrainerHparams(hp.Hparams):
         save_weights_only (bool, optional): See :class:`.CheckpointSaver`.
         checkpoint_save_interval (str, optional): See
             :class:`~composer.callbacks.callback_hparams.CheckpointSaverHparams`.
-        save_num_checkpoints_to_keep (int, optional): See :class:`.CheckpointSaver`.
+        num_checkpoints_to_keep (int, optional): See :class:`.CheckpointSaver`.
         autoresume (bool, optional): See :class:`.Trainer`.
 
         deepspeed_config (Dict[str, JSON], optional): If set to a dict will be used for as the DeepSpeed
@@ -360,7 +360,7 @@ class TrainerHparams(hp.Hparams):
     save_overwrite: bool = hp.auto(Trainer, 'save_overwrite')
     save_weights_only: bool = hp.auto(Trainer, 'save_weights_only')
     checkpoint_save_interval: str = hp.auto(Trainer, 'checkpoint_save_interval')
-    save_num_checkpoints_to_keep: int = hp.auto(Trainer, 'save_num_checkpoints_to_keep')
+    num_checkpoints_to_keep: int = hp.auto(Trainer, 'num_checkpoints_to_keep')
 
     # Graceful Resumption
     autoresume: bool = hp.auto(Trainer, 'autoresume')
@@ -565,7 +565,7 @@ class TrainerHparams(hp.Hparams):
             save_latest_artifact_name=self.save_latest_artifact_name,
             checkpoint_save_interval=self.checkpoint_save_interval,
             save_weights_only=self.save_weights_only,
-            save_num_checkpoints_to_keep=self.save_num_checkpoints_to_keep,
+            num_checkpoints_to_keep=self.num_checkpoints_to_keep,
 
             # Graceful Resumption
             autoresume=self.autoresume,

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -250,7 +250,7 @@ class TrainerHparams(hp.Hparams):
         save_latest_artifact_name (str, optional): See :class:`.CheckpointSaver`.
         save_overwrite (str, optional): See :class:`.CheckpointSaver`.
         save_weights_only (bool, optional): See :class:`.CheckpointSaver`.
-        save_interval (str, optional): See
+        checkpoint_save_interval (str, optional): See
             :class:`~composer.callbacks.callback_hparams.CheckpointSaverHparams`.
         save_num_checkpoints_to_keep (int, optional): See :class:`.CheckpointSaver`.
         autoresume (bool, optional): See :class:`.Trainer`.
@@ -359,7 +359,7 @@ class TrainerHparams(hp.Hparams):
     save_latest_artifact_name: str = hp.auto(Trainer, 'save_latest_artifact_name')
     save_overwrite: bool = hp.auto(Trainer, 'save_overwrite')
     save_weights_only: bool = hp.auto(Trainer, 'save_weights_only')
-    save_interval: str = hp.auto(Trainer, 'save_interval')
+    checkpoint_save_interval: str = hp.auto(Trainer, 'checkpoint_save_interval')
     save_num_checkpoints_to_keep: int = hp.auto(Trainer, 'save_num_checkpoints_to_keep')
 
     # Graceful Resumption
@@ -563,7 +563,7 @@ class TrainerHparams(hp.Hparams):
             save_latest_filename=self.save_latest_filename,
             save_artifact_name=self.save_artifact_name,
             save_latest_artifact_name=self.save_latest_artifact_name,
-            save_interval=self.save_interval,
+            checkpoint_save_interval=self.checkpoint_save_interval,
             save_weights_only=self.save_weights_only,
             save_num_checkpoints_to_keep=self.save_num_checkpoints_to_keep,
 

--- a/composer/yamls/models/bert-base.yaml
+++ b/composer/yamls/models/bert-base.yaml
@@ -72,7 +72,7 @@ grad_clip_norm: -1.0 # Turn off gradient clipping
 grad_accum: auto # Use automatic gradient accumulation to avoid OOMs
 
 checkpoint_save_path: bert_checkpoints # The directory to save checkpoints to
-save_interval: 3500ba # Save checkpoints every 3500 batches
+checkpoint_save_interval: 3500ba # Save checkpoints every 3500 batches
 
 loggers:
   progress_bar: {} # Add a TQDM progress bar

--- a/composer/yamls/models/bert-base.yaml
+++ b/composer/yamls/models/bert-base.yaml
@@ -71,7 +71,7 @@ precision: amp # Use mixed-precision training
 grad_clip_norm: -1.0 # Turn off gradient clipping
 grad_accum: auto # Use automatic gradient accumulation to avoid OOMs
 
-save_folder: bert_checkpoints # The directory to save checkpoints to
+checkpoint_save_path: bert_checkpoints # The directory to save checkpoints to
 save_interval: 3500ba # Save checkpoints every 3500 batches
 
 loggers:

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -53,14 +53,12 @@ from composer.optim.scheduler import ConstantScheduler
 from composer.utils import LibcloudObjectStore
 from composer.utils import ensure_tuple as ensure_tuple
 
-
 try:
     import wandb
     _WANDB_INSTALLED = True
     del wandb  # unused
 except ImportError:
     _WANDB_INSTALLED = False
-
 
 try:
     import libcloud

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -53,6 +53,22 @@ from composer.optim.scheduler import ConstantScheduler
 from composer.utils import LibcloudObjectStore
 from composer.utils import ensure_tuple as ensure_tuple
 
+
+try:
+    import wandb
+    _WANDB_INSTALLED = True
+    del wandb  # unused
+except ImportError:
+    _WANDB_INSTALLED = False
+
+
+try:
+    import libcloud
+    _LIBCLOUD_INSTALLED = True
+    del libcloud  # unused
+except ImportError:
+    _LIBCLOUD_INSTALLED = False
+
 # Need to insert the repo root at the beginning of the path, since there may be other modules named `tests`
 # Assuming that docs generation is running from the `docs` directory
 _docs_dir = os.path.abspath('.')

--- a/docs/source/notes/resumption.rst
+++ b/docs/source/notes/resumption.rst
@@ -17,7 +17,7 @@ Resuming from checkpoints is commonly used to recover from hardware failures (e.
         save_filename="ep{epoch}.pt",
         checkpoint_save_path="./path/to/checkpoints",
         save_overwrite=True,
-        save_interval="1ep",  # Save checkpoints every epoch
+        checkpoint_save_interval="1ep",  # Save checkpoints every epoch
     )
     trainer.fit()
 
@@ -78,6 +78,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
 
 
 .. testcode::
+    :skipif: not _LIBCLOUD_INSTALLED
 
     from composer.loggers import ObjectStoreLogger
     from composer.utils.object_store import S3ObjectStore
@@ -111,6 +112,7 @@ Example: Fine-tuning
 To run fine-tuning on a spot instance, ``load_path`` would be set to the original weights and an object store logger would be added.
 
 .. testsetup:: fine_tune
+    :skipif: not _LIBCLOUD_INSTALLED
 
     from composer.loggers import ObjectStoreLogger
     from composer.utils.object_store import S3ObjectStore
@@ -134,6 +136,7 @@ To run fine-tuning on a spot instance, ``load_path`` would be set to the origina
     trainer.fit()
 
 .. testcode:: fine_tune
+    :skipif: not _LIBCLOUD_INSTALLED
 
     trainer = Trainer(
         ...,

--- a/docs/source/notes/resumption.rst
+++ b/docs/source/notes/resumption.rst
@@ -15,7 +15,7 @@ Resuming from checkpoints is commonly used to recover from hardware failures (e.
         train_dataloader=train_dataloader,
         max_duration="1ep",
         save_filename="ep{epoch}.pt",
-        save_folder="./path/to/checkpoints",
+        checkpoint_save_path="./path/to/checkpoints",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
     )
@@ -45,18 +45,18 @@ for another 65 epochs (to reach 90 epochs total).
 
 However, recovering from a failure here would still require manual intervention to relaunch a new job with the ``load_path`` pointing to the correct checkpoint.
 
-Instead, our trainer supports the ``autoresume=True`` feature. With autoresume, the trainer will automatically check the ``save_folder`` for the latest checkpoints and resume training.
+Instead, our trainer supports the ``autoresume=True`` feature. With autoresume, the trainer will automatically check the ``checkpoint_save_path`` for the latest checkpoints and resume training.
 
 .. testcode::
 
     trainer = Trainer(
         ...,
         autoresume=True,
-        save_folder='./path/to/folder',
+        checkpoint_save_path='./path/to/folder',
         run_name='my_cool_run',
     )
 
-With autoresume, users can re-submit the _same_ code to the training run, and the trainer will handle finding and resuming from the latest checkpoints. This works well with systems like Kubernetes that automatically resubmit the same job when there is a node failure (due to spot instances as well). For ``autoresume=True`` to work, we require that both a ``save_folder`` and a ``run_name`` be provided. These are used to search for existing checkpoints.
+With autoresume, users can re-submit the _same_ code to the training run, and the trainer will handle finding and resuming from the latest checkpoints. This works well with systems like Kubernetes that automatically resubmit the same job when there is a node failure (due to spot instances as well). For ``autoresume=True`` to work, we require that both a ``checkpoint_save_path`` and a ``run_name`` be provided. These are used to search for existing checkpoints.
 
 For an example code, see the `Checkpoint Autoresumption <examples/checkpoint_autoresume>`_ tutorial.
 
@@ -65,7 +65,7 @@ Implementation
 
 During training, the trainer always symlinks the latest checkpoint to a format (default is ``latest-rank{rank}`` for local files and ``{run_name}/checkpoints/latest-rank{rank}`` for object stores). When ``autoresume=True``, the Trainer searches for checkpoints of that format in the following order:
 
-1. Local checkpoints of the format ``"{save_folder}/latest-rank0"``. The format for the latest checkpoint can be configured with ``save_latest_filename`` argument (default: ``latest-rank{rank}``).
+1. Local checkpoints of the format ``"{checkpoint_save_path}/latest-rank0"``. The format for the latest checkpoint can be configured with ``save_latest_filename`` argument (default: ``latest-rank{rank}``).
 2. If no local checkpoints are found, then each logger is checked for files of the format ``"{run_name}/checkpoints/latest-rank{rank}"``. This is often used for resuming from an object store such as S3.
 3. Finally, ``load_path`` is used to load a checkpoint. This can be used for example, a fine-tuning run on a spot instance, where ``load_path`` would be set to the original weights.
 
@@ -93,7 +93,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
     trainer = Trainer(
         ...,
         autoresume=True,
-        save_folder='checkpoints',
+        checkpoint_save_path='checkpoints',
         save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
         run_name='my_cool_run',
         save_artifact_name='checkpoints/ep{epoch}.pt',
@@ -127,7 +127,7 @@ To run fine-tuning on a spot instance, ``load_path`` would be set to the origina
     trainer = Trainer(
         ...,
         save_filename='pretrained_weights/model.pt',
-        save_folder='.',
+        checkpoint_save_path='.',
         run_name='my_cool_run',
     )
 
@@ -140,7 +140,7 @@ To run fine-tuning on a spot instance, ``load_path`` would be set to the origina
         autoresume=True,
         load_path='pretrained_weights/model.pt',
         load_weights_only=True,
-        save_folder='checkpoints',
+        checkpoint_save_path='checkpoints',
         run_name='my_cool_run',
         loggers=[
             object_store_logger

--- a/docs/source/notes/resumption.rst
+++ b/docs/source/notes/resumption.rst
@@ -95,7 +95,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
         ...,
         autoresume=True,
         checkpoint_save_path='checkpoints',
-        save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
+        num_checkpoints_to_keep=0,  # delete all checkpoints locally
         run_name='my_cool_run',
         save_artifact_name='checkpoints/ep{epoch}.pt',
         loggers=[object_store_logger],

--- a/docs/source/trainer/artifact_logging.rst
+++ b/docs/source/trainer/artifact_logging.rst
@@ -139,6 +139,7 @@ Weights & Biases Artifacts
     The :class:`~composer.loggers.wandb_logger.WandBLogger` API Reference.
 
 .. testcode::
+    :skipif: not _WANDB_INSTALLED
 
     from composer.loggers import WandBLogger
     from composer import Trainer
@@ -169,6 +170,7 @@ with the :class:`~composer.utils.object_store.s3_object_store.S3ObjectStore` bac
     :class:`~composer.utils.object_store.s3_object_store.S3ObjectStore` API Reference.
 
 .. testcode::
+    :skipif: not _LIBCLOUD_INSTALLED
 
     from composer.loggers import ObjectStoreLogger
     from composer.utils.object_store import S3ObjectStore
@@ -204,6 +206,7 @@ Similar to the S3 Example above, we can log artifacts to a remote SFTP filesyste
     :class:`~composer.utils.object_store.sftp_object_store.SFTPObjectStore` API Reference.
 
 .. testcode::
+    :skipif: not _LIBCLOUD_INSTALLED
 
     from composer.loggers import ObjectStoreLogger
     from composer.utils.object_store import SFTPObjectStore

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -377,7 +377,7 @@ should be the path to the checkpoint file *within the container/bucket*.
 
 .. testcode::
     :skipif: not _LIBCLOUD_INSTALLED
-    
+
     from composer.utils import LibcloudObjectStore
     from composer.trainer import Trainer
 

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -1,16 +1,16 @@
 |:white_check_mark:| Checkpointing
 ==================================
 
-Composer can be configured to automatically save training checkpoints by passing the argument ``save_folder`` when
+Composer can be configured to automatically save training checkpoints by passing the argument ``checkpoint_save_path`` when
 creating the :class:`.Trainer`.
 
-To customize the filenames of checkpoints inside ``save_folder``, you can set the ``save_filename`` argument.
-By default, checkpoints will be named like ``'ep{epoch}-ba{batch}-rank{rank}'`` within the ``save_folder``.
+To customize the filenames of checkpoints inside ``checkpoint_save_path``, you can set the ``save_filename`` argument.
+By default, checkpoints will be named like ``'ep{epoch}-ba{batch}-rank{rank}'`` within the ``checkpoint_save_path``.
 
 In addition, the trainer creates a symlink called ``'latest-rank{rank}'``, which points to the latest saved checkpoint
 file. You can customize this symlink name by setting the ``save_latest_filename`` argument.
 
-The ``save_folder``, ``save_filename``, and ``save_latest`` arguments are Python format strings, so you can customize the folder
+The ``checkpoint_save_path``, ``save_filename``, and ``save_latest`` arguments are Python format strings, so you can customize the folder
 structure to include information such as the rank of the Python process or the current training progress. Please see
 the :class:`~.CheckpointSaver` for the full list of available format variables.
 
@@ -24,7 +24,7 @@ For example:
         model=model,
         train_dataloader=train_dataloader,
         max_duration="2ep",
-        save_folder="./path/to/checkpoints",
+        checkpoint_save_path="./path/to/checkpoints",
         save_filename="ep{epoch}",
         save_latest_filename="latest",
         save_overwrite=True,
@@ -59,7 +59,7 @@ Putting this together, here's how to save checkpoints:
         train_dataloader=train_dataloader,
         max_duration="1ep",
         save_filename="ep{epoch}.pt",
-        save_folder="./path/to/checkpoints",
+        checkpoint_save_path="./path/to/checkpoints",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
     )
@@ -102,7 +102,7 @@ will continue training from where the checkpoint left off.
         train_dataloader=train_dataloader,
         max_duration="1ep",
         save_filename="ep{epoch}.pt",
-        save_folder="./path/to/checkpoints",
+        checkpoint_save_path="./path/to/checkpoints",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
     )
@@ -180,7 +180,7 @@ only the model weights in a checkpoint, set ``save_weights_only=True``.
 
     trainer = Trainer(
         ...,
-        save_folder="checkpoints",
+        checkpoint_save_path="checkpoints",
         save_weights_only=True,
         save_overwrite=True,
     )
@@ -194,7 +194,7 @@ To save multiple checkpoint types, such as full checkpoints and weights-only che
 :class:`~.CheckpointSaver` can be passed directly into the ``callbacks`` argument of the trainer.
 Each :class:`~.CheckpointSaver` can have its own save folder, interval, and other parameters.
 
-When configuring checkpoints via the ``callbacks``, it is not necessary to specify the ``save_folder``
+When configuring checkpoints via the ``callbacks``, it is not necessary to specify the ``checkpoint_save_path``
 or other checkpoint saving parameters directly on the trainer.
 
 .. testcode::
@@ -244,7 +244,7 @@ Parameters with different names will ignored.
         train_dataloader=train_dataloader,
         max_duration="1ep",
         save_filename="ep{epoch}.pt",
-        save_folder="./path/to/checkpoints",
+        checkpoint_save_path="./path/to/checkpoints",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
     )
@@ -353,7 +353,7 @@ Once you've configured your object store logger per above, all that's left is to
         model=model,
         train_dataloader=train_dataloader,
         max_duration='90ep',
-        save_folder='checkpoints',
+        checkpoint_save_path='checkpoints',
         save_interval='1ep',
         save_overwrite=True,
         save_artifact_name='checkpoints/ep{epoch}.pt',

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -35,17 +35,17 @@ For example:
 Save Interval
 -------------
 
-By default, checkpoints are saved every epoch, but this interval can be configured using the ``save_interval`` argument.
-The ``save_interval`` can be an integer (interpreted as a number of epochs), a time string (see the
+By default, checkpoints are saved every epoch, but this interval can be configured using the ``checkpoint_save_interval`` argument.
+The ``checkpoint_save_interval`` can be an integer (interpreted as a number of epochs), a time string (see the
 :doc:`Time Guide </trainer/time>` for more information), or a function that takes
 (:class:`~.State`, :class:`~.Event`) and returns whether a checkpoint should be saved.
 
 For example:
 
-*   ``save_interval=1`` to save every epoch (the default).
-*   ``save_interval="10ep"`` to save every 10 epochs.
-*   ``save_interval="500ba"`` to save every 500 batches/steps.
-*   ``save_interval=lambda state, event: state.timestamp.epoch > 50 and event == Event.EPOCH_CHECKPOINT``
+*   ``checkpoint_save_interval=1`` to save every epoch (the default).
+*   ``checkpoint_save_interval="10ep"`` to save every 10 epochs.
+*   ``checkpoint_save_interval="500ba"`` to save every 500 batches/steps.
+*   ``checkpoint_save_interval=lambda state, event: state.timestamp.epoch > 50 and event == Event.EPOCH_CHECKPOINT``
     to save every epoch, starting after the 50th epoch.
 
 Putting this together, here's how to save checkpoints:
@@ -61,7 +61,7 @@ Putting this together, here's how to save checkpoints:
         save_filename="ep{epoch}.pt",
         checkpoint_save_path="./path/to/checkpoints",
         save_overwrite=True,
-        save_interval="1ep",  # Save checkpoints every epoch
+        checkpoint_save_interval="1ep",  # Save checkpoints every epoch
     )
     trainer.fit()
 
@@ -104,7 +104,7 @@ will continue training from where the checkpoint left off.
         save_filename="ep{epoch}.pt",
         checkpoint_save_path="./path/to/checkpoints",
         save_overwrite=True,
-        save_interval="1ep",  # Save checkpoints every epoch
+        checkpoint_save_interval="1ep",  # Save checkpoints every epoch
     )
     trainer.fit()
 
@@ -207,7 +207,7 @@ or other checkpoint saving parameters directly on the trainer.
         callbacks=[
             CheckpointSaver(
                 folder='full_checkpoints',
-                save_interval='5ep',
+                checkpoint_save_interval='5ep',
                 overwrite=True,
                 num_checkpoints_to_keep=1,  # only keep the latest, full checkpoint
             ),
@@ -246,7 +246,7 @@ Parameters with different names will ignored.
         save_filename="ep{epoch}.pt",
         checkpoint_save_path="./path/to/checkpoints",
         save_overwrite=True,
-        save_interval="1ep",  # Save checkpoints every epoch
+        checkpoint_save_interval="1ep",  # Save checkpoints every epoch
     )
     trainer.fit()
 
@@ -298,6 +298,7 @@ and then the :class:`.ObjectStoreLogger` logger will upload checkpoints to the s
 Behind the scenes, the :class:`.ObjectStoreLogger` uses :doc:`Apache Libcloud <libcloud:storage/index>`.
 
 .. testcode::
+    :skipif: not _LIBCLOUD_INSTALLED
 
     from composer.loggers import ObjectStoreLogger
     from composer.utils import LibcloudObjectStore
@@ -333,6 +334,7 @@ Once you've configured your object store logger per above, all that's left is to
 :class:`.Trainer` as part of the ``loggers``:
 
 .. testcode::
+    :skipif: not _LIBCLOUD_INSTALLED
 
     from composer.loggers import ObjectStoreLogger
 
@@ -354,7 +356,7 @@ Once you've configured your object store logger per above, all that's left is to
         train_dataloader=train_dataloader,
         max_duration='90ep',
         checkpoint_save_path='checkpoints',
-        save_interval='1ep',
+        checkpoint_save_interval='1ep',
         save_overwrite=True,
         save_artifact_name='checkpoints/ep{epoch}.pt',
         save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
@@ -374,7 +376,8 @@ Checkpoints saved to an object store can also be loaded in the same way as files
 should be the path to the checkpoint file *within the container/bucket*.
 
 .. testcode::
-
+    :skipif: not _LIBCLOUD_INSTALLED
+    
     from composer.utils import LibcloudObjectStore
     from composer.trainer import Trainer
 

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -323,7 +323,7 @@ Behind the scenes, the :class:`.ObjectStoreLogger` uses :doc:`Apache Libcloud <l
 
 There are a few additional trainer arguments which can be helpful to configure:
 
-*   ``save_num_checkpoints_to_keep``: Set this parameter to remove checkpoints from the local disk after they have been
+*   ``num_checkpoints_to_keep``: Set this parameter to remove checkpoints from the local disk after they have been
     uploaded. For example, setting this parameter to 1 will only keep the latest checkpoint locally; setting it to 0
     will remove each checkpoint after it has been uploaded. Checkpoints are never deleted from object stores.
 *   ``save_artifact_name``: To customize how checkpoints are named in the cloud bucket, modify this parameter. By
@@ -359,7 +359,7 @@ Once you've configured your object store logger per above, all that's left is to
         checkpoint_save_interval='1ep',
         save_overwrite=True,
         save_artifact_name='checkpoints/ep{epoch}.pt',
-        save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
+        num_checkpoints_to_keep=0,  # delete all checkpoints locally
         loggers=[object_store_logger],
     )
 

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -206,13 +206,13 @@ or other checkpoint saving parameters directly on the trainer.
         ...,
         callbacks=[
             CheckpointSaver(
-                folder='full_checkpoints',
+                checkpoint_save_path='full_checkpoints',
                 checkpoint_save_interval='5ep',
                 overwrite=True,
                 num_checkpoints_to_keep=1,  # only keep the latest, full checkpoint
             ),
             CheckpointSaver(
-                folder='weights_only_checkpoints',
+                checkpoint_save_path='weights_only_checkpoints',
                 weights_only=True,
                 overwrite=True,
             ),

--- a/docs/source/trainer/logging.rst
+++ b/docs/source/trainer/logging.rst
@@ -10,12 +10,14 @@ Biases <https://www.wandb.com/>`__ and also saves them to the file
 ``log.txt``.
 
 .. testsetup::
+    :skipif: not _WANDB_INSTALLED
 
     import os
 
     os.environ["WANDB_MODE"] = "disabled"
 
 .. testcode::
+    :skipif: not _WANDB_INSTALLED
 
     from composer import Trainer
     from composer.loggers import WandBLogger, FileLogger
@@ -31,6 +33,7 @@ Biases <https://www.wandb.com/>`__ and also saves them to the file
     )
 
 .. testcleanup::
+    :skipif: not _WANDB_INSTALLED
 
     trainer.engine.close()
     os.remove("log.txt")

--- a/docs/source/trainer/using_the_trainer.rst
+++ b/docs/source/trainer/using_the_trainer.rst
@@ -480,7 +480,7 @@ points during training and (2) load them back to resume training later.
         device='gpu',
         # Checkpointing params
         checkpoint_save_path: 'checkpoints',
-        save_interval: '1ep'
+        checkpoint_save_interval: '1ep'
     )
 
     # will save checkpoints to the 'checkpoints' folder every epoch

--- a/docs/source/trainer/using_the_trainer.rst
+++ b/docs/source/trainer/using_the_trainer.rst
@@ -479,7 +479,7 @@ points during training and (2) load them back to resume training later.
         max_duration='160ep',
         device='gpu',
         # Checkpointing params
-        save_folder: 'checkpoints',
+        checkpoint_save_path: 'checkpoints',
         save_interval: '1ep'
     )
 

--- a/examples/checkpoint_autoresume.ipynb
+++ b/examples/checkpoint_autoresume.ipynb
@@ -181,11 +181,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3.9.13 64-bit",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -195,13 +190,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.13"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "11dfb888bb479f515011eed10a40baecf75f0b99f616fa23bf77826fa87fb515"
-   }
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/checkpoint_autoresume.ipynb
+++ b/examples/checkpoint_autoresume.ipynb
@@ -54,7 +54,7 @@
     "\n",
     "**To see this example in action, run this notebook twice.**\n",
     "\n",
-    "* The first time the notebook is run, the trainer will save a checkpoint to the `save_folder` and train\n",
+    "* The first time the notebook is run, the trainer will save a checkpoint to the `checkpoint_save_path` and train\n",
     "  for one epoch.\n",
     "* Any subsequent time the notebook is run, the trainer will resume from the latest checkpoint if using `autoresume=True`. If\n",
     "  the latest checkpoint was saved at ``max_duration``, meaning all training is finished, the Trainer will\n",
@@ -116,7 +116,7 @@
     "\n",
     "    # Checkpoint configuration\n",
     "    run_name=run_name,\n",
-    "    save_folder='./my_autoresume_training_run', # Make sure to specify `save_folder` to enable saving\n",
+    "    checkpoint_save_path='./my_autoresume_training_run', # Make sure to specify `checkpoint_save_path` to enable saving\n",
     "    save_interval='1ep',\n",
     "\n",
     "    # Configure autoresume!\n",
@@ -181,6 +181,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.13 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -190,7 +195,13 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "11dfb888bb479f515011eed10a40baecf75f0b99f616fa23bf77826fa87fb515"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/checkpoint_autoresume.ipynb
+++ b/examples/checkpoint_autoresume.ipynb
@@ -117,7 +117,7 @@
     "    # Checkpoint configuration\n",
     "    run_name=run_name,\n",
     "    checkpoint_save_path='./my_autoresume_training_run', # Make sure to specify `checkpoint_save_path` to enable saving\n",
-    "    save_interval='1ep',\n",
+    "    checkpoint_save_interval='1ep',\n",
     "\n",
     "    # Configure autoresume!\n",
     "    autoresume=True,\n",

--- a/examples/checkpoint_with_wandb.py
+++ b/examples/checkpoint_with_wandb.py
@@ -49,7 +49,7 @@ trainer = Trainer(
     # Checkpoint Saving Configuration
     loggers=wandb_logger,  # Log checkpoints via the WandB Logger
     checkpoint_save_path='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
-    save_interval='1ep',
+    checkpoint_save_interval='1ep',
     save_artifact_name='epoch{epoch}.pt',  # Name checkpoints like epoch1.pt, epoch2.pt, etc...
     save_num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B
 )
@@ -85,7 +85,7 @@ trainer = Trainer(
     #  (Optional) Checkpoint Saving Configuration to continue to save new checkpoints
     loggers=wandb_logger,  # Log checkpoints via the WandB Logger
     checkpoint_save_path='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
-    save_interval='1ep',
+    checkpoint_save_interval='1ep',
     save_artifact_name='epoch{epoch}.pt',  # Name checkpoints like epoch1.pt, epoch2.pt, etc...
     save_num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B
 )

--- a/examples/checkpoint_with_wandb.py
+++ b/examples/checkpoint_with_wandb.py
@@ -48,7 +48,7 @@ trainer = Trainer(
 
     # Checkpoint Saving Configuration
     loggers=wandb_logger,  # Log checkpoints via the WandB Logger
-    save_folder='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
+    checkpoint_save_path='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
     save_interval='1ep',
     save_artifact_name='epoch{epoch}.pt',  # Name checkpoints like epoch1.pt, epoch2.pt, etc...
     save_num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B
@@ -84,7 +84,7 @@ trainer = Trainer(
 
     #  (Optional) Checkpoint Saving Configuration to continue to save new checkpoints
     loggers=wandb_logger,  # Log checkpoints via the WandB Logger
-    save_folder='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
+    checkpoint_save_path='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
     save_interval='1ep',
     save_artifact_name='epoch{epoch}.pt',  # Name checkpoints like epoch1.pt, epoch2.pt, etc...
     save_num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B

--- a/examples/checkpoint_with_wandb.py
+++ b/examples/checkpoint_with_wandb.py
@@ -48,7 +48,8 @@ trainer = Trainer(
 
     # Checkpoint Saving Configuration
     loggers=wandb_logger,  # Log checkpoints via the WandB Logger
-    checkpoint_save_path='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
+    checkpoint_save_path=
+    '/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
     checkpoint_save_interval='1ep',
     save_artifact_name='epoch{epoch}.pt',  # Name checkpoints like epoch1.pt, epoch2.pt, etc...
     num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B
@@ -84,7 +85,8 @@ trainer = Trainer(
 
     #  (Optional) Checkpoint Saving Configuration to continue to save new checkpoints
     loggers=wandb_logger,  # Log checkpoints via the WandB Logger
-    checkpoint_save_path='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
+    checkpoint_save_path=
+    '/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
     checkpoint_save_interval='1ep',
     save_artifact_name='epoch{epoch}.pt',  # Name checkpoints like epoch1.pt, epoch2.pt, etc...
     num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B

--- a/examples/checkpoint_with_wandb.py
+++ b/examples/checkpoint_with_wandb.py
@@ -51,7 +51,7 @@ trainer = Trainer(
     checkpoint_save_path='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
     checkpoint_save_interval='1ep',
     save_artifact_name='epoch{epoch}.pt',  # Name checkpoints like epoch1.pt, epoch2.pt, etc...
-    save_num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B
+    num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B
 )
 
 # Train!
@@ -87,7 +87,7 @@ trainer = Trainer(
     checkpoint_save_path='/tmp/checkpoints',  # The trainer requires that checkpoints must be saved locally before being upload
     checkpoint_save_interval='1ep',
     save_artifact_name='epoch{epoch}.pt',  # Name checkpoints like epoch1.pt, epoch2.pt, etc...
-    save_num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B
+    num_checkpoints_to_keep=0,  # Do not keep any checkpoints locally after they have been uploaded to W & B
 )
 
 # Verify that we loaded the checkpoint. This should print 1ep, since we already trained for 1 epoch.

--- a/examples/exporting_for_inference.ipynb
+++ b/examples/exporting_for_inference.ipynb
@@ -260,7 +260,7 @@
    "metadata": {},
    "source": [
     "## Run Training\n",
-    "Now we construct the trainer using this callback. The model is exported at the end of the training. In the later part of this tutorail we show model exporting from a checkpoint, so we also supply trainer `save_folder` and `save_interval` to save some checkpoints. "
+    "Now we construct the trainer using this callback. The model is exported at the end of the training. In the later part of this tutorail we show model exporting from a checkpoint, so we also supply trainer `checkpoint_save_path` and `save_interval` to save some checkpoints. "
    ]
   },
   {
@@ -282,7 +282,7 @@
     "    train_dataloader=dataloader,\n",
     "    optimizers=optimizer,\n",
     "    schedulers=scheduler,\n",
-    "    save_folder=working_dir.name,\n",
+    "    checkpoint_save_path=working_dir.name,\n",
     "    algorithms=[SqueezeExcite()],\n",
     "    callbacks=[export_callback],\n",
     "    max_duration='2ep',\n",

--- a/examples/exporting_for_inference.ipynb
+++ b/examples/exporting_for_inference.ipynb
@@ -260,7 +260,7 @@
    "metadata": {},
    "source": [
     "## Run Training\n",
-    "Now we construct the trainer using this callback. The model is exported at the end of the training. In the later part of this tutorail we show model exporting from a checkpoint, so we also supply trainer `checkpoint_save_path` and `save_interval` to save some checkpoints. "
+    "Now we construct the trainer using this callback. The model is exported at the end of the training. In the later part of this tutorail we show model exporting from a checkpoint, so we also supply trainer `checkpoint_save_path` and `checkpoint_save_interval` to save some checkpoints. "
    ]
   },
   {
@@ -286,7 +286,7 @@
     "    algorithms=[SqueezeExcite()],\n",
     "    callbacks=[export_callback],\n",
     "    max_duration='2ep',\n",
-    "    save_interval='1ep')\n",
+    "    checkpoint_save_interval='1ep')\n",
     "trainer.fit()"
    ]
   },

--- a/examples/glue/glue_entrypoint.ipynb
+++ b/examples/glue/glue_entrypoint.ipynb
@@ -192,7 +192,7 @@
     "      grad_clip_norm: -1.0               # Turn off gradient clipping\n",
     "      grad_accum: 'auto'                 # Use automatic gradient accumulation to avoid OOMs\n",
     "\n",
-    "      save_folder: checkpoints           # The directory to save checkpoints to\n",
+    "      checkpoint_save_path: checkpoints           # The directory to save checkpoints to\n",
     "      save_interval: 3500ba              # Save checkpoints every 3500 batches\n",
     "      save_artifact_name: '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}' \n",
     "      save_num_checkpoints_to_keep: 0\n",
@@ -255,7 +255,7 @@
     "\n",
     "To run the entire end-to-end pipeline, you are expected to provide the script with your pre-train configuration as explained above, as well as any overrides to apply to the fine-tuning jobs.\n",
     "\n",
-    "In this case, the script is run in two distinct stages for distributed pre-training and multiprocessed fine-tuning; however, all information transferred between the stages is automatically handled by the script.  Checkpoints are automatically saved to your specified `save_folder` and loaded from wherever pre-training saved them, therefore the `finetune_ckpts` section of `finetune_hparams` is ignored if specified."
+    "In this case, the script is run in two distinct stages for distributed pre-training and multiprocessed fine-tuning; however, all information transferred between the stages is automatically handled by the script.  Checkpoints are automatically saved to your specified `checkpoint_save_path` and loaded from wherever pre-training saved them, therefore the `finetune_ckpts` section of `finetune_hparams` is ignored if specified."
    ]
   },
   {
@@ -285,7 +285,7 @@
     "data = {\n",
     "  'finetune_hparams': {\n",
     "    'load_object_store': {'s3': {'bucket': 'mosaicml-internal-checkpoints-bert'}},\n",
-    "    'save_folder': 'checkpoints',\n",
+    "    'checkpoint_save_path': 'checkpoints',\n",
     "    'finetune_ckpts': ['bert-baseline-tokenizer-2uoe/checkpoints/ep0-ba68796-rank0']\n",
     "  }\n",
     "}"

--- a/examples/glue/glue_entrypoint.ipynb
+++ b/examples/glue/glue_entrypoint.ipynb
@@ -195,7 +195,7 @@
     "      checkpoint_save_path: checkpoints           # The directory to save checkpoints to\n",
     "      checkpoint_save_interval: 3500ba              # Save checkpoints every 3500 batches\n",
     "      save_artifact_name: '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}' \n",
-    "      save_num_checkpoints_to_keep: 0\n",
+    "      num_checkpoints_to_keep: 0\n",
     "      save_overwrite: True\n",
     "\n",
     "      loggers:\n",

--- a/examples/glue/glue_entrypoint.ipynb
+++ b/examples/glue/glue_entrypoint.ipynb
@@ -193,7 +193,7 @@
     "      grad_accum: 'auto'                 # Use automatic gradient accumulation to avoid OOMs\n",
     "\n",
     "      checkpoint_save_path: checkpoints           # The directory to save checkpoints to\n",
-    "      save_interval: 3500ba              # Save checkpoints every 3500 batches\n",
+    "      checkpoint_save_interval: 3500ba              # Save checkpoints every 3500 batches\n",
     "      save_artifact_name: '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}' \n",
     "      save_num_checkpoints_to_keep: 0\n",
     "      save_overwrite: True\n",
@@ -262,9 +262,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "❗ **Note**: The script runs all 8 GLUE fine-tuning tasks on **every saved pre-training checkpoint**, so set your [save_interval][save_interval] within your `pretrain_hparams` appropriately to avoid unnecessarily long evaluation times. \n",
+    "❗ **Note**: The script runs all 8 GLUE fine-tuning tasks on **every saved pre-training checkpoint**, so set your [checkpoint_save_interval][checkpoint_save_interval] within your `pretrain_hparams` appropriately to avoid unnecessarily long evaluation times. \n",
     "\n",
-    "[save_interval]: https://docs.mosaicml.com/en/stable/trainer/checkpointing.html#save-interval"
+    "[checkpoint_save_interval]: https://docs.mosaicml.com/en/stable/trainer/checkpointing.html#save-interval"
    ]
   },
   {

--- a/examples/glue/glue_example.yaml
+++ b/examples/glue/glue_example.yaml
@@ -74,7 +74,7 @@ pretrain_hparams:
   checkpoint_save_path: &folder checkpoints   # The directory to save checkpoints to, aliased as 'folder' for future reference in this file
   checkpoint_save_interval: 3500ba              # Save checkpoints every 3500 batches
   save_artifact_name: '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}' # comment if you do not want to checkpoint to cloud
-  save_num_checkpoints_to_keep: 0
+  num_checkpoints_to_keep: 0
   save_overwrite: True
 
   loggers:

--- a/examples/glue/glue_example.yaml
+++ b/examples/glue/glue_example.yaml
@@ -72,7 +72,7 @@ pretrain_hparams:
   grad_accum: 'auto'                 # Use automatic gradient accumulation to avoid OOMs
 
   checkpoint_save_path: &folder checkpoints   # The directory to save checkpoints to, aliased as 'folder' for future reference in this file
-  save_interval: 3500ba              # Save checkpoints every 3500 batches
+  checkpoint_save_interval: 3500ba              # Save checkpoints every 3500 batches
   save_artifact_name: '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}' # comment if you do not want to checkpoint to cloud
   save_num_checkpoints_to_keep: 0
   save_overwrite: True

--- a/examples/glue/glue_example.yaml
+++ b/examples/glue/glue_example.yaml
@@ -71,7 +71,7 @@ pretrain_hparams:
   grad_clip_norm: -1.0               # Turn off gradient clipping
   grad_accum: 'auto'                 # Use automatic gradient accumulation to avoid OOMs
 
-  save_folder: &folder checkpoints   # The directory to save checkpoints to, aliased as 'folder' for future reference in this file
+  checkpoint_save_path: &folder checkpoints   # The directory to save checkpoints to, aliased as 'folder' for future reference in this file
   save_interval: 3500ba              # Save checkpoints every 3500 batches
   save_artifact_name: '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}' # comment if you do not want to checkpoint to cloud
   save_num_checkpoints_to_keep: 0
@@ -97,4 +97,4 @@ finetune_hparams:
         - finetune
   load_object_store:
     *bucket
-  save_folder: *folder                # Refers to previously defined alias of 'folder'
+  checkpoint_save_path: *folder                # Refers to previously defined alias of 'folder'

--- a/examples/glue/nlp_trainer_hparams.py
+++ b/examples/glue/nlp_trainer_hparams.py
@@ -40,14 +40,14 @@ class GLUETrainerHparams(hp.Hparams):
         load_path (str, optional): See :class:`.Trainer`.
         loggers (List[LoggerDestination], optional): See :class:`.Trainer`.
         run_name (str, optional): See :class:`.Trainer`.
-        save_folder (str, optional): See :class:`.Trainer`.
+        checkpoint_save_path (str, optional): See :class:`.Trainer`.
         seed_overrides (Dict[str, List[int]], optional): A dictionary mapping task names to the list of seed overrides it should use
             per checkpoint. Each key must correspond to one of the GLUE tasks. This lets you train multiple fine-tune runs per
             checkpoint on a single task (one for each seed). Tasks that are not included in the dictionary use the (single) seed
             in their default YAML.
 
     Example:
-        Specifying ``save_folder: path/to/example/folder`` in a yaml will force all glue tasks in composer/yamls/models/glue/ to
+        Specifying ``checkpoint_save_path: path/to/example/folder`` in a yaml will force all glue tasks in composer/yamls/models/glue/ to
         save checkpoints to ``path/to/example/folder.``
 
     """
@@ -60,7 +60,7 @@ class GLUETrainerHparams(hp.Hparams):
     load_path: Optional[str] = hp.auto(Trainer, 'load_path')
     loggers: Optional[List[LoggerDestination]] = hp.auto(Trainer, 'loggers')
     run_name: Optional[str] = hp.auto(Trainer, 'run_name')
-    save_folder: Optional[str] = hp.auto(Trainer, 'save_folder')
+    checkpoint_save_path: Optional[str] = hp.auto(Trainer, 'checkpoint_save_path')
     seed_overrides: Optional[Dict[str, List[int]]] = hp.optional(
         doc='A dictionary mapping task names to the list of seed overrides it should use '
         'per checkpoint. Each key must correspond to one of the GLUE tasks. This lets you train multiple fine-tune runs per '

--- a/examples/glue/run_glue_trainer.py
+++ b/examples/glue/run_glue_trainer.py
@@ -429,9 +429,9 @@ def get_finetune_hparams() -> Tuple[GLUETrainerHparams, str, bool, bool]:
 def get_ckpt_names(hp: TrainerHparams, run_name: str, dataloader_len: int) -> List[str]:
     """Extract list of checkpoints that will be saved by the given configuration."""
     ckpt_names = []
-    assert hp.save_interval is not None
+    assert hp.checkpoint_save_interval is not None
     assert hp.max_duration is not None
-    interval = Time.from_timestring(str(hp.save_interval))
+    interval = Time.from_timestring(str(hp.checkpoint_save_interval))
     duration = Time.from_timestring(str(hp.max_duration))
 
     ep = 0

--- a/examples/glue/run_glue_trainer.py
+++ b/examples/glue/run_glue_trainer.py
@@ -509,7 +509,8 @@ def run_pretrainer(training_scheme: str, file: str, finetune_hparams: GLUETraine
         finetune_hparams.finetune_ckpts = get_ckpt_names(hp, run_name, dataloader_len)
 
     # call via composer to ensure pretraining done distributedly across all available GPUs
-    subprocess.run(args=['composer', training_script, '-f', tmp_file, '--checkpoint_save_path', checkpoint_save_path], check=True)
+    subprocess.run(args=['composer', training_script, '-f', tmp_file, '--checkpoint_save_path', checkpoint_save_path],
+                   check=True)
 
 
 def run_finetuner(training_scheme: str, file: str, save_locally: bool, load_locally: bool, checkpoint_save_path: str,
@@ -566,8 +567,8 @@ def _main() -> None:
     # Finetune
     if training_scheme in ('finetune', 'all'):
         assert finetune_hparams.checkpoint_save_path is not None
-        results = run_finetuner(training_scheme, file, save_locally, load_locally, finetune_hparams.checkpoint_save_path,
-                                finetune_hparams)
+        results = run_finetuner(training_scheme, file, save_locally, load_locally,
+                                finetune_hparams.checkpoint_save_path, finetune_hparams)
         print('FINETUNING COMPLETE')
 
         # Process and print the collected results into final GLUE metrics

--- a/examples/glue/run_glue_trainer.py
+++ b/examples/glue/run_glue_trainer.py
@@ -169,7 +169,7 @@ def merge_hparams(hparams: TrainerHparams, override_hparams: GLUETrainerHparams)
     hparams.loggers = override_hparams.loggers if override_hparams.loggers else hparams.loggers
     hparams.model = override_hparams.model if override_hparams.model else hparams.model
     hparams.run_name = override_hparams.run_name if override_hparams.run_name else hparams.run_name
-    hparams.save_folder = override_hparams.save_folder if override_hparams.save_folder else hparams.save_folder
+    hparams.checkpoint_save_path = override_hparams.checkpoint_save_path if override_hparams.checkpoint_save_path else hparams.checkpoint_save_path
 
     return hparams
 
@@ -185,7 +185,7 @@ def _setup_gpu_queue(num_gpus: int, manager: SyncManager):
 def spawn_finetuning_jobs(
     task_to_save_ckpt: Dict[str, bool],
     ckpt_load_paths: List[str],
-    ckpt_save_folder: str,
+    checkpoint_save_path: str,
     base_yaml_file: str,
     save_locally: bool,
     load_locally: bool,
@@ -233,7 +233,7 @@ def spawn_finetuning_jobs(
                         result = pool.apply_async(
                             train_finetune,
                             args=(gpu_queue, base_yaml_file, task, save_ckpt, ckpt_load_path, parent_ckpt, parent_idx,
-                                  ckpt_save_folder, save_locally, load_locally, free_port + rank, load_ignore_keys,
+                                  checkpoint_save_path, save_locally, load_locally, free_port + rank, load_ignore_keys,
                                   seed),
                         )
                         results.append(result)
@@ -254,7 +254,7 @@ def train_finetune(
         load_path: str,
         parent_ckpt: str,
         parent_idx: int,
-        save_folder: str,
+        checkpoint_save_path: str,
         save_locally: bool,
         load_locally: bool,
         master_port: int,
@@ -310,19 +310,19 @@ def train_finetune(
     # saving single checkpoint at the end of training the task
     if save_ckpt:
         # add task specific artifact logging information
-        ft_hparams.save_folder = f'{save_folder}/{task}-{parent_idx:03d}'
-        save_artifact_name = f'{save_folder}/{task}-{parent_idx:03d}/ep{{epoch}}-ba{{batch}}-rank{{rank}}'  # ignored if not uploading
-        save_latest_artifact_name = f'{save_folder}/{task}-{parent_idx:03d}/latest-rank{{rank}}'
+        ft_hparams.checkpoint_save_path = f'{checkpoint_save_path}/{task}-{parent_idx:03d}'
+        save_artifact_name = f'{checkpoint_save_path}/{task}-{parent_idx:03d}/ep{{epoch}}-ba{{batch}}-rank{{rank}}'  # ignored if not uploading
+        save_latest_artifact_name = f'{checkpoint_save_path}/{task}-{parent_idx:03d}/latest-rank{{rank}}'
         ft_hparams.save_artifact_name = save_artifact_name
         ft_hparams.save_latest_artifact_name = save_latest_artifact_name
 
         if save_locally:
-            if not os.path.exists(ft_hparams.save_folder):
-                os.makedirs(ft_hparams.save_folder)
+            if not os.path.exists(ft_hparams.checkpoint_save_path):
+                os.makedirs(ft_hparams.checkpoint_save_path)
 
     else:
         # Disable saving
-        ft_hparams.save_folder = None
+        ft_hparams.checkpoint_save_path = None
 
     print(
         f'\n --------\n SPAWNING TASK {task.upper()}\n DEVICE: {torch.cuda.current_device()}\n CKPT: {parent_ckpt}\n --------'
@@ -500,24 +500,24 @@ def run_pretrainer(training_scheme: str, file: str, finetune_hparams: GLUETraine
     dataloader_len = len(dataloader.dataloader)  # type: ignore
     run_name = hp.run_name
     assert run_name is not None
-    assert hp.save_folder is not None
-    save_folder = os.path.join(run_name, hp.save_folder)
+    assert hp.checkpoint_save_path is not None
+    checkpoint_save_path = os.path.join(run_name, hp.checkpoint_save_path)
 
     if training_scheme == 'all':  # extract run_name from trainer args for finetuning
         # list and save checkpoint paths
-        finetune_hparams.save_folder = save_folder
+        finetune_hparams.checkpoint_save_path = checkpoint_save_path
         finetune_hparams.finetune_ckpts = get_ckpt_names(hp, run_name, dataloader_len)
 
     # call via composer to ensure pretraining done distributedly across all available GPUs
-    subprocess.run(args=['composer', training_script, '-f', tmp_file, '--save_folder', save_folder], check=True)
+    subprocess.run(args=['composer', training_script, '-f', tmp_file, '--checkpoint_save_path', checkpoint_save_path], check=True)
 
 
-def run_finetuner(training_scheme: str, file: str, save_locally: bool, load_locally: bool, save_folder: str,
+def run_finetuner(training_scheme: str, file: str, save_locally: bool, load_locally: bool, checkpoint_save_path: str,
                   finetune_hparams) -> List[Tuple[str, str, Dict[str, Any]]]:
     """Logic for handling a finetuning job spawn based on storage and training settings."""
     # set automatic load and save paths
     if load_locally:
-        all_ckpts_list = os.listdir(save_folder)
+        all_ckpts_list = os.listdir(checkpoint_save_path)
     else:
         all_ckpts_list = finetune_hparams.finetune_ckpts
 
@@ -525,7 +525,7 @@ def run_finetuner(training_scheme: str, file: str, save_locally: bool, load_loca
     task_to_save_ckpt = {'cola': False, 'sst-2': False, 'qqp': False, 'qnli': False, 'mnli': True}
     results_a = spawn_finetuning_jobs(task_to_save_ckpt,
                                       all_ckpts_list,
-                                      save_folder,
+                                      checkpoint_save_path,
                                       file,
                                       save_locally,
                                       load_locally,
@@ -533,12 +533,12 @@ def run_finetuner(training_scheme: str, file: str, save_locally: bool, load_loca
 
     # Second, fine-tune RTE, MRPC, and STS-B from every pre-trained checkpoint's downstream MNLI checkpoints
     # Note: If MNLI ran for multiple seeds, this checkpoint will come from the last MNLI seed to finish.
-    ckpt_filenames = [f'{save_folder}/mnli-{idx:03d}/latest-rank0.pt' for idx in range(len(all_ckpts_list))]
+    ckpt_filenames = [f'{checkpoint_save_path}/mnli-{idx:03d}/latest-rank0.pt' for idx in range(len(all_ckpts_list))]
     mnli_task_to_save_ckpt = {'rte': False, 'mrpc': False, 'stsb': False}
     results_b = spawn_finetuning_jobs(
         mnli_task_to_save_ckpt,
         ckpt_filenames,
-        save_folder,
+        checkpoint_save_path,
         file,
         save_locally,
         load_locally=save_locally,
@@ -565,8 +565,8 @@ def _main() -> None:
 
     # Finetune
     if training_scheme in ('finetune', 'all'):
-        assert finetune_hparams.save_folder is not None
-        results = run_finetuner(training_scheme, file, save_locally, load_locally, finetune_hparams.save_folder,
+        assert finetune_hparams.checkpoint_save_path is not None
+        results = run_finetuner(training_scheme, file, save_locally, load_locally, finetune_hparams.checkpoint_save_path,
                                 finetune_hparams)
         print('FINETUNING COMPLETE')
 

--- a/examples/imagenet/train_resnet_imagenet1k.py
+++ b/examples/imagenet/train_resnet_imagenet1k.py
@@ -212,7 +212,7 @@ def _main():
     lr_monitor = LRMonitor()  # Logs the learning rate
 
     # Callback for checkpointing
-    checkpoint_saver = CheckpointSaver(folder=args.save_checkpoint_dir, save_interval=args.checkpoint_interval)
+    checkpoint_saver = CheckpointSaver(folder=args.save_checkpoint_dir, checkpoint_save_interval=args.checkpoint_interval)
     logging.info('Built SpeedMonitor, LRMonitor, and CheckpointSaver callbacks\n')
 
     # Recipes for training ResNet architectures on ImageNet in order of increasing training time and accuracy

--- a/examples/imagenet/train_resnet_imagenet1k.py
+++ b/examples/imagenet/train_resnet_imagenet1k.py
@@ -212,7 +212,8 @@ def _main():
     lr_monitor = LRMonitor()  # Logs the learning rate
 
     # Callback for checkpointing
-    checkpoint_saver = CheckpointSaver(checkpoint_save_path=args.save_checkpoint_dir, checkpoint_save_interval=args.checkpoint_interval)
+    checkpoint_saver = CheckpointSaver(checkpoint_save_path=args.save_checkpoint_dir,
+                                       checkpoint_save_interval=args.checkpoint_interval)
     logging.info('Built SpeedMonitor, LRMonitor, and CheckpointSaver callbacks\n')
 
     # Recipes for training ResNet architectures on ImageNet in order of increasing training time and accuracy

--- a/examples/imagenet/train_resnet_imagenet1k.py
+++ b/examples/imagenet/train_resnet_imagenet1k.py
@@ -212,7 +212,7 @@ def _main():
     lr_monitor = LRMonitor()  # Logs the learning rate
 
     # Callback for checkpointing
-    checkpoint_saver = CheckpointSaver(folder=args.save_checkpoint_dir, checkpoint_save_interval=args.checkpoint_interval)
+    checkpoint_saver = CheckpointSaver(checkpoint_save_path=args.save_checkpoint_dir, checkpoint_save_interval=args.checkpoint_interval)
     logging.info('Built SpeedMonitor, LRMonitor, and CheckpointSaver callbacks\n')
 
     # Recipes for training ResNet architectures on ImageNet in order of increasing training time and accuracy

--- a/examples/training_without_local_storage.ipynb
+++ b/examples/training_without_local_storage.ipynb
@@ -188,7 +188,7 @@
     "    # Flush log files every batch\n",
     "    loggers=get_tensorboard_logger(),\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
-    "    save_interval=\"1ba\",\n",
+    "    checkpoint_save_interval=\"1ba\",\n",
     "    run_name='local_training_run',\n",
     ")"
    ]
@@ -324,7 +324,7 @@
     "        get_tensorboard_logger(),\n",
     "    ],\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
-    "    save_interval=\"1ba\",\n",
+    "    checkpoint_save_interval=\"1ba\",\n",
     "    # Because we are uploading checkpoints to the cloud, we set\n",
     "    # save_num_checkpoints_to_keep to 0 to delete them locally\n",
     "    # after uploading to save disk space!\n",
@@ -433,7 +433,7 @@
     "        tensorboard_logger,\n",
     "    ],\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
-    "    save_interval=\"1ba\",\n",
+    "    checkpoint_save_interval=\"1ba\",\n",
     "    save_num_checkpoints_to_keep=0,\n",
     "    run_name='cloud_training_run',\n",
     ")"
@@ -690,7 +690,7 @@
     "        get_tensorboard_logger(),\n",
     "    ],\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
-    "    save_interval=\"1ba\",\n",
+    "    checkpoint_save_interval=\"1ba\",\n",
     "    save_num_checkpoints_to_keep=0,\n",
     "    run_name='streaming_training_run',\n",
     ")"
@@ -966,7 +966,7 @@
     "        TensorboardLogger(log_dir=tensorboard_log_dir, flush_interval=1),\n",
     "    ],\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
-    "    save_interval=\"1ba\",\n",
+    "    checkpoint_save_interval=\"1ba\",\n",
     "    # Because we are uploading checkpoints to the cloud,\n",
     "    # delete them locally to save disk space!\n",
     "    save_num_checkpoints_to_keep=0,\n",
@@ -1001,7 +1001,7 @@
     "        TensorboardLogger(log_dir=tensorboard_log_dir, flush_interval=1),\n",
     "    ],\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
-    "    save_interval=\"1ba\",\n",
+    "    checkpoint_save_interval=\"1ba\",\n",
     "    save_num_checkpoints_to_keep=0,\n",
     "    run_name=run_name,\n",
     ")\n",

--- a/examples/training_without_local_storage.ipynb
+++ b/examples/training_without_local_storage.ipynb
@@ -326,9 +326,9 @@
     "    checkpoint_save_path=checkpoint_dir,\n",
     "    checkpoint_save_interval=\"1ba\",\n",
     "    # Because we are uploading checkpoints to the cloud, we set\n",
-    "    # save_num_checkpoints_to_keep to 0 to delete them locally\n",
+    "    # num_checkpoints_to_keep to 0 to delete them locally\n",
     "    # after uploading to save disk space!\n",
-    "    save_num_checkpoints_to_keep=0,\n",
+    "    num_checkpoints_to_keep=0,\n",
     "    run_name='cloud_training_run',\n",
     ")"
    ]
@@ -434,7 +434,7 @@
     "    ],\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
     "    checkpoint_save_interval=\"1ba\",\n",
-    "    save_num_checkpoints_to_keep=0,\n",
+    "    num_checkpoints_to_keep=0,\n",
     "    run_name='cloud_training_run',\n",
     ")"
    ]
@@ -691,7 +691,7 @@
     "    ],\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
     "    checkpoint_save_interval=\"1ba\",\n",
-    "    save_num_checkpoints_to_keep=0,\n",
+    "    num_checkpoints_to_keep=0,\n",
     "    run_name='streaming_training_run',\n",
     ")"
    ]
@@ -969,7 +969,7 @@
     "    checkpoint_save_interval=\"1ba\",\n",
     "    # Because we are uploading checkpoints to the cloud,\n",
     "    # delete them locally to save disk space!\n",
-    "    save_num_checkpoints_to_keep=0,\n",
+    "    num_checkpoints_to_keep=0,\n",
     "    run_name=run_name,\n",
     ")\n",
     "\n",
@@ -1002,7 +1002,7 @@
     "    ],\n",
     "    checkpoint_save_path=checkpoint_dir,\n",
     "    checkpoint_save_interval=\"1ba\",\n",
-    "    save_num_checkpoints_to_keep=0,\n",
+    "    num_checkpoints_to_keep=0,\n",
     "    run_name=run_name,\n",
     ")\n",
     "\n",

--- a/examples/training_without_local_storage.ipynb
+++ b/examples/training_without_local_storage.ipynb
@@ -1069,11 +1069,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3.9.13 64-bit",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1083,13 +1078,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.13"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "11dfb888bb479f515011eed10a40baecf75f0b99f616fa23bf77826fa87fb515"
-   }
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/training_without_local_storage.ipynb
+++ b/examples/training_without_local_storage.ipynb
@@ -187,7 +187,7 @@
     "    eval_subset_num_batches=5,\n",
     "    # Flush log files every batch\n",
     "    loggers=get_tensorboard_logger(),\n",
-    "    save_folder=checkpoint_dir,\n",
+    "    checkpoint_save_path=checkpoint_dir,\n",
     "    save_interval=\"1ba\",\n",
     "    run_name='local_training_run',\n",
     ")"
@@ -323,7 +323,7 @@
     "        get_object_store_logger(),\n",
     "        get_tensorboard_logger(),\n",
     "    ],\n",
-    "    save_folder=checkpoint_dir,\n",
+    "    checkpoint_save_path=checkpoint_dir,\n",
     "    save_interval=\"1ba\",\n",
     "    # Because we are uploading checkpoints to the cloud, we set\n",
     "    # save_num_checkpoints_to_keep to 0 to delete them locally\n",
@@ -432,7 +432,7 @@
     "        cloud_logger,\n",
     "        tensorboard_logger,\n",
     "    ],\n",
-    "    save_folder=checkpoint_dir,\n",
+    "    checkpoint_save_path=checkpoint_dir,\n",
     "    save_interval=\"1ba\",\n",
     "    save_num_checkpoints_to_keep=0,\n",
     "    run_name='cloud_training_run',\n",
@@ -689,7 +689,7 @@
     "        get_object_store_logger(),\n",
     "        get_tensorboard_logger(),\n",
     "    ],\n",
-    "    save_folder=checkpoint_dir,\n",
+    "    checkpoint_save_path=checkpoint_dir,\n",
     "    save_interval=\"1ba\",\n",
     "    save_num_checkpoints_to_keep=0,\n",
     "    run_name='streaming_training_run',\n",
@@ -965,7 +965,7 @@
     "        cloud_logger,\n",
     "        TensorboardLogger(log_dir=tensorboard_log_dir, flush_interval=1),\n",
     "    ],\n",
-    "    save_folder=checkpoint_dir,\n",
+    "    checkpoint_save_path=checkpoint_dir,\n",
     "    save_interval=\"1ba\",\n",
     "    # Because we are uploading checkpoints to the cloud,\n",
     "    # delete them locally to save disk space!\n",
@@ -1000,7 +1000,7 @@
     "        cloud_logger,\n",
     "        TensorboardLogger(log_dir=tensorboard_log_dir, flush_interval=1),\n",
     "    ],\n",
-    "    save_folder=checkpoint_dir,\n",
+    "    checkpoint_save_path=checkpoint_dir,\n",
     "    save_interval=\"1ba\",\n",
     "    save_num_checkpoints_to_keep=0,\n",
     "    run_name=run_name,\n",
@@ -1069,6 +1069,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.13 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1078,7 +1083,13 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "11dfb888bb479f515011eed10a40baecf75f0b99f616fa23bf77826fa87fb515"
+   }
   }
  },
  "nbformat": 4,

--- a/tests/algorithms/test_algorithm_resumption.py
+++ b/tests/algorithms/test_algorithm_resumption.py
@@ -51,7 +51,7 @@ def test_algorithm_resumption(
         train_dataloader=get_alg_dataloader(alg_cls),
         optimizers=optimizer,
         schedulers=scheduler,
-        save_folder=folder1,
+        checkpoint_save_path=folder1,
         algorithms=alg_cls(**alg_kwargs),
         **shared_config,
     )
@@ -71,7 +71,7 @@ def test_algorithm_resumption(
         load_strict_model_weights=False,
         optimizers=optimizer,
         schedulers=scheduler,
-        save_folder=folder2,
+        checkpoint_save_path=folder2,
         algorithms=alg_cls(**alg_kwargs),
         **shared_config,
     )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -56,9 +56,9 @@ class TestEventCalls:
         pytest.param('cpu', None, id='cpu-ddp'),
         pytest.param('gpu', None, id='gpu-ddp', marks=pytest.mark.gpu),
     ])
-    @pytest.mark.parametrize('save_interval', ['1ep', '1ba'])
-    def test_event_calls(self, world_size, device, deepspeed_zero_stage, save_interval):
-        save_interval = Time.from_timestring(save_interval)
+    @pytest.mark.parametrize('checkpoint_save_interval', ['1ep', '1ba'])
+    def test_event_calls(self, world_size, device, deepspeed_zero_stage, checkpoint_save_interval):
+        checkpoint_save_interval = Time.from_timestring(checkpoint_save_interval)
 
         if deepspeed_zero_stage:
             deepspeed_config = {'zero_optimization': {'stage': deepspeed_zero_stage}}
@@ -68,12 +68,12 @@ class TestEventCalls:
         trainer = self.get_trainer(
             device=device,
             deepspeed_config=deepspeed_config,
-            save_interval=save_interval,
-            eval_interval=save_interval,
+            checkpoint_save_interval=checkpoint_save_interval,
+            eval_interval=checkpoint_save_interval,
         )
         trainer.fit()
 
-        self._assert_expected_event_calls(trainer, save_interval, num_epochs=2)
+        self._assert_expected_event_calls(trainer, checkpoint_save_interval, num_epochs=2)
 
     def _assert_expected_event_calls(self, trainer: Trainer, eval_interval: Time, num_epochs: int):
         state = trainer.state

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -158,7 +158,7 @@ class TestCheckpointLoading:
             grad_accum=2,
             precision='fp32',
             train_subset_num_batches=5,
-            save_interval='1ep',
+            checkpoint_save_interval='1ep',
             eval_interval='1ba',
             save_filename='ep{epoch}.pt',
             max_duration='2ep',
@@ -411,7 +411,7 @@ class TestCheckpointResumption:
         pytest.param('gpu', 2, id='deepspeed-zero2', marks=pytest.mark.gpu),
     ])
     @pytest.mark.parametrize(
-        'seed,save_interval,save_filename,resume_file,final_checkpoint',
+        'seed,checkpoint_save_interval,save_filename,resume_file,final_checkpoint',
         [
             [None, '1ep', 'ep{epoch}-rank{rank}.pt', 'ep1-rank{rank}.pt', 'latest-rank{rank}.pt'
             ],  # test randomized seed saving and symlinking
@@ -431,7 +431,7 @@ class TestCheckpointResumption:
         device: str,
         world_size: int,
         deepspeed_zero_stage: Optional[int],
-        save_interval: str,
+        checkpoint_save_interval: str,
         save_filename: str,
         resume_file: str,
         final_checkpoint: str,
@@ -457,8 +457,8 @@ class TestCheckpointResumption:
         trainer_1 = self.get_trainer(
             checkpoint_save_path=os.path.join(checkpoint_save_path, 'first'),
             save_filename=save_filename,
-            save_interval=save_interval,
-            eval_interval=save_interval,
+            checkpoint_save_interval=checkpoint_save_interval,
+            eval_interval=checkpoint_save_interval,
             deepspeed_config=deepspeed_config,
             seed=seed,
             device=device,
@@ -469,7 +469,7 @@ class TestCheckpointResumption:
 
         self._assert_expected_num_checkpoints(
             checkpoint_save_path=os.path.join(checkpoint_save_path, 'first'),
-            save_interval=save_interval,
+            checkpoint_save_interval=checkpoint_save_interval,
             num_epochs=2,  # set in get_trainer()
             num_batches_per_epoch=5,  # set in get_trainer()
             is_deepspeed=deepspeed_config is not None,
@@ -484,8 +484,8 @@ class TestCheckpointResumption:
         trainer_2 = self.get_trainer(
             checkpoint_save_path=os.path.join(checkpoint_save_path, 'second'),
             save_filename=save_filename,
-            save_interval=save_interval,
-            eval_interval=save_interval,
+            checkpoint_save_interval=checkpoint_save_interval,
+            eval_interval=checkpoint_save_interval,
             deepspeed_config=deepspeed_config,
             seed=seed,
             device=device,
@@ -530,12 +530,12 @@ class TestCheckpointResumption:
     def _assert_expected_num_checkpoints(
         self,
         checkpoint_save_path: str,
-        save_interval: str,
+        checkpoint_save_interval: str,
         num_epochs: int,
         num_batches_per_epoch: int,
         is_deepspeed: bool,
     ):
-        interval = Time.from_timestring(save_interval)
+        interval = Time.from_timestring(checkpoint_save_interval)
         if interval.unit == TimeUnit.EPOCH:
             expected_num_files = ((num_epochs - 1) // interval.value) + 1
         else:
@@ -584,7 +584,7 @@ def test_rotate_checkpoints(
         train_dataloader=DataLoader(dataset=RandomImageDataset()),
         checkpoint_save_path=str(checkpoint_save_path),
         save_filename='checkpoint_{rank}_{batch}.pt',
-        save_interval='1ba',
+        checkpoint_save_interval='1ba',
         max_duration='10ba',
         save_num_checkpoints_to_keep=num_keep,
         device=device,

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -586,7 +586,7 @@ def test_rotate_checkpoints(
         save_filename='checkpoint_{rank}_{batch}.pt',
         checkpoint_save_interval='1ba',
         max_duration='10ba',
-        save_num_checkpoints_to_keep=num_keep,
+        num_checkpoints_to_keep=num_keep,
         device=device,
         deepspeed_config=deepseed_config,
     )

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -819,7 +819,11 @@ class TestTrainerEquivalence():
         config = copy.deepcopy(config)  # ensure the reference model is not passed to tests
 
         checkpoint_save_path = tmp_path_factory.mktemp('{device}-{precision}'.format(**config))
-        config.update({'checkpoint_save_interval': '1ep', 'checkpoint_save_path': str(checkpoint_save_path), 'save_filename': 'ep{epoch}.pt'})
+        config.update({
+            'checkpoint_save_interval': '1ep',
+            'checkpoint_save_path': str(checkpoint_save_path),
+            'save_filename': 'ep{epoch}.pt'
+        })
 
         trainer = Trainer(**config)
         trainer.fit()

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -818,14 +818,14 @@ class TestTrainerEquivalence():
         """Trains the reference model, and saves checkpoints."""
         config = copy.deepcopy(config)  # ensure the reference model is not passed to tests
 
-        save_folder = tmp_path_factory.mktemp('{device}-{precision}'.format(**config))
-        config.update({'save_interval': '1ep', 'save_folder': str(save_folder), 'save_filename': 'ep{epoch}.pt'})
+        checkpoint_save_path = tmp_path_factory.mktemp('{device}-{precision}'.format(**config))
+        config.update({'save_interval': '1ep', 'checkpoint_save_path': str(checkpoint_save_path), 'save_filename': 'ep{epoch}.pt'})
 
         trainer = Trainer(**config)
         trainer.fit()
 
         self.reference_model = trainer.state.model
-        self.reference_folder = save_folder
+        self.reference_folder = checkpoint_save_path
 
     def test_determinism(self, config, *args):
         trainer = Trainer(**config)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -819,7 +819,7 @@ class TestTrainerEquivalence():
         config = copy.deepcopy(config)  # ensure the reference model is not passed to tests
 
         checkpoint_save_path = tmp_path_factory.mktemp('{device}-{precision}'.format(**config))
-        config.update({'save_interval': '1ep', 'checkpoint_save_path': str(checkpoint_save_path), 'save_filename': 'ep{epoch}.pt'})
+        config.update({'checkpoint_save_interval': '1ep', 'checkpoint_save_path': str(checkpoint_save_path), 'save_filename': 'ep{epoch}.pt'})
 
         trainer = Trainer(**config)
         trainer.fit()


### PR DESCRIPTION
1.  Rename arguments
      1. `Trainer.save_folder` -> `Trainer.checkpoint_save_path`
      2. `Trainer.save_interval`  -> `Trainer.checkpoint_save_interval`
      3. `CheckpointSaver.folder` -> `CheckpointSaver.checkpoint_save_path`
      4. `Trainer.save_num_checkpoints_to_keep` -> `Trainer.num_checkpoints_to_keep`
      5. `CheckpointSaver.filename` -> `CheckpointSaver.checkpoint_filename`
      6. `CheckpointSaver.latest_filename` -> `CheckpointSaver.latest_checkpoint_filename`

2. Along for the ride
    *  Add skip tests for uninstalled modules (wandb and libcloud)

[PR Part 2](https://github.com/eracah/evan-composer/pull/1)