### PR TITLE
Fix source code links in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.napoleon',
     'sphinxcontrib.katex',
-    'sphinx.ext.linkcode',
+    'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'sphinxemoji.sphinxemoji',
     'sphinxext.opengraph',
@@ -518,36 +518,6 @@ def _determine_lineno_of_attribute(module: types.ModuleType, attribute: str):
             if any(isinstance(x, ast.Name) and x.id == attribute for x in stmt.targets):
                 return stmt.lineno
     return None
-
-
-def linkcode_resolve(domain: str, info: Dict[str, str]):
-    """Adds links to the GitHub source code in the API Reference."""
-    assert domain == 'py', f'unsupported domain: {domain}'
-    module_name = info['module']
-
-    # Get the object and determine the line number
-    obj_name_in_module = info['fullname']
-    module = importlib.import_module(module_name)
-    lineno = _determine_lineno_of_attribute(module, obj_name_in_module)
-    if lineno is None:
-        obj = _recursive_getattr(module, obj_name_in_module)
-        if isinstance(obj, property):
-            # For properties, return the getter, where it is documented
-            obj = obj.fget
-        try:
-            _, lineno = inspect.getsourcelines(obj)
-        except TypeError:
-            # `inspect.getsourcelines` does not work on all object types (e.g. attributes).
-            # If it fails, it still might be possible to determine the source line through better parsing
-            # in _determine_lineno_of_attribute
-            pass
-    if lineno is None:
-        log.debug(f'Could not determine source line number for {module_name}.{obj_name_in_module}.')
-        return None
-    # Format the link
-    filename = module_name.replace('.', '/')
-    commit_sha = _COMMIT_SHA
-    return f'https://github.com/mosaicml/composer/blob/{commit_sha}/{filename}.py#L{lineno}'
 
 
 class PatchedHTMLTranslator(HTML5Translator):


### PR DESCRIPTION
# What does this PR do?

Fixes a bug that was introduced in the API Reference refactor.  Implements quick fix to switch to `sphinx.ext.viewcode` plugin instead of previous `sphinx.ext.linkcode` plugin since source code GH URL 

# What issue(s) does this change relate to?

Fixes [CO-1382](https://mosaicml.atlassian.net/browse/CO-1382).

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
