### PR TITLE
Add coreweave object store support.

### DIFF
--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -93,6 +93,9 @@ class S3ObjectStore(ObjectStore):
         if client_config is None:
             client_config = {}
         config = Config(**client_config)
+        if 'AWS_ENDPOINT_URL' in os.environ and endpoint_url is None:
+            endpoint_url = os.environ['AWS_ENDPOINT_URL']
+
         self.client = boto3.Session().client(
             's3',
             config=config,

--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -93,8 +93,8 @@ class S3ObjectStore(ObjectStore):
         if client_config is None:
             client_config = {}
         config = Config(**client_config)
-        if 'AWS_ENDPOINT_URL' in os.environ and endpoint_url is None:
-            endpoint_url = os.environ['AWS_ENDPOINT_URL']
+        if 'S3_ENDPOINT_URL' in os.environ and endpoint_url is None:
+            endpoint_url = os.environ['S3_ENDPOINT_URL']
 
         self.client = boto3.Session().client(
             's3',

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -331,7 +331,7 @@ and delete the checkpoints from the local disk. The checkpoints will be located 
 
 For uploading checkpoints to [Coreweave's object store](https://docs.coreweave.com/storage/object-storage), the code is very similar to the
 above S3 uploading code. The only difference is you must set your Coreweave endpoint url.
-To do this you can just set the ``AWS_ENDPOINT_URL`` environment variable before creating the
+To do this you can just set the ``S3_ENDPOINT_URL`` environment variable before creating the
 :class:`.Trainer`, like so:
 
 .. testcode::
@@ -339,7 +339,7 @@ To do this you can just set the ``AWS_ENDPOINT_URL`` environment variable before
 
     import os
 
-    os.environ['AWS_ENDPOINT_URL'] = 'https://object.las1.coreweave.com'
+    os.environ['S3_ENDPOINT_URL'] = 'https://object.las1.coreweave.com'
     from composer.trainer import Trainer
 
     # Save checkpoints every epoch to s3://my_bucket/checkpoints

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -327,19 +327,19 @@ For example, for S3:
 This will train your model, saving the checkpoints locally, upload them to the S3 Bucket ``my_bucket``,
 and delete the checkpoints from the local disk. The checkpoints will be located on S3 inside your bucket as
 ``checkpoints/ep3.pt`` for third epoch's checkpoints, for example. The full URI in this case would be:
-``s3://my_bucket/checkpoints/ep3.pt``. 
+``s3://my_bucket/checkpoints/ep3.pt``.
 
-For uploading checkpoints to Coreweave's object store, the code is very similar to the 
+For uploading checkpoints to Coreweave's object store, the code is very similar to the
 above S3 uploading code. The only difference is you must set your Coreweave endpoint url.
-To do this you can just set the ``AWS_ENDPOINT_URL`` environment variable before creating the 
-:class:`.Trainer`, like so: 
+To do this you can just set the ``AWS_ENDPOINT_URL`` environment variable before creating the
+:class:`.Trainer`, like so:
 
 .. testcode::
     :skipif: not _LIBCLOUD_INSTALLED
 
     import os
-    
-    os.environ['AWS_ENDPOINT_URL'] = 'https://object.las1.coreweave.com' 
+
+    os.environ['AWS_ENDPOINT_URL'] = 'https://object.las1.coreweave.com'
     from composer.trainer import Trainer
 
     # Save checkpoints every epoch to s3://my_bucket/checkpoints

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -327,7 +327,35 @@ For example, for S3:
 This will train your model, saving the checkpoints locally, upload them to the S3 Bucket ``my_bucket``,
 and delete the checkpoints from the local disk. The checkpoints will be located on S3 inside your bucket as
 ``checkpoints/ep3.pt`` for third epoch's checkpoints, for example. The full URI in this case would be:
-``s3://my_bucket/checkpoints/ep3.pt``.
+``s3://my_bucket/checkpoints/ep3.pt``. 
+
+For uploading checkpoints to Coreweave's object store, the code is very similar to the 
+above S3 uploading code. The only difference is you must set your Coreweave endpoint url.
+To do this you can just set the ``AWS_ENDPOINT_URL`` environment variable before creating the 
+:class:`.Trainer`, like so: 
+
+.. testcode::
+    :skipif: not _LIBCLOUD_INSTALLED
+
+    import os
+    
+    os.environ['AWS_ENDPOINT_URL'] = 'https://object.las1.coreweave.com' 
+    from composer.trainer import Trainer
+
+    # Save checkpoints every epoch to s3://my_bucket/checkpoints
+    trainer = Trainer(
+        model=model,
+        train_dataloader=train_dataloader,
+        max_duration='10ep',
+        save_folder='s3://my_bucket/checkpoints',
+        save_interval='1ep',
+        save_overwrite=True,
+        save_filename='ep{epoch}.pt',
+        save_num_checkpoints_to_keep=0,  # delete all checkpoints locally
+    )
+
+    trainer.fit()
+
 
 Similarly for OCI:
 

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -329,7 +329,7 @@ and delete the checkpoints from the local disk. The checkpoints will be located 
 ``checkpoints/ep3.pt`` for third epoch's checkpoints, for example. The full URI in this case would be:
 ``s3://my_bucket/checkpoints/ep3.pt``.
 
-For uploading checkpoints to Coreweave's object store, the code is very similar to the
+For uploading checkpoints to [Coreweave's object store](https://docs.coreweave.com/storage/object-storage), the code is very similar to the
 above S3 uploading code. The only difference is you must set your Coreweave endpoint url.
 To do this you can just set the ``AWS_ENDPOINT_URL`` environment variable before creating the
 :class:`.Trainer`, like so:


### PR DESCRIPTION
# What does this PR do?

Coreweave object store is compatible with boto3. Uploading objects to Coreweave object store is almost exactly like writing to S3 using S3Object Store, except an endpoint_url must be set: `https://object.<region>.coreweave.com`.

Unfortunately, the endpoint_url can only be set programmatically (AWS doesn't support an endpoint_url env var or config field), so we create our own env var called `AWS_ENDPOINT_URL`, that we check for in the `S3ObjectStore`. The Trainer interface for the user is exactly the same as normal S3, except they have to set this env var.

Tested manually for save and load checkpoint

# What issue(s) does this change relate to?

fix CO-1471
