### PR TITLE
Remove unused fixture

### DIFF
--- a/tests/fixtures/new_fixtures.py
+++ b/tests/fixtures/new_fixtures.py
@@ -4,7 +4,6 @@
 """These fixtures are shared globally across the test suite."""
 import datetime
 import os
-import shutil
 import time
 
 import coolname
@@ -74,15 +73,6 @@ def configure_dist(request: pytest.FixtureRequest):
     # any test before other ranks are ready to start it, which could be a cause of random timeouts
     # (e.g. rank 1 starts the next test while rank 0 is finishing up the previous test).
     dist.barrier()
-
-
-# Class-scoped temporary directory. That deletes itself. This is useful for e.g. not
-# writing too many checkpoints.
-@pytest.fixture(scope='class')
-def self_destructing_tmp(tmp_path_factory: pytest.TempPathFactory):
-    my_tmp_path = tmp_path_factory.mktemp('checkpoints')
-    yield my_tmp_path
-    shutil.rmtree(str(my_tmp_path))
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
# What does this PR do?

Removes unused fixture, which likely was a leftover from after we switched to the inbuilt `tmp_path` fixture.

# What issue(s) does this change relate to?

N/A
