### PR TITLE
Cleaning up error checking for FSDP sharding strategies with fp32 precision

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -174,11 +174,6 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     sharding_map_key = fsdp_config.get('sharding_strategy', 'FULL_SHARD').upper()
     sharding_strategy = sharding_map[sharding_map_key]
 
-    if precision == Precision.FP32 and sharding_map_key != 'NO_SHARD':
-        raise ValueError(
-            f'FSDP in PyTorch 1.13 does not support precision `{precision}` with sharding_strategy `{sharding_map_key}.` '
-            f'Consider using `amp` or `bf16` for precision for with sharding strategy `{sharding_map_key}.`')
-
     cpu_offload = CPUOffload(offload_params=True) if fsdp_config.get('cpu_offload', False) else None
     if cpu_offload is not None:
         raise ValueError('FSDP CPU Offload not supported yet.')
@@ -213,13 +208,19 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     else:
         raise ValueError(f'Unable to interpret mixed_precision={mixed_precision}')
 
-    if sharding_map_key != 'NO_SHARD' and (
-            precision == Precision.AMP_FP16 and param_dtype not in [torch.float16, None] or
-            precision == Precision.AMP_BF16 and param_dtype not in [torch.bfloat16, None]):
-        raise ValueError(
-            f'FSDP in PyTorch 1.13 does not support precision `{precision}` with sharding strategy `{sharding_strategy}` '
-            f'and param_dtype `{param_dtype}.` Consider using one of the predefined mixed_precision strategies '
-            "(choose: `'FULL'`, `'DEFAULT'`, `'PURE'`)")
+    if sharding_map_key != 'NO_SHARD':
+        if (precision == Precision.AMP_FP16 and param_dtype not in [torch.float16, None] or
+                precision == Precision.AMP_BF16 and param_dtype not in [torch.bfloat16, None]):
+            raise ValueError(
+                f'FSDP in PyTorch 1.13 does not support precision `{precision}` with sharding strategy `{sharding_strategy}` '
+                f'and param_dtype `{param_dtype}.` Consider using one of the predefined mixed_precision strategies '
+                "(choose: `'FULL'`, `'DEFAULT'`, `'PURE'`)")
+
+        if param_dtype == torch.float32:
+            raise ValueError(
+                f'FSDP in PyTorch 1.13 does not support param_dtype `{param_dtype}` with sharding_strategy `{sharding_map_key}` '
+                f'Consider using `amp` or `bf16` for precision or setting param_dtype in mixed_precision to `None` '
+                f'with sharding strategy `{sharding_map_key}.`')
 
     keep_low_precision_grads = fsdp_config.get('keep_low_precision_grads', False)
 


### PR DESCRIPTION
# What does this PR do?
We should be able to train models w/ FSDP and a sharding strategy with precision `fp32,` we just need to make sure param_dtype is not `fp32`. This cleans up the ValueError checking for sharding strategies. 

FSDP throws internal assertion errors when the sharding strategy isn't `NO_SHARD` and param_dtype is `fp32` e.g. 

```
Expects full precision but got torch.float32
  File "/workdisk/brandon/examples_fork/llm/main.py", line 180, in <module>
    main(cfg)
  File "/workdisk/brandon/examples_fork/llm/main.py", line 136, in main
    trainer = Trainer(
  File "/usr/lib/python3/dist-packages/composer/trainer/trainer.py", line 974, in __init__
    prepare_fsdp_module(model, optimizers, self.fsdp_config, precision)
  File "/usr/lib/python3/dist-packages/composer/trainer/dist_strategy.py", line 340, in prepare_fsdp_module
    fsdp_obj = FullyShardedDataParallel(
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 1062, in __init__
    self._materialize_module(module, param_init_fn, device_from_device_id)
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 1368, in _materialize_module
    param_init_fn(module)
  File "/usr/lib/python3/dist-packages/composer/trainer/dist_strategy.py", line 314, in _param_init_fn
    module.apply(obj.param_init_fn)
  File "/usr/lib/python3/dist-packages/torch/nn/modules/module.py", line 728, in apply
    module.apply(fn)
  File "/usr/lib/python3/dist-packages/torch/nn/modules/module.py", line 728, in apply
    module.apply(fn)
  File "/usr/lib/python3/dist-packages/torch/nn/modules/module.py", line 728, in apply
    module.apply(fn)
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 1668, in apply
    with self._summon_full_params(recurse=False, writeback=True):
  File "/usr/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 2981, in _summon_full_params
    free_unsharded_flat_params = [handle.needs_unshard() for handle in self._handles]
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 2981, in <listcomp>
    free_unsharded_flat_params = [handle.needs_unshard() for handle in self._handles]
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/flat_param.py", line 681, in needs_unshard
    unsharded_flat_param = self._get_padded_unsharded_flat_param()
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/flat_param.py", line 714, in _get_padded_unsharded_flat_param
    p_assert(
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/_utils.py", line 147, in p_assert
    traceback.print_stack()
Traceback (most recent call last):
  File "/workdisk/brandon/examples_fork/llm/main.py", line 180, in <module>
    main(cfg)
  File "/workdisk/brandon/examples_fork/llm/main.py", line 136, in main
    trainer = Trainer(
  File "/usr/lib/python3/dist-packages/composer/trainer/trainer.py", line 974, in __init__
    prepare_fsdp_module(model, optimizers, self.fsdp_config, precision)
  File "/usr/lib/python3/dist-packages/composer/trainer/dist_strategy.py", line 340, in prepare_fsdp_module
    fsdp_obj = FullyShardedDataParallel(
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 1062, in __init__
    self._materialize_module(module, param_init_fn, device_from_device_id)
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 1368, in _materialize_module
    param_init_fn(module)
  File "/usr/lib/python3/dist-packages/composer/trainer/dist_strategy.py", line 314, in _param_init_fn
    module.apply(obj.param_init_fn)
  File "/usr/lib/python3/dist-packages/torch/nn/modules/module.py", line 728, in apply
    module.apply(fn)
  File "/usr/lib/python3/dist-packages/torch/nn/modules/module.py", line 728, in apply
    module.apply(fn)
  File "/usr/lib/python3/dist-packages/torch/nn/modules/module.py", line 728, in apply
    module.apply(fn)
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 1668, in apply
    with self._summon_full_params(recurse=False, writeback=True):
  File "/usr/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 2981, in _summon_full_params
    free_unsharded_flat_params = [handle.needs_unshard() for handle in self._handles]
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 2981, in <listcomp>
    free_unsharded_flat_params = [handle.needs_unshard() for handle in self._handles]
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/flat_param.py", line 681, in needs_unshard
    unsharded_flat_param = self._get_padded_unsharded_flat_param()
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/flat_param.py", line 714, in _get_padded_unsharded_flat_param
    p_assert(
  File "/usr/lib/python3/dist-packages/torch/distributed/fsdp/_utils.py", line 149, in p_assert
    raise AssertionError
AssertionError
```

# What issue(s) does this change relate to?

[CO-1700](https://mosaicml.atlassian.net/browse/CO-1700)

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ x] Did you run the tests locally to make sure they pass?
- [x ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
