### PR TITLE
Remove pip install all from coverage action

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -81,7 +81,6 @@ jobs:
         run: |
           set -ex
           python -m pip install --upgrade pip wheel
-          python -m pip install -e .[all]
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -68,7 +68,7 @@ jobs:
           python -m coverage combine
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage-${{ github.sha }}
+          name: coverage-${{ github.sha }}-${{ matrix.name }}
           path: .coverage
   coverage:
     needs: [ pytest ]

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -36,11 +36,11 @@ jobs:
             markers: 'not daily and not gpu and not vision and not remote and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:latest
+            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'not daily and not gpu and vision and not remote and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:latest
+            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'not daily and not gpu and not vision and not remote and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     container: ${{ matrix.container }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -81,6 +81,7 @@ jobs:
         run: |
           set -ex
           python -m pip install --upgrade pip wheel
+          pip install coverage[toml]==6.5.0
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
# What does this PR do?
As title, also switches to explicit docker image tags for the vision images because it is faster.

# What issue(s) does this change relate to?
N/A

