### PR TITLE
Add Pandoc to Docker images, bump version to 2.19.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,6 @@ ARG PILLOW_SIMD_VERSION=7.0.0.post3
 # Levave blank for no Mellanox Drivers
 ARG MOFED_VERSION=5.5-1.0.3.2
 
-# Pandoc is needed for the documentation buid and is a nuisance to install via pip so just installing via dpkg
-ARG PANDOC_VERSION=2.19.2
-
 ########################
 # Vision Image Arguments
 ########################
@@ -223,9 +220,10 @@ RUN if [ -n "$CUDA_VERSION" ] ; then \
 ###########################
 # Install Pandoc Dependency
 ###########################
-RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb && \
-    dpkg -i pandoc-${PANDOC_VERSION}-1-amd64.deb && \
-    rm pandoc-${PANDOC_VERSION}-1-amd64.deb
+# Pandoc is needed for the documentation buid and is a nuisance to install via pip so just installing via dpkg
+RUN wget https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-1-amd64.deb && \
+    dpkg -i pandoc-2.19.2-1-amd64.deb && \
+    rm pandoc-2.19.2-1-amd64.deb
 
 ################################
 # Use the correct python version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ ARG PILLOW_SIMD_VERSION=7.0.0.post3
 ARG MOFED_VERSION=5.5-1.0.3.2
 
 # Pandoc is needed for the documentation buid and is a nuisance to install via pip so just installing via dpkg
-ARG PANDOC_VERSION=2.18
+ARG PANDOC_VERSION=2.19.2
 
 ########################
 # Vision Image Arguments

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,9 @@ ARG PILLOW_SIMD_VERSION=7.0.0.post3
 # Levave blank for no Mellanox Drivers
 ARG MOFED_VERSION=5.5-1.0.3.2
 
+# Pandoc is needed for the documentation buid and is a nuisance to install via pip so just installing via dpkg
+ARG PANDOC_VERSION=2.18
+
 ########################
 # Vision Image Arguments
 ########################
@@ -217,6 +220,12 @@ RUN if [ -n "$CUDA_VERSION" ] ; then \
         pip${PYTHON_VERSION} install --no-cache-dir git+https://github.com/mvpatel2000/flash-attention@main ; \
     fi
 
+###########################
+# Install Pandoc Dependency
+###########################
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-1-amd64.deb && \
+    dpkg -i pandoc-${PANDOC_VERSION}-1-amd64.deb && \
+    rm pandoc-${PANDOC_VERSION}-1-amd64.deb
 
 ################################
 # Use the correct python version

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,7 @@ if not shutil.which('pandoc'):
                 target_folder = '/Applications/pandoc'
             # Not handling windows; nobody uses root on windows lol
 
-        download_pandoc(version='2.18', download_folder=tmpdir, targetfolder=target_folder, delete_installer=True)
+        download_pandoc(version='2.19.2', download_folder=tmpdir, targetfolder=target_folder, delete_installer=True)
 
 sys.path.insert(0, os.path.abspath('..'))
 


### PR DESCRIPTION
* Previously relying on installing pandoc through the documentation build 
* PyPandoc PyPi wrapper seems to be unreliable, at the time of this PR the `download_pandoc()` function is broken
* Solution: Install pandoc directly in the Docker image, will leave the conf.py as is to handle local builds