### PR TITLE
pin setuptools in build requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+# build requirements
+[build-system]
+requires = ["setuptools <= 68.0.0"]
+build-backend = "setuptools.build_meta"
 
 # iSort
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # build requirements
 [build-system]
-requires = ["setuptools <= 68.0.0"]
+requires = ["setuptools < 68.0.0"]
 build-backend = "setuptools.build_meta"
 
 # iSort


### PR DESCRIPTION
# What does this PR do?
We ran into an issue where a setuptools release broke pip install from source. This is because pip uses an isolated build environment, which would always install the latest setuptools. In this PR we pin the setuptools version for building the package so that we have control over when to upgrade. Tested `pip install -e '.[all]'` locally.

# What issue(s) does this change relate to?
Closes [CO-1702](https://mosaicml.atlassian.net/browse/CO-1702)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1702]: https://mosaicml.atlassian.net/browse/CO-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ