### PR TITLE
Add missing _enabled flag, post_close, and clean up comet ml tests

### DIFF
--- a/tests/loggers/test_cometml_logger.py
+++ b/tests/loggers/test_cometml_logger.py
@@ -1,15 +1,122 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 import os
 import zipfile
+from collections import defaultdict
 from json import JSONDecoder
 from pathlib import Path
 
 import pytest
+from torch.utils.data import DataLoader
+
+from composer.trainer import Trainer
+from tests.common import RandomClassificationDataset, SimpleModel
 
 
-def test_comet_ml_logging(monkeypatch, tmp_path):
+def test_comet_ml_logging_train_loop(monkeypatch, tmp_path):
+    pytest.importorskip('comet_ml', reason='comet_ml is optional')
+    import comet_ml
+
+    monkeypatch.setattr(comet_ml, 'Experiment', comet_ml.OfflineExperiment)
+    from composer.loggers import CometMLLogger
+
+    # Set offline directory.
+    offline_directory = str(tmp_path / Path('.my_cometml_runs'))
+    os.environ['COMET_OFFLINE_DIRECTORY'] = offline_directory
+
+    comet_logger = CometMLLogger()
+
+    trainer = Trainer(
+        model=SimpleModel(),
+        train_dataloader=DataLoader(RandomClassificationDataset()),
+        train_subset_num_batches=2,
+        max_duration='2ep',
+        loggers=comet_logger,
+    )
+    trainer.fit()
+
+    del trainer
+
+    assert comet_logger.experiment is not None
+
+    # Open, decompress, decode, and extract offline dump of metrics.
+    comet_exp_dump_filepath = str(Path(offline_directory) / Path(comet_logger.experiment.id).with_suffix('.zip'))
+    zf = zipfile.ZipFile(comet_exp_dump_filepath)
+    comet_logs_path = zf.extract('messages.json', path=offline_directory)
+    jd = JSONDecoder()
+    msg_type_to_msgs = defaultdict(list)
+
+    with open(comet_logs_path) as f:
+        for line in f.readlines():
+            parsed_line = jd.decode(line)
+            msg_type_to_msgs[parsed_line['type']].append(parsed_line['payload'])
+
+    # Check that init set the run name
+    assert comet_logger.name is not None
+    assert comet_logger.experiment.name is not None
+
+    # Check that basic metrics appear in the comet logs
+    assert len([
+        metric_msg for metric_msg in msg_type_to_msgs['metric_msg'] if metric_msg['metric']['metricName'] == 'epoch'
+    ]) == 2
+
+    # Check that basic params appear in the comet logs
+    assert len([
+        metric_msg for metric_msg in msg_type_to_msgs['metric_msg'] if metric_msg['metric']['metricName'] == 'epoch'
+    ]) > 0
+
+
+def test_comet_ml_post_close(monkeypatch, tmp_path):
+    pytest.importorskip('comet_ml', reason='comet_ml is optional')
+    import comet_ml
+
+    monkeypatch.setattr(comet_ml, 'Experiment', comet_ml.OfflineExperiment)
+    from composer.loggers import CometMLLogger
+
+    # Set offline directory.
+    offline_directory = str(tmp_path / Path('.my_cometml_runs'))
+    os.environ['COMET_OFFLINE_DIRECTORY'] = offline_directory
+
+    comet_logger = CometMLLogger()
+    comet_logger.post_close()
+
+    assert comet_logger.experiment is not None
+    assert comet_logger.experiment.ended
+
+
+def test_comet_ml_log_created_from_key(monkeypatch, tmp_path):
+    pytest.importorskip('comet_ml', reason='comet_ml is optional')
+    import comet_ml
+
+    monkeypatch.setattr(comet_ml, 'Experiment', comet_ml.OfflineExperiment)
+    from composer.loggers import CometMLLogger
+
+    # Set offline directory.
+    offline_directory = str(tmp_path / Path('.my_cometml_runs'))
+    os.environ['COMET_OFFLINE_DIRECTORY'] = offline_directory
+
+    comet_logger = CometMLLogger()
+    comet_logger.post_close()
+
+    assert comet_logger.experiment is not None
+
+    # Open, decompress, decode, and check for Created from key logged
+    comet_exp_dump_filepath = str(Path(offline_directory) / Path(comet_logger.experiment.id).with_suffix('.zip'))
+    zf = zipfile.ZipFile(comet_exp_dump_filepath)
+    comet_logs_path = zf.extract('messages.json', path=offline_directory)
+    jd = JSONDecoder()
+    created_from_found = False
+    expected_created_from_log = {'key': 'Created from', 'val': 'mosaicml-composer'}
+    with open(comet_logs_path) as f:
+        for line in f.readlines():
+            comet_msg = jd.decode(line)
+            if comet_msg['type'] == 'ws_msg' and comet_msg['payload'].get('log_other', {}) == expected_created_from_log:
+                created_from_found = True
+
+    assert created_from_found
+
+
+def test_comet_ml_log_metrics_and_hyperparameters(monkeypatch, tmp_path):
     """Check metrics logged with CometMLLogger are properly written to offline dump."""
     pytest.importorskip('comet_ml', reason='comet_ml is optional')
     import comet_ml
@@ -35,7 +142,11 @@ def test_comet_ml_logging(monkeypatch, tmp_path):
     comet_logger.log_hyperparameters(dict(zip(param_names, param_values)))
     for step, metric_value in zip(steps, metric_values):
         comet_logger.log_metrics({'my_test_metric': metric_value}, step=step)
-    comet_logger.experiment.end()
+
+    # Simulate the post_close call to end the CometML experiment
+    comet_logger.post_close()
+
+    assert comet_logger.experiment is not None
 
     # Open, decompress, decode, and extract offline dump of metrics.
     comet_exp_dump_filepath = str(Path(offline_directory) / Path(comet_logger.experiment.id).with_suffix('.zip'))
@@ -59,5 +170,8 @@ def test_comet_ml_logging(monkeypatch, tmp_path):
     assert [msg['metricValue'] for msg in metric_msgs] == metric_values
     assert [msg['step'] for msg in metric_msgs] == steps
     assert all([msg['metricName'] == metric_name for msg in metric_msgs])
+
+    # Assert dummy params input to log_hyperparameters are the same as
+    # those written to offline dump
     assert [msg['paramValue'] for msg in param_msgs] == param_values
     assert [msg['paramName'] for msg in param_msgs] == param_names


### PR DESCRIPTION
- Call experiment.end in post_close
- Log a Created from value to CometML
- Refactor test to be more complete

Items 2 and 3 from CO-1104
Also fixes CO-1160

Run from v0.10.0 branch: https://www.comet.com/mosaic-ml/daniel-test/92f7bd9ec1a948408fccfd59eb47f0bc?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step
Run from the commit in this PR on top of v0.10.0 (not on top of dev, because MNIST example is broken on dev right now): https://www.comet.com/mosaic-ml/daniel-test/dca086a1a5b1453f9640d9c165d38bb4?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step

Can see that the run on v0.10.0 branch (1:27pm) has an extra ghost experiment, while the run with this PR (1:22pm) does not 
<img width="1918" alt="Screen Shot 2022-09-29 at 1 30 12 PM" src="https://user-images.githubusercontent.com/43149077/193135731-3d111012-b686-419c-a1c1-733ca2bbbc4b.png">

BERT run from this PR: https://www.comet.com/mosaic-ml/daniel-test/a80735743905431da12661c664f7e52f?experiment-tab=chart&showOutliers=true&smoothing=0&transformY=smoothing&xAxis=step
