### PR TITLE
Assign eval microbatch to self.state.batch

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2522,7 +2522,7 @@ class Trainer:
                     # Note: We use uint8 instead of bool as BOR is not supported on all torch.distributed backends
                     found_cuda_oom = 0
                     try:
-                        for eval_microbatch in data_spec.split_batch(self.state.batch, self.state.eval_batch_split):
+                        for self.state.batch in data_spec.split_batch(self.state.batch, self.state.eval_batch_split):
                             self.engine.run_event(Event.EVAL_BEFORE_FORWARD)
                             with get_precision_context(self.state.precision):
                                 if hasattr(self._original_model, 'validate'):  # backwards compatibility check
@@ -2530,9 +2530,9 @@ class Trainer:
                                         'Using validate() is no longer supported and will be removed in a future version. Please use eval_forward() instead.'
                                     )
                                     assert isinstance(self._original_model.validate, Callable)
-                                    self.state.outputs, target = self._original_model.validate(eval_microbatch)
+                                    self.state.outputs, target = self._original_model.validate(self.state.batch)
                                 else:
-                                    self.state.outputs = self._original_model.eval_forward(eval_microbatch)
+                                    self.state.outputs = self._original_model.eval_forward(self.state.batch)
                                     target = None
 
                             self.engine.run_event(Event.EVAL_AFTER_FORWARD)
@@ -2552,7 +2552,7 @@ class Trainer:
                                 else:
                                     for _, metric in metrics.items():
                                         self._original_model.update_metric(
-                                            eval_microbatch,
+                                            self.state.batch,
                                             outputs,
                                             metric,
                                         )

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -338,15 +338,12 @@ def test_infinite_eval_dataloader(eval_subset_num_batches):
 class BreakBatchAlgorithm(Algorithm):
 
     def __init__(self):
-        print('callback init')
         super().__init__()
 
     def match(self, event, state):
-        print('callback match')
         return event == Event.EVAL_BEFORE_FORWARD
 
     def apply(self, event, state, logger):
-        print('helloooooooooo')
         del event, logger  # unused
         state.batch = None
 

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -8,7 +8,7 @@ import pytest
 from torch.utils.data import DataLoader
 from torchmetrics import Accuracy
 
-from composer.core import Event
+from composer.core import Algorithm, Event
 from composer.core.evaluator import Evaluator, evaluate_periodically
 from composer.core.state import State
 from composer.core.time import Time, TimeUnit
@@ -333,3 +333,35 @@ def test_infinite_eval_dataloader(eval_subset_num_batches):
             max_duration='1ep',
             eval_subset_num_batches=eval_subset_num_batches,
         )
+
+
+class BreakBatchAlgorithm(Algorithm):
+
+    def __init__(self):
+        print('callback init')
+        super().__init__()
+
+    def match(self, event, state):
+        print('callback match')
+        return event == Event.EVAL_BEFORE_FORWARD
+
+    def apply(self, event, state, logger):
+        print('helloooooooooo')
+        del event, logger  # unused
+        state.batch = None
+
+
+@pytest.mark.parametrize('add_algorithm', [True, False])
+def test_eval_batch_can_be_modified(add_algorithm: bool):
+    train_dataset = RandomClassificationDataset(size=8)
+    train_dataloader = DataLoader(train_dataset, batch_size=4, sampler=dist.get_sampler(train_dataset))
+    eval_dataset = RandomClassificationDataset(size=8)
+    eval_dataloader = DataLoader(eval_dataset, batch_size=4, sampler=dist.get_sampler(eval_dataset))
+
+    with contextlib.nullcontext() if not add_algorithm else pytest.raises(TypeError):
+        trainer = Trainer(model=SimpleModel(),
+                          train_dataloader=train_dataloader,
+                          eval_dataloader=eval_dataloader,
+                          max_duration='1ep',
+                          algorithms=[BreakBatchAlgorithm()] if add_algorithm else [])
+        trainer.eval()


### PR DESCRIPTION
# What does this PR do?
`eval_microbatch` was a local variable, which meant that modifying `state.batch` on `EVAL_BEFORE_FORWARD` did not successfully modify the batch. This PR fixes that to match the behavior in the training loop.

# What issue(s) does this change relate to?
Fixes [1420](https://mosaicml.atlassian.net/browse/CO-1420)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
