### PR TITLE
Adds auto object store creation to `get_file`

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -18,7 +18,6 @@ import warnings
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, ContextManager, Dict, Iterable, List, Optional, Sequence, TextIO, Tuple, Union, cast
-from urllib.parse import urlparse
 
 import coolname
 import torch
@@ -44,9 +43,11 @@ from composer.trainer._deepspeed import _fix_batch_precision_for_deepspeed, _par
 from composer.trainer._scale_schedule import scale_pytorch_scheduler
 from composer.trainer._scaler import ClosureGradScaler
 from composer.trainer.dist_strategy import DDPSyncStrategy, ddp_sync_context, prepare_ddp_module, prepare_fsdp_module
-from composer.utils import (ExportFormat, MissingConditionalImportError, ObjectStore, S3ObjectStore, Transform,
-                            checkpoint, dist, ensure_tuple, export_with_logger, format_name_with_dist, get_device,
-                            get_file, is_tpu_installed, map_collection, model_eval_mode, reproducibility)
+from composer.utils import (ExportFormat, MissingConditionalImportError, ObjectStore, Transform, checkpoint, dist,
+                            ensure_tuple, export_with_logger, format_name_with_dist, get_device, get_file,
+                            is_tpu_installed, map_collection, maybe_create_object_store_from_uri,
+                            maybe_create_remote_uploader_downloader_from_uri, model_eval_mode, parse_uri,
+                            reproducibility)
 
 if is_tpu_installed():
     import torch_xla.core.xla_model as xm
@@ -283,53 +284,6 @@ def _generate_run_name() -> str:
     dist.broadcast_object_list(run_name_list)
     generated_run_name = run_name_list[0]
     return generated_run_name
-
-
-def _maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
-    backend, bucket_name, _ = _parse_uri(uri)
-    if backend == '':
-        return None
-    if backend == 's3':
-        return S3ObjectStore(bucket=bucket_name)
-    elif backend == 'wandb':
-        raise NotImplementedError(f'There is no implementation for WandB load_object_store via URI. Please use '
-                                  'WandBLogger')
-    else:
-        raise NotImplementedError(f'There is no implementation for the cloud backend {backend} via URI. Please use '
-                                  's3 or one of the supported object stores')
-
-
-def _maybe_create_remote_uploader_downloader_from_uri(
-        uri: str, loggers: List[LoggerDestination]) -> Optional[RemoteUploaderDownloader]:
-    existing_remote_uds = [logger_dest for logger_dest in loggers if isinstance(logger_dest, RemoteUploaderDownloader)]
-    backend, bucket_name, _ = _parse_uri(uri)
-    if backend == '':
-        return None
-    for existing_remote_ud in existing_remote_uds:
-        if ((existing_remote_ud.remote_backend_name == backend) and
-            (existing_remote_ud.remote_bucket_name == bucket_name)):
-            warnings.warn(
-                f'There already exists a RemoteUploaderDownloader object to handle the uri: {uri} you specified')
-            return None
-    if backend == 's3':
-        return RemoteUploaderDownloader(bucket_uri=f'{backend}://{bucket_name}')
-
-    elif backend == 'wandb':
-        raise NotImplementedError(f'There is no implementation for WandB via URI. Please use '
-                                  'WandBLogger with log_artifacts set to True')
-
-    else:
-        raise NotImplementedError(f'There is no implementation for the cloud backend {backend} via URI. Please use '
-                                  's3 or one of the supported RemoteUploaderDownloader object stores')
-
-
-def _parse_uri(uri: str) -> Tuple[str, str, str]:
-    parse_result = urlparse(uri)
-    backend, bucket_name, path = parse_result.scheme, parse_result.netloc, parse_result.path
-    if backend == '' and bucket_name == '':
-        return backend, bucket_name, path
-    else:
-        return backend, bucket_name, path.lstrip('/')
 
 
 class Trainer:
@@ -1010,7 +964,7 @@ class Trainer:
                 ))
 
         if save_folder is not None:
-            remote_ud = _maybe_create_remote_uploader_downloader_from_uri(save_folder, loggers)
+            remote_ud = maybe_create_remote_uploader_downloader_from_uri(save_folder, loggers)
             if remote_ud is not None:
                 loggers.append(remote_ud)
 
@@ -1035,7 +989,7 @@ class Trainer:
         self._checkpoint_saver = None
         latest_remote_file_name = None
         if save_folder is not None:
-            _, _, parsed_save_folder = _parse_uri(save_folder)
+            _, _, parsed_save_folder = parse_uri(save_folder)
 
             # If user passes a URI with s3:// and a bucket_name, but no other
             # path then we assume they just want their checkpoints saved directly in their
@@ -1258,12 +1212,12 @@ class Trainer:
         # Actually load the checkpoint from potentially updated arguments
         if load_path is not None:
             if load_object_store is None:
-                load_object_store = _maybe_create_object_store_from_uri(load_path)
+                load_object_store = maybe_create_object_store_from_uri(load_path)
             if isinstance(load_object_store, WandBLogger):
                 import wandb
                 if wandb.run is None:
                     load_object_store.init(self.state, self.logger)
-            _, _, parsed_load_path = _parse_uri(load_path)
+            _, _, parsed_load_path = parse_uri(load_path)
             self._rng_state = checkpoint.load_checkpoint(
                 state=self.state,
                 logger=self.logger,

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -13,7 +13,7 @@ from composer.utils.file_helpers import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, F
                                          create_symlink_file, ensure_folder_has_no_conflicting_files,
                                          ensure_folder_is_empty, format_name_with_dist, format_name_with_dist_and_time,
                                          get_file, is_tar, maybe_create_object_store_from_uri,
-                                         maybe_create_remote_uploader_downloader_from_uri)
+                                         maybe_create_remote_uploader_downloader_from_uri, parse_uri)
 from composer.utils.import_helpers import MissingConditionalImportError, import_object
 from composer.utils.inference import ExportFormat, Transform, export_for_inference, export_with_logger, quantize_dynamic
 from composer.utils.iter_helpers import IteratorFileStream, ensure_tuple, map_collection
@@ -74,6 +74,7 @@ __all__ = [
     'is_tar',
     'maybe_create_object_store_from_uri',
     'maybe_create_remote_uploader_downloader_from_uri',
+    'parse_uri',
     'batch_get',
     'batch_set',
     'configure_excepthook',

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -12,7 +12,8 @@ from composer.utils.device import get_device, is_tpu_installed
 from composer.utils.file_helpers import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, FORMAT_NAME_WITH_DIST_TABLE,
                                          create_symlink_file, ensure_folder_has_no_conflicting_files,
                                          ensure_folder_is_empty, format_name_with_dist, format_name_with_dist_and_time,
-                                         get_file, is_tar)
+                                         get_file, is_tar, maybe_create_object_store_from_uri,
+                                         maybe_create_remote_uploader_downloader_from_uri)
 from composer.utils.import_helpers import MissingConditionalImportError, import_object
 from composer.utils.inference import ExportFormat, Transform, export_for_inference, export_with_logger, quantize_dynamic
 from composer.utils.iter_helpers import IteratorFileStream, ensure_tuple, map_collection
@@ -71,6 +72,8 @@ __all__ = [
     'format_name_with_dist',
     'format_name_with_dist_and_time',
     'is_tar',
+    'maybe_create_object_store_from_uri',
+    'maybe_create_remote_uploader_downloader_from_uri',
     'batch_get',
     'batch_set',
     'configure_excepthook',

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -305,7 +305,7 @@ Args:
 
 
 def parse_uri(uri: str) -> Tuple[str, str, str]:
-    """Uses :meth:`~urllib.parse.urlparse` to parse the provided URI.
+    """Uses :py:func:`urllib.parse.urlparse` to parse the provided URI.
 
     Args:
         uri (str): The provided URI string
@@ -323,16 +323,16 @@ def parse_uri(uri: str) -> Tuple[str, str, str]:
 
 
 def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
-    """Automatically creates an ObjectStore from supported URI formats.
+    """Automatically creates an :class:`composer.utils.ObjectStore` from supported URI formats.
 
     Args:
-        uri (str): The path to (maybe) create an ObjectStore from
+        uri (str): The path to (maybe) create an :class:`composer.utils.ObjectStore` from
 
     Raises:
         NotImplementedError: Raises when the URI format is not supported.
 
     Returns:
-        Optional[ObjectStore]: Returns an ObjectStore if the URI is of a supported format, otherwise None
+        Optional[ObjectStore]: Returns an :class:`composer.utils.ObjectStore` if the URI is of a supported format, otherwise None
     """
     from composer.utils.object_store import S3ObjectStore
     backend, bucket_name, _ = parse_uri(uri)
@@ -350,17 +350,17 @@ def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
 
 def maybe_create_remote_uploader_downloader_from_uri(
         uri: str, loggers: List[LoggerDestination]) -> Optional['RemoteUploaderDownloader']:
-    """Automatically creates a RemoteUploaderDownloader from supported URI formats.
+    """Automatically creates a :class:`composer.loggers.RemoteUploaderDownloader` from supported URI formats.
 
     Args:
-        uri (str):The path to (maybe) create a RemoteUploaderDownloader from
-        loggers (List[LoggerDestination]): List of the existing LoggerDestinations so as to not create a duplicate
+        uri (str):The path to (maybe) create a :class:`composer.loggers.RemoteUploaderDownloader` from
+        loggers (List[:class:`composer.loggers.LoggerDestination`]): List of the existing :class:`composer.loggers.LoggerDestination` s so as to not create a duplicate
 
     Raises:
         NotImplementedError: Raises when the URI format is not supported.
 
     Returns:
-        Optional[RemoteUploaderDownloader]: Returns a RemoteUploaderDownloader if the URI is of a supported format, otherwise None
+        Optional[RemoteUploaderDownloader]: Returns a :class:`composer.loggers.RemoteUploaderDownloader` if the URI is of a supported format, otherwise None
     """
     from composer.loggers import RemoteUploaderDownloader
     existing_remote_uds = [logger_dest for logger_dest in loggers if isinstance(logger_dest, RemoteUploaderDownloader)]
@@ -403,7 +403,7 @@ def get_file(
             *   If ``object_store`` is not specified but the ``path`` begins with ``http://`` or ``https://``,
                 the object at this URL will be downloaded.
 
-            *   If ``object_store`` is not specified, but the ``path`` begins with ``s3://``, an :class:`~composer.utils.object_store.S3ObjectStore`
+            *   If ``object_store`` is not specified, but the ``path`` begins with ``s3://``, an :class:`composer.utils.S3ObjectStore`
                 will be created and used.
 
             *   Otherwise, ``path`` is presumed to be a local filepath.

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 __all__ = [
     'get_file', 'ensure_folder_is_empty', 'ensure_folder_has_no_conflicting_files', 'format_name_with_dist',
     'format_name_with_dist_and_time', 'is_tar', 'create_symlink_file', 'maybe_create_object_store_from_uri',
-    'maybe_create_remote_uploader_downloader_from_uri'
+    'maybe_create_remote_uploader_downloader_from_uri', 'parse_uri'
 ]
 
 
@@ -305,7 +305,16 @@ Args:
 """
 
 
-def _parse_uri(uri: str) -> Tuple[str, str, str]:
+def parse_uri(uri: str) -> Tuple[str, str, str]:
+    """Uses :meth:`~urllib.parse.urlparse` to parse the provided URI.
+
+    Args:
+        uri (str): The provided URI string
+
+    Returns:
+        Tuple[str, str, str]: A tuple containing the backend (e.g. s3), bucket name, and path.
+                              Backend and bucket name will be empty string if the input is a local path
+    """
     parse_result = urlparse(uri)
     backend, bucket_name, path = parse_result.scheme, parse_result.netloc, parse_result.path
     if backend == '' and bucket_name == '':
@@ -326,7 +335,7 @@ def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
     Returns:
         Optional[ObjectStore]: Returns an ObjectStore if the URI is of a supported format, otherwise None
     """
-    backend, bucket_name, _ = _parse_uri(uri)
+    backend, bucket_name, _ = parse_uri(uri)
     if backend == '':
         return None
     if backend == 's3':
@@ -354,7 +363,7 @@ def maybe_create_remote_uploader_downloader_from_uri(
         Optional[RemoteUploaderDownloader]: Returns a RemoteUploaderDownloader if the URI is of a supported format, otherwise None
     """
     existing_remote_uds = [logger_dest for logger_dest in loggers if isinstance(logger_dest, RemoteUploaderDownloader)]
-    backend, bucket_name, _ = _parse_uri(uri)
+    backend, bucket_name, _ = parse_uri(uri)
     if backend == '':
         return None
     for existing_remote_ud in existing_remote_uds:

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -20,7 +20,7 @@ import tqdm
 
 from composer.utils import dist
 from composer.utils.iter_helpers import iterate_with_callback
-from composer.utils.object_store import ObjectStore
+from composer.utils.object_store import ObjectStore, S3ObjectStore
 
 if TYPE_CHECKING:
     from composer.core import Timestamp
@@ -334,7 +334,6 @@ def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
     Returns:
         Optional[ObjectStore]: Returns an :class:`composer.utils.ObjectStore` if the URI is of a supported format, otherwise None
     """
-    from composer.utils.object_store import S3ObjectStore
     backend, bucket_name, _ = parse_uri(uri)
     if backend == '':
         return None

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -18,14 +18,13 @@ from urllib.parse import urlparse
 import requests
 import tqdm
 
-from composer.loggers import RemoteUploaderDownloader
 from composer.utils import dist
 from composer.utils.iter_helpers import iterate_with_callback
 from composer.utils.object_store import ObjectStore
 
 if TYPE_CHECKING:
     from composer.core import Timestamp
-    from composer.loggers import LoggerDestination
+    from composer.loggers import LoggerDestination, RemoteUploaderDownloader
 
 log = logging.getLogger(__name__)
 
@@ -350,7 +349,7 @@ def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
 
 
 def maybe_create_remote_uploader_downloader_from_uri(
-        uri: str, loggers: List[LoggerDestination]) -> Optional[RemoteUploaderDownloader]:
+        uri: str, loggers: List[LoggerDestination]) -> Optional['RemoteUploaderDownloader']:
     """Automatically creates a RemoteUploaderDownloader from supported URI formats.
 
     Args:
@@ -363,6 +362,7 @@ def maybe_create_remote_uploader_downloader_from_uri(
     Returns:
         Optional[RemoteUploaderDownloader]: Returns a RemoteUploaderDownloader if the URI is of a supported format, otherwise None
     """
+    from composer.loggers import RemoteUploaderDownloader
     existing_remote_uds = [logger_dest for logger_dest in loggers if isinstance(logger_dest, RemoteUploaderDownloader)]
     backend, bucket_name, _ = parse_uri(uri)
     if backend == '':

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -21,7 +21,7 @@ import tqdm
 from composer.loggers import RemoteUploaderDownloader
 from composer.utils import dist
 from composer.utils.iter_helpers import iterate_with_callback
-from composer.utils.object_store import ObjectStore, S3ObjectStore
+from composer.utils.object_store import ObjectStore
 
 if TYPE_CHECKING:
     from composer.core import Timestamp
@@ -335,6 +335,7 @@ def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
     Returns:
         Optional[ObjectStore]: Returns an ObjectStore if the URI is of a supported format, otherwise None
     """
+    from composer.utils.object_store import S3ObjectStore
     backend, bucket_name, _ = parse_uri(uri)
     if backend == '':
         return None

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -403,6 +403,9 @@ def get_file(
             *   If ``object_store`` is not specified but the ``path`` begins with ``http://`` or ``https://``,
                 the object at this URL will be downloaded.
 
+            *   If ``object_store`` is not specified, but the ``path`` begins with ``s3://``, an :class:`~composer.utils.object_store.S3ObjectStore`
+                will be created and used.
+
             *   Otherwise, ``path`` is presumed to be a local filepath.
 
         destination (str): The destination filepath.
@@ -426,6 +429,10 @@ def get_file(
     Raises:
         FileNotFoundError: If the ``path`` does not exist.
     """
+    if object_store is None and not (path.lower().startswith('http://') or path.lower().startswith('https://')):
+        object_store = maybe_create_object_store_from_uri(path)
+        _, _, path = parse_uri(path)
+
     if path.endswith('.symlink'):
         with tempfile.TemporaryDirectory() as tmpdir:
             symlink_file_name = os.path.join(tmpdir, 'file.symlink')

--- a/tests/loggers/test_remote_uploader_downloader.py
+++ b/tests/loggers/test_remote_uploader_downloader.py
@@ -21,16 +21,18 @@ from composer.utils.object_store.object_store import ObjectStore
 class DummyObjectStore(ObjectStore):
     """Dummy ObjectStore implementation that is backed by a local directory."""
 
-    def __init__(self, dir: pathlib.Path, always_fail: bool = False, **kwargs: Dict[str, Any]) -> None:
-        self.dir = str(dir)
+    def __init__(self, dir: Optional[pathlib.Path] = None, always_fail: bool = False, **kwargs: Dict[str, Any]) -> None:
+        self.dir = str(dir) if dir is not None else kwargs['bucket']
         self.always_fail = always_fail
+        assert isinstance(self.dir, str)
         os.makedirs(self.dir, exist_ok=True)
 
     def get_uri(self, object_name: str) -> str:
         return 'local://' + object_name
 
     def _get_abs_path(self, object_name: str):
-        return self.dir + '/' + object_name
+        assert isinstance(self.dir, str)
+        return os.path.abspath(self.dir + '/' + object_name)
 
     def upload_object(
         self,


### PR DESCRIPTION
# What does this PR do?
I have had to write code that autoparses the URI to create an `S3ObjectStore` and then calls `get_file` with that newly created object store a couple of times, and the util to pull huggingface tokenizer/model out of a composer checkpoint is going to need to do the same, so I added the same auto parsing support as in trainer to the `get_file` function. It shouldn't change any behavior of any existing code interacting with `get_file`.

Manual tested that I can download a file from S3 using this, and also that checkpointing/autoresume from S3 still works.

# What issue(s) does this change relate to?
Part of [CO-1110](https://mosaicml.atlassian.net/browse/CO-1110)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
