### PR TITLE
Remove Graph in Auto Grad Accum

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -197,8 +197,12 @@ def _adjust_grad_accum(state: State, device_batch_size):
                            'and the batch will be retrained with a '
                            f'micro-batchsize of {device_batch_size // state.grad_accum}'))
     # Clear gradients in case failure happened during backwards pass
+    if hasattr(state, 'outputs'):
+        del state.outputs
+    if hasattr(state, 'loss'):
+        del state.loss
     for optimizer in state.optimizers:
-        optimizer.zero_grad()
+        optimizer.zero_grad(set_to_none=True)
     torch.cuda.empty_cache()
 
 


### PR DESCRIPTION
# What does this PR do?

Auto grad accum used to fail if it crashed in backwards pass as the graph was leftover. This cleans it up.

# What issue(s) does this change relate to?

[CO-1117 ](https://mosaicml.atlassian.net/browse/CO-1117)among others.

No tests since it's too hard to reliably repro in a unit test.
