### PR TITLE
Raise error if max duration is in epochs and dataloader is infinite

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1689,6 +1689,12 @@ class Trainer:
         if self.state.max_duration is None:
             _raise_missing_argument_exception('max_duration')
 
+        if self.state.dataloader_len is None and self.state.max_duration.unit == TimeUnit.EPOCH:
+            raise ValueError(
+                ('max_duration cannot be specified in epochs when using an infinite dataloader. Please either '
+                 'provide a dataloader with a length, specify max_duration in batches, samples, or tokens, or provide '
+                 'train_subset_num_batches.'))
+
         if self.state.max_duration <= self.state.timestamp.get(self.state.max_duration.unit) and not reset_time:
             raise ValueError(
                 (f'The max_duration ({self.state.max_duration}) is less than or equal to the elapsed training duration '

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
 
 __all__ = ['Trainer']
 
-# syntax to shorten the Scheduler type annoations
+# syntax to shorten the Scheduler type annotations
 Scheduler = Union[ComposerScheduler, PyTorchScheduler]
 
 
@@ -622,7 +622,7 @@ class Trainer:
             If ``None`` then no checkpoint will be loaded. (default: ``None``)
         load_object_store (Union[ObjectStore, LoggerDestination], optional): If the ``load_path`` is in an
             object store (i.e. AWS S3 or Google Cloud Storage), an instance of :class:`.ObjectStore` or
-            :class:`.LoggerDestination` which will be used to retreive the checkpoint. Otherwise, if the
+            :class:`.LoggerDestination` which will be used to retrieve the checkpoint. Otherwise, if the
             checkpoint is a local filepath, set to ``None``. Also, it can be ``None`` if the ``load_path`` is
             an S3 URI because the appropriate object store will be automatically constructed in that case.
             Ignored if ``load_path`` is ``None``.
@@ -1007,7 +1007,7 @@ class Trainer:
             optimizers = map_collection(optimizers, device.optimizer_to_device)
 
         # Microbatching
-        # To support backwards compatability, we currently support both device_train_microbatch_size
+        # To support backwards compatibility, we currently support both device_train_microbatch_size
         # and grad_accum. If both are specified with grad_accum=1, we will use device_train_microbatch_size.
         if device_train_microbatch_size is not None:
             using_device_microbatch_size = True

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -5,8 +5,8 @@ import types
 from typing import List, Type
 
 from tests.common.compare import deep_compare
-from tests.common.datasets import (RandomClassificationDataset, RandomImageDataset, RandomSegmentationDataset,
-                                   RandomTextClassificationDataset, SimpleDataset)
+from tests.common.datasets import (InfiniteClassificationDataset, RandomClassificationDataset, RandomImageDataset,
+                                   RandomSegmentationDataset, RandomTextClassificationDataset, SimpleDataset)
 from tests.common.events import EventCounterCallback
 from tests.common.markers import device, world_size
 from tests.common.models import (ConvModel, EmbeddedWeightTiedModel, SimpleConvModel, SimpleModel,
@@ -20,8 +20,23 @@ def get_module_subclasses(module: types.ModuleType, cls: Type) -> List[Type]:
 
 
 __all__ = [
-    'assert_state_equivalent', 'RandomClassificationDataset', 'RandomTextClassificationDataset', 'RandomImageDataset',
-    'RandomSegmentationDataset', 'ConvModel', 'SimpleConvModel', 'SimpleModel', 'SimpleTransformerClassifier',
-    'EmbeddedWeightTiedModel', 'SimpleWeightTiedModel', 'EventCounterCallback', 'deep_compare', 'device', 'world_size',
-    'get_module_subclasses', 'SimpleModelWithDropout', 'SimpleDataset'
+    'assert_state_equivalent',
+    'RandomClassificationDataset',
+    'RandomTextClassificationDataset',
+    'RandomImageDataset',
+    'RandomSegmentationDataset',
+    'ConvModel',
+    'SimpleConvModel',
+    'SimpleModel',
+    'SimpleTransformerClassifier',
+    'EmbeddedWeightTiedModel',
+    'SimpleWeightTiedModel',
+    'EventCounterCallback',
+    'deep_compare',
+    'device',
+    'world_size',
+    'get_module_subclasses',
+    'SimpleModelWithDropout',
+    'SimpleDataset',
+    'InfiniteClassificationDataset',
 ]

--- a/tests/common/datasets.py
+++ b/tests/common/datasets.py
@@ -5,11 +5,28 @@ from typing import Sequence
 import pytest
 import torch
 from PIL import Image
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader, Dataset, IterableDataset
 from torchvision.datasets import VisionDataset
 
 from composer.utils import dist
 from tests.common.models import configure_tiny_bert_tokenizer, configure_tiny_gpt2_tokenizer
+
+
+class InfiniteClassificationDataset(IterableDataset):
+    """Classification dataset that never ends.
+
+    Args:
+        shape (Sequence[int]): shape of features (default: (1, 1, 1))
+        num_classes (int): number of classes (default: 2)
+    """
+
+    def __init__(self, shape: Sequence[int] = (1, 1, 1), num_classes: int = 2):
+        self.shape = shape
+        self.num_classes = num_classes
+
+    def __iter__(self):
+        while True:
+            yield torch.randn(*self.shape), torch.randint(0, self.num_classes, size=(1,))[0]
 
 
 class RandomClassificationDataset(Dataset):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -186,10 +186,22 @@ class TestTrainerInitOrFit:
         # Assert that the states are equivalent
         assert_state_equivalent(init_trainer.state, fit_trainer.state)
 
-    def test_max_duration_epoch_with_infinite_train_loader(self, model: ComposerModel):
-        with pytest.raises(ValueError, match='max_duration cannot be specified in epochs'):
+    @pytest.mark.parametrize('max_duration', [1, '1ep', '1ba', '1sp'])
+    @pytest.mark.parametrize('train_subset_num_batches', [-1, 1])
+    def test_infinite_train_loader(self, model: ComposerModel, max_duration: Union[int, str],
+                                   train_subset_num_batches: int):
+        should_raise = (isinstance(max_duration, int) or
+                        max_duration.endswith('ep')) and (train_subset_num_batches is None or
+                                                          train_subset_num_batches == -1)
+        context = pytest.raises(
+            ValueError,
+            match='max_duration cannot be specified in epochs') if should_raise else contextlib.nullcontext()
+        with context:
             train_loader = DataLoader(InfiniteClassificationDataset(), batch_size=4)
-            trainer = Trainer(model=model, train_dataloader=train_loader, max_duration='1ep')
+            trainer = Trainer(model=model,
+                              train_dataloader=train_loader,
+                              max_duration=max_duration,
+                              train_subset_num_batches=train_subset_num_batches)
             trainer.fit()
 
     @pytest.mark.parametrize('reset_time', [True, False])

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -187,11 +187,7 @@ class TestTrainerInitOrFit:
         assert_state_equivalent(init_trainer.state, fit_trainer.state)
 
     def test_max_duration_epoch_with_infinite_train_loader(self, model: ComposerModel):
-        with pytest.raises(
-                ValueError,
-                match=
-                'max_duration cannot be in epochs when using a DataLoader without a length and not specifying train_subset_num_batches.'
-        ):
+        with pytest.raises(ValueError, match='max_duration cannot be specified in epochs'):
             train_loader = DataLoader(InfiniteClassificationDataset(), batch_size=4)
             trainer = Trainer(model=model, train_dataloader=train_loader, max_duration='1ep')
             trainer.fit()


### PR DESCRIPTION
# What does this PR do?
Raises an error if the train dataloader is infinite and max duration is specified in epochs.

UX:
```
In [11]: trainer.fit()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[11], line 1
----> 1 trainer.fit()

File ~/github/composer/composer/trainer/trainer.py:1693, in Trainer.fit(self, train_dataloader, train_dataloader_label, train_subset_num_batches, duration, reset_time, schedulers, scale_schedule_ratio, step_schedulers_every_batch, eval_dataloader, eval_subset_num_batches, eval_interval, grad_accum, device_train_microbatch_size, precision)
   1690     _raise_missing_argument_exception('max_duration')
   1692 if self.state.dataloader_len is None and self.state.max_duration.unit == TimeUnit.EPOCH:
-> 1693     raise ValueError(
   1694         ('max_duration cannot be specified in epochs when using an infinite dataloader. Please either '
   1695          'provide a dataloader with a length, specify max_duration in batches, samples, or tokens, or provide '
   1696          'train_subset_num_batches.'))
   1698 if self.state.max_duration <= self.state.timestamp.get(self.state.max_duration.unit) and not reset_time:
   1699     raise ValueError(
   1700         (f'The max_duration ({self.state.max_duration}) is less than or equal to the elapsed training duration '
   1701          f'({self.state.timestamp.get(self.state.max_duration.unit)}). No training would occur. '
   1702          'Please provide the `duration` or specify `reset_time=True` in Trainer.fit().'))

ValueError: max_duration cannot be specified in epochs when using an infinite dataloader. Please either provide a dataloader with a length, specify max_duration in batches, samples, or tokens, or provide train_subset_num_batches.
```

# What issue(s) does this change relate to?
Closes [CO-1738](https://mosaicml.atlassian.net/browse/CO-1738)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1738]: https://mosaicml.atlassian.net/browse/CO-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ