### PR TITLE
Raise an error in FSDP `meta` tensor initialization if there's no initialization functions, fix associated flaky FSDP test

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -314,8 +314,8 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
                 else:
                     raise ValueError(
                         f'Object `{obj_name}` does not have a ``param_init_fn`` or a ``reset_parameters`` function. '
-                        'This can lead to bad parameter initialization. Please add a ``param_init_fn`` or ``reset_parameters`` '
-                        f'to your module `{obj_name}`.')
+                        'This leaves parameters without initialization. Please add a ``param_init_fn`` or ``reset_parameters`` '
+                        f'to module `{obj_name}`.')
 
             # Choose which modules to FSDP wrap according to the following priority:
             # If module has attribute `module._fsdp_wrap = ...`, always respect it

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -40,11 +40,13 @@ def test_fsdp_device_initialization(model: ComposerClassifier, device: str):
 
     trainer.fit()
     if isinstance(model, SimpleWeightTiedModel):
-        weight_1 = torch.nan_to_num(model.mlp.fc1.weight.data, 0.0)
-        weight_2 = torch.nan_to_num(model.mlp.fc2.weight.data, 0.0)
-        assert (torch.equal(weight_1, weight_2))
+        weight_1 = model.mlp.fc1.weight
+        weight_2 = model.mlp.fc2.weight
+        assert (id(weight_1) == id(weight_2))
+        assert (torch.equal(torch.nan_to_num(weight_1.data, 0.0), torch.nan_to_num(weight_2.data, 0.0)))
 
     if isinstance(model, EmbeddedWeightTiedModel):
-        weight_1 = torch.nan_to_num(model.net1.fc1.weight.data, 0.0)
-        weight_2 = torch.nan_to_num(model.net2.fc1.weight.data, 0.0)
-        assert (torch.equal(weight_1, weight_2))
+        weight_1 = model.net1.fc1.weight
+        weight_2 = model.net2.fc1.weight
+        assert (id(weight_1) == id(weight_2))
+        assert (torch.equal(torch.nan_to_num(weight_1.data, 0.0), torch.nan_to_num(weight_2.data, 0.0)))

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -24,7 +24,7 @@ def test_fsdp_device_initialization(model: ComposerClassifier, device: str):
     'meta' devices. This is because 'meta' will result in deferred initialization until FSDP is initialized
 
     """
-    num_classes = 2
+    num_classes = 10
     model = model(num_features=num_classes, device=device)
     dataset = RandomClassificationDataset(shape=(num_classes,), size=2, num_classes=num_classes)
     dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -24,7 +24,7 @@ def test_fsdp_device_initialization(model: ComposerClassifier, device: str):
     'meta' devices. This is because 'meta' will result in deferred initialization until FSDP is initialized
 
     """
-    num_classes = 10
+    num_classes = 2
     model = model(num_features=num_classes, device=device)
     dataset = RandomClassificationDataset(shape=(num_classes,), size=2, num_classes=num_classes)
     dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))
@@ -43,10 +43,10 @@ def test_fsdp_device_initialization(model: ComposerClassifier, device: str):
         weight_1 = model.mlp.fc1.weight
         weight_2 = model.mlp.fc2.weight
         assert (id(weight_1) == id(weight_2))
-        assert (torch.equal(torch.nan_to_num(weight_1.data, 0.0), torch.nan_to_num(weight_2.data, 0.0)))
+        assert (torch.equal(weight_1, weight_2))
 
     if isinstance(model, EmbeddedWeightTiedModel):
         weight_1 = model.net1.fc1.weight
         weight_2 = model.net2.fc1.weight
         assert (id(weight_1) == id(weight_2))
-        assert (torch.equal(torch.nan_to_num(weight_1.data, 0.0), torch.nan_to_num(weight_2.data, 0.0)))
+        assert (torch.equal(weight_1, weight_2))

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -40,7 +40,11 @@ def test_fsdp_device_initialization(model: ComposerClassifier, device: str):
 
     trainer.fit()
     if isinstance(model, SimpleWeightTiedModel):
-        assert (torch.equal(model.mlp.fc1.weight, model.mlp.fc2.weight))
+        weight_1 = torch.nan_to_num(model.mlp.fc1.weight.data, 0.0)
+        weight_2 = torch.nan_to_num(model.mlp.fc2.weight.data, 0.0)
+        assert (torch.equal(weight_1, weight_2))
 
     if isinstance(model, EmbeddedWeightTiedModel):
-        assert (torch.equal(model.net1.fc1.weight, model.net2.fc1.weight))
+        weight_1 = torch.nan_to_num(model.net1.fc1.weight.data, 0.0)
+        weight_2 = torch.nan_to_num(model.net2.fc1.weight.data, 0.0)
+        assert (torch.equal(weight_1, weight_2))


### PR DESCRIPTION
# What does this PR do?

Ensure FSDP throws an error if the underlying `module` in composer doesn't have a `param_init_fn` or `reset_parameters` function.

1. Does a pointer comparison to ensure the pointers to the underlying data are the same.
2. Adds a `param_init_fn` to the tested modules.

# What issue(s) does this change relate to?

[CO-1689](https://mosaicml.atlassian.net/browse/CO-1689)

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [x ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ x] Did you run the tests locally to make sure they pass?
- [x ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))



[CO-1689]: https://mosaicml.atlassian.net/browse/CO-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ