### PR TITLE
Add mvpatel2000 as codeowner for algos

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,10 +17,10 @@
 # as an owner for all sections, so anyone on Composer Eng can approve any Composer PR
 # According to the CODEOWNER docs, the last match takes precedence, so @mosaicml/composer-team-eng
 # must be mentioned for each rule below.
-/composer/algorithms/ @dskhudia
+/composer/algorithms/ @dskhudia @mvpatel2000
 /composer/cli/ @jbloxham
 /composer/datasets/ @knighton
-/composer/functional/ @dblalock
+/composer/functional/ @dblalock @mvpatel2000
 /composer/loggers/ @eracah
 /composer/loss/ @mosaicml/composer-team-eng
 /composer/metrics/ @mosaicml/composer-team-eng


### PR DESCRIPTION
# What does this PR do?

As people add new algorithms, it's important that we ensure they are compatible in agent. I've run into several problems with new additions that had edge cases which could have been avoided if I was aware of them, either by adding mitigations in agent (eg blacklist incompatabilities) or suggesting alternative solutions (`required_on_load=True`). I'd like to be added to codeowner for algorithms so I'm pinged whenever someone puts something new out so I don't keep having to go back and hotfix issues