### PR TITLE
Add ADE20K and COCO v2 dataset behind a version flag

### DIFF
--- a/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
+++ b/composer/yamls/models/deeplabv3_streaming_ade20k_optimized.yaml
@@ -1,5 +1,6 @@
 train_dataset:
   streaming_ade20k:
+    version: 2
     remote: your-bucket-here
     local: /tmp/mds-cache/mds-ade20k/
     split: train
@@ -12,6 +13,7 @@ train_dataset:
     shuffle: true
 val_dataset:
   streaming_ade20k:
+    version: 2
     remote: your-bucket-here
     local: /tmp/mds-cache/mds-ade20k/
     split: val


### PR DESCRIPTION
## Description 
- Add a ADE20K and COCO v2 dataset behind a version flag
- Old PR with a similar change for reference https://github.com/mosaicml/composer/pull/1507