### PR TITLE
Simpler auto log hparams

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1891,9 +1891,6 @@ class Trainer:
         """Run training for the specified number of epochs and log results."""
         # print training start
         log.info('Using precision %s', self.state.precision)
-        self.logger.log_hyperparameters(
-            {'enabled_algorithms/' + algo.__class__.__name__: True for algo in self.state.algorithms})
-
         assert self.state.dataloader is not None, 'dataloader is set in __init__() or fit()'
         assert self._train_data_spec is not None, 'The train data spec is set in __init__() or fit()'
         assert self.state.scaler is not None, 'scaler should have been set in __init__()'

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -4,6 +4,8 @@
 """Helper utilities."""
 import warnings
 
+from composer.utils.auto_log_hparams import (convert_flat_dict_to_nested_dict, convert_nested_dict_to_flat_dict,
+                                             extract_hparams)
 from composer.utils.batch_helpers import batch_get, batch_set
 from composer.utils.checkpoint import PartialFilePath, load_checkpoint, save_checkpoint
 from composer.utils.collect_env import (configure_excepthook, disable_env_report, enable_env_report,
@@ -82,4 +84,7 @@ __all__ = [
     'ExportFormat',
     'Transform',
     'export_with_logger',
+    'extract_hparams',
+    'convert_nested_dict_to_flat_dict',
+    'convert_flat_dict_to_nested_dict',
 ]

--- a/composer/utils/auto_log_hparams.py
+++ b/composer/utils/auto_log_hparams.py
@@ -1,0 +1,105 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contains helper functions for auto-logging hparams."""
+
+from typing import Any, Dict, List, Tuple
+
+__all__ = ['extract_hparams', 'convert_nested_dict_to_flat_dict', 'convert_flat_dict_to_nested_dict']
+
+
+def extract_hparams(locals_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Takes in local symbol table and recursively grabs any hyperparameter.
+    Args:
+        locals_dict (Dict[str, Any]): The local symbol table returned when calling locals(),
+            which maps any free local variables' names to their values.
+    Returns:
+        Dict[str, Any]: A nested dictionary with every element of locals_dict mapped to its
+            value or to another sub_dict.
+    """
+    hparams = {}
+    if 'self' in locals_dict:
+        locals_dict.pop('self')
+
+    for k, v in locals_dict.items():
+        hparams_to_add = _grab_hparams(v)
+        hparams[k] = hparams_to_add
+    return hparams
+
+
+def _grab_hparams(obj) -> Any:
+    """Helper function parses objects for their hyperparameters going only one level deep."""
+
+    # If the object has already grabbed its hyperparameters (it calls extract_hparams inside __init__)
+    # then parse hparams attribute (which is a dict) and name those sub-hyperparameters
+    if hasattr(obj, 'local_hparams'):
+        return {obj.__class__.__name__: obj.local_hparams}
+    elif isinstance(obj, List) or isinstance(obj, Tuple):
+        return [_get_obj_repr(sub_obj) for sub_obj in obj]
+    elif isinstance(obj, Dict):
+        return {k: _get_obj_repr(sub_obj) for k, sub_obj in obj.items()}
+    else:
+        return _get_obj_repr(obj)
+
+
+def _get_obj_repr(obj: Any):
+    """Returns best representation of object.
+
+    Args:
+        obj (Any): the object.
+    Returns:
+        float(obj) if object is a float, int(obj) if object is an int, str(obj) if object
+        is str or has a buitlin __str__ method, obj.__class__.__name__ otherwise.
+    """
+    if obj.__class__.__module__ == 'builtins':
+        return obj
+    else:
+        return obj.__class__.__name__
+
+
+def convert_nested_dict_to_flat_dict(nested_dict: Dict, prefix='') -> Dict:
+    """Takes in a nested dict converts it to a flat dict with keys separated by slashes.
+    Args:
+        nested_dict (Dict): A dictionary containing at least one other dictionary.
+        prefix (str, optional): A prefix to left append to the keys in the dictionary.
+            'Defaults to ''.
+    Returns:
+        Dict: A flat dictionary representation of the nested one (contains no other
+            dictionaries inside of it)
+    """
+    flat_dict = {}
+    for k, v in nested_dict.items():
+        key = prefix + '/' + k if prefix != '' else k
+        # Recursively crawl sub-dictionary.
+        if isinstance(v, dict):
+            sub_flat_dict = convert_nested_dict_to_flat_dict(prefix=key, nested_dict=v)
+            flat_dict.update(sub_flat_dict)
+        else:
+            flat_dict[key] = v
+    return flat_dict
+
+
+def convert_flat_dict_to_nested_dict(flat_dict: Dict) -> Dict:
+    """Converts flat dictionary separated by slashes to nested dictionary.
+    Args:
+        flat_dict (Dict): flat dictionary containing no sub-dictionary with keys
+            separated by slashes. e.g. {'a':1, 'b/c':2}
+    Returns:
+        Dict: a nested dict.
+    """
+    nested_dict = {}
+    for k, v in flat_dict.items():
+        # Initially sub_dict is the main nested_dict, but we will continually update it to be the
+        # sub-dictionary of sub_dict.
+        sub_dict = nested_dict
+        sub_keys = k.split('/')
+        for sub_key in sub_keys[:-1]:
+            if sub_key not in sub_dict:
+                # Create a new sub-dictionary inside of sub_dict.
+                sub_dict[sub_key] = {}
+            # Change the sub_dict reference to be the sub-dictionary of sub_dict (i.e. go one level deeper).
+            sub_dict = sub_dict[sub_key]
+        # The last key in sub_keys does not map to a dict. It just maps to v.
+        sub_dict[sub_keys[-1]] = v
+    # Changes to sub_dict will be reflected in nested_dict, so we can just return nested_dict.
+    return nested_dict

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -1,0 +1,175 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+from torch.optim import Adam
+from torch.utils.data import DataLoader
+
+from composer.algorithms import EMA
+from composer.callbacks import SpeedMonitor
+from composer.loggers import MLFlowLogger
+from composer.trainer import Trainer
+from composer.utils import convert_flat_dict_to_nested_dict, convert_nested_dict_to_flat_dict, extract_hparams
+from tests.common.datasets import RandomClassificationDataset
+from tests.common.models import SimpleModel
+
+
+def test_convert_nested_dict_to_flat_dict():
+    test_nested_dict = {'a': 1, 'b': {'c': 2, 'd': 3}, 'e': {'f': {'g': 4}}}
+
+    expected_flat_dict = {'a': 1, 'b/c': 2, 'b/d': 3, 'e/f/g': 4}
+    actual_flat_dict = convert_nested_dict_to_flat_dict(test_nested_dict)
+    assert actual_flat_dict == expected_flat_dict
+
+
+def test_convert_flat_dict_to_nested_dict():
+    expected_nested_dict = {'a': 1, 'b': {'c': 2, 'd': 3}, 'e': {'f': {'g': 4}}}
+
+    test_flat_dict = {'a': 1, 'b/c': 2, 'b/d': 3, 'e/f/g': 4}
+    actual_nested_dict = convert_flat_dict_to_nested_dict(test_flat_dict)
+    assert actual_nested_dict == expected_nested_dict
+
+
+def test_extract_hparams():
+
+    class Foo:
+
+        def __init__(self):
+            self.g = 7
+
+    class Bar:
+
+        def __init__(self):
+            self.local_hparams = {'m': 11}
+
+    locals_dict = {'a': 1.5, 'b': {'c': 2.5, 'd': 3}, 'e': [4, 5, 6.2], 'f': Foo(), 'p': Bar()}
+
+    expected_parsed_dict = {
+        'a': 1.5,
+        'b': {
+            'c': 2.5,
+            'd': 3
+        },
+        'e': [4, 5, 6.2],
+        'f': 'Foo',
+        'p': {
+            'Bar': {
+                'm': 11,
+            }
+        },
+    }
+
+    parsed_dict = extract_hparams(locals_dict)
+    assert parsed_dict == expected_parsed_dict
+
+
+def test_extract_hparams_trainer():
+    train_dl = DataLoader(RandomClassificationDataset(), batch_size=16)
+    model = SimpleModel()
+    optimizer = Adam(model.parameters(), eps=1e-3)
+    trainer = Trainer(
+        model=model,
+        train_dataloader=train_dl,
+        optimizers=optimizer,
+        auto_log_hparams=True,
+        progress_bar=False,
+        log_to_console=False,
+        run_name='test',
+        seed=3,
+        algorithms=[EMA()],
+        loggers=[MLFlowLogger()],
+        callbacks=[SpeedMonitor()],
+    )
+
+    expected_hparams = {
+        'model': 'SimpleModel',
+
+        # Train Dataloader
+        'train_dataloader': 'DataLoader',
+        'train_dataloader_label': 'train',
+        'train_subset_num_batches': -1,
+
+        # Stopping Condition
+        'max_duration': None,
+
+        # Algorithms
+        'algorithms': ['EMA'],
+
+        # Engine Pass Registration
+        'algorithm_passes': None,
+
+        # Optimizers and Scheduling
+        'optimizers': 'Adam',
+        'schedulers': None,
+        'scale_schedule_ratio': 1.0,
+        'step_schedulers_every_batch': None,
+
+        # Evaluators
+        'eval_dataloader': None,
+        'eval_interval': 1,
+        'eval_subset_num_batches': -1,
+
+        # Callbacks and Logging
+        'callbacks': ['SpeedMonitor'],
+        'loggers': ['MLFlowLogger'],
+        'run_name': 'test',
+        'progress_bar': False,
+        'log_to_console': False,
+        'console_stream': 'stderr',
+        'console_log_interval': '1ep',
+        'log_traces': False,
+        'auto_log_hparams': True,
+
+        # Load Checkpoint
+        'load_path': None,
+        'load_object_store': None,
+        'load_weights_only': False,
+        'load_strict_model_weights': False,
+        'load_progress_bar': True,
+        'load_ignore_keys': None,
+        'load_exclude_algorithms': None,
+
+        # Save Checkpoint
+        'save_folder': None,
+        'save_filename': 'ep{epoch}-ba{batch}-rank{rank}.pt',
+        'save_latest_filename': 'latest-rank{rank}.pt',
+        'save_overwrite': False,
+        'save_interval': '1ep',
+        'save_weights_only': False,
+        'save_num_checkpoints_to_keep': -1,
+
+        # Graceful Resumption
+        'autoresume': False,
+
+        # DeepSpeed
+        'deepspeed_config': None,
+        'fsdp_config': None,
+
+        # System/Numerics
+        'device': 'DeviceCPU',
+        'precision': 'Precision',
+        'grad_accum': 1,
+        'device_train_microbatch_size': None,
+
+        # Reproducibility
+        'seed': 3,
+        'deterministic_mode': False,
+
+        # Distributed Training
+        'dist_timeout': 1800.0,
+        'ddp_sync_strategy': None,
+
+        # Profiling
+        'profiler': None,
+
+        # Python logging
+        'python_log_level': None,
+        'auto_microbatching': False,
+        'rank_zero_seed': 3,
+        'eval_batch_split': 1,
+        'latest_remote_file_name': None,
+        'num_optimizers': 1,
+        'remote_ud_has_format_string': [False],
+        'using_device_microbatch_size': False
+    }
+
+    assert trainer.local_hparams == expected_hparams


### PR DESCRIPTION
# What does this PR do?

logs just hparams passed directly to Trainer. Any non-builtin objects are just logged as `obj.__class__.__name__` instead of crawling them for haprams

# What issue(s) does this change relate to?

fix CO-586


Manual Test:
```python
transform = transforms.Compose([transforms.ToTensor()])
train_set = datasets.MNIST("data", train=True, download=True, transform=transform)
val_set = datasets.MNIST("data", train=False, download=True, transform=transform)
train_dataloader = DataLoader(train_set, batch_size=128)
eval_dataloader = DataLoader(val_set, batch_size=64)
model=mnist_model(num_classes=10)


trainer = Trainer(
    model=model,
    train_dataloader=train_dataloader,
    eval_dataloader=eval_dataloader,
    max_duration="3ep",
    train_subset_num_batches=4,
    optimizers=[Adam(model.parameters(), eps=1e-3)],
    progress_bar=False,
    log_traces=False,
    log_to_console=True,
    console_log_interval='1ep',
    auto_log_hparams=True,
    algorithms=[ChannelsLast(), ColOut(), BlurPool()],
    callbacks=[SpeedMonitor(), MemoryMonitor(), ImageVisualizer()],
    loggers=[WandBLogger()],
)
trainer.fit()
```

[Wandb Result](https://wandb.ai/mosaic-ml/evan-composer-manual_tests/runs/23qgcv6v)
Console result:
```
Config:
algorithm_passes: null
algorithms:
- ChannelsLast
- ColOut
- BlurPool
auto_log_hparams: true
auto_microbatching: false
autoresume: false
blurpool/num_blurconv_layers: 0
blurpool/num_blurpool_layers: 0
callbacks:
- SpeedMonitor
- MemoryMonitor
- ImageVisualizer
console_log_interval: 1ep
console_stream: stderr
ddp_sync_strategy: null
deepspeed_config: null
deterministic_mode: false
device: DeviceCPU
device_train_microbatch_size: null
dist_timeout: 1800.0
eval_batch_split: 1
eval_dataloader: DataLoader
eval_interval: 1
eval_subset_num_batches: -1
fsdp_config: null
grad_accum: 1
latest_remote_file_name: null
load_exclude_algorithms: null
load_ignore_keys: null
load_object_store: null
load_path: null
load_progress_bar: true
load_strict_model_weights: false
load_weights_only: false
log_to_console: true
log_traces: false
loggers:
- WandBLogger
- ConsoleLogger
max_duration: 3ep
model: ComposerClassifier
num_cpus_per_node: 1
num_nodes: 1
num_optimizers: 1
optimizers:
- Adam
precision: Precision
profiler: null
progress_bar: false
python_log_level: null
rank_zero_seed: 791585187
remote_ud_has_format_string:
- false
- false
run_name: 1672804048-impossible-viper
save_filename: ep{epoch}-ba{batch}-rank{rank}.pt
save_folder: null
save_interval: 1ep
save_latest_filename: latest-rank{rank}.pt
save_num_checkpoints_to_keep: -1
save_overwrite: false
save_weights_only: false
scale_schedule_ratio: 1.0
schedulers: null
seed: 791585187
step_schedulers_every_batch: null
train_dataloader: DataLoader
train_dataloader_label: train
train_subset_num_batches: 4
using_device_microbatch_size: false
```
