### PR TITLE
Fixed html path for make host command for docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,7 +8,7 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
 PYTHON_BIN 	  ?= python
-HTML_BUILDDIR ?= $(BUILDDIR)/_html
+HTML_BUILDDIR ?= $(BUILDDIR)/html
 HTTP_MODULE   = http.server
 
 # Put it first so that "make" without argument is like "make help".


### PR DESCRIPTION
# What does this PR do?
- Fixed html path for make host command for docs. It should be `_build/html` instead of `_build/_html`

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
