### PR TITLE
Pinned setuptools version to fix distutils version error

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   host:
     - python >=3.7
-    - setuptools
+    - setuptools <=59.5.0
     - git
   run:
     - python >=3.7,<4

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,7 @@ extra_deps['dev'] = [
     'mock-ssh-server==0.9.1',
     'cryptography==38.0.1',
     'pytest-httpserver>=1.0.4,<1.1',
+    'setuptools<=59.5.0',
 ]
 
 extra_deps['deepspeed'] = [


### PR DESCRIPTION
## Description
- Composer CI unittest is failing `AttributeError: module 'distutils' has no attribute 'version'`. This is because distutils Version classes are deprecated and recommendation is use `packaging.version` instead but the changes is not controlled by us as it is getting originated from [PyTorch Tensorboard code](https://github.com/pytorch/pytorch/blob/master/torch/utils/tensorboard/__init__.py#L2).
- Recommendation step mentioned in `https://github.com/pytorch/pytorch/issues/69894` is to pinned `setuptools` to `59.5.0`.
- There is already a tracking issue in PyTorch to fix this issue `https://github.com/pytorch/pytorch/issues/84712`.