### PR TITLE
Disable test_streaming_datasets in pytest-daily

### DIFF
--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -2,9 +2,6 @@ name: Pytest-Daily
 on:
   schedule:
     - cron: '30 2 * * *' # 2:30 every day
-  pull_request:
-    branches:
-      - dev
   push:
     branches:
       - dev
@@ -181,5 +178,4 @@ jobs:
         id: tests
         run: |
           set -ex
-          export PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          python .github/mcp/mcp_pytest.py --image '${{ matrix.container }}' --pr_number $PR_NUMBER --pytest_markers '${{ matrix.markers }}' --pytest_command '${{ matrix.pytest_command }}'
+          python .github/mcp/mcp_pytest.py --image '${{ matrix.container }}' --git_commit $GITHUB_SHA --pytest_markers '${{ matrix.markers }}' --pytest_command '${{ matrix.pytest_command }}'

--- a/.github/workflows/pytest-daily.yaml
+++ b/.github/workflows/pytest-daily.yaml
@@ -2,6 +2,9 @@ name: Pytest-Daily
 on:
   schedule:
     - cron: '30 2 * * *' # 2:30 every day
+  pull_request:
+    branches:
+      - dev
   push:
     branches:
       - dev
@@ -178,4 +181,5 @@ jobs:
         id: tests
         run: |
           set -ex
-          python .github/mcp/mcp_pytest.py --image '${{ matrix.container }}' --git_commit $GITHUB_SHA --pytest_markers '${{ matrix.markers }}' --pytest_command '${{ matrix.pytest_command }}'
+          export PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          python .github/mcp/mcp_pytest.py --image '${{ matrix.container }}' --pr_number $PR_NUMBER --pytest_markers '${{ matrix.markers }}' --pytest_command '${{ matrix.pytest_command }}'

--- a/tests/datasets/test_streaming_datasets_train.py
+++ b/tests/datasets/test_streaming_datasets_train.py
@@ -15,6 +15,7 @@ from composer.utils import dist
 from tests.common import device, world_size
 
 
+@pytest.mark.skip(reason='CO-1735, failing intermittently on different nodes, additional debug required')
 @pytest.mark.daily
 @pytest.mark.remote
 @device('cpu', 'gpu')


### PR DESCRIPTION
# What does this PR do?

Disable `test_streaming_datasets` test in `pytest-daily`.  This test fails intermittently on all tested nodes, additional debug is required.  A Jira issue has been filed to track this, the test will be re-enabled after a fix has been identified.

To test I temporarily enabled this workflow for pull requests, see the following GHA runs:
https://github.com/mosaicml/composer/actions/runs/4079311935/jobs/7030550011
https://github.com/mosaicml/composer/actions/runs/4079311935/jobs/7030550179
https://github.com/mosaicml/composer/actions/runs/4079311935/jobs/7030550288

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

# To Do
- [x] Remove hack to enable `pytest-daily` in PR for testing

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
