### PR TITLE
Update workflow names

### DIFF
--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -71,6 +71,7 @@ jobs:
     needs: [ pytest ]
     timeout-minutes: 30
     runs-on: ubuntu-20.04
+    if: github.repository_owner == 'mosaicml'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -15,7 +15,7 @@ jobs:
   pytest:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
-    if: github.repository_owner == 'mosaicml'
+    # if: github.repository_owner == 'mosaicml'
     strategy:
       matrix:
         include:

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -15,7 +15,7 @@ jobs:
   pytest:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
-    # if: github.repository_owner == 'mosaicml'
+    if: github.repository_owner == 'mosaicml'
     strategy:
       matrix:
         include:

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -71,7 +71,7 @@ jobs:
     needs: [ pytest ]
     timeout-minutes: 30
     runs-on: ubuntu-20.04
-    if: github.repository_owner == 'mosaicml'
+    # if: github.repository_owner == 'mosaicml'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -1,4 +1,4 @@
-name: Pytest
+name: Pytest-CPU
 on:
   pull_request:
     branches:
@@ -12,7 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 jobs:
-  pytest:
+  pytest-cpu:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     if: github.repository_owner == 'mosaicml'
@@ -68,10 +68,10 @@ jobs:
           name: coverage-${{ github.sha }}-${{ matrix.name }}
           path: .coverage
   coverage:
-    needs: [ pytest ]
+    needs: [ pytest-cpu ]
     timeout-minutes: 30
     runs-on: ubuntu-20.04
-    # if: github.repository_owner == 'mosaicml'
+    if: github.repository_owner == 'mosaicml'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -1,6 +1,6 @@
 name: Pytest
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - dev
       - main
@@ -15,7 +15,7 @@ jobs:
   pytest:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
-    # if: github.repository_owner == 'mosaicml'
+    if: github.repository_owner == 'mosaicml'
     strategy:
       matrix:
         include:

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -15,7 +15,7 @@ jobs:
   pytest:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
-    if: github.repository_owner == 'mosaicml'
+    # if: github.repository_owner == 'mosaicml'
     strategy:
       matrix:
         include:

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -1,4 +1,4 @@
-name: Pytest
+name: Pytest-GPU
 on:
   pull_request_target:
     branches:
@@ -12,7 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 jobs:
-  pytest:
+  pytest-gpu:
     timeout-minutes: 30
     runs-on: ubuntu-20.04
     if: github.repository_owner == 'mosaicml'

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -1,6 +1,6 @@
 name: Pytest
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - dev
       - main


### PR DESCRIPTION
# What does this PR do?

Github is sometimes not running tests as the workflow for GPUs and CPUs has the same name. This leads to GHA cancelling one of them because of the concurrency check telling it to only run the latest one.