### PR TITLE
Typo due to stale MCLI docs 

### DIFF
--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
 
     # Create run
     run = create_run(config)
-    print(f'Run created: {run.run}')
+    print(f'Run created: {run.name}')
 
     # Wait until run starts before fetching logs
     run = wait_for_run_status(run, status='running')


### PR DESCRIPTION
# What does this PR do?

Fixes typo in script due to stale MCLI docs. CI currently broken because of this