### PR TITLE
Adding in erroring for when using GradMonitor and DeepSpeed

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -28,7 +28,7 @@ from torch.utils.data import DataLoader, DistributedSampler
 from torchmetrics import Metric
 
 from composer.algorithms import GradientClipping
-from composer.callbacks import CheckpointSaver
+from composer.callbacks import CheckpointSaver, GradMonitor
 from composer.core import (Algorithm, Callback, DataSpec, Engine, Evaluator, Event, Precision, State, Time, Timestamp,
                            ensure_data_spec, ensure_evaluator, ensure_time)
 from composer.core.precision import get_precision_context
@@ -1046,6 +1046,12 @@ class Trainer:
         self._ddp_sync_strategy = _get_ddp_sync_strategy(ddp_sync_strategy, self._find_unused_parameters)
         # Configure Deepspeed
         if self.state.deepspeed_config is not None:
+            for callback in self.state.callbacks:
+                if isinstance(callback, GradMonitor):
+                    raise ValueError('GradMonitor is not supported with DeepSpeed because DeepSpeed clears '
+                                    'the gradients before in the last call to .backward see: '
+                                    'https://github.com/microsoft/DeepSpeed/issues/2329 for more details.')
+
             try:
                 import deepspeed
             except ImportError as e:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1049,8 +1049,8 @@ class Trainer:
             for callback in self.state.callbacks:
                 if isinstance(callback, GradMonitor):
                     raise ValueError('GradMonitor is not supported with DeepSpeed because DeepSpeed clears '
-                                    'the gradients before in the last call to .backward see: '
-                                    'https://github.com/microsoft/DeepSpeed/issues/2329 for more details.')
+                                     'the gradients before in the last call to .backward see: '
+                                     'https://github.com/microsoft/DeepSpeed/issues/2329 for more details.')
 
             try:
                 import deepspeed


### PR DESCRIPTION
As above. When running with DeepSpeed and GradMonitor throw an error:

`Traceback (most recent call last): File "/workdisk/brandon/composer_git/scratch/run_composer_trainer.py", line 76, in <module> _main() File "/workdisk/brandon/composer_git/scratch/run_composer_trainer.py", line 46, in _main trainer = hparams.initialize_object() File "/workdisk/brandon/composer_git/composer/trainer/trainer_hparams.py", line 515, in initialize_object trainer = Trainer( File "/workdisk/brandon/composer_git/composer/trainer/trainer.py", line 1051, in __init__ raise TypeError('GradMonitor is not supported with DeepSpeed because DeepSpeed clears ' TypeError: GradMonitor is not supported with DeepSpeed because DeepSpeed clears the gradients before in the last call to .backward see:https://github.com/microsoft/DeepSpeed/issues/2329 for more details.`