### PR TITLE
Remove tensorflow-io from setup.py

### DIFF
--- a/examples/training_without_local_storage.ipynb
+++ b/examples/training_without_local_storage.ipynb
@@ -1071,11 +1071,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3.10.6 ('ec': venv)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1085,13 +1080,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.6"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "0686aae3475ddc031b78643f3167ba8bdbdc3abbaca8e672761c7d1fadf2f6e5"
-   }
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/training_without_local_storage.ipynb
+++ b/examples/training_without_local_storage.ipynb
@@ -94,6 +94,7 @@
    "outputs": [],
    "source": [
     "%pip install 'mosaicml[streaming,tensorboard]'\n",
+    "%pip install 'tensorflow-io'\n",
     "\n",
     "# To install from source instead of the last release, comment the command above and uncomment the following one.\n",
     "# %pip install 'mosaicml[streaming,tensorboard] @ git+https://github.com/mosaicml/composer.git'"
@@ -1070,6 +1071,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.6 ('ec': venv)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -1079,7 +1085,13 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0686aae3475ddc031b78643f3167ba8bdbdc3abbaca8e672761c7d1fadf2f6e5"
+   }
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,6 @@ extra_deps['comet_ml'] = ['comet_ml>=3.31.12,<4.0.0']
 
 extra_deps['tensorboard'] = [
     'tensorboard>=2.9.1,<3.0.0',
-    'tensorflow-io>=0.26.0,<0.28',
 ]
 
 extra_deps['unet'] = [


### PR DESCRIPTION
removes tensorflow-io as a requirement and adds tensorflow-io import to `examples/training_without_local_storage.ipynb`