### PR TITLE
Temporarily pin pip to <23

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup
         run: |
           set -ex
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade 'pip<23' wheel
           python -m pip install --upgrade .${{ matrix.pip_deps }}
       - name: Run checks
         run: |

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -ex
           export PATH=/composer-python:$PATH
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade 'pip<23' wheel
           python -m pip install --upgrade .[all]
       - name: Run Tests
         id: tests
@@ -78,7 +78,7 @@ jobs:
       - name: Setup
         run: |
           set -ex
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade 'pip<23' wheel
           pip install coverage[toml]==6.5.0
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -70,7 +70,7 @@ jobs:
         run: |
           set -ex
           export PATH=/composer-python:$PATH
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade 'pip<23' wheel
           python -m pip install --upgrade .[all]
       - name: Run Tests
         id: tests
@@ -107,7 +107,7 @@ jobs:
       - name: Setup
         run: |
           set -ex
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade 'pip<23' wheel
           pip install coverage[toml]==6.5.0
       - name: Download artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
# What does this PR do?
This is a temporary workaround to unblock CI while we figure out the root cause. Currently installing from source does not work with pip==23 outside of a virtual env.