### PR TITLE
fix loss and eval_forward for HF models

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -96,13 +96,19 @@ class HuggingFaceModel(ComposerModel):
         return output
 
     def loss(self, outputs, batch):
-        return outputs['loss']
+        if self.config.use_return_dict:
+            return outputs['loss']
+        else:
+            return outputs[0]
 
     def eval_forward(self, batch, outputs: Optional[Any] = None):
         output = outputs if outputs else self.forward(batch)
         if self.use_logits:
             self.labels = batch.pop('labels')
-            output = output['logits']
+            if self.config.use_return_dict:
+                output = output['logits']
+            else:
+                output = output[1]
 
             # if we are in the single class case, then remove the classes dimension
             if output.shape[1] == 1:

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -99,6 +99,7 @@ class HuggingFaceModel(ComposerModel):
         if self.config.use_return_dict:
             return outputs['loss']
         else:
+            # loss is at index 0 in the output tuple
             return outputs[0]
 
     def eval_forward(self, batch, outputs: Optional[Any] = None):
@@ -108,6 +109,7 @@ class HuggingFaceModel(ComposerModel):
             if self.config.use_return_dict:
                 output = output['logits']
             else:
+                # logits are at index 1 in the output tuple
                 output = output[1]
 
             # if we are in the single class case, then remove the classes dimension


### PR DESCRIPTION
HuggingFace model output is a dict or a tuple based on `use_return_dict` config. For loss/eval_forward we assume that it's a dict. Fix this. 

TEST: 
Model with config that has `return_dict=True` works fine. 