### PR TITLE
Update Docker images to use ‘posix_prefix’ paths

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -159,7 +159,7 @@ RUN \
 ARG PYTHON_VERSION
 
 # Python 3.10 changes where packages are installed. Workaround until all packages support new format
-ENV DEB_PYTHON_INSTALL_LAYOUT=deb 
+ENV DEB_PYTHON_INSTALL_LAYOUT=deb
 
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -158,6 +158,9 @@ RUN \
 ################
 ARG PYTHON_VERSION
 
+# Python 3.10 changes where packages are installed. Workaround until all packages support new format
+ENV DEB_PYTHON_INSTALL_LAYOUT=deb 
+
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/tests/test_full_nlp.py
+++ b/tests/test_full_nlp.py
@@ -189,7 +189,7 @@ def inference_test_helper(finetuning_output_path, rud, finetuning_model, algorit
 
 @device('cpu', 'gpu')
 # Note: the specificity of these settings are due to incompatibilities (e.g. the simpletransformer model is not traceable)
-@pytest.mark.parametrize('model_type,algorithms,save_format', [('tinybert_hf', [GatedLinearUnits()], 'onnx'),
+@pytest.mark.parametrize('model_type,algorithms,save_format', [('tinybert_hf', [GatedLinearUnits], 'onnx'),
                                                                ('simpletransformer', [], 'torchscript')])
 def test_full_nlp_pipeline(model_type, algorithms, save_format, tiny_bert_tokenizer, tmp_path, request, device):
     """This test is intended to exercise our full pipeline for NLP.
@@ -199,6 +199,8 @@ def test_full_nlp_pipeline(model_type, algorithms, save_format, tiny_bert_tokeni
     """
     pytest.importorskip('libcloud')
     pytest.importorskip('transformers')
+
+    algorithms = [algorithm() for algorithm in algorithms]
 
     device = get_device(device)
 


### PR DESCRIPTION
# What does this PR do?

For Debian distros, Python 3.10 sysconfig default install paths have changed to `posix_local` instead of `posix_prefix` per:
https://lists.debian.org/debian-python/2022/03/msg00039.html

This is an issue with Triton which specifically uses `sysconfig.get_paths()` to determine install paths.  This PR sets the `DEB_PYTHON_INSTALL_LAYOUT=deb` to force previous default behavior in the Python 3.10 image.

# What issue(s) does this change relate to?

Fixes [CO-1605](https://mosaicml.atlassian.net/browse/CO-1605)

