### PR TITLE
Switch flash attention to tag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -226,7 +226,7 @@ RUN if [ -n "$CUDA_VERSION" ] ; then \
 # Install Flash Attention
 ##########################
 RUN if [ -n "$CUDA_VERSION" ] ; then \
-        pip${PYTHON_VERSION} install --no-cache-dir git+https://github.com/mvpatel2000/flash-attention@main ; \
+        pip${PYTHON_VERSION} install --no-cache-dir git+https://github.com/HazyResearch/flash-attention.git@v0.2.2 ; \
     fi
 
 ###########################


### PR DESCRIPTION
# What does this PR do?

Now that flash attention has tags, we should use a release tag instead of a frozen fork.

# What issue(s) does this change relate to?

[CO-1455](https://mosaicml.atlassian.net/browse/CO-1455)