### PR TITLE
Remove Fused LayerNorm deprecation

### DIFF
--- a/composer/algorithms/fused_layernorm/fused_layernorm.py
+++ b/composer/algorithms/fused_layernorm/fused_layernorm.py
@@ -32,12 +32,6 @@ def check_if_apex_installed():
         )
 
 
-def warn_fln_deprecation():
-    warnings.warn(
-        DeprecationWarning(
-            'Fused LayerNorm will be deprecated and removed in v0.13. Please use Low Precision LayerNorm instead.'))
-
-
 def from_LayerNorm(layer: torch.nn.Module, module_index: int) -> APEXFusedLayerNorm:
     """Defines a replacement policy from a `torch.nn.LayerNorm` to a `apex.normalization.fused_layer_norm`"""
     assert isinstance(layer,
@@ -101,7 +95,6 @@ class FusedLayerNorm(Algorithm):
 
     def __init__(self):
         # FusedLayerNorm takes no arguments
-        warn_fln_deprecation()
         check_if_apex_installed()
 
     def __repr__(self) -> str:


### PR DESCRIPTION
A deprecation warning for Fused LayerNorm was added in PR #1789, informing users that FLN would be removed in Composer 0.13. The thought behind this was that Low Precision LayerNorm was strictly better, since it does not depend on Apex, and has equivalent performance.

However, our NLP testing plan found that Low Precision LayerNorm is not scriptable (i.e. we cannot use torchscript to export a model with LowPrecision LayerNorm for inference), making it inferior to Fused LayerNorm for users who want to export their models.

We should hold off deprecating Fused LayerNorm until this issue has been resolved, since it is an important component of many NLP models. Both algorithms can live side-by-side for the time being---the documentation for LPLN clearly states it is an alternative to FLN.