### PR TITLE
inference mode

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1902,7 +1902,7 @@ class Trainer:
         assert self._train_data_spec is not None, 'The train data spec should be set on __init__ or fit()'
         assert self.state.train_metrics is not None, 'The train metrics should be set on __init__ or fit()'
 
-        with torch.no_grad(),\
+        with torch.inference_mode(),\
                 model_eval_mode(self.state.model),\
                 get_precision_context(self.state.precision):
             if hasattr(self._original_model, 'validate'):  # backwards compatibility check
@@ -2245,7 +2245,7 @@ class Trainer:
         outputs = []
         cpu_device = DeviceCPU()
 
-        with torch.no_grad(), model_eval_mode(self.state.model):
+        with torch.inference_mode(), model_eval_mode(self.state.model):
 
             self.engine.run_event(Event.PREDICT_START)
 
@@ -2482,7 +2482,7 @@ class Trainer:
 
         last_wct = datetime.datetime.now()
 
-        with torch.no_grad(), model_eval_mode(self.state.model):
+        with torch.inference_mode(), model_eval_mode(self.state.model):
             self.state.set_dataloader(data_spec.dataloader, dataloader_label, subset_num_batches)
             assert self.state.dataloader is not None, 'dataloader is set'
 


### PR DESCRIPTION
# What does this PR do?

Inference mode is faster than `torch.no_grad`. It disables some metadata tracking to go faster. 

# What issue(s) does this change relate to?

[CO-1431](https://mosaicml.atlassian.net/browse/CO-1431)
