### PR TITLE
Return empty dict if wandb disabled

### DIFF
--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -125,13 +125,19 @@ class WandBLogger(LoggerDestination):
         if self._enabled:
             if wandb.run is None:
                 raise ValueError('wandb module must be initialized before serialization.')
-            return {
-                'name': wandb.run.name,
-                'project': wandb.run.project,
-                'entity': wandb.run.entity,
-                'id': wandb.run.id,
-                'group': wandb.run.group
-            }
+
+            # If WandB is disabled, most things are RunDisabled objects, which are not
+            # pickleable due to overriding __getstate__ but not __setstate__
+            if wandb.run.disabled:
+                return {}
+            else:
+                return {
+                    'name': wandb.run.name,
+                    'project': wandb.run.project,
+                    'entity': wandb.run.entity,
+                    'id': wandb.run.id,
+                    'group': wandb.run.group
+                }
         else:
             return {}
 


### PR DESCRIPTION
# What does this PR do?
When WandB is disabled, many things are instances of `wandb.sdk.lib.disabled.RunDisabled`, which looks like this
```

class RunDisabled(str):
    def __init__(self, *args, **kwargs):
        object.__setattr__(self, "___dict", {})

    def __add__(self, other):
        return self

    def __sub__(self, other):
        return self

    def __mul__(self, other):
        return self

    def __truediv__(self, other):
        return self

    def __floordiv__(self, other):
        return self

    def __mod__(self, other):
        return self

    def __pow__(self, other, modulo=None):
        return self

    def __lshift__(self, other):
        return self

    def __rshift__(self, other):
        return self

    def __and__(self, other):
        return self

    def __xor__(self, other):
        return self

    def __or__(self, other):
        return self

    def __iadd__(self, other):
        return self

    def __isub__(self, other):
        return self

    def __imul__(self, other):
        return self

    def __idiv__(self, other):
        return self

    def __ifloordiv__(self, other):
        return self

    def __imod__(self, other):
        return self

    def __ipow__(self, other, modulo=None):
        return self

    def __ilshift__(self, other):
        return self

    def __irshift__(self, other):
        return self

    def __iand__(self, other):
        return self

    def __ixor__(self, other):
        return self

    def __ior__(self, other):
        return self

    def __neg__(self):
        return self

    def __pos__(self):
        return self

    def __abs__(self):
        return self

    def __invert__(self):
        return self

    def __complex__(self):
        return 1 + 0j

    def __int__(self):
        return 1

    def __long__(self):
        return 1

    def __float__(self):
        return 1.0

    def __oct__(self):
        return oct(1)

    def __hex__(self):
        return hex(1)

    def __lt__(self, other):
        return True

    def __le__(self, other):
        return True

    def __eq__(self, other):
        return True

    def __ne__(self, other):
        return True

    def __gt__(self, other):
        return True

    def __ge__(self, other):
        return True

    def __getattr__(self, attr):
        return self[attr]

    def __getitem__(self, key):
        d = object.__getattribute__(self, "___dict")
        try:
            if key in d:
                return d[key]
        except TypeError:
            key = str(key)
            if key in d:
                return d[key]
        dummy = RunDisabled()
        d[key] = dummy
        return dummy

    def __setitem__(self, key, value):
        object.__getattribute__(self, "___dict")[key] = value

    def __setattr__(self, key, value):
        self[key] = value

    def __call__(self, *args, **kwargs):
        return RunDisabled()

    def __len__(self):
        return 1

    def __str__(self):
        return ""

    def __enter__(self):
        return self

    def __exit__(self, exc_type, exc_val, exc_tb):
        return exc_type is None

    def __repr__(self):
        return ""

    def __nonzero__(self):
        return True

    def __bool__(self):
        return True

    def __getstate__(self):
        return 1
```

Notably, this overrides `__getstate__` but not `__setstate__`. The default `__setstate__` expects a dict, not an integer, and so this object cannot be dumped and loaded via pickle. This causes checkpoints saved while WandB is disabled to not be loadable.
e.g.
```
In [1]: import pickle

In [2]: class Test:
   ...:     def __getstate__(self):
   ...:         return 1
   ...: 

In [3]: pickle.loads(pickle.dumps(Test()))
---------------------------------------------------------------------------
UnpicklingError                           Traceback (most recent call last)
<ipython-input-3-fd93b83a4470> in <cell line: 1>()
----> 1 pickle.loads(pickle.dumps(Test()))

UnpicklingError: state is not a dictionary
```

To fix, we just return an empty dictionary for the `WandBLogger` state dict if WandB is disabled. We haven't implemented `load_state_dict` for `WandBLogger`, so this is really just metadata right now.

# What issue(s) does this change relate to?
Fixes [CO-1357](https://mosaicml.atlassian.net/browse/CO-1357?atlOrigin=eyJpIjoiOTMwNmNhMGM1NWJkNGI1MjhhMzE5MmM0YTk0MjQ2OGQiLCJwIjoiaiJ9)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))
