### PR TITLE
Add composer version state

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -508,6 +508,19 @@ class State(Serializable):
                 return True
         return False
 
+    def _get_state_metadata(self):
+        """Gets a dictionary of metadata to store in the state dict.
+
+        This metadata is used for checking compatibility between the current environment/setup
+        and the environment/setup that was used for the checkpoint that is being loaded in
+        """
+        import composer
+
+        metadata_dict = {}
+        metadata_dict['composer_version'] = composer.__version__
+
+        return metadata_dict
+
     def state_dict(self) -> Dict[str, Any]:
         state_dict = {}
 
@@ -544,6 +557,8 @@ class State(Serializable):
                 serialized_value = attribute_value
 
             state_dict[attribute_name] = serialized_value
+
+        state_dict['metadata'] = self._get_state_metadata()
 
         return state_dict
 
@@ -727,6 +742,10 @@ class State(Serializable):
         for attribute_name, serialized_value in state.items():
             # Skip removed attributes as well as algorithms and model, which was already loaded
             if attribute_name not in self.serialized_attributes or attribute_name == 'model':
+                continue
+
+            # Skip metadata, which is not an attribute on State
+            if attribute_name == 'metadata':
                 continue
 
             # Restructure algorithms serialized_value from list to dict

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -23,7 +23,7 @@ from composer.core.event import Event
 from composer.core.precision import Precision
 from composer.core.serializable import Serializable
 from composer.core.time import Time, Timestamp, TimeUnit
-from composer.utils import batch_get, batch_set, dist, ensure_tuple, is_model_deepspeed
+from composer.utils import batch_get, batch_set, dist, ensure_tuple, get_composer_env_dict, is_model_deepspeed
 
 if TYPE_CHECKING:
     import deepspeed
@@ -514,10 +514,8 @@ class State(Serializable):
         This metadata is used for checking compatibility between the current environment/setup
         and the environment/setup that was used for the checkpoint that is being loaded in
         """
-        import composer
-
         metadata_dict = {}
-        metadata_dict['composer_version'] = composer.__version__
+        metadata_dict['composer_env_info'] = get_composer_env_dict()
 
         return metadata_dict
 

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -6,7 +6,8 @@ import warnings
 
 from composer.utils.batch_helpers import batch_get, batch_set
 from composer.utils.checkpoint import PartialFilePath, load_checkpoint, save_checkpoint
-from composer.utils.collect_env import configure_excepthook, disable_env_report, enable_env_report, print_env
+from composer.utils.collect_env import (configure_excepthook, disable_env_report, enable_env_report,
+                                        get_composer_env_dict, print_env)
 from composer.utils.device import get_device, is_tpu_installed
 from composer.utils.file_helpers import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, FORMAT_NAME_WITH_DIST_TABLE,
                                          create_symlink_file, ensure_folder_has_no_conflicting_files,
@@ -76,6 +77,7 @@ __all__ = [
     'disable_env_report',
     'enable_env_report',
     'print_env',
+    'get_composer_env_dict',
     'retry',
     'model_eval_mode',
     'get_device',

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -51,7 +51,7 @@ import psutil
 
 from composer.utils.misc import is_notebook
 
-__all__ = ['configure_excepthook', 'disable_env_report', 'enable_env_report', 'print_env']
+__all__ = ['configure_excepthook', 'disable_env_report', 'enable_env_report', 'print_env', 'get_composer_env_dict']
 
 # Check if PyTorch is installed
 try:
@@ -283,9 +283,9 @@ CUDA Device Count: {cuda_device_count}
 """.strip()
 
 
-# Get Composer environment info
-def get_composer_env() -> str:
-    """Query Composer pertinent system information."""
+# Get composer environment info as a dictionary
+def get_composer_env_dict() -> dict:
+    """Query Composer pertinent system information as a dict."""
     mutable_dict = ComposerEnv(
         composer_version=get_composer_version(),
         composer_commit_hash=get_composer_commit_hash(),
@@ -296,7 +296,13 @@ def get_composer_env() -> str:
         local_world_size=get_local_world_size(),
         cuda_device_count=get_cuda_device_count(),
     )._asdict()
+    return mutable_dict
 
+
+# Get Composer environment info
+def get_composer_env() -> str:
+    """Query Composer pertinent system information."""
+    mutable_dict = get_composer_env_dict()
     return _COMPOSER_ENV_INFO_FORMAT.format(**mutable_dict)
 
 

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -81,7 +81,7 @@ The above code, when run, will produce the checkpoints below:
     >>> list(state_dict)
     ['state', 'rng']
     >>> list(state_dict['state'].keys())
-    ['model', 'optimizers', 'schedulers', 'algorithms', 'callbacks', 'scaler', 'timestamp', 'rank_zero_seed', 'train_metrics', 'eval_metrics', 'run_name']
+    ['model', 'optimizers', 'schedulers', 'algorithms', 'callbacks', 'scaler', 'timestamp', 'rank_zero_seed', 'train_metrics', 'eval_metrics', 'run_name', 'metadata']
 
 Resume training
 ---------------

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
+import composer
 from composer.core import Batch, Precision, State
 from composer.loggers import Logger
 from tests.common import SimpleModel, assert_state_equivalent
@@ -124,3 +125,14 @@ def test_state_batch_set_item(batch, key, val):
 
     state.batch_set_item(key=key, value=val)
     assert state.batch_get_item(key) == val
+
+
+def test_composer_version_in_state_dict(tmp_path):
+    state = get_dummy_state()
+    save_path = pathlib.Path(tmp_path) / 'state_dict.pt'
+    with open(save_path, 'wb') as _tmp_file:
+        torch.save(state.state_dict(), _tmp_file)
+
+    loaded_state_dict = torch.load(save_path)
+
+    assert loaded_state_dict['metadata']['composer_version'] == composer.__version__

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -127,12 +127,17 @@ def test_state_batch_set_item(batch, key, val):
     assert state.batch_get_item(key) == val
 
 
-def test_composer_version_in_state_dict(tmp_path):
+def test_composer_env_info_in_state_dict(tmp_path):
     state = get_dummy_state()
     save_path = pathlib.Path(tmp_path) / 'state_dict.pt'
     with open(save_path, 'wb') as _tmp_file:
         torch.save(state.state_dict(), _tmp_file)
 
     loaded_state_dict = torch.load(save_path)
-
-    assert loaded_state_dict['metadata']['composer_version'] == composer.__version__
+    expected_env_info_keys = set([
+        'composer_version', 'composer_commit_hash', 'node_world_size', 'host_processor_model_name',
+        'host_processor_core_count', 'local_world_size', 'accelerator_model_name', 'cuda_device_count'
+    ])
+    actual_env_info_keys = set(loaded_state_dict['metadata']['composer_env_info'].keys())
+    assert expected_env_info_keys == actual_env_info_keys
+    assert loaded_state_dict['metadata']['composer_env_info']['composer_version'] == composer.__version__


### PR DESCRIPTION
# What does this PR do?
Adds composer version to a `metadata` section of the state dict. This will allow us to do compatibility checks in the future, and also debug checkpoints that may be broken.

# What issue(s) does this change relate to?
Is a start to [CO-1428](https://mosaicml.atlassian.net/browse/CO-1428)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
