### PR TITLE
Add step explicitly to ImageVisualizer logging calls

### DIFF
--- a/composer/callbacks/image_visualizer.py
+++ b/composer/callbacks/image_visualizer.py
@@ -123,7 +123,7 @@ class ImageVisualizer(Callback):
             # Only log to the wandb logger if it is available
             for destination in ensure_tuple(logger.destinations):
                 if isinstance(destination, WandBLogger) or isinstance(destination, InMemoryLogger):
-                    destination.log_metrics({data_name: table})
+                    destination.log_metrics({data_name: table}, state.timestamp.batch.value)
 
     def _log_segmented_inputs(self, state: State, logger: Logger, data_name: str):
         inputs = state.batch_get_item(key=self.input_key)
@@ -144,7 +144,7 @@ class ImageVisualizer(Callback):
         # Only log to the wandb logger if it is available
         for destination in ensure_tuple(logger.destinations):
             if isinstance(destination, WandBLogger) or isinstance(destination, InMemoryLogger):
-                destination.log_metrics({data_name: table})
+                destination.log_metrics({data_name: table}, state.timestamp.batch.value)
 
     def before_forward(self, state: State, logger: Logger):
         if self.mode.lower() == 'input' and state.timestamp.get(self.interval.unit).value % self.interval.value == 0:


### PR DESCRIPTION
# What does this PR do?
Resolves an issue where `ImageVisualizer` was not logging images to w&b with a step. This caused an issue because w&b auto increments step on every log call if you don't pass it in.

# What issue(s) does this change relate to?
Fixes CO-1169.

# Manual test
Experiment before the fix (note that `metrics/eval` is not present: https://wandb.ai/mosaic-ml/daniel-debug/runs/2sbl8ujb
Experiment after the fix (note that `metrics/eval` is present, but everything else is the same): https://wandb.ai/mosaic-ml/daniel-debug/runs/1vt8vmea

Spawned tickets:
- CO-1181: Add a unit test, not including in this PR because it is a hot fix.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))
