### PR TITLE
Lazy Logging +  pretty print dict for hparams

### DIFF
--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -16,6 +16,7 @@ from composer.core.time import Timestamp, TimeUnit
 from composer.loggers.logger import Logger, format_log_data_value
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import dist, is_notebook
+import yaml
 
 __all__ = ['ProgressBarLogger']
 
@@ -163,6 +164,8 @@ class ProgressBarLogger(LoggerDestination):
 
         self.stream = stream
         self.state: Optional[State] = None
+        self.hparams: Dict[str, Any] = {}
+        self.hparams_already_logged_to_console: bool = False
 
     @property
     def show_pbar(self) -> bool:
@@ -175,11 +178,22 @@ class ProgressBarLogger(LoggerDestination):
                 self._log_to_console(f'[trace]: {trace_name}:' + trace_str + '\n')
 
     def log_hyperparameters(self, hyperparameters: Dict[str, Any]):
+        # Lazy logging of hyperparameters
+        self.hparams.update(hyperparameters)
+        # self.hparams.update(hyperparameters)
+        # for hparam_name, hparam in hyperparameters.items():
+        #     hparam_str = format_log_data_value(hparam)
+        #     log_str = f'[hyperparameter]: {hparam_name}: {hparam_str}'
+        #     self._log_to_console(log_str)
+
+    def _log_hparams_to_console(self):
         if self.should_log_to_console or self._show_pbar:
-            for hparam_name, hparam in hyperparameters.items():
-                hparam_str = format_log_data_value(hparam)
-                log_str = f'[hyperparameter]: {hparam_name}: {hparam_str}'
-                self._log_to_console(log_str)
+            if dist.get_local_rank() == 0:
+                self._log_to_console('*' * 30)
+                self._log_to_console('Config:')
+                self._log_to_console(yaml.dump(self.hparams))
+                self._log_to_console('*' * 30)
+
 
     def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None) -> None:
         for metric_name, metric_value in metrics.items():
@@ -304,6 +318,16 @@ class ProgressBarLogger(LoggerDestination):
                 timestamp_key='',
             )
         self.state = state
+
+    def fit_start(self, state: State, logger: Logger) -> None:
+        if not self.hparams_already_logged_to_console:
+            self.hparams_already_logged_to_console = True
+            self._log_hparams_to_console()
+    
+    def eval_start(self, state: State, logger: Logger) -> None:
+        if not self.hparams_already_logged_to_console:
+            self.hparams_already_logged_to_console = True
+            self._log_hparams_to_console()
 
     def epoch_start(self, state: State, logger: Logger) -> None:
         if self.show_pbar and not self.train_pbar:

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -10,13 +10,13 @@ import sys
 from typing import Any, Dict, List, Optional, TextIO, Union
 
 import tqdm.auto
+import yaml
 
 from composer.core.state import State
 from composer.core.time import Timestamp, TimeUnit
 from composer.loggers.logger import Logger, format_log_data_value
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import dist, is_notebook
-import yaml
 
 __all__ = ['ProgressBarLogger']
 
@@ -178,13 +178,8 @@ class ProgressBarLogger(LoggerDestination):
                 self._log_to_console(f'[trace]: {trace_name}:' + trace_str + '\n')
 
     def log_hyperparameters(self, hyperparameters: Dict[str, Any]):
-        # Lazy logging of hyperparameters
+        # Lazy logging of hyperparameters.
         self.hparams.update(hyperparameters)
-        # self.hparams.update(hyperparameters)
-        # for hparam_name, hparam in hyperparameters.items():
-        #     hparam_str = format_log_data_value(hparam)
-        #     log_str = f'[hyperparameter]: {hparam_name}: {hparam_str}'
-        #     self._log_to_console(log_str)
 
     def _log_hparams_to_console(self):
         if self.should_log_to_console or self._show_pbar:
@@ -193,7 +188,6 @@ class ProgressBarLogger(LoggerDestination):
                 self._log_to_console('Config:')
                 self._log_to_console(yaml.dump(self.hparams))
                 self._log_to_console('*' * 30)
-
 
     def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None) -> None:
         for metric_name, metric_value in metrics.items():
@@ -323,17 +317,15 @@ class ProgressBarLogger(LoggerDestination):
         if not self.hparams_already_logged_to_console:
             self.hparams_already_logged_to_console = True
             self._log_hparams_to_console()
-    
-    def eval_start(self, state: State, logger: Logger) -> None:
-        if not self.hparams_already_logged_to_console:
-            self.hparams_already_logged_to_console = True
-            self._log_hparams_to_console()
 
     def epoch_start(self, state: State, logger: Logger) -> None:
         if self.show_pbar and not self.train_pbar:
             self.train_pbar = self._build_pbar(state=state, is_train=True)
 
     def eval_start(self, state: State, logger: Logger) -> None:
+        if not self.hparams_already_logged_to_console:
+            self.hparams_already_logged_to_console = True
+            self._log_hparams_to_console()
         if self.show_pbar:
             self.eval_pbar = self._build_pbar(state, is_train=False)
 

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -318,6 +318,11 @@ class ProgressBarLogger(LoggerDestination):
             self.hparams_already_logged_to_console = True
             self._log_hparams_to_console()
 
+    def predict_start(self, state: State, logger: Logger) -> None:
+        if not self.hparams_already_logged_to_console:
+            self.hparams_already_logged_to_console = True
+            self._log_hparams_to_console()
+
     def epoch_start(self, state: State, logger: Logger) -> None:
         if self.show_pbar and not self.train_pbar:
             self.train_pbar = self._build_pbar(state=state, is_train=True)

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -319,6 +319,7 @@ class ProgressBarLogger(LoggerDestination):
             self._log_hparams_to_console()
 
     def predict_start(self, state: State, logger: Logger) -> None:
+
         if not self.hparams_already_logged_to_console:
             self.hparams_already_logged_to_console = True
             self._log_hparams_to_console()

--- a/examples/imagenet/train_resnet_imagenet1k.py
+++ b/examples/imagenet/train_resnet_imagenet1k.py
@@ -110,8 +110,10 @@ def _main():
         args.train_batch_size = args.train_batch_size // dist.get_world_size()
         args.eval_batch_size = args.eval_batch_size // dist.get_world_size()
 
-    IMAGENET_CHANNEL_MEAN = (0.485, 0.456, 0.406)
-    IMAGENET_CHANNEL_STD = (0.229, 0.224, 0.225)
+    # Scale by 255 since the collate `pil_image_collate` results in images in range 0-255
+    # If using ToTensor() and the default collate, remove the scaling by 255
+    IMAGENET_CHANNEL_MEAN = (0.485 * 255, 0.456 * 255, 0.406 * 255)
+    IMAGENET_CHANNEL_STD = (0.229 * 255, 0.224 * 255, 0.225 * 255)
 
     # Train dataset
     logging.info('Building train dataloader')

--- a/examples/run_composer_trainer.py
+++ b/examples/run_composer_trainer.py
@@ -58,13 +58,6 @@ def _main():
                 overwrite=True,
             )
 
-    # Print the config to the terminal and log to remote file system if on each local rank 0
-    if dist.get_local_rank() == 0:
-        print('*' * 30)
-        print('Config:')
-        print(hparams.to_yaml())
-        print('*' * 30)
-
     trainer.fit()
 
 


### PR DESCRIPTION
# What does this PR do?

Lazily logs hyperparameters to console and pretty prints them exactly like the yahp entrypoint does.


Before:

```
[hyperparameter]: seed: 42


[hyperparameter]: deterministic_mode: False


[hyperparameter]: dist_timeout: 300.0000
```

After:
```
******************************
Config:
algorithms: null
autoresume: false
callbacks:
  lr_monitor: {}
  speed_monitor:
    window_size: 100
console_stream: stderr
dataloader:
  num_workers: 8
  persistent_workers: true
  pin_memory: true
  prefetch_factor: 2
  timeout: 0.0
ddp_sync_strategy: null
deepspeed_config: null
deterministic_mode: false
device:
  gpu:
    allow_tf32: true
    device_id: null
dist_timeout: 300.0
eval_batch_size: auto
eval_interval: 1ep
eval_subset_num_batches: -1
evaluators: null
grad_accum: auto
grad_clip_norm: -1.0
load_ignore_keys: null
load_logger_destination: null
load_object_store: null
load_path: null
load_progress_bar: true
load_strict_model_weights: false
load_weights_only: false
log_to_console: null
loggers:
  object_store:
    bucket_uri: s3://mosaicml-internal-checkpoints-demo
    file_path_format_string: '{remote_file_name}'
    num_attempts: 3
    num_concurrent_uploads: 1
    object_store_hparams: null
    upload_staging_folder: null
    use_procs: true
max_duration: 1ep
model:
  resnet:
    groups: 1
    initializers:
    - KAIMING_NORMAL
    - BN_UNIFORM
    - LINEAR_LOG_CONSTANT_BIAS
    loss_name: binary_cross_entropy_with_logits
    model_name: resnet50
    num_classes: 1000
    pretrained: false
    weights: null
    width_per_group: 64
num_gpus_per_node: 8
num_nodes: 1
optimizers:
  decoupled_sgdw:
    dampening: 0.0
    lr: 2.048
    momentum: 0.875
    nesterov: false
    weight_decay: 0.0005
precision: AMP
profiler: null
progress_bar: true
python_log_level: INFO
rank_zero_seed: 42
run_name: resnet-50-demo-autoresume-27sm
save_filename: ep{epoch}-ba{batch}-rank{rank}.pt
save_folder: null
save_interval: 10ba
save_latest_filename: latest-rank{rank}.pt
save_num_checkpoints_to_keep: -1
save_overwrite: false
save_weights_only: false
scale_schedule_ratio: 1.0
schedulers:
  cosine_decay_with_warmup:
    alpha_f: 0.0
    scale_warmup: false
    t_max: 1dur
    t_warmup: 8ep
seed: 42
step_schedulers_every_batch: null
train_batch_size: 2048
train_dataloader_label: train
train_dataset:
  streaming_imagenet1k:
    crop_size: 176
    drop_last: true
    local: /tmp/mds-cache/mds-imagenet1k/
    remote: s3://mosaicml-internal-dataset-imagenet1k/mds/1/
    resize_size: -1
    shuffle: true
    split: train
    version: 1
train_subset_num_batches: -1
val_dataset:
  streaming_imagenet1k:
    crop_size: 224
    drop_last: false
    local: /tmp/mds-cache/mds-imagenet1k/
    remote: s3://mosaicml-internal-dataset-imagenet1k/mds/1/
    resize_size: 256
    shuffle: false
    split: val
    version: 1
******************************    
```

# What issue(s) does this change relate to?

fixes CO-1250

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
