### PR TITLE
Add support for FP8 on H100 using NVidia's TransformerEngine

### DIFF
--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -5,11 +5,18 @@
 
 import contextlib
 import os
+import textwrap
 from typing import Generator, Union
 
 import torch
 
 from composer.utils import StringEnum
+
+try:
+    import transformer_engine.pytorch as te
+    te_installed = True
+except ImportError:
+    te_installed = False
 
 __all__ = ['Precision', 'get_precision_context']
 
@@ -19,13 +26,15 @@ class Precision(StringEnum):
 
     Attributes:
         FP32: Use 32-bit floating-point precision. Compatible with CPUs and GPUs.
-        AMP_FP16: Use :mod:`torch.cuda.amp` wih 16-bit floating-point precision. Only compatible
+        AMP_FP16: Use :mod:`torch.cuda.amp` with 16-bit floating-point precision. Only compatible
             with GPUs.
-        AMP_BF16: Use :mod:`torch.cuda.amp` wih 16-bit BFloat precision.
+        AMP_BF16: Use :mod:`torch.cuda.amp` with 16-bit BFloat precision.
+        AMP_FP8: Use :mod:`transformer_engine.pytorch.fp8_autocast` with 8-bit FP8 precison.
     """
     FP32 = 'fp32'
     AMP_FP16 = 'amp_fp16'
     AMP_BF16 = 'amp_bf16'
+    AMP_FP8 = 'amp_fp8'
 
 
 @contextlib.contextmanager
@@ -54,5 +63,25 @@ def get_precision_context(precision: Union[str, Precision]) -> Generator[None, N
         else:
             os.environ['XLA_USE_BF16'] = '1'
             yield
+    elif precision == Precision.AMP_FP8:
+        if te_installed and torch.cuda.get_device_capability()[0] > 8:
+            from transformer_engine.common.recipe import DelayedScaling, Format
+
+            # These default values for fp8_recipe are taken from NVidia's docs. We may want to change
+            # these once we get a chance to do more convergence experiments.
+            # https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html#id1
+            fp8_format = Format.HYBRID  # E4M3 during forward pass, E5M2 during backward pass
+            fp8_recipe = DelayedScaling(fp8_format=fp8_format, amax_history_len=16, amax_compute_algo='max')
+            with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
+                yield
+        else:
+            if te_installed:
+                raise RuntimeError('AMP_FP8 precision is used but current device does not support it.')
+            else:
+                raise ImportError(
+                    textwrap.dedent("""\
+                        AMP_FP8 precision is used but TransformerEngine is not installed.
+                        After making sure torch is already installed, please install it using
+                        pip install --upgrade git+https://github.com/NVIDIA/TransformerEngine.git@stable"""))
     else:
         raise ValueError(f'Unsupported precision: {precision}')

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -132,6 +132,10 @@ def get_torch_dtype(dtype: Union[Precision, str]):
         return torch.float16
     elif dtype in ['bfloat16', 'bfloat', 'torch.bfloat16', 'bf16', 'amp_bf16']:
         return torch.bfloat16
+    elif dtype in ['amp_fp8']:
+        # We use torch.bfloat16 by default for amp_fp8 as there is no
+        # fp8 datatype in PyTorch yet.
+        return torch.bfloat16
     else:
         raise ValueError(f'Not sure how to convert dtype={dtype} to a torch dtype.')
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -471,7 +471,7 @@ class TestTrainerInitOrFit:
         assert_state_equivalent(init_trainer.state, fit_trainer.state)
 
     @pytest.mark.gpu
-    @pytest.mark.parametrize('precision', list(Precision))
+    @pytest.mark.parametrize('precision', [Precision.FP32, Precision.AMP_BF16, Precision.AMP_FP16])
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_deepspeed(
         self,
@@ -496,7 +496,7 @@ class TestTrainerInitOrFit:
     @pytest.mark.gpu
     @pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
                         reason='requires PyTorch 1.13 or higher')
-    @pytest.mark.parametrize('precision', list(Precision))
+    @pytest.mark.parametrize('precision', [Precision.FP32, Precision.AMP_BF16, Precision.AMP_FP16])
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_fsdp(
         self,
@@ -578,7 +578,7 @@ class TestTrainerInitOrFit:
         assert all(p.device.type == 'cuda' for p in trainer_2.state.model.parameters())
         map_collection(trainer_2.state.optimizers, _assert_optimizer_is_on_device)
 
-    @pytest.mark.parametrize('precision', list(Precision))
+    @pytest.mark.parametrize('precision', [Precision.FP32, Precision.AMP_BF16, Precision.AMP_FP16])
     @pytest.mark.parametrize('device', ['cpu', pytest.param('gpu', marks=pytest.mark.gpu)])
     def test_precision(
         self,


### PR DESCRIPTION
# What does this PR do?

Adds amp_fp8 precision. This will allows us to train model faster using FP8 precision on H100 systems. It's a no op if amp_fp8 precision is not used. 

# What issue(s) does this change relate to?
FP8 training support on H100 
