### PR TITLE
Add nccl env var

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -289,8 +289,8 @@ def _launch_processes(
                 MASTER_ADDR=master_addr,
                 MASTER_PORT=str(master_port),
                 PYTHONUNBUFFERED='1',
+                NCCL_ASYNC_ERROR_HANDLING='1',
         ):
-
             # Populate the distributed variables in all launcher args
             for arg in training_script_args:
                 cmd.append(os.path.expandvars(os.path.expanduser(arg)))

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -746,7 +746,7 @@ class Trainer:
 
             .. seealso:: :mod:`composer.utils.reproducibility` for more details on reproducibility.
         dist_timeout (float, optional): Timeout, in seconds, for initializing the distributed process group.
-            (default: ``15.0``)
+            (default: ``1800.0``)
         ddp_sync_strategy (str | DDPSyncStrategy, optional): The strategy to use for synchronizing gradients.
             Leave unset to let the trainer auto-configure this. See :class:`.DDPSyncStrategy`
             for more details.
@@ -851,7 +851,7 @@ class Trainer:
         deterministic_mode: bool = False,
 
         # Distributed Training
-        dist_timeout: float = 300.0,
+        dist_timeout: float = 1800.0,
         ddp_sync_strategy: Optional[Union[str, DDPSyncStrategy]] = None,
 
         # Grad Clip Norm


### PR DESCRIPTION
# What does this PR do?

The timeout variable was being ignored before. We should actually use it by setting the appropriate env vars. From Pytorch Dist docs:

"""
– Timeout for operations executed against the process group. Default value equals 30 minutes. This is applicable for the gloo backend. For nccl, this is applicable only if the environment variable NCCL_BLOCKING_WAIT or NCCL_ASYNC_ERROR_HANDLING is set to 1.
"""

Also updates default dist_timeout to be same as what Pytorch has (30 min).

# What issue(s) does this change relate to?

[CO-1356](https://mosaicml.atlassian.net/browse/CO-1356)