### PR TITLE
Faster metrics calculations + Fix warnings added by the new version of torchmetrics

### DIFF
--- a/composer/metrics/map.py
+++ b/composer/metrics/map.py
@@ -148,6 +148,9 @@ class MAP(Metric):
         ValueError: If ``class_metrics`` is not a boolean.
     """
 
+    # Have default behavior for this complex metric
+    full_state_update = True
+
     def __init__(
             self,
             class_metrics: bool = False,

--- a/composer/metrics/metrics.py
+++ b/composer/metrics/metrics.py
@@ -30,6 +30,9 @@ class MIoU(Metric):
         ignore_index (int, optional): the index to ignore when computing mIoU. Default: ``-1``.
     """
 
+    # Make torchmetrics call update only once
+    full_state_update = False
+
     def __init__(self, num_classes: int, ignore_index: int = -1):
         super().__init__(dist_sync_on_step=True)
         self.num_classes = num_classes
@@ -70,6 +73,9 @@ class Dice(Metric):
     Args:
         num_classes (int): the number of classes in the segmentation task.
     """
+
+    # Make torchmetrics call update only once
+    full_state_update = False
 
     def __init__(self, num_classes: int):
         super().__init__(dist_sync_on_step=True)
@@ -138,6 +144,9 @@ class CrossEntropy(Metric):
         dist_sync_on_step (bool, optional): sync distributed metrics every step. Default: ``False``.
     """
 
+    # Make torchmetrics call update only once
+    full_state_update = False
+
     def __init__(self, ignore_index: int = -100, dist_sync_on_step: bool = False):
         super().__init__(dist_sync_on_step=dist_sync_on_step)
         self.ignore_index = ignore_index
@@ -167,6 +176,9 @@ class LossMetric(Metric):
 
         dist_sync_on_step (bool, optional): sync distributed metrics every step. Default: ``False``.
     """
+
+    # Make torchmetrics call update only once
+    full_state_update = False
 
     def __init__(self, loss_function: Callable, dist_sync_on_step: bool = False):
         super().__init__(dist_sync_on_step=dist_sync_on_step)

--- a/composer/metrics/nlp.py
+++ b/composer/metrics/nlp.py
@@ -26,6 +26,9 @@ class MaskedAccuracy(Metric):
             each forward() before returning the value at the step. Default: ``False``.
     """
 
+    # Make torchmetrics call update only once
+    full_state_update = False
+
     def __init__(self, ignore_index: int = -100, dist_sync_on_step: bool = False):
         # state from multiple processes
         super().__init__(dist_sync_on_step=dist_sync_on_step)
@@ -66,6 +69,9 @@ class LanguageCrossEntropy(Metric):
             each forward() before returning the value at the step. Default: ``False``.
         ignore_index (int, optional): The class index to ignore. Default: ``-100``.
     """
+
+    # Make torchmetrics call update only once
+    full_state_update = False
 
     def __init__(self, vocab_size: int, dist_sync_on_step=False, ignore_index: int = -100):
         super().__init__(dist_sync_on_step=dist_sync_on_step)
@@ -118,6 +124,9 @@ class BinaryF1Score(Metric):
             each forward() before returning the value at the step. Default: ``False``.
     """
 
+    # Make torchmetrics call update only once
+    full_state_update = False
+
     def __init__(self, dist_sync_on_step: bool = False):
         super().__init__(dist_sync_on_step=dist_sync_on_step)
 
@@ -162,6 +171,9 @@ class HFCrossEntropy(Metric):
         dist_sync_on_step (bool, optional): Synchronize metric state across processes at
             each forward() before returning the value at the step. Default: ``False``
     """
+
+    # Make torchmetrics call update only once
+    full_state_update = False
 
     def __init__(self, dist_sync_on_step=False):
         super().__init__(dist_sync_on_step=dist_sync_on_step)

--- a/composer/models/ssd/ssd.py
+++ b/composer/models/ssd/ssd.py
@@ -122,6 +122,9 @@ class SSD(ComposerModel):
 
 class coco_map(Metric):
 
+    # Have default behavior for this complex metric
+    full_state_update = True
+
     def __init__(self, data):
         super().__init__()
         try:


### PR DESCRIPTION
# What does this PR do?

Newer version of torchmetrics can be faster if we update our custom metrics.

# What issue(s) does this change relate to?

Composer generating extra warning


TEST:

No warning with this change. 
```
import torch
from torchmetrics.utilities import check_forward_full_state_property



from composer.metrics import MaskedAccuracy

batch_size = 16
num_classes = 10
generated_preds = torch.rand((batch_size, num_classes))
true_labels = torch.randint(low=0, high=num_classes - 1, size=(batch_size,))

m = MaskedAccuracy(ignore_index=0)
m.update(generated_preds.float(), true_labels.float())
```

```
import torch
from torchmetrics.utilities import check_forward_full_state_property

from composer.metrics import MaskedAccuracy

batch_size = 16
num_classes = 10
generated_preds = torch.rand((batch_size, num_classes))
true_labels = torch.randint(low=0, high=num_classes - 1, size=(batch_size,))

check_forward_full_state_property(
    MaskedAccuracy,
    init_args={"ignore_index": 0},
    input_args={"preds": generated_preds.float(), "target": true_labels.float()},
)
```