### PR TITLE
Adding in the possibility of 'None' for MixedPrecision FSDP

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -184,7 +184,6 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     param_dtype = None
     reduce_dtype = None
     buffer_dtype = None
-    keep_low_precision_grads = False
     if isinstance(mixed_precision, dict):
         param_dtype = mixed_precision.get('param_dtype', None)
         if param_dtype is not None:

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -191,19 +191,14 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     elif isinstance(mixed_precision, str):
         mixed_precision = mixed_precision.upper()
         if mixed_precision == 'FULL':
-            param_dtype = torch.float32
-            reduce_dtype = torch.float32
-            buffer_dtype = torch.float32
+            pass
         elif mixed_precision == 'DEFAULT':
-            param_dtype = torch.float32
             reduce_dtype = get_torch_dtype(precision)
             buffer_dtype = torch.float32
         elif mixed_precision == 'PURE':
             param_dtype = get_torch_dtype(precision)
             reduce_dtype = get_torch_dtype(precision)
             buffer_dtype = get_torch_dtype(precision)
-        elif mixed_precision == 'NONE':
-            pass
         else:
             raise ValueError(f'Unable to interpret mixed_precision={mixed_precision}')
     else:

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -204,15 +204,6 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     else:
         raise ValueError(f'Unable to interpret mixed_precision={mixed_precision}')
 
-    if sharding_map_key != 'NO_SHARD' and (
-            precision == Precision.AMP_FP16 and param_dtype not in [torch.float16, None] or
-            precision == Precision.AMP_BF16 and param_dtype not in [torch.bfloat16, None]):
-        raise ValueError(
-            f'FSDP in PyTorch 1.13 does not support precision `{precision}` with sharding strategy `{sharding_strategy}` '
-            f'and param_dtype `{param_dtype}.` param_dtype needs to match the precision data type `{precision}.` '
-            "Please adjust the MixedPrecision parameter, for example `mixed_precision='PURE'` or `mixed_precision='NONE'`."
-        )
-
     mixed_precision = MixedPrecision(
         param_dtype=param_dtype,
         reduce_dtype=reduce_dtype,

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -209,21 +209,21 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     else:
         raise ValueError(f'Unable to interpret mixed_precision={mixed_precision}')
 
-    if mixed_precision == 'NONE':
-        mixed_precision = MixedPrecision()
-    else:
-        if sharding_map_key != 'NO_SHARD' and (precision == Precision.AMP_FP16 and param_dtype != torch.float16 or
-                                               precision == Precision.AMP_BF16 and param_dtype != torch.bfloat16):
-            raise ValueError(
-                f'FSDP in PyTorch 1.13 does not support precision `{precision}` with sharding strategy `{sharding_strategy}` '
-                f'and param_dtype `{param_dtype}.` param_dtype needs to match the precision data type `{precision}.` '
-                "Please adjust the MixedPrecision parameter, for example `mixed_precision='PURE'`.")
-        mixed_precision = MixedPrecision(
-            param_dtype=param_dtype,
-            reduce_dtype=reduce_dtype,
-            buffer_dtype=buffer_dtype,
-            keep_low_precision_grads=False,
+    if sharding_map_key != 'NO_SHARD' and (
+            precision == Precision.AMP_FP16 and param_dtype not in [torch.float16, None] or
+            precision == Precision.AMP_BF16 and param_dtype not in [torch.bfloat16, None]):
+        raise ValueError(
+            f'FSDP in PyTorch 1.13 does not support precision `{precision}` with sharding strategy `{sharding_strategy}` '
+            f'and param_dtype `{param_dtype}.` param_dtype needs to match the precision data type `{precision}.` '
+            "Please adjust the MixedPrecision parameter, for example `mixed_precision='PURE'` or `mixed_precision='NONE'`."
         )
+
+    mixed_precision = MixedPrecision(
+        param_dtype=param_dtype,
+        reduce_dtype=reduce_dtype,
+        buffer_dtype=buffer_dtype,
+        keep_low_precision_grads=False,
+    )
 
     backward_prefetch_map = {
         'NONE': None,

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -185,9 +185,9 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     reduce_dtype = None
     buffer_dtype = None
     if isinstance(mixed_precision, dict):
-        param_dtype = get_torch_dtype(mixed_precision.get('param_dtype', 'float32'))
-        reduce_dtype = get_torch_dtype(mixed_precision.get('reduce_dtype', 'float32'))
-        buffer_dtype = get_torch_dtype(mixed_precision.get('buffer_dtype', 'float32'))
+        param_dtype = get_torch_dtype(mixed_precision.get('param_dtype', None))
+        reduce_dtype = get_torch_dtype(mixed_precision.get('reduce_dtype', None))
+        buffer_dtype = get_torch_dtype(mixed_precision.get('buffer_dtype', None))
     elif isinstance(mixed_precision, str):
         mixed_precision = mixed_precision.upper()
         if mixed_precision == 'FULL':


### PR DESCRIPTION
# What does this PR do?
Passing in 'NONE' as a value for MixedPrecision in FSDP will keep all values in 'FULL' precision:

https://github.com/pytorch/pytorch/blob/eb56b08f96fdbca17ee09ab8500ca145085e1a3a/test/distributed/fsdp/test_fsdp_mixed_precision.py#L78

# What issue(s) does this change relate to?
[CO-1503](https://mosaicml.atlassian.net/browse/CO-1503)


# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
