### PR TITLE
Updating how we load metrics in a state_dict so we don't add extra memory overhead 

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -948,8 +948,13 @@ class State(Serializable):
                 state_field_value = getattr(self, attribute_name)
                 # Update the metrics with the serialized values
                 for metric_name, metric in serialized_value.items():
-                    state_field_value[metric_name] = metric
-                    metric._device = self.device._device
+                    if attribute_name == 'train_metrics':
+                        state_field_value[metric_name] = metric
+                        metric._device = self.device._device
+                    else:
+                        for eval_key, eval_metric in metric.items():
+                            state_field_value[metric_name][eval_key] = eval_metric
+                            eval_metric._device = self.device._device
             elif attribute_name in _STATE_DICT_SERIALIZED_ATTRIBUTES:
                 state_field_value = getattr(self, attribute_name)
                 for target in ensure_tuple(state_field_value):

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -950,7 +950,6 @@ class State(Serializable):
                 for metric_name, metric in serialized_value.items():
                     state_field_value[metric_name] = metric
                     metric._device = self.device._device
-                continue
             elif attribute_name in _STATE_DICT_SERIALIZED_ATTRIBUTES:
                 state_field_value = getattr(self, attribute_name)
                 for target in ensure_tuple(state_field_value):

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -944,6 +944,13 @@ class State(Serializable):
                 self._load_dataset_state(serialized_value)
             elif attribute_name == 'optimizers':
                 self.load_optim_state(state)
+            elif attribute_name in ['train_metrics', 'eval_metrics']:
+                state_field_value = getattr(self, attribute_name)
+                # Update the metrics with the serialized values
+                for metric_name, metric in serialized_value.items():
+                    state_field_value[metric_name] = metric
+                    metric._device = self.device._device
+                continue
             elif attribute_name in _STATE_DICT_SERIALIZED_ATTRIBUTES:
                 state_field_value = getattr(self, attribute_name)
                 for target in ensure_tuple(state_field_value):

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -944,17 +944,17 @@ class State(Serializable):
                 self._load_dataset_state(serialized_value)
             elif attribute_name == 'optimizers':
                 self.load_optim_state(state)
-            elif attribute_name in ['train_metrics', 'eval_metrics']:
+            elif attribute_name == 'train_metrics':
                 state_field_value = getattr(self, attribute_name)
-                # Update the metrics with the serialized values
                 for metric_name, metric in serialized_value.items():
-                    if attribute_name == 'train_metrics':
-                        state_field_value[metric_name] = metric
+                    state_field_value[metric_name] = metric
+                    metric._device = self.device._device
+            elif attribute_name == 'eval_metrics':
+                state_field_value = getattr(self, attribute_name)
+                for eval_key, eval_metrics in serialized_value.items():
+                    for metric_name, metric in eval_metrics.items():
+                        state_field_value[eval_key][metric_name] = metric
                         metric._device = self.device._device
-                    else:
-                        for eval_key, eval_metric in metric.items():
-                            state_field_value[metric_name][eval_key] = eval_metric
-                            eval_metric._device = self.device._device
             elif attribute_name in _STATE_DICT_SERIALIZED_ATTRIBUTES:
                 state_field_value = getattr(self, attribute_name)
                 for target in ensure_tuple(state_field_value):

--- a/composer/devices/device.py
+++ b/composer/devices/device.py
@@ -31,6 +31,7 @@ class Device(Serializable, ABC):
 
     dist_backend: str = ''
     name: str = ''
+    _device = None
 
     @abstractmethod
     def module_to_device(self, module: T_nnModule) -> T_nnModule:


### PR DESCRIPTION
# What does this PR do?
When loading composer state dicts, we load in train and eval metrics. However, these metrics have a defined `_device` which is usually always the rank 0 device since that's what stored in the `state_dict.` As a result, we need to manually copy over each metric (so we don't override a user's current metrics) and manually set the devices.

Before our memory overhead was:
|    0   N/A  N/A   3770555      C                                   31567MiB |
|    0   N/A  N/A   3770556      C                                     965MiB |
|    1   N/A  N/A   3770556      C                                   31567MiB 

Now, our memory overhead when loading models is normal:
|    0   N/A  N/A   3770555      C                                   31567MiB |
|    1   N/A  N/A   3770556      C                                   31567MiB |

# What issue(s) does this change relate to?
[CO-1485](https://mosaicml.atlassian.net/browse/CO-1485)


# Before submitting
- [ x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x ] Did you run the tests locally to make sure they pass?
- [x ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1485]: https://mosaicml.atlassian.net/browse/CO-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ