### PR TITLE
Fix ImageNet Example normalization values

### DIFF
--- a/examples/imagenet/train_resnet_imagenet1k.py
+++ b/examples/imagenet/train_resnet_imagenet1k.py
@@ -110,8 +110,10 @@ def _main():
         args.train_batch_size = args.train_batch_size // dist.get_world_size()
         args.eval_batch_size = args.eval_batch_size // dist.get_world_size()
 
-    IMAGENET_CHANNEL_MEAN = (0.485, 0.456, 0.406)
-    IMAGENET_CHANNEL_STD = (0.229, 0.224, 0.225)
+    # Scale by 255 since the collate `pil_image_collate` results in images in range 0-255
+    # If using ToTensor() and the default collate, remove the scaling by 255
+    IMAGENET_CHANNEL_MEAN = (0.485 * 255, 0.456 * 255, 0.406 * 255)
+    IMAGENET_CHANNEL_STD = (0.229 * 255, 0.224 * 255, 0.225 * 255)
 
     # Train dataset
     logging.info('Building train dataloader')


### PR DESCRIPTION
# What does this PR do?

Scales the ImageNet example normalization values by 255 since `pil_image_collate` results in inputs with values in between 0-255 instead of 0-1 (when using `ToTensor`). Also added a comment clarifying the differences

# What issue(s) does this change relate to?

Fixes https://github.com/mosaicml/composer/issues/1634

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

