### PR TITLE
Search index filtered by project

### DIFF
--- a/docs/source/_templates/base.html
+++ b/docs/source/_templates/base.html
@@ -115,7 +115,7 @@
       indexName: "mosaicml",
       container: '#algoliasearch',
       searchParameters: {
-        filters: `version:${siteVersion}`,
+        filters: `(version:${siteVersion} AND projects:composer)`,
         attributesToRetrieve: ['*']
       },
       transformItems(items) {


### PR DESCRIPTION
With indexes starting to include other projects - like streaming - we need a way to filter out search results for those projects