### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@
 # as an owner for all sections, so anyone on Composer Eng can approve any Composer PR
 # According to the CODEOWNER docs, the last match takes precedence, so @mosaicml/composer-team-eng
 # must be mentioned for each rule below.
-/composer/algorithms/ @dskhudia @mvpatel2000
+/composer/algorithms/ @dskhudia @mvpatel2000 @nik-mosaic
 /composer/cli/ @jbloxham
 /composer/datasets/ @knighton
 /composer/functional/ @dblalock @mvpatel2000

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,9 +19,9 @@
 # must be mentioned for each rule below.
 /composer/algorithms/ @dskhudia @mvpatel2000 @nik-mosaic
 /composer/cli/ @mosaicml/composer-team-eng
-/composer/datasets/ @knighton
+/composer/datasets/ @knighton @karan6181
 /composer/functional/ @dblalock @mvpatel2000
-/composer/loggers/ @eracah
+/composer/loggers/ @eracah @dakinggg
 /composer/loss/ @mosaicml/composer-team-eng
 /composer/metrics/ @mosaicml/composer-team-eng
 /composer/models/ @mosaicml/composer-team-eng

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@
 # According to the CODEOWNER docs, the last match takes precedence, so @mosaicml/composer-team-eng
 # must be mentioned for each rule below.
 /composer/algorithms/ @dskhudia @mvpatel2000 @nik-mosaic
-/composer/cli/ @jbloxham
+/composer/cli/ @mosaicml/composer-team-eng
 /composer/datasets/ @knighton
 /composer/functional/ @dblalock @mvpatel2000
 /composer/loggers/ @eracah


### PR DESCRIPTION
# What does this PR do?

- Add nik-mosaic to algo codeowners
- update CLI codeowners to eng team instead of just @jbloxham since he's busy with other stuff :) 
- adds karan to datasets (we shouldn't have single person owners in case of OOO)
- adds Daniel to logging (we shouldn't have single person owners in case of OOO)