### PR TITLE
Fix bug in trainer.eval and add test cases for test_console_logger

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2552,7 +2552,7 @@ class Trainer:
 
         """
         if eval_dataloader is not None:
-
+            eval_passed_in = True
             eval_metrics = deepcopy(self._original_model.get_metrics(is_train=False))
             metric_names = [str(k) for k in eval_metrics.keys()]
 
@@ -2560,6 +2560,7 @@ class Trainer:
                 ensure_evaluator(evaluator, default_metric_names=metric_names)
                 for evaluator in ensure_tuple(eval_dataloader)
             ]
+            
 
             if self.state.eval_metrics:
                 for evaluator in evaluators:
@@ -2581,6 +2582,7 @@ class Trainer:
             )
             self.state.evaluators.extend(evaluators)  # Add evaluators to state.evaluators
         else:
+            eval_passed_in = False
             if not self.state.evaluators:
                 raise ValueError('eval_dataloader must be provided to either Trainer init() or eval().')
             evaluators = self.state.evaluators
@@ -2592,7 +2594,8 @@ class Trainer:
                 subset_num_batches=subset_num_batches,
                 metrics=self.state.eval_metrics[evaluator.label],
             )
-            self.state.evaluators.remove(evaluator)  # Remove them from state once eval is finished.
+            if eval_passed_in:
+                self.state.evaluators.remove(evaluator)  # Remove them from state once eval is finished.
 
     def _eval_loop(
         self,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2579,6 +2579,7 @@ class Trainer:
                 eval_interval='1ep',  # ignored
                 subset_num_batches=subset_num_batches,
             )
+            self.state.evaluators.extend(evaluators)  # Add evaluators to state.evaluators
         else:
             if not self.state.evaluators:
                 raise ValueError('eval_dataloader must be provided to either Trainer init() or eval().')
@@ -2591,6 +2592,7 @@ class Trainer:
                 subset_num_batches=subset_num_batches,
                 metrics=self.state.eval_metrics[evaluator.label],
             )
+            self.state.evaluators.remove(evaluator)  # Remove them from state once eval is finished.
 
     def _eval_loop(
         self,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2560,7 +2560,6 @@ class Trainer:
                 ensure_evaluator(evaluator, default_metric_names=metric_names)
                 for evaluator in ensure_tuple(eval_dataloader)
             ]
-            
 
             if self.state.eval_metrics:
                 for evaluator in evaluators:

--- a/tests/loggers/test_console_logger.py
+++ b/tests/loggers/test_console_logger.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader
 from torchmetrics import MetricCollection
 
 from composer.callbacks import SpeedMonitor
+from composer.core import Evaluator
 from composer.loggers.console_logger import NUM_EVAL_LOGGING_EVENTS
 from composer.trainer import Trainer
 from tests.common import RandomClassificationDataset, SimpleModel
@@ -102,7 +103,19 @@ def test_console_logger_interval_with_eval(console_logger_test_stream, console_l
                       eval_dataloader=DataLoader(RandomClassificationDataset(size=eval_dataset_size),
                                                  batch_size=eval_batch_size),
                       max_duration=f'{max_duration}{max_duration_unit}')
+    # 1. Run with empty fit
     trainer.fit()
+    console_logger_test_stream.flush()
+    # 2. Run again with eval, while passing an eval_dataloader
+    trainer.eval(eval_dataloader=Evaluator(label='trainer.eval_dataloader',
+                                           dataloader=DataLoader(RandomClassificationDataset(size=eval_dataset_size),
+                                                                 batch_size=eval_batch_size)))
+    console_logger_test_stream.flush()
+    # 3. Run again with fit
+    trainer.fit(eval_dataloader=DataLoader(RandomClassificationDataset(size=eval_dataset_size),
+                                           batch_size=eval_batch_size),
+                reset_time=True,
+                eval_interval=f'{eval_interval}{eval_interval_unit}')
     console_logger_test_stream.flush()
     console_logger_test_stream.close()
 
@@ -115,9 +128,10 @@ def test_console_logger_interval_with_eval(console_logger_test_stream, console_l
     actual_num_eval_log_lines = sum([1 if bool(eval_reg_exp.search(line)) else 0 for line in lines])
 
     assert model.val_metrics is not None
-    num_eval_metrics = len(list(model.val_metrics.keys())) if isinstance(model.val_metrics, MetricCollection) else 1
+    num_eval_metrics_per_event = len(list(model.val_metrics.keys())) if isinstance(model.val_metrics,
+                                                                                   MetricCollection) else 1
     num_eval_losses = 0
-    num_eval_metrics_and_losses_per_logging_event = num_eval_metrics + num_eval_losses
+    num_eval_metrics_and_losses_per_logging_event = num_eval_metrics_per_event + num_eval_losses
 
     if eval_interval_unit == max_duration_unit:
         expected_num_eval_logging_events, remainder = divmod(max_duration, eval_interval)
@@ -136,6 +150,13 @@ def test_console_logger_interval_with_eval(console_logger_test_stream, console_l
 
     expected_num_eval_lines = expected_num_eval_logging_events * (num_eval_metrics_and_losses_per_logging_event +
                                                                   num_eval_progress_lines_per_eval_event)
+
+    expected_num_eval_lines *= 2  # Because we run fit twice
+    expected_num_eval_logging_events_for_trainer_eval_call = 1
+    expected_num_eval_lines_in_trainer_eval_call = (
+        expected_num_eval_logging_events_for_trainer_eval_call *
+        (num_eval_progress_lines_per_eval_event + num_eval_metrics_per_event))
+    expected_num_eval_lines += expected_num_eval_lines_in_trainer_eval_call  # because we run trainer.eval
 
     assert actual_num_eval_log_lines == expected_num_eval_lines
 

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -49,32 +49,38 @@ def test_eval_call():
     # Assert that there is some accuracy
     assert trainer.state.eval_metrics['eval']['Accuracy'].compute() != 0.0
 
+
 def test_eval_call_with_trainer_evaluators():
     trainer_dataset = RandomClassificationDataset()
-    trainer_evaluator = Evaluator(label='trainer', 
-            dataloader=DataLoader(
-            dataset=trainer_dataset,
-            sampler=dist.get_sampler(trainer_dataset),
-        ))
+    trainer_evaluator = Evaluator(label='trainer',
+                                  dataloader=DataLoader(
+                                      dataset=trainer_dataset,
+                                      sampler=dist.get_sampler(trainer_dataset),
+                                  ))
 
     eval_call_dataset = RandomClassificationDataset()
     eval_call_evaluator = Evaluator(label='eval_call',
-                                          dataloader=DataLoader(
-                                                dataset=eval_call_dataset,
-                                                sampler=dist.get_sampler(eval_call_dataset)))
+                                    dataloader=DataLoader(dataset=eval_call_dataset,
+                                                          sampler=dist.get_sampler(eval_call_dataset)))
     # Construct the trainer
-    trainer = Trainer(model=SimpleModel(),
-                      eval_dataloader=trainer_evaluator)
+    trainer = Trainer(model=SimpleModel(), eval_dataloader=trainer_evaluator)
 
-    # Evaluate the model
+    # Empty eval call.
+    trainer.eval()
+
+    # Check trainer_evaluator is not deleted.
+    assert trainer_evaluator in trainer.state.evaluators
+
+    # Eval call with an evaluator passed.
     trainer.eval(eval_dataloader=eval_call_evaluator)
 
     # Evaluators passed to constructor permanently reside in trainer.state.evaluators.
+    # Check trainer_evaluator is NOT deleted.
     assert trainer_evaluator in trainer.state.evaluators
     # Evaluators passed to eval temporarily reside in trainer.state.evaluators for the duration
     # of evaluation.
+    # Check eval_call_evaluator IS deleted.
     assert eval_call_evaluator not in trainer.state.evaluators
-
 
 
 def test_trainer_eval_loop():

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -49,6 +49,33 @@ def test_eval_call():
     # Assert that there is some accuracy
     assert trainer.state.eval_metrics['eval']['Accuracy'].compute() != 0.0
 
+def test_eval_call_with_trainer_evaluators():
+    trainer_dataset = RandomClassificationDataset()
+    trainer_evaluator = Evaluator(label='trainer', 
+            dataloader=DataLoader(
+            dataset=trainer_dataset,
+            sampler=dist.get_sampler(trainer_dataset),
+        ))
+
+    eval_call_dataset = RandomClassificationDataset()
+    eval_call_evaluator = Evaluator(label='eval_call',
+                                          dataloader=DataLoader(
+                                                dataset=eval_call_dataset,
+                                                sampler=dist.get_sampler(eval_call_dataset)))
+    # Construct the trainer
+    trainer = Trainer(model=SimpleModel(),
+                      eval_dataloader=trainer_evaluator)
+
+    # Evaluate the model
+    trainer.eval(eval_dataloader=eval_call_evaluator)
+
+    # Evaluators passed to constructor permanently reside in trainer.state.evaluators.
+    assert trainer_evaluator in trainer.state.evaluators
+    # Evaluators passed to eval temporarily reside in trainer.state.evaluators for the duration
+    # of evaluation.
+    assert eval_call_evaluator not in trainer.state.evaluators
+
+
 
 def test_trainer_eval_loop():
     # Construct the trainer


### PR DESCRIPTION
# What does this PR do?
hot fix for bug caused by ConsoleLogger due to `trainer.eval` (when called with an `eval_dataloader` specified) not adding `evaluators` to `state.evaluators`:

1. Adds any passed in evaluators to state.evaluators and then once eval is done; removes them.
2. Adds tests to `test_console_logger` for the following use cases:
      *  `trainer.eval(eval_dataloader=...)`
      *  `trainer.fit(eval_dataloader=...)`

# Tests

1. modified console_logger unit tests as described above
2. local manual test:
```python
transform = transforms.Compose([transforms.ToTensor()])
train_set = datasets.MNIST("data", train=True, download=True, transform=transform)
val_set = datasets.MNIST("data", train=False, download=True, transform=transform)
train_dataloader = DataLoader(train_set, batch_size=128)
eval_dataloader = DataLoader(val_set, batch_size=16)
eval_dataloader2 = Evaluator(label='eval2', dataloader=eval_dataloader)
eval_dataloader3 = Evaluator(label='eval3', dataloader=eval_dataloader)
model=mnist_model(num_classes=10)


trainer = Trainer(
    model=model,
    train_dataloader=train_dataloader,
    eval_dataloader=[eval_dataloader, eval_dataloader2],
    max_duration="4ba",
    optimizers=[Adam(model.parameters())],
    eval_interval='2ba',
    log_to_console=True,
    # auto_log_hparams=True,
    progress_bar=False,
    # callbacks=[SpeedMonitor(), MemoryMonitor()],
)

trainer.fit()
trainer.eval(eval_dataloader=eval_dataloader3)
trainer.fit(eval_dataloader=eval_dataloader3, reset_time=True, eval_interval='2ba')
```
Results:
```bash
[batch=1/4]:
         Train epoch: 0
         Train trainer/global_step: 0
         Train trainer/batch_idx: 0
         Train trainer/grad_accum: 1
         Train loss/train/total: 2.3045
         Train metrics/train/Accuracy: 0.0938
[batch=2/4]:
         Train trainer/global_step: 1
         Train trainer/batch_idx: 1
         Train trainer/grad_accum: 1
         Train loss/train/total: 2.2840
         Train metrics/train/Accuracy: 0.1406
[Eval batch=1/625] Eval on eval data
[Eval batch=63/625] Eval on eval data
[Eval batch=126/625] Eval on eval data
[Eval batch=188/625] Eval on eval data
[Eval batch=251/625] Eval on eval data
[Eval batch=313/625] Eval on eval data
[Eval batch=375/625] Eval on eval data
[Eval batch=438/625] Eval on eval data
[Eval batch=500/625] Eval on eval data
[Eval batch=563/625] Eval on eval data
[Eval batch=625/625] Eval on eval data:
         Eval CrossEntropy: 2.3021
         Eval Accuracy: 0.0958
[Eval batch=1/625] Eval on eval2 data
[Eval batch=63/625] Eval on eval2 data
[Eval batch=126/625] Eval on eval2 data
[Eval batch=188/625] Eval on eval2 data
[Eval batch=251/625] Eval on eval2 data
[Eval batch=313/625] Eval on eval2 data
[Eval batch=375/625] Eval on eval2 data
[Eval batch=438/625] Eval on eval2 data
[Eval batch=500/625] Eval on eval2 data
[Eval batch=563/625] Eval on eval2 data
[Eval batch=625/625] Eval on eval2 data:
         Eval CrossEntropy: 2.3021
         Eval Accuracy: 0.0958
[batch=3/4]:
         Train epoch: 0
         Train trainer/global_step: 2
         Train metrics/eval/CrossEntropy: 2.3021
         Train metrics/eval/Accuracy: 0.0958
         Train metrics/eval2/CrossEntropy: 2.3021
         Train metrics/eval2/Accuracy: 0.0958
         Train trainer/batch_idx: 2
         Train trainer/grad_accum: 1
         Train loss/train/total: 2.2447
         Train metrics/train/Accuracy: 0.2422
[batch=4/4]:
         Train trainer/global_step: 3
         Train trainer/batch_idx: 3
         Train trainer/grad_accum: 1
         Train loss/train/total: 2.2098
         Train metrics/train/Accuracy: 0.3125
[Eval batch=1/625] Eval on eval data
[Eval batch=63/625] Eval on eval data
[Eval batch=126/625] Eval on eval data
[Eval batch=188/625] Eval on eval data
[Eval batch=251/625] Eval on eval data
[Eval batch=313/625] Eval on eval data
[Eval batch=375/625] Eval on eval data
[Eval batch=438/625] Eval on eval data
[Eval batch=500/625] Eval on eval data
[Eval batch=563/625] Eval on eval data
[Eval batch=625/625] Eval on eval data:
         Eval CrossEntropy: 2.2971
         Eval Accuracy: 0.0958
[Eval batch=1/625] Eval on eval2 data
[Eval batch=63/625] Eval on eval2 data
[Eval batch=126/625] Eval on eval2 data
[Eval batch=188/625] Eval on eval2 data
[Eval batch=251/625] Eval on eval2 data
[Eval batch=313/625] Eval on eval2 data
[Eval batch=375/625] Eval on eval2 data
[Eval batch=438/625] Eval on eval2 data
[Eval batch=500/625] Eval on eval2 data
[Eval batch=563/625] Eval on eval2 data
[Eval batch=625/625] Eval on eval2 data:
         Eval CrossEntropy: 2.2971
         Eval Accuracy: 0.0958
[Eval batch=1/625] Eval on eval3 data
[Eval batch=63/625] Eval on eval3 data
[Eval batch=126/625] Eval on eval3 data
[Eval batch=188/625] Eval on eval3 data
[Eval batch=251/625] Eval on eval3 data
[Eval batch=313/625] Eval on eval3 data
[Eval batch=375/625] Eval on eval3 data
[Eval batch=438/625] Eval on eval3 data
[Eval batch=500/625] Eval on eval3 data
[Eval batch=563/625] Eval on eval3 data
[Eval batch=625/625] Eval on eval3 data:
         Eval CrossEntropy: 2.2971
         Eval Accuracy: 0.0958
[batch=1/4]:
         Train epoch: 0
         Train trainer/global_step: 0
         Train metrics/eval/CrossEntropy: 2.2971
         Train metrics/eval/Accuracy: 0.0958
         Train metrics/eval2/CrossEntropy: 2.2971
         Train metrics/eval2/Accuracy: 0.0958
         Train metrics/eval3/CrossEntropy: 2.2971
         Train metrics/eval3/Accuracy: 0.0958
         Train trainer/batch_idx: 0
         Train trainer/grad_accum: 1
         Train loss/train/total: 2.1587
         Train metrics/train/Accuracy: 0.2344
[batch=2/4]:
         Train trainer/global_step: 1
         Train trainer/batch_idx: 1
         Train trainer/grad_accum: 1
         Train loss/train/total: 2.1629
         Train metrics/train/Accuracy: 0.2812
[batch=3/4]:
         Train trainer/global_step: 2
         Train trainer/batch_idx: 2
         Train trainer/grad_accum: 1
         Train loss/train/total: 2.1253
         Train metrics/train/Accuracy: 0.2812
[batch=4/4]:
         Train trainer/global_step: 3
         Train trainer/batch_idx: 3
         Train trainer/grad_accum: 1
         Train loss/train/total: 2.0864
         Train metrics/train/Accuracy: 0.3516
[Eval batch=1/625] Eval on eval3 data
[Eval batch=63/625] Eval on eval3 data
[Eval batch=126/625] Eval on eval3 data
[Eval batch=188/625] Eval on eval3 data
[Eval batch=251/625] Eval on eval3 data
[Eval batch=313/625] Eval on eval3 data
[Eval batch=375/625] Eval on eval3 data
[Eval batch=438/625] Eval on eval3 data
[Eval batch=500/625] Eval on eval3 data
[Eval batch=563/625] Eval on eval3 data
[Eval batch=625/625] Eval on eval3 data:
         Eval CrossEntropy: 2.2776
         Eval Accuracy: 0.1502
```


# What issue(s) does this change relate to?

fix CO-1732

