### PR TITLE
Autoresume related error messages

### DIFF
--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -56,7 +56,6 @@ class RemoteUploaderDownloader(LoggerDestination):
 
         remote_uploader_downloader = RemoteUploaderDownloader(
             bucket_uri="s3://my-bucket",
-            file_path_format_string="path/to/my/checkpoints/{remote_file_name}",
         )
 
         # Construct the trainer using this logger
@@ -160,7 +159,7 @@ class RemoteUploaderDownloader(LoggerDestination):
             .. doctest:: composer.loggers.remote_uploader_downloader.RemoteUploaderDownloader.__init__.file_path_format_string
 
                 >>> remote_uploader_downloader = RemoteUploaderDownloader(..., file_path_format_string='rank_{rank}/{remote_file_name}')
-                >>> trainer = Trainer(..., run_name='foo', loggers=[remote_uploader_downloader])
+                >>> trainer = Trainer(..., save_latest_filename=None, run_name='foo', loggers=[remote_uploader_downloader])
                 >>> trainer.logger.upload_file(
                 ...     remote_file_name='bar.txt',
                 ...     file_path='path/to/file.txt',

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1015,10 +1015,12 @@ class Trainer:
         self.logger = Logger(state=self.state, destinations=loggers)
 
         if save_latest_filename is not None:
-            if any(
-                    isinstance(logger_destination, RemoteUploaderDownloader) and
-                    logger_destination.file_path_format_string != '{remote_file_name}'
-                    for logger_destination in self.logger.destinations):
+            remote_ud_has_format_string = [
+                isinstance(logger_destination, RemoteUploaderDownloader) and
+                logger_destination.file_path_format_string != '{remote_file_name}'
+                for logger_destination in self.logger.destinations
+            ]
+            if any(remote_ud_has_format_string):
                 raise ValueError(
                     'Specifying a `file_path_format_string` to a `RemoteUploaderDownloader` is not currently supported while using `save_latest_filename`. '
                     'Please specify the path formatting via `save_folder`, `save_filename`, and `save_latest_filename`')
@@ -1223,9 +1225,12 @@ class Trainer:
                 raise ValueError(
                     'The `run_name` must be specified when using autoresume so Event.INIT is run with the correct run name.'
                 )
-            if any(
-                    isinstance(logger_destination, RemoteUploaderDownloader) and
-                    logger_destination._num_concurrent_uploads != 1 for logger_destination in self.logger.destinations):
+
+            remote_ud_has_multiple_concurrent_uploads = [
+                isinstance(logger_destination, RemoteUploaderDownloader) and
+                logger_destination._num_concurrent_uploads != 1 for logger_destination in self.logger.destinations
+            ]
+            if any(remote_ud_has_multiple_concurrent_uploads):
                 raise ValueError(
                     'Multiple concurrent uploads is not currently supported when using autoresume. Please set `num_concurrent_uploads` to 1 '
                     'for all `RemoteUploaderDownloader` instances.')

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1014,6 +1014,15 @@ class Trainer:
         # Logger
         self.logger = Logger(state=self.state, destinations=loggers)
 
+        if save_latest_filename is not None:
+            if any(
+                    isinstance(logger_destination, RemoteUploaderDownloader) and
+                    logger_destination.file_path_format_string != '{remote_file_name}'
+                    for logger_destination in self.logger.destinations):
+                raise ValueError(
+                    'Specifying a `file_path_format_string` to a `RemoteUploaderDownloader` is not currently supported while using `save_latest_filename`. '
+                    'Please specify the path formatting via `save_folder`, `save_filename`, and `save_latest_filename`')
+
         # Callbacks
         self.state.callbacks[:] = list(cast(List[Callback], loggers)) + self.state.callbacks
 
@@ -1214,6 +1223,12 @@ class Trainer:
                 raise ValueError(
                     'The `run_name` must be specified when using autoresume so Event.INIT is run with the correct run name.'
                 )
+            if any(
+                    isinstance(logger_destination, RemoteUploaderDownloader) and
+                    logger_destination._num_concurrent_uploads != 1 for logger_destination in self.logger.destinations):
+                raise ValueError(
+                    'Multiple concurrent uploads is not currently supported when using autoresume. Please set `num_concurrent_uploads` to 1 '
+                    'for all `RemoteUploaderDownloader` instances.')
             assert latest_remote_file_name is not None
             autoresume_checkpoint_path = self._get_autoresume_checkpoint(
                 save_folder=save_folder,

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -153,8 +153,8 @@ class TestCheckpointSaving:
             with pytest.warns(UserWarning):
                 trainer = self.get_trainer(save_folder='s3://bucket_name/{run_name}/checkpoints',
                                            loggers=[
-                                               RemoteUploaderDownloader(
-                                                   's3://bucket_name', file_path_format_string='{run_name}/checkpoints')
+                                               RemoteUploaderDownloader('s3://bucket_name',
+                                                                        file_path_format_string='{remote_file_name}')
                                            ])
         else:
             trainer = self.get_trainer(save_folder='s3://bucket_name/{run_name}/checkpoints')

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1209,6 +1209,7 @@ class TestAutoresumeCompatibility:
         }
 
     def test_autoresume_and_concurrent_uploads_error(self, tmp_path: pathlib.Path, config: Dict[str, Any]):
+        pytest.importorskip('libcloud')
         config.update({
             'run_name': 'autoresume_concurrent_uploads_run',
             'save_folder': str(tmp_path / 'checkpoints'),
@@ -1225,6 +1226,7 @@ class TestAutoresumeCompatibility:
             _ = Trainer(**config)
 
     def test_latest_and_object_format_string_error(self, tmp_path: pathlib.Path, config: Dict[str, Any]):
+        pytest.importorskip('libcloud')
         config.update({
             'run_name':
                 'latest_format_string_run',
@@ -1250,6 +1252,7 @@ class TestAutoresumeCompatibility:
         _ = Trainer(**config)
 
     def test_autoresume_and_default_remote_uploader_downloader(self, tmp_path: pathlib.Path, config: Dict[str, Any]):
+        pytest.importorskip('libcloud')
         config.update({
             'run_name': 'autoresume_default_remote_ud_run',
             'save_folder': str(tmp_path / 'checkpoints'),

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -8,7 +8,7 @@ import datetime
 import os
 import pathlib
 import time
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 import torch
@@ -26,8 +26,7 @@ from composer.core.state import State
 from composer.core.time import Time, TimeUnit
 from composer.datasets.ffcv_utils import write_ffcv_dataset
 from composer.datasets.imagenet import build_ffcv_imagenet_dataloader
-from composer.loggers.in_memory_logger import InMemoryLogger
-from composer.loggers.logger import Logger
+from composer.loggers import InMemoryLogger, Logger, RemoteUploaderDownloader
 from composer.loss import soft_cross_entropy
 from composer.models.base import ComposerModel
 from composer.optim.scheduler import ExponentialScheduler
@@ -1154,3 +1153,92 @@ def test_state_run_name():
     run_names = dist.all_gather_object(run_name)
     assert len(run_names) == 2  # 2 ranks
     assert all(run_name == run_names[0] for run_name in run_names)
+
+
+class TestAutoresumeCompatibility:
+
+    def get_logger(self,
+                   tmp_path: pathlib.Path,
+                   num_concurrent_uploads: int = 1,
+                   file_path_format_string: Optional[str] = None):
+        """Returns an object store logger that saves locally."""
+        remote_dir = str(tmp_path / 'object_store')
+        os.makedirs(remote_dir, exist_ok=True)
+
+        return RemoteUploaderDownloader(bucket_uri='libcloud://.',
+                                        backend_kwargs={
+                                            'provider': 'local',
+                                            'container': '.',
+                                            'provider_kwargs': {
+                                                'key': remote_dir,
+                                            },
+                                        },
+                                        num_concurrent_uploads=num_concurrent_uploads,
+                                        use_procs=False,
+                                        upload_staging_folder=str(tmp_path / 'staging_folder'),
+                                        **({
+                                            'file_path_format_string': file_path_format_string
+                                        } if file_path_format_string is not None else {}))
+
+    @pytest.fixture
+    def config(self):
+        """Returns the reference config."""
+
+        train_dataset = RandomClassificationDataset()
+        eval_dataset = RandomClassificationDataset()
+
+        return {
+            'model':
+                SimpleModel(),
+            'train_dataloader':
+                DataLoader(
+                    dataset=train_dataset,
+                    batch_size=4,
+                    sampler=dist.get_sampler(train_dataset),
+                ),
+            'eval_dataloader':
+                DataLoader(
+                    dataset=eval_dataset,
+                    sampler=dist.get_sampler(eval_dataset),
+                ),
+            'max_duration':
+                '2ep',
+            'autoresume':
+                True,
+            'loggers': [],
+        }
+
+    def test_autoresume_and_concurrent_uploads_error(self, tmp_path: pathlib.Path, config: Dict[str, Any]):
+        config.update({
+            'run_name': 'autoresume_concurrent_uploads_run',
+            'save_folder': str(tmp_path / 'checkpoints'),
+            'loggers': [self.get_logger(tmp_path, num_concurrent_uploads=2),
+                        self.get_logger(tmp_path)]
+        })
+
+        with pytest.raises(ValueError, match='There is a race condition'):
+            _ = Trainer(**config)
+
+    def test_autoresume_and_object_format_string_error(self, tmp_path: pathlib.Path, config: Dict[str, Any]):
+        config.update({
+            'run_name':
+                'autoresume_format_string_run',
+            'save_folder':
+                str(tmp_path / 'checkpoints'),
+            'loggers': [
+                self.get_logger(tmp_path, file_path_format_string='test/{remote_file_name}'),
+                self.get_logger(tmp_path)
+            ]
+        })
+
+        with pytest.raises(ValueError, match='There is an incompatibility'):
+            _ = Trainer(**config)
+
+    def test_autoresume_and_default_remote_uploader_downloader(self, tmp_path: pathlib.Path, config: Dict[str, Any]):
+        config.update({
+            'run_name': 'autoresume_default_remote_ud_run',
+            'save_folder': str(tmp_path / 'checkpoints'),
+            'loggers': [self.get_logger(tmp_path), self.get_logger(tmp_path)]
+        })
+
+        _ = Trainer(**config)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1220,7 +1220,8 @@ class TestAutoresumeCompatibility:
         # The root cause of this is that it is possible for an updated symlink file to be uploaded before the corresponding
         # checkpoint has finished uploading, and then the run dies, leaving the symlink contents pointing to a checkpoint that
         # does not exist
-        with pytest.raises(ValueError, match='There is a race condition'):
+        with pytest.raises(ValueError,
+                           match='Multiple concurrent uploads is not currently supported when using autoresume'):
             _ = Trainer(**config)
 
     def test_latest_and_object_format_string_error(self, tmp_path: pathlib.Path, config: Dict[str, Any]):
@@ -1238,11 +1239,14 @@ class TestAutoresumeCompatibility:
         # Test that trainer errors out if save_latest_filename is set, and RemoteUploaderDownloader file_path_format_string
         # is not default. The root cause of this is that the symlink file contents are created outside of the RemoteUploaderDownloader
         # and do not take into account its path formatting
-        with pytest.raises(ValueError, match='There is an incompatibility'):
+        with pytest.raises(
+                ValueError,
+                match='Specifying a `file_path_format_string` to a `RemoteUploaderDownloader` is not currently supported'
+        ):
             _ = Trainer(**config)
 
         # Ensure that if save_latest_filename is not set, it does not error
-        config.update({'save_latest_filename': None})
+        config.update({'save_latest_filename': None, 'autoresume': False})
         _ = Trainer(**config)
 
     def test_autoresume_and_default_remote_uploader_downloader(self, tmp_path: pathlib.Path, config: Dict[str, Any]):


### PR DESCRIPTION
# What does this PR do?
Adds errors so that users should not be able to hit edge case bugs. See linked issues.

@mvpatel2000 I think I can fix the symlink/formatting issue (CO-1272), but wanted to get these in now for your full pipeline testing.

# What issue(s) does this change relate to?
Closes [CO-1365](https://mosaicml.atlassian.net/browse/CO-1365?atlOrigin=eyJpIjoiMmRhNWViNjU4ZGMwNGM1MTgwMzUzZmMzMWZkOWRjZDMiLCJwIjoiaiJ9).
Relates to [CO-1270](https://mosaicml.atlassian.net/browse/CO-1270) and [CO-1272](https://mosaicml.atlassian.net/browse/CO-1272)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

