### PR TITLE
ConsoleLogger: log first batch and first epoch when using console_log_interval

### DIFF
--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -83,7 +83,7 @@ class ConsoleLogger(LoggerDestination):
         cur_epoch = int(state.timestamp.epoch)  # epoch gets incremented right before EPOCH_END
         unit = self.log_interval.unit
 
-        if unit == TimeUnit.EPOCH and cur_epoch % int(self.log_interval) == 0:
+        if unit == TimeUnit.EPOCH and (cur_epoch % int(self.log_interval) == 0 or cur_epoch == 1):
             log_dict = {**state.train_metric_values}
             if state.total_loss_dict:
                 log_dict.update(state.total_loss_dict)
@@ -92,7 +92,7 @@ class ConsoleLogger(LoggerDestination):
     def batch_end(self, state: State, logger: Logger) -> None:
         cur_batch = int(state.timestamp.batch)
         unit = self.log_interval.unit
-        if unit == TimeUnit.BATCH and cur_batch % int(self.log_interval) == 0:
+        if unit == TimeUnit.BATCH and (cur_batch % int(self.log_interval) == 0 or cur_batch == 1):
             log_dict = {**state.train_metric_values}
             if state.total_loss_dict:
                 log_dict.update(state.total_loss_dict)

--- a/tests/loggers/test_console_logger.py
+++ b/tests/loggers/test_console_logger.py
@@ -67,6 +67,8 @@ def test_console_logger_interval(console_logger_test_stream, console_logger_test
     else:  # for the case where log_interval_unit == 'ep' and max_duration == 'ba'.
         total_epochs = max_duration // batches_per_epoch
         expected_num_logging_events = total_epochs // log_interval
+    if log_interval != 1:
+        expected_num_logging_events += 1  # Because we automatically log the first batch or epoch.
 
     expected_num_lines = expected_num_logging_events * num_metrics_and_losses_per_logging_event
 


### PR DESCRIPTION
# What does this PR do?

Always log first batch and first epoch even if console_log_interval != 1

# What issue(s) does this change relate to?

fix CO-1617