### PR TITLE
Update python version in setup.py and fixed pypi download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
         <img alt="PyPi Package Version" src="https://img.shields.io/pypi/v/mosaicml">
     </a>
     <a href="https://pepy.tech/project/mosaicml/">
-        <img alt="PyPi Downloads" src="https://static.pepy.tech/personalized-badge/mosaicml?period=month&units=international_system&left_color=grey&right_color=blue&left_text=Downloads">
+        <img alt="PyPi Downloads" src="https://static.pepy.tech/personalized-badge/mosaicml?period=month&units=international_system&left_color=grey&right_color=blue&left_text=Downloads/month">
     </a>
     <a href="https://docs.mosaicml.com/en/stable/">
         <img alt="Documentation" src="https://readthedocs.org/projects/composer/badge/?version=stable">

--- a/setup.py
+++ b/setup.py
@@ -228,9 +228,9 @@ setup(name=package_name,
       packages=setuptools.find_packages(exclude=['docker*', 'examples*', 'scripts*', 'tests*']),
       classifiers=[
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
       ],
       install_requires=install_requires,
       entry_points={
@@ -241,7 +241,7 @@ setup(name=package_name,
       },
       extras_require=extra_deps,
       dependency_links=['https://developer.download.nvidia.com/compute/redist'],
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       ext_package='composer',
       cmdclass={'develop': develop})
 


### PR DESCRIPTION
# What does this PR do?
- Add the new python version `3.10` in setup.py file and removed the old deprecated `3.7`.
- Fixed the download badge where now it says `download/month` instead of `download` since we are tracking number of downloads per month. 

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
