### PR TITLE
add stop method

### DIFF
--- a/composer/callbacks/early_stopper.py
+++ b/composer/callbacks/early_stopper.py
@@ -134,10 +134,10 @@ class EarlyStopper(Callback):
         assert self.best_occurred is not None
         if self.patience.unit == TimeUnit.EPOCH:
             if state.timestamp.epoch - self.best_occurred.epoch > self.patience:
-                state.max_duration = state.timestamp.batch
+                state.stop_training()
         elif self.patience.unit == TimeUnit.BATCH:
             if state.timestamp.batch - self.best_occurred.batch > self.patience:
-                state.max_duration = state.timestamp.batch
+                state.stop_training()
         else:
             raise ValueError(f'The units of `patience` should be EPOCH or BATCH.')
 

--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -347,7 +347,7 @@ class MLPerfCallback(Callback):
 
         if accuracy > self.target and self.exit_at_target:
             # stop training
-            state.max_duration = state.timestamp.batch
+            state.stop_training()
 
     def close(self, state: State, logger: Logger) -> None:
         if self._file_handler is not None:

--- a/composer/callbacks/threshold_stopper.py
+++ b/composer/callbacks/threshold_stopper.py
@@ -102,7 +102,7 @@ class ThresholdStopper(Callback):
             metric_val = torch.tensor(metric_val)
 
         if self.comp_func(metric_val, self.threshold):
-            state.max_duration = state.timestamp.batch
+            state.stop_training()
 
     def eval_end(self, state: State, logger: Logger) -> None:
         if self.dataloader_label == state.dataloader_label:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -396,6 +396,14 @@ class State(Serializable):
             return None
         return self.timestamp.get(self.max_duration.unit) / self.max_duration
 
+    def stop_training(self):
+        """Gracefully stop training.
+
+        The current batch of training will finish, and any scheduled evaluation,
+        logging, and evaluation for that batch, as well as any epoch end events.
+        """
+        self.max_duration = self.timestamp.batch
+
     @property
     def optimizers(self):
         """The optimizers."""


### PR DESCRIPTION
# What does this PR do?

Adds a `state.stop_training()` method for algorithms and callbacks to gracefully stop training (finishing the rest of the events in the current batch and any scheduled evals and epoch ends). The EarlyStopping and MLPerf callback now uses this interface instead of setting the max duration itself.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
