### PR TITLE
Disable new notebook in CI

### DIFF
--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -30,15 +30,15 @@ jobs:
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
           - name: 'daily-cpu-3.8-1.11'
@@ -50,15 +50,15 @@ jobs:
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-vision'
-            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-doctest'
-            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     name: ${{ matrix.name }}

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -17,6 +17,7 @@ jobs:
   pytest:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
+    fail-fast: false
     strategy:
       matrix:
         include:

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -34,11 +34,11 @@ jobs:
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
           - name: 'daily-cpu-3.8-1.11'
@@ -54,11 +54,11 @@ jobs:
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     name: ${{ matrix.name }}

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -30,15 +30,15 @@ jobs:
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04g
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04g
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
           - name: 'daily-cpu-3.8-1.11'
@@ -50,15 +50,15 @@ jobs:
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04g
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04g
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     name: ${{ matrix.name }}

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -30,15 +30,15 @@ jobs:
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04g
             markers: 'not daily and (remote or not remote) and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04g
             markers: 'not daily and (remote or not remote) and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
           - name: 'daily-cpu-3.8-1.11'
@@ -50,15 +50,15 @@ jobs:
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04g
             markers: 'daily and (remote or not remote) and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'daily-cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04g
             markers: 'daily and (remote or not remote) and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     name: ${{ matrix.name }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,15 +27,15 @@ jobs:
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     name: ${{ matrix.name }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,15 +27,15 @@ jobs:
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     name: ${{ matrix.name }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -31,11 +31,11 @@ jobs:
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'not daily and not remote and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     name: ${{ matrix.name }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,15 +27,15 @@ jobs:
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-3.10-1.13'
-            container: mosaicml/pytorch:1.13.0_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-vision'
-            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
           - name: 'cpu-doctest'
-            container: mosaicml/pytorch_vision:1.13.0_cpu-python3.10-ubuntu20.04
+            container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
     name: ${{ matrix.name }}

--- a/docs/source/composer_model.rst
+++ b/docs/source/composer_model.rst
@@ -9,8 +9,8 @@ to easily speed up training.
 Using your own Model
 --------------------
 
-To create a trainable torchvision ResNet-18 classifier with cross-entropy loss,
-define the |forward| and |loss| methods.
+To create your own model, define the |forward| and |loss| methods. Here is
+an example with a trainable torchvision ResNet-18 classifier with cross-entropy loss.
 
 Notice how the forward pass is still under user control (no magic here!)
 and encapsulated together clearly within the architecture.

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -151,11 +151,11 @@
     "<a id=\"model\"></a>\n",
     "### Model\n",
     "\n",
-    "Next, we create our model. We're using Composer's built-in ResNet56. To use your own custom model, please see the [custom models tutorial][custom_models_tutorial].\n",
+    "Next, we create our model. We're using Composer's built-in ResNet56. To use your own custom model, please see this [custom model example][custom_model_example].\n",
     "\n",
     "**Note**: The model below is an instance of a [ComposerModel][composer_model]. Models need to be wrapped in this class, which provides a convenient interface between the underlying PyTorch model and the Trainer.\n",
     "\n",
-    "[custom_models_tutorial]: https://docs.mosaicml.com/en/stable/tutorials/adding_models_datasets.html#models\n",
+    "[custom_model_example]: https://docs.mosaicml.com/en/stable/composer_model.html#using-your-own-model\n",
     "[composer_model]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.ComposerModel.html#composer.ComposerModel"
    ]
   },

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -96,6 +96,8 @@ def test_notebook(notebook: str, device: str, s3_bucket: str):
     notebook_name = os.path.split(notebook)[-1][:-len('.ipynb')]
     if notebook_name == 'medical_image_segmentation':
         pytest.skip('Dataset is only available via kaggle; need to authenticate on ci/cd')
+    if notebook_name == 'training_with_submitit':
+        pytest.skip('The CI does not support SLURM and submitit')
     if notebook_name == 'auto_microbatching' and device == 'cpu':
         pytest.skip('auto_grad_accum notebook only runs with a gpu')
     if notebook_name == 'TPU_Training_in_composer':


### PR DESCRIPTION
# What does this PR do?

Disables new notebook test in CI flow

Also removes fast fail on daily tests since we want to see all faillures

Also bumps images to torch 1.13.1 now that we've switched over
