### PR TITLE
torch_xla multi-device support

### DIFF
--- a/composer/trainer/devices/device_tpu.py
+++ b/composer/trainer/devices/device_tpu.py
@@ -27,9 +27,12 @@ class DeviceTPU(Device):
     """
 
     def __init__(self):
-        import torch_xla.core.xla_model as xm
-
-        self._device = xm.xla_device()
+        # Can't use xm.xla_device() api here!
+        # Device is created before distributed is initialized.
+        # Initializing distributed after making a call to xm.xla_device
+        # results in the following error at dist init
+        # RuntimeError: Cannot replicate if number of devices (1) is different from 8
+        self._device = torch.device(f'xla:0')
 
     def module_to_device(self, module: T_nnModule) -> T_nnModule:
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -45,7 +45,7 @@ from composer.trainer._scaler import ClosureGradScaler
 from composer.trainer.ddp import DDPSyncStrategy, ddp_sync_context, prepare_ddp_module
 from composer.trainer.devices import Device, DeviceCPU, DeviceGPU, DeviceMPS, DeviceTPU
 from composer.utils import (ObjectStore, checkpoint, dist, ensure_tuple, format_name_with_dist, is_model_deepspeed,
-                            map_collection, model_eval_mode, reproducibility)
+                            is_torch_xla_installed, map_collection, model_eval_mode, reproducibility)
 from composer.utils.file_helpers import get_file
 from composer.utils.import_helpers import MissingConditionalImportError
 from composer.utils.inference import ExportFormat, Transform, export_with_logger
@@ -236,7 +236,7 @@ def _get_device(device: Optional[Union[str, Device]]):
         elif device.lower() == 'mps':
             device = DeviceMPS()
         elif device.lower() == 'tpu':
-            if not _is_tpu_installed():
+            if not is_torch_xla_installed():
                 raise ImportError(
                     'Unable to import torch_xla. Please follow installation instructions at https://github.com/pytorch/xla'
                 )
@@ -289,17 +289,7 @@ def _generate_run_name() -> str:
     return generated_run_name
 
 
-def _is_tpu_installed() -> bool:
-    try:
-        import torch_xla.core.xla_model as xm
-        del xm
-    except ImportError:
-        return False
-    else:
-        return True
-
-
-if _is_tpu_installed():
+if is_torch_xla_installed():
     import torch_xla.core.xla_model as xm
     import torch_xla.distributed.parallel_loader as pl
 

--- a/composer/trainer/trainer_hparams.py
+++ b/composer/trainer/trainer_hparams.py
@@ -37,8 +37,8 @@ from composer.profiler import Profiler
 from composer.trainer.ddp import DDPSyncStrategy
 from composer.trainer.devices import Device, DeviceCPU, DeviceGPU, DeviceTPU
 from composer.trainer.devices.device_hparams_registry import device_registry
-from composer.trainer.trainer import Trainer, _is_tpu_installed
-from composer.utils import dist, reproducibility
+from composer.trainer.trainer import Trainer
+from composer.utils import dist, is_torch_xla_installed, reproducibility
 from composer.utils.object_store.object_store_hparams import ObjectStoreHparams, object_store_registry
 
 if TYPE_CHECKING:
@@ -476,7 +476,7 @@ class TrainerHparams(hp.Hparams):
         model = self.model.initialize_object()
         # on TPUs, model must be moved to device before optimizer creation
         if isinstance(device, DeviceTPU):
-            if not _is_tpu_installed():
+            if not is_torch_xla_installed():
                 raise ImportError(
                     'Unable to import torch_xla. Please follow installation instructions at https://github.com/pytorch/xla'
                 )

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -13,7 +13,7 @@ from composer.utils.file_helpers import (create_symlink_file, ensure_folder_has_
 from composer.utils.import_helpers import MissingConditionalImportError, import_object
 from composer.utils.inference import export_for_inference, export_with_logger, quantize_dynamic
 from composer.utils.iter_helpers import IteratorFileStream, ensure_tuple, map_collection
-from composer.utils.misc import is_model_deepspeed, is_notebook, model_eval_mode
+from composer.utils.misc import is_model_deepspeed, is_notebook, is_torch_xla_installed, model_eval_mode
 from composer.utils.object_store import (LibcloudObjectStore, ObjectStore, ObjectStoreTransientError, S3ObjectStore,
                                          SFTPObjectStore)
 from composer.utils.retrying import retry
@@ -52,6 +52,7 @@ __all__ = [
     'import_object',
     'is_model_deepspeed',
     'is_notebook',
+    'is_torch_xla_installed',
     'StringEnum',
     'load_checkpoint',
     'save_checkpoint',

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -10,7 +10,10 @@ from typing import Type
 import torch
 from torch.nn.parallel import DistributedDataParallel
 
-__all__ = ['is_model_deepspeed', 'is_notebook', 'warning_on_one_line', 'get_free_tcp_port', 'model_eval_mode']
+__all__ = [
+    'is_model_deepspeed', 'is_notebook', 'warning_on_one_line', 'get_free_tcp_port', 'model_eval_mode',
+    'is_torch_xla_installed'
+]
 
 
 def is_model_deepspeed(model: torch.nn.Module) -> bool:
@@ -62,3 +65,14 @@ def model_eval_mode(model: torch.nn.Module):
         yield
     finally:
         model.train(mode=is_training)
+
+
+def is_torch_xla_installed() -> bool:
+    """Whether torch_xla is installed in the current environment."""
+    try:
+        import torch_xla.core.xla_model as xm
+        del xm
+    except ModuleNotFoundError:
+        return False
+    else:
+        return True


### PR DESCRIPTION
Adds support for multi-device training using torch_xla. 

The resnet9 on cifar10 trains fine on 2 GPUs using torch_xla.  


Some of the issues I ran into while adding this support:
- with torch_xla on GPUs, dist.is_initialized()returns false
    - Everything is handled by ENV vars
- composer.utils.dist.initialize_dist is called twice in YAHP flow.
    - Which make torch_xla thing we have 2x the number of GPUS
- There are some env vars that we need to setup before forking
- xm.* functions cannot be called until torch_xla env. is init properly.
    - We call them before init in constructing device object.
- broadcast doesn't exist in current release of torch_xla
  - Implemented with all_reduce. 

Test: 

`composer -n 2 examples/run_composer_trainer.py -f composer/yamls/models/resnet9_cifar10.yaml --train_dataset.cifar10.datadir /tmp/cifar --train_dataset.cifar10.download true --val_dataset.cifar10.datadir /tmp/cifar --val_dataset.cifar10.download true --max_duration 2ep --train_subset_num_batches 2 --device 'tpu'`