### PR TITLE
Add support for Path in CheckpointSaver

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -279,9 +279,10 @@ class CheckpointSaver(Callback):  # noqa: D101
         self,
         folder: Union[str, pathlib.Path] = '{run_name}/checkpoints',
         filename: Union[str, pathlib.Path] = 'ep{epoch}-ba{batch}-rank{rank}.pt',
-        remote_file_name: Union[str, pathlib.Path, None] = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt',
-        latest_filename: Union[str, pathlib.Path, None] = 'latest-rank{rank}.pt',
-        latest_remote_file_name: Union[str, pathlib.Path, None] = '{run_name}/checkpoints/latest-rank{rank}.pt',
+        remote_file_name: Optional[Union[str,
+                                         pathlib.Path]] = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt',
+        latest_filename: Optional[Union[str, pathlib.Path, None]] = 'latest-rank{rank}.pt',
+        latest_remote_file_name: Optional[Union[str, pathlib.Path]] = '{run_name}/checkpoints/latest-rank{rank}.pt',
         save_interval: Union[Time, str, int, Callable[[State, Event], bool]] = '1ep',
         *,
         overwrite: bool = False,
@@ -290,9 +291,9 @@ class CheckpointSaver(Callback):  # noqa: D101
     ):
         folder = str(folder)
         filename = str(filename)
-        remote_file_name = str(remote_file_name) if remote_file_name else None
-        latest_filename = str(latest_filename) if latest_filename else None
-        latest_remote_file_name = str(latest_remote_file_name) if latest_remote_file_name else None
+        remote_file_name = str(remote_file_name) if remote_file_name is not None else None
+        latest_filename = str(latest_filename) if latest_filename is not None else None
+        latest_remote_file_name = str(latest_remote_file_name) if latest_remote_file_name is not None else None
 
         if not callable(save_interval):
             save_interval = checkpoint_periodically(save_interval)

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -281,7 +281,7 @@ class CheckpointSaver(Callback):  # noqa: D101
         filename: Union[str, pathlib.Path] = 'ep{epoch}-ba{batch}-rank{rank}.pt',
         remote_file_name: Optional[Union[str,
                                          pathlib.Path]] = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt',
-        latest_filename: Optional[Union[str, pathlib.Path, None]] = 'latest-rank{rank}.pt',
+        latest_filename: Optional[Union[str, pathlib.Path]] = 'latest-rank{rank}.pt',
         latest_remote_file_name: Optional[Union[str, pathlib.Path]] = '{run_name}/checkpoints/latest-rank{rank}.pt',
         save_interval: Union[Time, str, int, Callable[[State, Event], bool]] = '1ep',
         *,

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import os
+import pathlib
 import tempfile
 import textwrap
 from typing import Callable, List, Optional, Union
@@ -276,17 +277,23 @@ class CheckpointSaver(Callback):  # noqa: D101
 
     def __init__(
         self,
-        folder: str = '{run_name}/checkpoints',
-        filename: str = 'ep{epoch}-ba{batch}-rank{rank}.pt',
-        remote_file_name: Optional[str] = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt',
-        latest_filename: Optional[str] = 'latest-rank{rank}.pt',
-        latest_remote_file_name: Optional[str] = '{run_name}/checkpoints/latest-rank{rank}.pt',
+        folder: Union[str, pathlib.Path] = '{run_name}/checkpoints',
+        filename: Union[str, pathlib.Path] = 'ep{epoch}-ba{batch}-rank{rank}.pt',
+        remote_file_name: Union[str, pathlib.Path, None] = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt',
+        latest_filename: Union[str, pathlib.Path, None] = 'latest-rank{rank}.pt',
+        latest_remote_file_name: Union[str, pathlib.Path, None] = '{run_name}/checkpoints/latest-rank{rank}.pt',
         save_interval: Union[Time, str, int, Callable[[State, Event], bool]] = '1ep',
         *,
         overwrite: bool = False,
         num_checkpoints_to_keep: int = -1,
         weights_only: bool = False,
     ):
+        folder = str(folder)
+        filename = str(filename)
+        remote_file_name = str(remote_file_name) if remote_file_name else None
+        latest_filename = str(latest_filename) if latest_filename else None
+        latest_remote_file_name = str(latest_remote_file_name) if latest_remote_file_name else None
+
         if not callable(save_interval):
             save_interval = checkpoint_periodically(save_interval)
         self.save_interval = save_interval

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -156,9 +156,9 @@ def test_checkpoint_saver_folder_filename_path(folder: Union[str, pathlib.Path],
       '{run_name}/checkpoints/latest-rank{rank}.pt'),
      (pathlib.Path('{run_name}/my_checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt'), pathlib.Path('latest-rank{rank}.pt'),
       pathlib.Path('{run_name}/checkpoints/latest-rank{rank}.pt'))])
-def test_checkpoint_filenames(remote_file_name: Union[str, pathlib.Path,
-                                                      None], latest_filename: Union[str, pathlib.Path, None],
-                              latest_remote_file_name: Union[str, pathlib.Path, None]):
+def test_checkpoint_filenames(remote_file_name: Optional[Union[str, pathlib.Path]],
+                              latest_filename: Optional[Union[str, pathlib.Path]],
+                              latest_remote_file_name: Optional[Union[str, pathlib.Path]]):
     checkpoint_saver = CheckpointSaver(remote_file_name=remote_file_name,
                                        latest_filename=latest_filename,
                                        latest_remote_file_name=latest_remote_file_name)
@@ -173,9 +173,9 @@ def test_checkpoint_filenames(remote_file_name: Union[str, pathlib.Path,
 
 
 @pytest.mark.parametrize('remote_file_name,latest_filename,latest_remote_file_name', [(None, None, None)])
-def test_checkpoint_filenames_none(remote_file_name: Union[str, pathlib.Path,
-                                                           None], latest_filename: Union[str, pathlib.Path, None],
-                                   latest_remote_file_name: Union[str, pathlib.Path, None]):
+def test_checkpoint_filenames_none(remote_file_name: Optional[Union[str, pathlib.Path]],
+                                   latest_filename: Optional[Union[str, pathlib.Path]],
+                                   latest_remote_file_name: Optional[Union[str, pathlib.Path]]):
     checkpoint_saver = CheckpointSaver(remote_file_name=remote_file_name,
                                        latest_filename=latest_filename,
                                        latest_remote_file_name=latest_remote_file_name)

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -19,6 +19,7 @@ import torch.distributed
 from pytest import MonkeyPatch
 from torch.utils.data import DataLoader
 
+from composer.callbacks.checkpoint_saver import CheckpointSaver
 from composer.core.callback import Callback
 from composer.core.time import Time, TimeUnit
 from composer.loggers import RemoteUploaderDownloader, remote_uploader_downloader
@@ -137,6 +138,51 @@ def test_ignore_params(remove_field_paths: List[List[str]], filter_params: List[
 
     glob_filter(filter_params)(new_dict)
     assert base_dict == new_dict
+
+
+@pytest.mark.parametrize('folder,filename',
+                         [('{run_name}/my_checkpoints', 'ep{epoch}-rank{rank}.pt'),
+                          (pathlib.Path('{run_name}/my_checkpoints'), pathlib.Path('ep{epoch}-rank{rank}.pt'))])
+def test_checkpoint_saver_folder_filename_path(folder: Union[str, pathlib.Path], filename: Union[str, pathlib.Path]):
+    checkpoint_saver = CheckpointSaver(folder=folder, filename=filename)
+
+    assert checkpoint_saver.folder == str(folder)
+    assert checkpoint_saver.filename.filename == str(filename)
+
+
+@pytest.mark.parametrize(
+    'remote_file_name,latest_filename,latest_remote_file_name',
+    [('{run_name}/my_checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt', 'latest-rank{rank}.pt',
+      '{run_name}/checkpoints/latest-rank{rank}.pt'),
+     (pathlib.Path('{run_name}/my_checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt'), pathlib.Path('latest-rank{rank}.pt'),
+      pathlib.Path('{run_name}/checkpoints/latest-rank{rank}.pt'))])
+def test_checkpoint_filenames(remote_file_name: Union[str, pathlib.Path,
+                                                      None], latest_filename: Union[str, pathlib.Path, None],
+                              latest_remote_file_name: Union[str, pathlib.Path, None]):
+    checkpoint_saver = CheckpointSaver(remote_file_name=remote_file_name,
+                                       latest_filename=latest_filename,
+                                       latest_remote_file_name=latest_remote_file_name)
+
+    assert checkpoint_saver.remote_file_name is not None
+    assert checkpoint_saver.latest_filename is not None
+    assert checkpoint_saver.latest_remote_file_name is not None
+
+    assert checkpoint_saver.remote_file_name.filename == str(remote_file_name)
+    assert checkpoint_saver.latest_filename.filename == str(latest_filename)
+    assert checkpoint_saver.latest_remote_file_name.filename == str(latest_remote_file_name)
+
+
+@pytest.mark.parametrize('remote_file_name,latest_filename,latest_remote_file_name', [(None, None, None)])
+def test_checkpoint_filenames_none(remote_file_name: Union[str, pathlib.Path,
+                                                           None], latest_filename: Union[str, pathlib.Path, None],
+                                   latest_remote_file_name: Union[str, pathlib.Path, None]):
+    checkpoint_saver = CheckpointSaver(remote_file_name=remote_file_name,
+                                       latest_filename=latest_filename,
+                                       latest_remote_file_name=latest_remote_file_name)
+
+    assert checkpoint_saver.remote_file_name == None
+    assert checkpoint_saver.latest_filename == None
+    assert checkpoint_saver.latest_remote_file_name == None
 
 
 class TestCheckpointSaving:


### PR DESCRIPTION
Adds support for `Path` objects alongside `str`, per #1573. Additional tests were added to explicitly test `__init__` of `CheckpointSaver`, since #1573 talks about subclassing.

- Related to #1573

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
