### PR TITLE
Adjust speed monitor

### DIFF
--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -96,7 +96,7 @@ class SpeedMonitor(Callback):
         )
         self.total_eval_wct = state['total_eval_wct']
 
-    def batch_start(self, state: State, logger: Logger) -> None:
+    def before_dataloader(self, state: State, logger: Logger) -> None:
         del logger  # unused
         self.batch_start_wct = state.timestamp.total_wct.total_seconds()
         self.batch_start_num_samples = int(state.timestamp.sample)


### PR DESCRIPTION
# What does this PR do?

Adjusts speed monitor to start tracking at `BEFORE_DATALOADER` instead of `BEFORE_BATCH`. This resolves issues with dataloader bottlenecks being potentially masked. Note that currently it should still work since data transfer is done async, but to be safe, we should start the clock on `BEFORE_DATALOADER`.