### PR TITLE
unregister

### DIFF
--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -445,6 +445,8 @@ class Engine():
             # Do not attempt to shutdown again, since close() already ran via __atexit__ or was already invoked
             return
         self.close()
+        atexit.unregister(_set_atexit_ran)
+        atexit.unregister(self._close)
 
     def _debug_log(self, event: Event, msg: str):
         """Helper to include timestamp and event info in log messages."""


### PR DESCRIPTION
# What does this PR do?

Fixes memory not being freed with object deletion. 

Experiment training resnet twice in same python process
Before:
<img width="867" alt="image" src="https://user-images.githubusercontent.com/17102158/204939972-842189c4-9fa1-404b-b442-31eb2648b5b8.png">
After: 
<img width="801" alt="image" src="https://user-images.githubusercontent.com/17102158/204940177-c91e29b8-696e-4bc9-bdb5-69e09e7b8d14.png">



# What issue(s) does this change relate to?

[CO-1443](https://mosaicml.atlassian.net/browse/CO-1443)