### PR TITLE
Add more robust casting to int for fsdp min_params

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -194,7 +194,7 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
         'BACKWARD_POST': BackwardPrefetch.BACKWARD_POST,
     }
     backward_prefetch = backward_prefetch_map[fsdp_config.get('backward_prefetch', 'BACKWARD_POST').upper()]
-    min_params = int(fsdp_config.get('min_params', 1e8))
+    min_params = int(float(fsdp_config.get('min_params', 1e8)))
     activation_checkpointing = fsdp_config.get('activation_checkpointing', False)
     activation_cpu_offload = fsdp_config.get('activation_cpu_offload', False)
 


### PR DESCRIPTION
One-line fix for [CO-1197](https://mosaicml.atlassian.net/browse/CO-1197).

Right now, if your `min_params` for fsdp is a string like '1e8', this line throws. I encountered this when using our public GPT benchmarks.