### PR TITLE
Remove warning when `master_port` is auto selected

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -220,9 +220,6 @@ def _parse_args():
             args.master_addr = '127.0.0.1'
 
         if args.master_port is None:
-            warnings.warn('AutoSelectPortWarning: The distributed key-value port was auto-selected. '
-                          'This may lead to race conditions when launching multiple training processes simultaneously. '
-                          'To eliminate this race condition, explicitly specify a port with --master_port PORT_NUMBER')
             args.master_port = get_free_tcp_port()
 
     return args


### PR DESCRIPTION
# What does this PR do?

Remove warning re. race condition when `master_port` is auto selected. I don't think there is any race condition involved as the args are constructed in the main thread, before any subprocesses are launched. There would only be a race if the toplevel command `composer ...` itself was launched in multiple processes at once, which should never be the case...

# What issue(s) does this change relate to?
[CO-1230]

[CO-1230]: https://mosaicml.atlassian.net/browse/CO-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ