### PR TITLE
Fix hf tokenizer test for new hf version

### DIFF
--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -127,6 +127,16 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     # extra key that is not important
     tokenizer1.__dict__.pop('deprecation_warnings')
     tokenizer2.__dict__.pop('deprecation_warnings')
+
+    # tokenizer.init_kwargs['model_max_length'] is unset when the tokenizer does not specify it, but is set
+    # to a very large number when you save and reload, so here we just check that its the same if it is present in
+    # both tokenizers. There is a separate tokenizer.model_max_length that will still get checked for equivalence
+    model_max_length_1 = tokenizer1.init_kwargs.get('model_max_length', None)
+    model_max_length_2 = tokenizer2.init_kwargs.get('model_max_length', None)
+    if model_max_length_1 is not None and model_max_length_2 is not None:
+        assert model_max_length_1 == model_max_length_2
+    tokenizer1.__dict__['init_kwargs'].pop('model_max_length', None)
+    tokenizer2.__dict__['init_kwargs'].pop('model_max_length', None)
     assert tokenizer1.__dict__ == tokenizer2.__dict__
 
 


### PR DESCRIPTION
# What does this PR do?
New HF version changed whether a certain key is present on the tokenizer representation. If this becomes a recurring problem, I can revisit the tests that rely a bit on internal HF tokenizer details.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
