### PR TITLE
Check and make sure that metric names is a list of strings

### DIFF
--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -156,17 +156,19 @@ class Evaluator:
         self.dataloader = ensure_data_spec(dataloader)
 
         self.metric_names = []
-        if metric_names or metrics:
-            if (metric_names and metrics):
-                raise ValueError('only one of ``metrics`` or ``metric_names`` should be specified.')
-            if metric_names:
-                self.metric_names = metric_names
-            elif metrics:
-                warnings.warn(DeprecationWarning('``metrics`` is deprecated and will be removed in a future release.'))
-                if isinstance(metrics, Metric):
-                    self.metric_names = [metrics.__class__.__name__]
-                else:
-                    self.metric_names = [str(k) for k, _ in metrics.items()]
+        if (metric_names is not None) and (metrics is not None):
+            raise ValueError('only one of ``metrics`` or ``metric_names`` should be specified.')
+
+        if metric_names is not None:
+            if not isinstance(metric_names, list):
+                raise ValueError(f'``metric_names`` should be a list of strings, not a {type(metric_names)}')
+            self.metric_names = metric_names
+        elif metrics is not None:
+            warnings.warn(DeprecationWarning('``metrics`` is deprecated and will be removed in a future release.'))
+            if isinstance(metrics, Metric):
+                self.metric_names = [metrics.__class__.__name__]
+            else:
+                self.metric_names = [str(k) for k, _ in metrics.items()]
 
         self.subset_num_batches = subset_num_batches
         self._eval_interval = None

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -163,7 +163,7 @@ class Evaluator:
                 raise ValueError(f'``metric_names`` should be a list of strings, not a {type(metric_names)}')
             self.metric_names = metric_names
         elif metrics is not None:
-            warnings.warn(DeprecationWarning('``metrics`` is deprecated and will be removed in a future release.'))
+            warnings.warn(DeprecationWarning('``metrics`` is deprecated and will be removed in 0.13.0.'))
             if isinstance(metrics, Metric):
                 self.metric_names = [metrics.__class__.__name__]
             else:

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -158,8 +158,7 @@ class Evaluator:
         self.metric_names = []
         if (metric_names is not None) and (metrics is not None):
             raise ValueError('only one of ``metrics`` or ``metric_names`` should be specified.')
-
-        if metric_names is not None:
+        elif metric_names is not None:
             if not isinstance(metric_names, list):
                 raise ValueError(f'``metric_names`` should be a list of strings, not a {type(metric_names)}')
             self.metric_names = metric_names

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -156,7 +156,7 @@ class Evaluator:
         self.dataloader = ensure_data_spec(dataloader)
 
         self.metric_names = []
-        if (metric_names is not None) and (metrics is not None):
+        if metric_names is not None and metrics is not None:
             raise ValueError('only one of ``metrics`` or ``metric_names`` should be specified.')
         elif metric_names is not None:
             if not isinstance(metric_names, list):

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -338,3 +338,14 @@ def test_eval_batch_can_be_modified(add_algorithm: bool):
                           max_duration='1ep',
                           algorithms=[BreakBatchAlgorithm()] if add_algorithm else [])
         trainer.eval()
+
+
+@pytest.mark.parametrize('metric_names', ['Accuracy', ['Accuracy']])
+def test_evaluator_metric_names_string_errors(metric_names):
+    eval_dataset = RandomClassificationDataset(size=8)
+    eval_dataloader = DataLoader(eval_dataset, batch_size=4, sampler=dist.get_sampler(eval_dataset))
+
+    context = contextlib.nullcontext() if isinstance(metric_names, list) else pytest.raises(
+        ValueError, match='should be a list of strings')
+    with context:
+        _ = Evaluator(label='evaluator', dataloader=eval_dataloader, metric_names=metric_names)


### PR DESCRIPTION
# What does this PR do?
If you accidentally pass a string to `Evaluator` for `metric_names`, you get a semi nasty silent error of not actually filtering your metrics, because `_filter_metrics` will happily loop over the string you provided. This PR explicitly checks that the input of `metric_names` is a list.

# What issue(s) does this change relate to?
Closes [CO-1505](https://mosaicml.atlassian.net/browse/CO-1505)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)? 
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
