### PR TITLE
Deepspeed Docs Typo

### DIFF
--- a/docs/source/notes/distributed_training.rst
+++ b/docs/source/notes/distributed_training.rst
@@ -94,10 +94,10 @@ Deepspeed
 Composer comes with DeepSpeed support, allowing you to leverage their
 full set of features that makes it easier to train large models across
 (1) any type of GPU and (2) multiple nodes. For more details on DeepSpeed,
-see `their website <https://www.deepspeed.ai>`_.
+see `their website <https://www.deepspeed.ai>`__.
 
 We support optimizer and gradient sharing via
-`Deepspeed Zero`_` stages 1 and 2 respectively. In the future, we'll support model
+`Deepspeed Zero`_ stages 1 and 2 respectively. In the future, we'll support model
 sharding via Zero-3. These methods reduce model state memory by a
 factor of (1 / the number of data-parallel devices).
 

--- a/docs/source/notes/distributed_training.rst
+++ b/docs/source/notes/distributed_training.rst
@@ -94,7 +94,7 @@ Deepspeed
 Composer comes with DeepSpeed support, allowing you to leverage their
 full set of features that makes it easier to train large models across
 (1) any type of GPU and (2) multiple nodes. For more details on DeepSpeed,
-see `their website <https://www.deepspeed.ai>`__.
+see `their website <https://www.deepspeed.ai>`_.
 
 We support optimizer and gradient sharing via
 `Deepspeed Zero`_` stages 1 and 2 respectively. In the future, we'll support model


### PR DESCRIPTION
# What does this PR do?

Fixes minor typo in deepspeed docs
<img width="814" alt="image" src="https://user-images.githubusercontent.com/17102158/194685067-d52428f8-1e55-47f3-b1bd-29d1141118ee.png">


