### PR TITLE
Fix typing in EMA's _move_params_to_device()

### DIFF
--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -298,8 +298,10 @@ def _move_params_to_device(model: torch.nn.Module, destination_model: torch.nn.M
     with torch.no_grad():
         destination_params = destination_model.parameters()
         params = model.parameters()
-        model.param_list = [s.to(d.device) for s, d in zip(params, destination_params)]
+        for s, d in zip(params, destination_params):
+            s.to(d.device)
 
         destination_buffers = destination_model.buffers()
         buffers = model.buffers()
-        model.buffer_list = [s.to(d.device) for s, d in zip(buffers, destination_buffers)]
+        for s, d in zip(buffers, destination_buffers):
+            s.to(d.device)


### PR DESCRIPTION
This PR cleans up the `_move_params_to_device()` function in EMA to account for `param_list` and `buffer_list` no longer existing after #1524. This was causing errors with Pyright 1.1.277. EMA functionality be identical after this change.