### PR TITLE
Fix hyperparameters logged to console even when progress_bar and log_to_console are False

### DIFF
--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -175,10 +175,11 @@ class ProgressBarLogger(LoggerDestination):
                 self._log_to_console(f'[trace]: {trace_name}:' + trace_str + '\n')
 
     def log_hyperparameters(self, hyperparameters: Dict[str, Any]):
-        for hparam_name, hparam in hyperparameters.items():
-            hparam_str = format_log_data_value(hparam)
-            log_str = f'[hyperparameter]: {hparam_name}: {hparam_str}'
-            self._log_to_console(log_str)
+        if self.should_log_to_console or self._show_pbar:
+            for hparam_name, hparam in hyperparameters.items():
+                hparam_str = format_log_data_value(hparam)
+                log_str = f'[hyperparameter]: {hparam_name}: {hparam_str}'
+                self._log_to_console(log_str)
 
     def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None) -> None:
         for metric_name, metric_value in metrics.items():


### PR DESCRIPTION
# What does this PR do?

In ProgressBarLogger: checks to see if `log_to_console` or `progress_bar` is True before logging hyperparameters.

Especially helpful for decreasing verbosity in doctests, where `log_to_console` and `progress_bar` are set to False

Before in doctests:
```
[hyperparameter]: num_nodes: 1
[hyperparameter]: num_cpus_per_node: 1
[hyperparameter]: rank_zero_seed: 3942616347
```

After:
```
```

# What issue(s) does this change relate to?

fixes CO-1284

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a JIRA issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
