### PR TITLE
add ignore_modules to fsdp

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -239,6 +239,7 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     sync_module_states = fsdp_config.get('sync_module_states', False)
     forward_prefetch = fsdp_config.get('forward_prefetch', False)
     limit_all_gathers = fsdp_config.get('limit_all_gathers', False)
+    ignored_modules = fsdp_config.get('ignored_modules', None)
 
     # We choose to not wrap the ComposerModel directly, but instead wrap any submodules like `ComposerModel.model`
     # This makes it safer to call ComposerModel-specific functions like 'eval_forward' that
@@ -279,6 +280,7 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
                 cpu_offload=cpu_offload,
                 mixed_precision=mixed_precision,
                 backward_prefetch=backward_prefetch,
+                ignored_modules=ignored_modules,
                 param_init_fn=_param_init_fn,
                 device_id=torch.cuda.current_device(),
                 sync_module_states=sync_module_states,


### PR DESCRIPTION
# What does this PR do?

This enables users to pass `ignored_modules` to the FSDP module

# What issue(s) does this change relate to?

This PR is related to [RESEARCH-351](https://mosaicml.atlassian.net/browse/RESEARCH-351).
MoE modules which handle their own sharding / grad accum strategy should be ignored by FSDP; this PR enables that.

## Note for the future
FSDP will eventually deprecate `ignored_modules` in favor of `ignored_parameters`. We'll need to migrate when this happens.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->

[RESEARCH-351]: https://mosaicml.atlassian.net/browse/RESEARCH-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ