### PR TITLE
Changed default logging to WARN for doctests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,10 +17,10 @@
 # as an owner for all sections, so anyone on Composer Eng can approve any Composer PR
 # According to the CODEOWNER docs, the last match takes precedence, so @mosaicml/composer-team-eng
 # must be mentioned for each rule below.
-/composer/algorithms/ @dskhudia
+/composer/algorithms/ @dskhudia @mvpatel2000
 /composer/cli/ @jbloxham
 /composer/datasets/ @knighton
-/composer/functional/ @dblalock
+/composer/functional/ @dblalock @mvpatel2000
 /composer/loggers/ @eracah
 /composer/loss/ @mosaicml/composer-team-eng
 /composer/metrics/ @mosaicml/composer-team-eng

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -10,6 +10,9 @@ The script is run before any doctests are executed,
 so all imports and variables are available in any doctest.
 The output of this setup script does not show up in the documentation.
 """
+import logging
+
+logging.basicConfig(level=logging.WARN)
 import os
 import sys
 import tempfile


### PR DESCRIPTION
# What does this PR do?

Changes to logging level to WARN for doctests. This reduces the verbosity of doctests and makes it easier to see your error.

# What issue(s) does this change relate to?

CO-1285

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
