### PR TITLE
Attempt to fix flaky doctest

### DIFF
--- a/docs/source/notes/resumption.rst
+++ b/docs/source/notes/resumption.rst
@@ -14,7 +14,7 @@ Resuming from checkpoints is commonly used to recover from hardware failures (e.
         model=model,
         train_dataloader=train_dataloader,
         max_duration="1ep",
-        save_filename='ep{epoch}.pt',
+        save_filename="ep{epoch}.pt",
         save_folder="./path/to/checkpoints",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
@@ -58,11 +58,10 @@ Instead, our trainer supports the ``autoresume=True`` feature. With autoresume, 
         model=model,
         train_dataloader=train_dataloader,
         max_duration="1ep",
-        save_filename='ep{epoch}.pt',
+        save_filename="ep{epoch}.pt",
         save_folder="./path/to/folder",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
-        run_name='my_cool_run'
     )
     trainer.fit()
     trainer.close()
@@ -73,7 +72,7 @@ Instead, our trainer supports the ``autoresume=True`` feature. With autoresume, 
         ...,
         autoresume=True,
         save_folder='./path/to/folder',
-        run_name='my_cool_run_1',
+        run_name='my_cool_run',
         max_duration='10ep'
     )
 
@@ -113,7 +112,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
         autoresume=True,
         save_folder='checkpoints',
         save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
-        run_name='my_cool_run_2',
+        run_name='my_cool_run',
         save_filename='ep{epoch}.pt',
         loggers=[remote_uploader_downloader],
         max_duration='10ep'

--- a/docs/source/notes/resumption.rst
+++ b/docs/source/notes/resumption.rst
@@ -58,11 +58,11 @@ Instead, our trainer supports the ``autoresume=True`` feature. With autoresume, 
         model=model,
         train_dataloader=train_dataloader,
         max_duration="1ep",
-        save_filename='ep{epoch}-ba{batch}-rank{rank}.pt',
+        save_filename='ep{epoch}.pt',
         save_folder="./path/to/folder",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
-        run_name='my_cool_run_1'
+        run_name='my_cool_run'
     )
     trainer.fit()
     trainer.close()
@@ -97,36 +97,6 @@ Example: Object Store
 
 A typical use case is saving checkpoints to object store (e.g. S3) when there is no local file storage shared across runs. For example, a setup such as this:
 
-.. testsetup::
-    :skipif: not _LIBCLOUD_INSTALLED
-
-    from composer.loggers import RemoteUploaderDownloader
-    from composer.utils.object_store import S3ObjectStore
-
-    # this assumes credentials are already configured via boto3
-    remote_uploader_downloader = RemoteUploaderDownloader(
-        bucket_uri=f"s3://checkpoint-debugging",
-    )
-
-    import os
-    import shutil
-
-    from composer import Trainer
-
-    trainer = Trainer(
-        model=model,
-        train_dataloader=train_dataloader,
-        max_duration="1ep",
-        save_filename='ep{epoch}-ba{batch}-rank{rank}.pt',
-        save_folder="checkpoints",
-        save_overwrite=True,
-        save_interval="1ep",  # Save checkpoints every epoch
-        loggers=[remote_uploader_downloader],
-        run_name='my_cool_run_2'
-    )
-    trainer.fit()
-    trainer.close()
-
 .. testcode::
     :skipif: not _LIBCLOUD_INSTALLED
 
@@ -144,7 +114,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
         save_folder='checkpoints',
         save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
         run_name='my_cool_run_2',
-        save_filename='ep{epoch}-ba{batch}-rank{rank}.pt',
+        save_filename='ep{epoch}.pt',
         loggers=[remote_uploader_downloader],
         max_duration='10ep'
     )
@@ -175,7 +145,7 @@ To run fine-tuning on a spot instance, ``load_path`` would be set to the origina
         ...,
         save_filename='pretrained_weights/model.pt',
         save_folder='checkpoints',
-        run_name='my_cool_run_3',
+        run_name='my_cool_run',
         max_duration='1ep'
     )
 
@@ -190,7 +160,7 @@ To run fine-tuning on a spot instance, ``load_path`` would be set to the origina
         load_path='pretrained_weights/model.pt',
         load_weights_only=True,
         save_folder='checkpoints',
-        run_name='my_cool_run_3',
+        run_name='my_cool_run',
         loggers=[
             remote_uploader_downloader
         ],

--- a/docs/source/notes/resumption.rst
+++ b/docs/source/notes/resumption.rst
@@ -14,7 +14,7 @@ Resuming from checkpoints is commonly used to recover from hardware failures (e.
         model=model,
         train_dataloader=train_dataloader,
         max_duration="1ep",
-        save_filename="ep{epoch}.pt",
+        save_filename='ep{epoch}-ba{batch}-rank{rank}.pt',
         save_folder="./path/to/checkpoints",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
@@ -58,7 +58,7 @@ Instead, our trainer supports the ``autoresume=True`` feature. With autoresume, 
         model=model,
         train_dataloader=train_dataloader,
         max_duration="1ep",
-        save_filename="ep{epoch}.pt",
+        save_filename='ep{epoch}-ba{batch}-rank{rank}.pt',
         save_folder="./path/to/folder",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
@@ -117,7 +117,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
         model=model,
         train_dataloader=train_dataloader,
         max_duration="1ep",
-        save_filename="ep{epoch}.pt",
+        save_filename='ep{epoch}-ba{batch}-rank{rank}.pt',
         save_folder="checkpoints",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
@@ -144,7 +144,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
         save_folder='checkpoints',
         save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
         run_name='my_cool_run_2',
-        save_filename='ep{epoch}.pt',
+        save_filename='ep{epoch}-ba{batch}-rank{rank}.pt',
         loggers=[remote_uploader_downloader],
         max_duration='10ep'
     )

--- a/docs/source/notes/resumption.rst
+++ b/docs/source/notes/resumption.rst
@@ -14,7 +14,7 @@ Resuming from checkpoints is commonly used to recover from hardware failures (e.
         model=model,
         train_dataloader=train_dataloader,
         max_duration="1ep",
-        save_filename='ep{epoch}-ba{batch}-rank{rank}.pt',
+        save_filename='ep{epoch}.pt',
         save_folder="./path/to/checkpoints",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch

--- a/docs/source/notes/resumption.rst
+++ b/docs/source/notes/resumption.rst
@@ -62,6 +62,7 @@ Instead, our trainer supports the ``autoresume=True`` feature. With autoresume, 
         save_folder="./path/to/folder",
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
+        run_name='my_cool_run_1'
     )
     trainer.fit()
     trainer.close()
@@ -72,7 +73,7 @@ Instead, our trainer supports the ``autoresume=True`` feature. With autoresume, 
         ...,
         autoresume=True,
         save_folder='./path/to/folder',
-        run_name='my_cool_run',
+        run_name='my_cool_run_1',
         max_duration='10ep'
     )
 
@@ -121,6 +122,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
         save_overwrite=True,
         save_interval="1ep",  # Save checkpoints every epoch
         loggers=[remote_uploader_downloader],
+        run_name='my_cool_run_2'
     )
     trainer.fit()
     trainer.close()
@@ -141,7 +143,7 @@ A typical use case is saving checkpoints to object store (e.g. S3) when there is
         autoresume=True,
         save_folder='checkpoints',
         save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
-        run_name='my_cool_run',
+        run_name='my_cool_run_2',
         save_filename='ep{epoch}.pt',
         loggers=[remote_uploader_downloader],
         max_duration='10ep'
@@ -173,7 +175,7 @@ To run fine-tuning on a spot instance, ``load_path`` would be set to the origina
         ...,
         save_filename='pretrained_weights/model.pt',
         save_folder='checkpoints',
-        run_name='my_cool_run',
+        run_name='my_cool_run_3',
         max_duration='1ep'
     )
 
@@ -188,7 +190,7 @@ To run fine-tuning on a spot instance, ``load_path`` would be set to the origina
         load_path='pretrained_weights/model.pt',
         load_weights_only=True,
         save_folder='checkpoints',
-        run_name='my_cool_run',
+        run_name='my_cool_run_3',
         loggers=[
             remote_uploader_downloader
         ],


### PR DESCRIPTION
# What does this PR do?
The doctests are extremely difficult to debug. The logs are different every time I run them locally, get swallowed when the doctest errors, and the offending doctest only fails some of the time. I couldn't figure it out, so I basically removed the offending doctest since this is blocking all CI. I can't be certain, but I believe the issue is limited to the doctests, because the normal tests pass, and I ran the doctest code in an ipython outside of the doctests and it worked consistently. If someone feels like they have a better handle on the doctests, they may want to try to figure this out.

# What issue(s) does this change relate to?
Fixes [CO-1290](https://mosaicml.atlassian.net/browse/CO-1290)
