### PR TITLE
Remove log level and should_log_artifact

### DIFF
--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -19,7 +19,6 @@ import composer
 from composer.core import State
 from composer.core.callback import Callback
 from composer.loggers import Logger
-from composer.loggers.logger import LogLevel
 from composer.utils import dist
 
 try:
@@ -221,7 +220,7 @@ class MLPerfCallback(Callback):
             })
 
             # optionally, upload the system description file
-            logger.file_artifact(LogLevel.FIT, self.system_desc_upload_name, self.systems_path)
+            logger.file_artifact(self.system_desc_upload_name, self.systems_path)
 
     def _create_submission_folders(self, root_folder: str, system_name: str, benchmark: str):
         os.makedirs(root_folder, exist_ok=True)
@@ -308,7 +307,7 @@ class MLPerfCallback(Callback):
     def epoch_end(self, state: State, logger: Logger) -> None:
         if _global_rank_zero():
             self.mllogger.event(key=constants.EPOCH_STOP, metadata={'epoch_num': state.timestamp.epoch.value})
-            logger.file_artifact(LogLevel.FIT, artifact_name=self.upload_name, file_path=self.filename)
+            logger.file_artifact(artifact_name=self.upload_name, file_path=self.filename)
 
     def eval_start(self, state: State, logger: Logger) -> None:
         if _global_rank_zero():

--- a/composer/loggers/__init__.py
+++ b/composer/loggers/__init__.py
@@ -15,7 +15,7 @@ define a custom logger and use it when training.
 from composer.loggers.cometml_logger import CometMLLogger
 from composer.loggers.file_logger import FileLogger
 from composer.loggers.in_memory_logger import InMemoryLogger
-from composer.loggers.logger import Logger, LogLevel
+from composer.loggers.logger import Logger
 from composer.loggers.logger_destination import LoggerDestination
 from composer.loggers.object_store_logger import ObjectStoreLogger
 from composer.loggers.progress_bar_logger import ProgressBarLogger
@@ -26,7 +26,6 @@ from composer.loggers.wandb_logger import WandBLogger
 __all__ = [
     'Logger',
     'LoggerDestination',
-    'LogLevel',
     'FileLogger',
     'InMemoryLogger',
     'ProgressBarLogger',

--- a/composer/loggers/file_logger.py
+++ b/composer/loggers/file_logger.py
@@ -12,7 +12,7 @@ import textwrap
 from typing import Any, Callable, Dict, Optional, TextIO
 
 from composer.core.state import State
-from composer.loggers.logger import Logger, LogLevel, format_log_data_value
+from composer.loggers.logger import Logger, format_log_data_value
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils.file_helpers import FORMAT_NAME_WITH_DIST_TABLE, format_name_with_dist
 
@@ -25,7 +25,7 @@ class FileLogger(LoggerDestination):  # noqa: D101
     Example usage:
         .. testcode::
 
-            from composer.loggers import FileLogger, LogLevel
+            from composer.loggers import FileLogger
             from composer.trainer import Trainer
             file_logger = FileLogger(
                 filename="{{run_name}}/logs-rank{{rank}}.txt",
@@ -277,7 +277,7 @@ class FileLogger(LoggerDestination):  # noqa: D101
 
         self.file.flush()
         os.fsync(self.file.fileno())
-        logger.file_artifact(LogLevel.FIT, self.artifact_name, self.file.name, overwrite=True)
+        logger.file_artifact(self.artifact_name, self.file.name, overwrite=True)
 
     def fit_end(self, state: State, logger: Logger) -> None:
         # Flush the file on fit_end, in case if was not flushed on epoch_end and the trainer is re-used

--- a/composer/loggers/in_memory_logger.py
+++ b/composer/loggers/in_memory_logger.py
@@ -30,7 +30,7 @@ class InMemoryLogger(LoggerDestination):
     Example usage:
         .. testcode::
 
-            from composer.loggers import InMemoryLogger, LogLevel
+            from composer.loggers import InMemoryLogger
             from composer.trainer import Trainer
             logger = InMemoryLogger(
             )
@@ -47,7 +47,7 @@ class InMemoryLogger(LoggerDestination):
             logged_data = trainer.logger.destinations[0].data
 
     Attributes:
-        data (Dict[str, List[Tuple[Timestamp, LogLevel, Any]]]): Mapping of a logged key to
+        data (Dict[str, List[Tuple[Timestamp, Any]]]): Mapping of a logged key to
             a (:class:`~.time.Timestamp`, logged value) tuple.
             This dictionary contains all logged data.
         most_recent_values (Dict[str, Any]): Mapping of a key to the most recent value for that key.

--- a/composer/loggers/logger.py
+++ b/composer/loggers/logger.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import collections.abc
 import operator
 import pathlib
-from enum import IntEnum
 from functools import reduce
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
 
@@ -21,33 +20,7 @@ if TYPE_CHECKING:
     from composer.core.state import State
     from composer.loggers.logger_destination import LoggerDestination
 
-__all__ = ['LoggerDestination', 'Logger', 'LogLevel', 'format_log_data_value']
-
-
-class LogLevel(IntEnum):
-    """LogLevel denotes when in the training loop log messages are generated.
-
-    Logging destinations use the LogLevel to determine whether to record a given
-    metric or state change.
-
-    Attributes:
-        FIT: Logged once per training run.
-        EPOCH: Logged once per epoch.
-        BATCH: Logged once per batch.
-    """
-    FIT = 1
-    EPOCH = 2
-    BATCH = 3
-
-    @classmethod
-    def _missing_(cls, value: object):
-        if isinstance(value, LogLevel):
-            return value
-        if isinstance(value, int):
-            return LogLevel(value)
-        if isinstance(value, str):
-            return LogLevel[value.upper()]
-        return super()._missing_(value)
+__all__ = ['LoggerDestination', 'Logger', 'format_log_data_value']
 
 
 class Logger:
@@ -110,7 +83,6 @@ class Logger:
 
     def file_artifact(
         self,
-        log_level: Union[str, int, LogLevel],
         artifact_name: str,
         file_path: Union[pathlib.Path, str],
         *,
@@ -124,20 +96,16 @@ class Logger:
         .. seealso:: :doc:`Artifact Logging</trainer/artifact_logging>` for notes for file artifact logging.
 
         Args:
-            log_level (str | int | LogLevel): The log level, which can be a name, value, or instance of
-                :class:`LogLevel`.
             artifact_name (str): A format string for the name of the artifact.
             file_path (str | pathlib.Path): A format string for the file path.
             overwrite (bool, optional): Whether to overwrite an existing artifact with the same ``artifact_name``.
                 (default: ``False``)
         """
-        log_level = LogLevel(log_level)
         file_path = format_name_with_dist(format_str=str(file_path), run_name=self._state.run_name)
         file_path = pathlib.Path(file_path)
         for destination in self.destinations:
             destination.log_file_artifact(
                 state=self._state,
-                log_level=log_level,
                 artifact_name=format_name_with_dist(format_str=artifact_name, run_name=self._state.run_name),
                 file_path=file_path,
                 overwrite=overwrite,

--- a/composer/loggers/logger_destination.py
+++ b/composer/loggers/logger_destination.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional
 
 from composer.core.callback import Callback
 from composer.core.state import State
-from composer.loggers.logger import LogLevel
 
 __all__ = ['LoggerDestination']
 
@@ -78,7 +77,6 @@ class LoggerDestination(Callback, ABC):
     def log_file_artifact(
         self,
         state: State,
-        log_level: LogLevel,
         artifact_name: str,
         file_path: pathlib.Path,
         *,
@@ -106,13 +104,12 @@ class LoggerDestination(Callback, ABC):
 
         Args:
             state (State): The training state.
-            log_level (Union[str, LogLevel]): A :class:`LogLevel`.
             artifact_name (str): The name of the artifact.
             file_path (pathlib.Path): The file path.
             overwrite (bool, optional): Whether to overwrite an existing artifact with the same ``artifact_name``.
                 (default: ``False``)
         """
-        del state, log_level, artifact_name, file_path, overwrite  # unused
+        del state, artifact_name, file_path, overwrite  # unused
         pass
 
     def get_file_artifact(

--- a/composer/loggers/logger_hparams_registry.py
+++ b/composer/loggers/logger_hparams_registry.py
@@ -22,7 +22,6 @@ from composer.loggers.object_store_logger import ObjectStoreLogger
 from composer.loggers.progress_bar_logger import ProgressBarLogger
 from composer.loggers.tensorboard_logger import TensorboardLogger
 from composer.loggers.wandb_logger import WandBLogger
-from composer.utils import import_object
 from composer.utils.object_store.object_store_hparams import ObjectStoreHparams, object_store_registry
 
 __all__ = [
@@ -37,16 +36,6 @@ class ObjectStoreLoggerHparams(hp.Hparams):
 
     Args:
         object_store_hparams (ObjectStoreHparams): The object store provider hparams.
-        should_log_artifact (str, optional): The path to a filter function which returns whether an artifact should be
-            logged. The path should be of the format ``path.to.module:filter_function_name``.
-
-            The function should take (:class:`~composer.core.State`, :class:`.LogLevel`, ``<artifact name>``).
-            The artifact name will be a string. The function should return a boolean indicating whether the artifact
-            should be logged.
-
-            .. seealso: :func:`composer.utils.import_helpers.import_object`
-
-            Setting this parameter to ``None`` (the default) will log all artifacts.
         object_name (str, optional): See :class:`.ObjectStoreLogger`.
         num_concurrent_uploads (int, optional): See :class:`.ObjectStoreLogger`.
         upload_staging_folder (str, optional): See :class:`.ObjectStoreLogger`.
@@ -58,8 +47,6 @@ class ObjectStoreLoggerHparams(hp.Hparams):
     }
 
     object_store_hparams: ObjectStoreHparams = hp.required('Object store provider hparams.')
-    should_log_artifact: Optional[str] = hp.optional(
-        'Path to a filter function which returns whether an artifact should be logged.', default=None)
     object_name: str = hp.auto(ObjectStoreLogger, 'object_name')
     num_concurrent_uploads: int = hp.auto(ObjectStoreLogger, 'num_concurrent_uploads')
     use_procs: bool = hp.auto(ObjectStoreLogger, 'use_procs')
@@ -71,8 +58,6 @@ class ObjectStoreLoggerHparams(hp.Hparams):
             object_store_cls=self.object_store_hparams.get_object_store_cls(),
             object_store_kwargs=self.object_store_hparams.get_kwargs(),
             object_name=self.object_name,
-            should_log_artifact=import_object(self.should_log_artifact)
-            if self.should_log_artifact is not None else None,
             num_concurrent_uploads=self.num_concurrent_uploads,
             upload_staging_folder=self.upload_staging_folder,
             use_procs=self.use_procs,

--- a/composer/loggers/object_store_logger.py
+++ b/composer/loggers/object_store_logger.py
@@ -20,7 +20,7 @@ from multiprocessing.context import SpawnProcess
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 from composer.core.state import State
-from composer.loggers.logger import Logger, LogLevel
+from composer.loggers.logger import Logger
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import ObjectStore, ObjectStoreTransientError, dist, format_name_with_dist, get_file, retry
 
@@ -138,7 +138,6 @@ class ObjectStoreLogger(LoggerDestination):
                 >>> object_store_logger = ObjectStoreLogger(..., object_name='rank_{rank}/{artifact_name}')
                 >>> trainer = Trainer(..., run_name='foo', loggers=[object_store_logger])
                 >>> trainer.logger.file_artifact(
-                ...     log_level=LogLevel.EPOCH,
                 ...     artifact_name='bar.txt',
                 ...     file_path='path/to/file.txt',
                 ... )
@@ -295,7 +294,6 @@ class ObjectStoreLogger(LoggerDestination):
     def log_file_artifact(
         self,
         state: State,
-        log_level: LogLevel,
         artifact_name: str,
         file_path: pathlib.Path,
         *,

--- a/composer/loggers/object_store_logger.py
+++ b/composer/loggers/object_store_logger.py
@@ -29,12 +29,6 @@ log = logging.getLogger(__name__)
 __all__ = ['ObjectStoreLogger']
 
 
-def _always_log(state: State, log_level: LogLevel, artifact_name: str):
-    """Function that can be passed into ``should_log_artifact`` to log all artifacts."""
-    del state, log_level, artifact_name  # unused
-    return True
-
-
 def _build_object_store(object_store_cls: Type[ObjectStore], object_store_kwargs: Dict[str, Any]):
     # error: Expected no arguments to "ObjectStore" constructor
     return object_store_cls(**object_store_kwargs)  # type: ignore
@@ -73,7 +67,7 @@ class ObjectStoreLogger(LoggerDestination):
 
     .. note::
 
-        This callback blocks the training loop to copy each artifact where ``should_log_artifact`` returns ``True``, as
+        This callback blocks the training loop to copy each artifact, as
         the uploading happens in the background. Here are some additional tips for minimizing the performance impact:
 
         *   Set ``should_log`` to filter which artifacts will be logged. By default, all artifacts are logged.
@@ -97,14 +91,6 @@ class ObjectStoreLogger(LoggerDestination):
 
             As individual :class:`.ObjectStore` instances are not necessarily thread safe, each worker will construct
             its own :class:`.ObjectStore` instance from ``object_store_cls`` and ``object_store_kwargs``.
-
-        should_log_artifact ((State, LogLevel, str) -> bool, optional): A function to filter which artifacts
-            are uploaded.
-
-            The function should take the (current training state, log level, artifact name) and return a boolean
-            indicating whether this file should be uploaded.
-
-            By default, all artifacts will be uploaded.
 
         object_name (str, optional): A format string used to determine the object name.
 
@@ -180,7 +166,6 @@ class ObjectStoreLogger(LoggerDestination):
     def __init__(self,
                  object_store_cls: Type[ObjectStore],
                  object_store_kwargs: Dict[str, Any],
-                 should_log_artifact: Optional[Callable[[State, LogLevel, str], bool]] = None,
                  object_name: str = '{artifact_name}',
                  num_concurrent_uploads: int = 4,
                  upload_staging_folder: Optional[str] = None,
@@ -188,9 +173,6 @@ class ObjectStoreLogger(LoggerDestination):
                  num_attempts: int = 3) -> None:
         self.object_store_cls = object_store_cls
         self.object_store_kwargs = object_store_kwargs
-        if should_log_artifact is None:
-            should_log_artifact = _always_log
-        self.should_log_artifact = should_log_artifact
         self.object_name = object_name
         self.num_attempts = num_attempts
         self._run_name = None
@@ -319,8 +301,6 @@ class ObjectStoreLogger(LoggerDestination):
         *,
         overwrite: bool,
     ):
-        if not self.should_log_artifact(state, log_level, artifact_name):
-            return
         copied_path = os.path.join(self._upload_staging_folder, str(uuid.uuid4()))
         os.makedirs(self._upload_staging_folder, exist_ok=True)
         shutil.copy2(file_path, copied_path)

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -111,7 +111,7 @@ class ProgressBarLogger(LoggerDestination):
     .. note::
 
         This logger is automatically instainatied by the trainer via the ``progress_bar``, ``log_to_console``,
-        ``log_level``, and ``console_stream`` options. This logger does not need to be created manually.
+        and ``console_stream`` options. This logger does not need to be created manually.
 
     `TQDM <https://github.com/tqdm/tqdm>`_ is used to display progress bars.
 

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from composer.core.state import State
-from composer.loggers.logger import Logger, LogLevel, format_log_data_value
+from composer.loggers.logger import Logger, format_log_data_value
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import dist
 from composer.utils.import_helpers import MissingConditionalImportError
@@ -153,8 +153,7 @@ class TensorboardLogger(LoggerDestination):
         file_path = self.writer.file_writer.event_writer._file_name
         event_file_name = Path(file_path).stem
 
-        logger.file_artifact(LogLevel.FIT,
-                             artifact_name=('tensorboard_logs/{run_name}/' +
+        logger.file_artifact(artifact_name=('tensorboard_logs/{run_name}/' +
                                             f'{event_file_name}-{dist.get_global_rank()}'),
                              file_path=file_path,
                              overwrite=True)

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -16,7 +16,7 @@ import warnings
 from typing import Any, Dict, List, Optional
 
 from composer.core.state import State
-from composer.loggers.logger import Logger, LogLevel
+from composer.loggers.logger import Logger
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import dist
 from composer.utils.import_helpers import MissingConditionalImportError
@@ -161,9 +161,8 @@ class WandBLogger(LoggerDestination):
         assert self.entity is not None, 'entity should be defined'
         assert self.project is not None, 'project should be defined'
 
-    def log_file_artifact(self, state: State, log_level: LogLevel, artifact_name: str, file_path: pathlib.Path, *,
-                          overwrite: bool):
-        del log_level, overwrite  # unused
+    def log_file_artifact(self, state: State, artifact_name: str, file_path: pathlib.Path, *, overwrite: bool):
+        del overwrite  # unused
 
         if self._enabled and self._log_artifacts:
             import wandb

--- a/composer/profiler/json_trace_handler.py
+++ b/composer/profiler/json_trace_handler.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from composer.core.state import State
 from composer.core.time import Timestamp
-from composer.loggers import Logger, LogLevel
+from composer.loggers import Logger
 from composer.profiler.json_trace_merger import merge_traces
 from composer.profiler.profiler_action import ProfilerAction
 from composer.profiler.trace_handler import TraceHandler
@@ -289,10 +289,7 @@ class JSONTraceHandler(TraceHandler):  # noqa: D101
 
             if self.artifact_name is not None:
                 artifact_name = format_name_with_dist_and_time(self.artifact_name, state.run_name, timestamp)
-                logger.file_artifact(LogLevel.BATCH,
-                                     artifact_name=artifact_name,
-                                     file_path=trace_filename,
-                                     overwrite=self.overwrite)
+                logger.file_artifact(artifact_name=artifact_name, file_path=trace_filename, overwrite=self.overwrite)
             # Gather the filenames
             trace_files = [pathlib.Path(x) for x in dist.all_gather_object(trace_filename)]
             self.saved_traces.append((timestamp, trace_files))
@@ -331,7 +328,6 @@ class JSONTraceHandler(TraceHandler):  # noqa: D101
                         state.run_name,
                     )
                     logger.file_artifact(
-                        LogLevel.BATCH,
                         artifact_name=merged_trace_artifact_name,
                         file_path=merged_trace_artifact_name,
                         overwrite=True,

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -16,7 +16,6 @@ from torch.profiler.profiler import ProfilerAction as TorchProfilerAction
 from composer.core.callback import Callback
 from composer.core.state import State
 from composer.loggers import Logger
-from composer.loggers.logger import LogLevel
 from composer.profiler.profiler_action import ProfilerAction
 from composer.utils import dist
 from composer.utils.file_helpers import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, FORMAT_NAME_WITH_DIST_TABLE,
@@ -214,8 +213,7 @@ class TorchProfiler(Callback):  # noqa: D101
                                                                      run_name=state.run_name,
                                                                      timestamp=timestamp)
                 trace_artifact_name = trace_artifact_name.lstrip('/')
-                logger.file_artifact(LogLevel.BATCH,
-                                     artifact_name=trace_artifact_name,
+                logger.file_artifact(artifact_name=trace_artifact_name,
                                      file_path=trace_file_name,
                                      overwrite=self.overwrite)
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2002,7 +2002,7 @@ class Trainer:
                 from torch.utils.data import DataLoader
 
                 from composer import Trainer, Callback
-                from composer.loggers import Logger, LogLevel
+                from composer.loggers import Logger
 
                 class PredictionSaver(Callback):
                     def __init__(self, folder: str):
@@ -2015,7 +2015,7 @@ class Trainer:
                         torch.save(state.outputs, filepath)
 
                         # Also log the outputs as an artifact
-                        logger.file_artifact(LogLevel.BATCH, artifact_name=name, file_path=filepath)
+                        logger.file_artifact(artifact_name=name, file_path=filepath)
 
                 trainer = Trainer(
                     ...,

--- a/composer/utils/inference.py
+++ b/composer/utils/inference.py
@@ -262,7 +262,6 @@ def export_with_logger(
     Returns:
         None
     """
-    from composer.loggers import LogLevel
     if save_object_store == None and logger.has_file_artifact_destination():
         with tempfile.TemporaryDirectory() as tmpdir:
             temp_local_save_path = os.path.join(str(tmpdir), f'model')
@@ -271,7 +270,7 @@ def export_with_logger(
                                  save_path=temp_local_save_path,
                                  sample_input=sample_input,
                                  transforms=transforms)
-            logger.file_artifact(log_level=LogLevel.FIT, artifact_name=save_path, file_path=temp_local_save_path)
+            logger.file_artifact(artifact_name=save_path, file_path=temp_local_save_path)
     else:
         export_for_inference(model=model,
                              save_format=save_format,

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -46,7 +46,6 @@ from composer.core import types as types
 from composer.datasets.synthetic import SyntheticBatchPairDataset
 from composer.loggers import InMemoryLogger as InMemoryLogger
 from composer.loggers import Logger as Logger
-from composer.loggers import LogLevel as LogLevel
 from composer.loggers import ObjectStoreLogger
 from composer.models import ComposerModel as ComposerModel
 from composer.optim.scheduler import ConstantScheduler

--- a/docs/source/trainer/artifact_logging.rst
+++ b/docs/source/trainer/artifact_logging.rst
@@ -64,14 +64,12 @@ It is also possible to log custom artifacts outside of an algorithm or callback.
 .. testcode::
 
     from composer import Trainer
-    from composer.loggers import LogLevel
 
     # Construct the trainer
     trainer = Trainer(...)
 
     # Log a custom artifact, such as a configuration YAML
     trainer.logger.file_artifact(
-        log_level=LogLevel.FIT,
         artifact_name='hparams.yaml',
         file_path='/path/to/hparams.yaml',
     )

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -97,7 +97,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from torchvision import datasets, transforms\n",
-    "from composer.loggers import InMemoryLogger, LogLevel\n",
+    "from composer.loggers import InMemoryLogger\n",
     "from composer.core.time import Time, Timestamp\n",
     "\n",
     "torch.manual_seed(42) # For replicability"

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -17,7 +17,6 @@ import sys
 import tempfile
 import warnings
 
-from composer.loggers import LogLevel
 from composer.trainer.trainer_hparams import TrainerHparams
 from composer.utils import dist, warn_yahp_deprecation
 from composer.utils.misc import warning_on_one_line
@@ -54,7 +53,6 @@ def _main():
             with open(hparams_name, 'w+') as f:
                 f.write(hparams.to_yaml())
             trainer.logger.file_artifact(
-                LogLevel.FIT,
                 artifact_name=f'{trainer.state.run_name}/hparams.yaml',
                 file_path=f.name,
                 overwrite=True,

--- a/tests/loggers/test_file_logger.py
+++ b/tests/loggers/test_file_logger.py
@@ -8,7 +8,7 @@ import sys
 from torch.utils.data import DataLoader
 
 from composer import Callback, Event, State, Trainer
-from composer.loggers import FileLogger, Logger, LoggerDestination, LogLevel
+from composer.loggers import FileLogger, Logger, LoggerDestination
 from composer.utils.collect_env import disable_env_report
 from tests.common.datasets import RandomClassificationDataset
 from tests.common.models import SimpleModel
@@ -19,10 +19,9 @@ class FileArtifactLoggerTracker(LoggerDestination):
     def __init__(self) -> None:
         self.logged_artifacts = []
 
-    def log_file_artifact(self, state: State, log_level: LogLevel, artifact_name: str, file_path: pathlib.Path, *,
-                          overwrite: bool):
+    def log_file_artifact(self, state: State, artifact_name: str, file_path: pathlib.Path, *, overwrite: bool):
         del state, overwrite  # unused
-        self.logged_artifacts.append((log_level, artifact_name, file_path))
+        self.logged_artifacts.append((artifact_name, file_path))
 
 
 def test_file_logger(dummy_state: State, tmp_path: pathlib.Path):

--- a/tests/loggers/test_logger.py
+++ b/tests/loggers/test_logger.py
@@ -4,7 +4,7 @@
 import pathlib
 
 from composer.core.state import State
-from composer.loggers import Logger, LoggerDestination, LogLevel
+from composer.loggers import Logger, LoggerDestination
 
 
 def test_logger_file_artifact(dummy_state: State):
@@ -13,8 +13,7 @@ def test_logger_file_artifact(dummy_state: State):
 
     class DummyLoggerDestination(LoggerDestination):
 
-        def log_file_artifact(self, state: State, log_level: LogLevel, artifact_name: str, file_path: pathlib.Path, *,
-                              overwrite: bool):
+        def log_file_artifact(self, state: State, artifact_name: str, file_path: pathlib.Path, *, overwrite: bool):
             nonlocal file_logged
             file_logged = True
             assert artifact_name == 'foo'
@@ -23,7 +22,6 @@ def test_logger_file_artifact(dummy_state: State):
 
     logger = Logger(state=dummy_state, destinations=[DummyLoggerDestination()])
     logger.file_artifact(
-        log_level='epoch',
         artifact_name='foo',
         file_path='bar',
         overwrite=True,

--- a/tests/loggers/test_object_store_logger.py
+++ b/tests/loggers/test_object_store_logger.py
@@ -18,11 +18,6 @@ from composer.loggers.object_store_logger import ObjectStoreLogger
 from composer.utils.object_store.object_store import ObjectStore
 
 
-def my_filter_func(state: State, log_level: LogLevel, artifact_name: str):
-    del state, log_level, artifact_name  # unused
-    return False
-
-
 class DummyObjectStore(ObjectStore):
     """Dummy ObjectStore implementation that is backed by a local directory."""
 
@@ -70,7 +65,6 @@ def object_store_test_helper(
     use_procs: bool = False,
     overwrite: bool = True,
     overwrite_delay: bool = False,
-    should_filter: bool = False,
 ):
     remote_dir = str(tmp_path / 'object_store')
     os.makedirs(remote_dir, exist_ok=True)
@@ -82,7 +76,6 @@ def object_store_test_helper(
         },
         num_concurrent_uploads=1,
         use_procs=use_procs,
-        should_log_artifact=my_filter_func if should_filter else None,
         upload_staging_folder=str(tmp_path / 'staging_folder'),
         num_attempts=1,
     )
@@ -138,22 +131,17 @@ def object_store_test_helper(
     expected_upload_uri = f'local://{artifact_name}'
     assert upload_uri == expected_upload_uri
 
-    if not should_filter:
-        # Test downloading artifact
-        download_path = os.path.join(tmp_path, 'download')
-        object_store_logger.get_file_artifact(artifact_name, download_path)
-        with open(download_path, 'r') as f:
-            assert f.read() == '1' if not overwrite else '2'
+    # Test downloading artifact
+    download_path = os.path.join(tmp_path, 'download')
+    object_store_logger.get_file_artifact(artifact_name, download_path)
+    with open(download_path, 'r') as f:
+        assert f.read() == '1' if not overwrite else '2'
 
     # now assert that we have a dummy file in the artifact folder
     artifact_file = os.path.join(str(remote_dir), artifact_name)
-    if should_filter:
-        # If the filter works, nothing should be logged
-        assert not os.path.exists(artifact_file)
-    else:
-        # Verify artifact contains the correct value
-        with open(artifact_file, 'r') as f:
-            assert f.read() == '1' if not overwrite else '2'
+    # Verify artifact contains the correct value
+    with open(artifact_file, 'r') as f:
+        assert f.read() == '1' if not overwrite else '2'
 
 
 def test_object_store_logger(tmp_path: pathlib.Path, dummy_state: State):
@@ -171,10 +159,6 @@ def test_object_store_logger_no_overwrite(tmp_path: pathlib.Path, dummy_state: S
                              dummy_state=dummy_state,
                              overwrite=False,
                              overwrite_delay=overwrite_delay)
-
-
-def test_object_store_logger_should_log_artifact_filter(tmp_path: pathlib.Path, dummy_state: State):
-    object_store_test_helper(tmp_path=tmp_path, dummy_state=dummy_state, should_filter=True)
 
 
 @pytest.mark.parametrize('use_procs', [True, False])

--- a/tests/loggers/test_object_store_logger.py
+++ b/tests/loggers/test_object_store_logger.py
@@ -13,7 +13,7 @@ import pytest
 
 from composer.core.event import Event
 from composer.core.state import State
-from composer.loggers import Logger, LogLevel
+from composer.loggers import Logger
 from composer.loggers.object_store_logger import ObjectStoreLogger
 from composer.utils.object_store.object_store import ObjectStore
 
@@ -87,7 +87,7 @@ def object_store_test_helper(
     file_path = os.path.join(tmp_path, f'file')
     with open(file_path, 'w+') as f:
         f.write('1')
-    logger.file_artifact(LogLevel.FIT, artifact_name, file_path, overwrite=overwrite)
+    logger.file_artifact(artifact_name, file_path, overwrite=overwrite)
 
     file_path_2 = os.path.join(tmp_path, f'file_2')
     with open(file_path_2, 'w+') as f:
@@ -106,7 +106,7 @@ def object_store_test_helper(
             # Wait for the first upload to go through
             time.sleep(2)
             # Do the second upload -- it should enqueue
-            logger.file_artifact(LogLevel.FIT, artifact_name, file_path_2, overwrite=overwrite)
+            logger.file_artifact(artifact_name, file_path_2, overwrite=overwrite)
             # Give it some time to finish the second upload
             # (Since the upload is really a file copy, it should be fast)
             time.sleep(2)
@@ -119,7 +119,7 @@ def object_store_test_helper(
         else:
             # Otherwise, if no delay, it should error when being enqueued
             with pytest.raises(FileExistsError):
-                logger.file_artifact(LogLevel.FIT, artifact_name, file_path_2, overwrite=overwrite)
+                logger.file_artifact(artifact_name, file_path_2, overwrite=overwrite)
 
     object_store_logger.close(dummy_state, logger)
 
@@ -193,7 +193,7 @@ def test_race_with_overwrite(tmp_path: pathlib.Path, use_procs: bool, dummy_stat
     artifact_name = 'artifact_name'
     for i in range(num_files):
         file_path = tmp_path / 'samples' / f'sample_{i}'
-        object_store_logger.log_file_artifact(dummy_state, LogLevel.FIT, artifact_name, file_path, overwrite=True)
+        object_store_logger.log_file_artifact(dummy_state, artifact_name, file_path, overwrite=True)
 
     # Shutdown the logger. This should wait until all objects are uploaded
     object_store_logger.close(dummy_state, logger=logger)
@@ -232,7 +232,7 @@ def test_close_on_failure(tmp_path: pathlib.Path, dummy_state: State):
 
     object_store_logger.run_event(Event.INIT, dummy_state, logger)
 
-    logger.file_artifact(LogLevel.FIT, 'dummy_artifact_name', tmpfile_path)
+    logger.file_artifact('dummy_artifact_name', tmpfile_path)
 
     # Wait enough time for the file to be enqueued
     time.sleep(0.5)
@@ -242,7 +242,7 @@ def test_close_on_failure(tmp_path: pathlib.Path, dummy_state: State):
         object_store_logger.run_event(Event.EPOCH_END, dummy_state, logger)
 
     # Enqueue the file again to ensure that the buffers are dirty
-    logger.file_artifact(LogLevel.FIT, 'dummy_artifact_name', tmpfile_path)
+    logger.file_artifact('dummy_artifact_name', tmpfile_path)
 
     # Shutdown the logger. This should not hang or cause any exception
     object_store_logger.close(dummy_state, logger=logger)

--- a/tests/loggers/test_wandb_logger.py
+++ b/tests/loggers/test_wandb_logger.py
@@ -15,7 +15,7 @@ from composer.core import Engine, Event
 from composer.core.callback import Callback
 from composer.core.state import State
 from composer.loggers import InMemoryLogger
-from composer.loggers.logger import Logger, LogLevel
+from composer.loggers.logger import Logger
 from composer.loggers.wandb_logger import WandBLogger
 from composer.trainer import Trainer
 from composer.utils import dist, retry
@@ -83,7 +83,6 @@ def test_wandb_artifacts(rank_zero_only: bool, tmp_path: pathlib.Path, dummy_sta
 
         # Log an artifact if rank zero
         logger.file_artifact(
-            log_level=LogLevel.FIT,
             file_path=dummy_artifact_path,
             artifact_name=artifact_name,
         )

--- a/tests/trainer/test_predict.py
+++ b/tests/trainer/test_predict.py
@@ -9,7 +9,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from composer.core import Callback, Event, State
-from composer.loggers import Logger, LogLevel
+from composer.loggers import Logger
 from composer.trainer.trainer import Trainer
 from tests.common import EventCounterCallback, RandomClassificationDataset, SimpleModel
 
@@ -45,7 +45,7 @@ class PredictionSaver(Callback):
         torch.save(state.outputs, filepath)
 
         # Also log the outputs as an artifact
-        logger.file_artifact(LogLevel.BATCH, artifact_name=name, file_path=filepath)
+        logger.file_artifact(artifact_name=name, file_path=filepath)
 
 
 class TestTrainerPredict():


### PR DESCRIPTION
# What does this PR do?
Removes the `should_log_artifact` which was unused as far as we know, and would require a user writing a custom filter function that takes in state and `LogLevel` to decide whether to log an artifact. Also, the `WandBLogger` did not support this argument. `should_log_artifact` was also the only use of `LogLevel`, so that has been removed everywhere.

# What issue(s) does this change relate to?
Closes CO-1189
Relates to CO-1167

# Manual testing
Manually tested saving (loading) checkpoints to (from) WandB and S3.
