### PR TITLE
Add durations arg to pytest

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -39,7 +39,7 @@ function cleanup()
 
 trap cleanup EXIT
 
-COMMON_ARGS="-v -m '$MARKERS' --s3_bucket '$S3_BUCKET' --sftp_uri '$SFTP_URI'"
+COMMON_ARGS="-v --durations=20 -m '$MARKERS' --s3_bucket '$S3_BUCKET' --sftp_uri '$SFTP_URI'"
 
 # Set the run directory to build/output, which will be caputred by Jenkins
 # Run pytest with coverage, and store the junit output


### PR DESCRIPTION
# What does this PR do?
Adds a duration arg to pytest so that if tests randomly slow down, a developer can at least see the slowest tests to look for a dramatic change.

Here is what it looks like in the logs:
<img width="1079" alt="Screen Shot 2022-12-06 at 1 29 05 PM" src="https://user-images.githubusercontent.com/43149077/206027059-31743f65-0658-4b0c-95d5-f7b52b9b8329.png">


# What issue(s) does this change relate to?
N/A

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
