### PR TITLE
allow eval metrics to be passed in to HuggingFaceModel directly

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -43,7 +43,7 @@ class HuggingFaceModel(ComposerModel):
                 using :meth:`HuggingFaceModel.hf_from_composer_checkpoint`. If the tokenizer is not provided here, it will not be saved in the composer checkpoint.
         use_logits (bool, optional): If True, the model's output logits will be used to calculate validation metrics. Else, metrics will be inferred from the HuggingFaceModel directly. Default: ``False``
         metrics (list[Metric], optional): list of torchmetrics to apply to the output of `eval_forward` during training. If ``eval_metrics`` is ``None``, these will also be used as ``eval_metrics``.  Default: ``None``.
-        eval_metrics (list[Metric], optional): list of torchmetrics to compute on the eval_dataloader, or be accessible to :class:`Evaluator`s.
+        eval_metrics (list[Metric], optional): list of torchmetrics to compute on the eval_dataloader, or be accessible to :class:`Evaluator`s. Default: ``None``.
         shift_labels (bool, optional): If True, the batch's labels will be shifted before being used to calculate metrics. This should be set to true for CausalLM models and false otherwise. If not specified, `shift_labels` will be set automatically based on the model class name. Default: ``None``.
 
         .. note:: To ensure correct behavior, set `shift_labels` manually if using a custom model (i.e., if `model` is not

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -10,6 +10,7 @@ import json
 import logging
 import tempfile
 import textwrap
+import warnings
 from collections import UserDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
@@ -41,7 +42,7 @@ class HuggingFaceModel(ComposerModel):
             .. note:: If the tokenizer is provided, its config will be saved in the composer checkpoint, and it can be reloaded
                 using :meth:`HuggingFaceModel.hf_from_composer_checkpoint`. If the tokenizer is not provided here, it will not be saved in the composer checkpoint.
         use_logits (bool, optional): If True, the model's output logits will be used to calculate validation metrics. Else, metrics will be inferred from the HuggingFaceModel directly. Default: ``False``
-        metrics (list[Metric], optional): list of torchmetrics to apply to the output of `eval_forward` during training. If ``eval_metrics`` is ``None``. These will also be used as ``eval_metrics``.  Default: ``None``.
+        metrics (list[Metric], optional): list of torchmetrics to apply to the output of `eval_forward` during training. If ``eval_metrics`` is ``None``, these will also be used as ``eval_metrics``.  Default: ``None``.
         eval_metrics (list[Metric], optional): list of torchmetrics to compute on the eval_dataloader, or be accessible to :class:`Evaluator`s.
         shift_labels (bool, optional): If True, the batch's labels will be shifted before being used to calculate metrics. This should be set to true for CausalLM models and false otherwise. If not specified, `shift_labels` will be set automatically based on the model class name. Default: ``None``.
 
@@ -383,6 +384,9 @@ class HuggingFaceModel(ComposerModel):
         return {'model': model_output, 'tokenizer': tokenizer_output}
 
     def add_eval_metrics(self, evaluator):
+        warnings.warn(
+            DeprecationWarning('The add_eval_metrics method is deprecated and will be removed in a future release. '
+                               'Please pass in `eval_metrics` directly to the constructor.'))
         evaluator_metrics = {m: METRIC_DEFAULT_CTORS[m]() for m in evaluator.metric_names}
         if self.val_metrics is not None:
             self.val_metrics.update(evaluator_metrics)

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -15,6 +15,7 @@ from torch.utils.data import DataLoader
 from torchmetrics import Metric
 from torchmetrics.classification import Accuracy
 
+from composer.core import Evaluator
 from composer.metrics.nlp import LanguageCrossEntropy, MaskedAccuracy
 from composer.trainer import Trainer
 from composer.utils import dist
@@ -575,12 +576,16 @@ def test_add_eval_metrics(tiny_bert_model, tiny_bert_tokenizer):
     from composer.models import HuggingFaceModel
 
     metrics: List[Metric] = [LanguageCrossEntropy(ignore_index=-100)]
-    eval_metrics: List[Metric] = [MaskedAccuracy(ignore_index=-100)]
+
+    dataset = RandomTextClassificationDataset(size=1, vocab_size=1, sequence_length=1, num_classes=1, use_keys=True)
+
+    dataloader = DataLoader(dataset, batch_size=1, sampler=dist.get_sampler(dataset))
+    evaluator = Evaluator(label='evaluator', dataloader=dataloader, metric_names=['InContextLearningLMAccuracy'])
 
     hf_model = HuggingFaceModel(tiny_bert_model, tokenizer=tiny_bert_tokenizer, metrics=metrics)
-    hf_model.add_eval_metrics(eval_metrics)
+    hf_model.add_eval_metrics(evaluator)
 
     assert hf_model.train_metrics is not None
     assert hf_model.val_metrics is not None
     assert hf_model.train_metrics.keys() == {'LanguageCrossEntropy'}
-    assert hf_model.val_metrics.keys() == {'LanguageCrossEntropy', 'MaskedAccuracy'}
+    assert hf_model.val_metrics.keys() == {'LanguageCrossEntropy', 'InContextLearningLMAccuracy'}

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -567,3 +567,20 @@ def test_separate_eval_metrics(tiny_bert_model, tiny_bert_tokenizer):
     assert hf_model.val_metrics is not None
     assert hf_model.train_metrics.keys() == {'LanguageCrossEntropy'}
     assert hf_model.val_metrics.keys() == {'MaskedAccuracy'}
+
+
+def test_add_eval_metrics(tiny_bert_model, tiny_bert_tokenizer):
+    pytest.importorskip('transformers')
+
+    from composer.models import HuggingFaceModel
+
+    metrics: List[Metric] = [LanguageCrossEntropy(ignore_index=-100)]
+    eval_metrics: List[Metric] = [MaskedAccuracy(ignore_index=-100)]
+
+    hf_model = HuggingFaceModel(tiny_bert_model, tokenizer=tiny_bert_tokenizer, metrics=metrics)
+    hf_model.add_eval_metrics(eval_metrics)
+
+    assert hf_model.train_metrics is not None
+    assert hf_model.val_metrics is not None
+    assert hf_model.train_metrics.keys() == {'LanguageCrossEntropy'}
+    assert hf_model.val_metrics.keys() == {'LanguageCrossEntropy', 'MaskedAccuracy'}

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -548,3 +548,22 @@ def test_hf_return_dict_false(tiny_bert_config, tiny_bert_tokenizer):
     trainer = get_lm_trainer(tiny_bert_model, tiny_bert_tokenizer, None, do_eval=True)
 
     trainer.fit()
+
+
+def test_separate_eval_metrics(tiny_bert_model, tiny_bert_tokenizer):
+    pytest.importorskip('transformers')
+
+    from composer.models import HuggingFaceModel
+
+    metrics: List[Metric] = [LanguageCrossEntropy(ignore_index=-100)]
+    eval_metrics: List[Metric] = [MaskedAccuracy(ignore_index=-100)]
+
+    hf_model = HuggingFaceModel(tiny_bert_model,
+                                tokenizer=tiny_bert_tokenizer,
+                                metrics=metrics,
+                                eval_metrics=eval_metrics)
+
+    assert hf_model.train_metrics is not None
+    assert hf_model.val_metrics is not None
+    assert hf_model.train_metrics.keys() == {'LanguageCrossEntropy'}
+    assert hf_model.val_metrics.keys() == {'MaskedAccuracy'}


### PR DESCRIPTION
# What does this PR do?
Previously `HuggingFaceModel` automatically used `metrics` for both `train_metrics` and `eval_metrics`. This can cause an issue if using `Evaluator`s with metrics that can't be applied during training (e.g. ICL metrics). Now, if you pass in `eval_metrics`, it will use that for `eval_metrics` instead.

# What issue(s) does this change relate to?
[CO-1788](https://mosaicml.atlassian.net/browse/CO-1788)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1788]: https://mosaicml.atlassian.net/browse/CO-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ