### PR TITLE
cache call to cpuinfo

### DIFF
--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -40,6 +40,7 @@ To disable automatic environment report generation, use the :func:`disable_env_r
 function.  Report generation can be re-enabled by using the :func:`enable_env_report` function.
 """
 
+import functools
 import json
 import sys
 import time
@@ -122,6 +123,7 @@ def get_composer_version() -> str:
     return str(composer.__version__)
 
 
+@functools.lru_cache(maxsize=None)
 def get_host_processor_name() -> str:
     """Query the host processor name."""
     cpu_info = cpuinfo.get_cpu_info()

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -123,7 +123,7 @@ def get_composer_version() -> str:
     return str(composer.__version__)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.lru_cache(maxsize=1)
 def get_host_processor_name() -> str:
     """Query the host processor name."""
     cpu_info = cpuinfo.get_cpu_info()


### PR DESCRIPTION
# What does this PR do?
The call `cpuinfo` is apparently kind of slow. Since we call it inside of `composer_collect_env` (which is called inside of `state.state_dict()`), it gets called a lot of times during the tests, particularly while checkpointing. Looks like it cut total PR time down from 26m to 17m.

# What issue(s) does this change relate to?
Closes [CO-1469](https://mosaicml.atlassian.net/browse/CO-1469)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
