### PR TITLE
Pin pip<23 in Docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -182,7 +182,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} - && \
-    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pip setuptools
+    pip${PYTHON_VERSION} install --no-cache-dir --upgrade 'pip<23' setuptools
 
 #####################
 # Install pillow-simd


### PR DESCRIPTION
# What does this PR do?
Pins `pip<23` in Docker images to unblock CI for the upcoming release.  This will be removed when we switch to miniconda Python.

# What issue(s) does this change relate to?
Fixes [CO-1710](https://mosaicml.atlassian.net/browse/CO-1710)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1710]: https://mosaicml.atlassian.net/browse/CO-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ