### PR TITLE
Updating FSDP supported config flags

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -227,6 +227,9 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     min_params = int(float(fsdp_config.get('min_params', 1e9)))
     activation_checkpointing = fsdp_config.get('activation_checkpointing', False)
     activation_cpu_offload = fsdp_config.get('activation_cpu_offload', False)
+    sync_module_states = fsdp_config.get('sync_module_states', False)
+    forward_prefetch = fsdp_config.get('forward_prefetch', False)
+    limit_all_gathers = fsdp_config.get('limit_all_gathers', False)
 
     # We choose to not wrap the ComposerModel directly, but instead wrap any submodules like `ComposerModel.model`
     # This makes it safer to call ComposerModel-specific functions like 'eval_forward' that
@@ -269,6 +272,9 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
                 backward_prefetch=backward_prefetch,
                 param_init_fn=_param_init_fn,
                 device_id=torch.cuda.current_device(),
+                sync_module_states=sync_module_states,
+                forward_prefetch=forward_prefetch,
+                limit_all_gathers=limit_all_gathers,
             )
 
             # Activation Checkpointing
@@ -309,6 +315,9 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
         print(f'FSDP: Using min_params={min_params}')
         print(f'FSDP: Using activation_checkpointing={activation_checkpointing}')
         print(f'FSDP: Using activation_cpu_offload={activation_cpu_offload}')
+        print(f'FSDP: Using sync_module_states={sync_module_states}')
+        print(f'FSDP: Using forward_prefetch={forward_prefetch}')
+        print(f'FSDP: Using limit_all_gathers={limit_all_gathers}')
 
     # Rebuild optimizer now that parameters are sharded
     if optimizers:


### PR DESCRIPTION
Updates the supported FSDP config flags in composer to include:
- sync_module_states
- forward_prefetch
- limit_all_gathers

Addresses:

[CO-1487](https://mosaicml.atlassian.net/browse/CO-1487)

Tested locally in LLM foundry (trains for a few gradient steps):
```
FSDP: Using sharding_strategy=ShardingStrategy.FULL_SHARD
FSDP: Using cpu_offload=None
FSDP: Using mixed_precision=MixedPrecision(param_dtype=torch.bfloat16, reduce_dtype=torch.bfloat16, buffer_dtype=torch.bfloat16, keep_low_precision_grads=False)
FSDP: Using backward_prefetch=BackwardPrefetch.BACKWARD_POST
FSDP: Using min_params=100000000
FSDP: Using activation_checkpointing=False
FSDP: Using activation_cpu_offload=False
FSDP: Using sync_module_states=True
FSDP: Using forward_prefetch=True
FSDP: Using limit_all_gathers=True
```

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
