### PR TITLE
Add upgrade flags to pip installs

### DIFF
--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         'integration_type': 'git_repo',
         'git_repo': 'mosaicml/composer',
         'ssh_clone': 'False',
-        'pip_install': '--upgrade --upgrade-strategy eager --user -e .[all]',
+        'pip_install': '--upgrade --user -e .[all]',
     }
     if args.git_branch is not None and args.git_commit is None:
         git_integration['git_branch'] = args.git_branch

--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         'integration_type': 'git_repo',
         'git_repo': 'mosaicml/composer',
         'ssh_clone': 'False',
-        'pip_install': '--user -e .[all]',
+        'pip_install': '--upgrade --upgrade-strategy eager --user -e .[all]',
     }
     if args.git_branch is not None and args.git_commit is None:
         git_integration['git_branch'] = args.git_branch

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -ex
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade -e .${{ matrix.pip_deps }}
+          python -m pip install --upgrade .${{ matrix.pip_deps }}
       - name: Run checks
         run: |
           pre-commit run --all-files

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -ex
           python -m pip install --upgrade pip wheel
-          python -m pip install -e .${{ matrix.pip_deps }}
+          python -m pip install --upgrade --upgrade_strategy eager -e .${{ matrix.pip_deps }}
       - name: Run checks
         run: |
           pre-commit run --all-files

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -ex
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade --upgrade-strategy eager -e .${{ matrix.pip_deps }}
+          python -m pip install --upgrade -e .${{ matrix.pip_deps }}
       - name: Run checks
         run: |
           pre-commit run --all-files

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           set -ex
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade --upgrade_strategy eager -e .${{ matrix.pip_deps }}
+          python -m pip install --upgrade --upgrade-strategy eager -e .${{ matrix.pip_deps }}
       - name: Run checks
         run: |
           pre-commit run --all-files

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -48,7 +48,7 @@ jobs:
           set -ex
           export PATH=/composer-python:$PATH
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade --upgrade-strategy eager -e .[all]
+          python -m pip install --upgrade -e .[all]
       - name: Run Tests
         id: tests
         run: |

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -48,7 +48,7 @@ jobs:
           set -ex
           export PATH=/composer-python:$PATH
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade -e .[all]
+          python -m pip install --upgrade .[all]
       - name: Run Tests
         id: tests
         run: |

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -48,7 +48,7 @@ jobs:
           set -ex
           export PATH=/composer-python:$PATH
           python -m pip install --upgrade pip wheel
-          python -m pip install -e .[all]
+          python -m pip install --upgrade --upgrade-strategy eager -e .[all]
       - name: Run Tests
         id: tests
         run: |

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -158,10 +158,20 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
       - name: Setup MCLI
         run: |
           set -ex
-          python -m pip install mosaicml-cli
+          python -m pip install --upgrade --upgrade-strategy eager mosaicml-cli
           mcli init --mcloud
           mcli version
       - name: Submit Run

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -71,7 +71,7 @@ jobs:
           set -ex
           export PATH=/composer-python:$PATH
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade -e .[all]
+          python -m pip install --upgrade .[all]
       - name: Run Tests
         id: tests
         run: |

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -158,16 +158,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
       - name: Setup MCLI
         run: |
           set -ex

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -171,7 +171,7 @@ jobs:
       - name: Setup MCLI
         run: |
           set -ex
-          python -m pip install --upgrade --upgrade-strategy eager mosaicml-cli
+          python -m pip install --upgrade mosaicml-cli
           mcli init --mcloud
           mcli version
       - name: Submit Run

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -71,7 +71,7 @@ jobs:
           set -ex
           export PATH=/composer-python:$PATH
           python -m pip install --upgrade pip wheel
-          python -m pip install -e .[all]
+          python -m pip install --upgrade -e .[all]
       - name: Run Tests
         id: tests
         run: |

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -33,16 +33,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
       - name: Setup MCLI
         run: |
           set -ex

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -33,10 +33,20 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
       - name: Setup MCLI
         run: |
           set -ex
-          python -m pip install mosaicml-cli
+          python -m pip install --upgrade --upgrade-strategy eager mosaicml-cli
           mcli init --mcloud
           mcli version
       - name: Submit Run

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup MCLI
         run: |
           set -ex
-          python -m pip install --upgrade --upgrade-strategy eager mosaicml-cli
+          python -m pip install --upgrade mosaicml-cli
           mcli init --mcloud
           mcli version
       - name: Submit Run


### PR DESCRIPTION
# What does this PR do?
Adds `--upgrade` to the `pip install`s in CI. This ensures that CI will flag a dependency that upgrade that breaks composer

Closes [CO-1707](https://mosaicml.atlassian.net/browse/CO-1707)



[CO-1707]: https://mosaicml.atlassian.net/browse/CO-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ