### PR TITLE
Fix mcp script to avoid follow

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -391,23 +391,6 @@ stage('Build') {
                 }
             }]
         }
-        else if (!isComposerImage) {
-            // If not rebuilding the docker image, and it's not a composer image, run GPU tests only on the "latest" image
-            // Only run tests on the 'mosaicml/pytorch' or 'mosaicml/pytorch_vision' images -- not 'mosaicml/composer'
-            Boolean isCpuImage = buildArgs['CUDA_VERSION'] == ''
-            Boolean shouldRunGpuTests = false
-
-            originalTags.each { tag ->
-                if (pytestGpuImageTagsToTest.contains(tag)) {
-                    shouldRunGpuTests = true
-                }
-            }
-
-            if (shouldRunGpuTests) {
-                String existingImageTag = originalTags[0]
-                scheduleJob(jobs, existingImageTag, buildArgs, originalTags)
-            }
-        }
     }
 
     if (dependenciesChanged) {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -391,6 +391,23 @@ stage('Build') {
                 }
             }]
         }
+        else if (!isComposerImage) {
+            // If not rebuilding the docker image, and it's not a composer image, run GPU tests only on the "latest" image
+            // Only run tests on the 'mosaicml/pytorch' or 'mosaicml/pytorch_vision' images -- not 'mosaicml/composer'
+            Boolean isCpuImage = buildArgs['CUDA_VERSION'] == ''
+            Boolean shouldRunGpuTests = false
+
+            originalTags.each { tag ->
+                if (pytestGpuImageTagsToTest.contains(tag)) {
+                    shouldRunGpuTests = true
+                }
+            }
+
+            if (shouldRunGpuTests) {
+                String existingImageTag = originalTags[0]
+                scheduleJob(jobs, existingImageTag, buildArgs, originalTags)
+            }
+        }
     }
 
     if (dependenciesChanged) {

--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -4,8 +4,9 @@
 """Run pytest using MCP."""
 
 import argparse
+from concurrent.futures import TimeoutError
 
-from mcli.sdk import RunConfig, RunStatus, create_run, follow_run_logs, wait_for_run_status
+from mcli.sdk import RunConfig, RunStatus, create_run, get_run_logs, stop_runs, wait_for_run_status
 
 if __name__ == '__main__':
 
@@ -74,13 +75,26 @@ if __name__ == '__main__':
     # Create run
     run = create_run(config)
 
-    # Wait till run starts before fetching logs
+    # Wait until run starts before fetching logs
     run = wait_for_run_status(run, status='running')
+    print('Run started. Waiting for run to complete...')
+
+    # Wait up to 30 minutes for run to complete
+    try:
+        run = wait_for_run_status(run, status='completed', timeout=60 * 30)
+    except TimeoutError:
+        print('Run timed out and did not complete in 30 minutes.')
+
+    # Get run status and stop run
+    success = run.status == RunStatus.COMPLETED
+    print(f'Run completed with status: {run.status} (success={success})')
+    if run.status == RunStatus.RUNNING:
+        stop_runs([run])
+        print('Run stopped.')
 
     # Print logs
-    for line in follow_run_logs(run):
+    for line in get_run_logs(run):
         print(line, end='')
 
-    # Fail if command exited with non-zero exit code
-    run = wait_for_run_status(run, 'completed')
-    assert run.status == RunStatus.COMPLETED
+    # Fail if command exited with non-zero exit code or timed out
+    assert success

--- a/composer/algorithms/squeeze_excite/README.md
+++ b/composer/algorithms/squeeze_excite/README.md
@@ -75,7 +75,7 @@ trainer = Trainer(
     model=model,
     train_dataloader=train_dataloader,
     eval_dataloader=eval_dataloader,
-    max_duration='10ep',
+    max_duration='1ep',
     algorithms=[algo]
 )
 

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ extra_deps['coco'] = [
 ]
 
 extra_deps['nlp'] = [
+    'datasets>=2,<3',
     'transformers>=4.11,<5',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,7 @@ extra_deps['coco'] = [
 ]
 
 extra_deps['nlp'] = [
-    'datasets>=2,<3',
+    'datasets>=2.4,<3',
     'transformers>=4.11,<5',
 ]
 


### PR DESCRIPTION
# What does this PR do?

`follow_run_logs` occasionally disconnects. Instead, we need to wait for the run to complete and then get logs. Additionally, we want to add a timeout to kill daily tests if they don't finish in time.

Along for ride, adds `datasets` to nlp install which breaks install rn

# What issue(s) does this change relate to?

[CO-1722](https://mosaicml.atlassian.net/browse/CO-1722)


[CO-1722]: https://mosaicml.atlassian.net/browse/CO-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ