### PR TITLE
Util for writing HuggingFace save_pretrained from a composer checkpoint

### DIFF
--- a/composer/models/__init__.py
+++ b/composer/models/__init__.py
@@ -15,7 +15,7 @@ from composer.models.classify_mnist import mnist_model
 from composer.models.deeplabv3 import composer_deeplabv3
 from composer.models.efficientnetb0 import composer_efficientnetb0
 from composer.models.gpt2 import create_gpt2
-from composer.models.huggingface import HuggingFaceModel
+from composer.models.huggingface import HuggingFaceModel, write_huggingface_pretrained_from_composer_checkpoint
 from composer.models.initializers import Initializer
 from composer.models.mmdetection import MMDetModel
 from composer.models.resnet import composer_resnet
@@ -34,6 +34,7 @@ __all__ = [
     'composer_efficientnetb0',
     'create_gpt2',
     'HuggingFaceModel',
+    'write_huggingface_pretrained_from_composer_checkpoint',
     'Initializer',
     'MMDetModel',
     'composer_resnet',

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -472,6 +472,8 @@ def write_huggingface_pretrained_from_composer_checkpoint(
 
     .. testcode::
 
+        from composer.models import write_huggingface_pretrained_from_composer_checkpoint
+
         write_huggingface_pretrained_from_composer_checkpoint('composer-hf-checkpoint.pt', './hf-save-pretrained-output')
         loaded_model = transformers.AutoModelForSequenceClassification.from_pretrained('./hf-save-pretrained-output')
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -169,7 +169,7 @@ class HuggingFaceModel(ComposerModel):
 
         Args:
             checkpoint_path (str): Path to the composer checkpoint, can be a local path, or a remote path beginning with ``s3://``, or another backend
-            supported by :meth:`composer.utils.maybe_create_object_store_from_uri`.
+                supported by :meth:`composer.utils.maybe_create_object_store_from_uri`.
             model_instantiation_class (Union[Type[:class:`transformers.PreTrainedModel`], Type[:class:`transformers.AutoModel`], str]), optional):
                 Class to use to create the HuggingFace model. Defaults to the model class used in the original checkpoint. If this argument is
                 a HuggingFace auto class (e.g. :class:`transformers.AutoModel` or :class:`transformers.AutoModelForSequenceClassification`), the ``from_config`` method will be used,

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -440,7 +440,7 @@ def write_huggingface_pretrained_from_composer_checkpoint(
         checkpoint_path: Union[Path, str],
         output_folder: Union[Path, str],
         local_checkpoint_save_location: Optional[Union[Path, str]] = None) -> None:
-    """Write the output of `transformers.PreTrainedModel.save_pretrained from a composer checkpoint
+    """Write the a `config.json` and `pytorch_model.bin`, like `transformers.PreTrainedModel.from_pretrained` expects, from a composer checkpoint
 
     .. note:: This function will not work properly if you used surgery algorithms when you trained your model. In that case you will want to
         load the model weights using the Composer :class:`~composer.Trainer` with the `load_path` argument.

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -440,7 +440,7 @@ def write_huggingface_pretrained_from_composer_checkpoint(
         checkpoint_path: Union[Path, str],
         output_folder: Union[Path, str],
         local_checkpoint_save_location: Optional[Union[Path, str]] = None) -> None:
-    """Write the a `config.json` and `pytorch_model.bin`, like `transformers.PreTrainedModel.from_pretrained` expects, from a composer checkpoint
+    """Write the a `config.json` and `pytorch_model.bin`, like :meth:`transformers.PreTrainedModel.from_pretrained` expects, from a composer checkpoint
 
     .. note:: This function will not work properly if you used surgery algorithms when you trained your model. In that case you will want to
         load the model weights using the Composer :class:`~composer.Trainer` with the `load_path` argument.

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -440,7 +440,7 @@ def write_huggingface_pretrained_from_composer_checkpoint(
         checkpoint_path: Union[Path, str],
         output_folder: Union[Path, str],
         local_checkpoint_save_location: Optional[Union[Path, str]] = None) -> None:
-    """Write the a ``config.json`` and ``pytorch_model.bin``, like :meth:`transformers.PreTrainedModel.from_pretrained` expects, from a composer checkpoint
+    """Write a ``config.json`` and ``pytorch_model.bin``, like :meth:`transformers.PreTrainedModel.from_pretrained` expects, from a composer checkpoint
 
     .. note:: This function will not work properly if you used surgery algorithms when you trained your model. In that case you will want to
         load the model weights using the Composer :class:`~composer.Trainer` with the ``load_path`` argument.

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -440,10 +440,10 @@ def write_huggingface_pretrained_from_composer_checkpoint(
         checkpoint_path: Union[Path, str],
         output_folder: Union[Path, str],
         local_checkpoint_save_location: Optional[Union[Path, str]] = None) -> None:
-    """Write the a `config.json` and `pytorch_model.bin`, like :meth:`transformers.PreTrainedModel.from_pretrained` expects, from a composer checkpoint
+    """Write the a ``config.json`` and ``pytorch_model.bin``, like :meth:`transformers.PreTrainedModel.from_pretrained` expects, from a composer checkpoint
 
     .. note:: This function will not work properly if you used surgery algorithms when you trained your model. In that case you will want to
-        load the model weights using the Composer :class:`~composer.Trainer` with the `load_path` argument.
+        load the model weights using the Composer :class:`~composer.Trainer` with the ``load_path`` argument.
 
     .. testsetup::
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -156,12 +156,15 @@ class HuggingFaceModel(ComposerModel):
         .. testcode::
 
             hf_model, hf_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint('composer-hf-checkpoint.pt')
+            # At this point, hf_model is randomly initialized
             composer_model = HuggingFaceModel(hf_model, hf_tokenizer)
             trainer = Trainer(model=composer_model,
                               train_dataloader=train_dataloader,
                               save_filename='composer-hf-checkpoint-2.pt',
                               max_duration='1ep',
-                              save_folder='./')
+                              save_folder='./',
+                              load_path='composer-hf-checkpoint.pt')
+            # At this point, the weights have been loaded from the composer checkpoint into hf_model
 
         Args:
             checkpoint_path (str): Path to the composer checkpoint, can be a local path, ``http(s)://`` url, or ``s3://`` uri

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -307,8 +307,8 @@ def test_hf_no_tokenizer_warning(caplog, pass_in_tokenizer: bool, tiny_bert_mode
 
 @pytest.mark.parametrize('checkpoint_upload_path', [None, 's3://checkpoints-bucket/remote-checkpoint.pt'])
 @pytest.mark.parametrize('local_save_filename', [None, 'local-checkpoint.pt'])
-def test_hf_loading_load_save_paths(checkpoint_upload_path: Optional[str], local_save_filename: str, tmp_path: Path,
-                                    tiny_bert_model, tiny_bert_tokenizer):
+def test_hf_loading_load_save_paths(checkpoint_upload_path: Optional[str], local_save_filename: Optional[str],
+                                    tmp_path: Path, tiny_bert_model, tiny_bert_tokenizer):
     pytest.importorskip('transformers')
     from composer.models import HuggingFaceModel
 
@@ -589,3 +589,39 @@ def test_add_eval_metrics(tiny_bert_model, tiny_bert_tokenizer):
     assert hf_model.val_metrics is not None
     assert hf_model.train_metrics.keys() == {'LanguageCrossEntropy'}
     assert hf_model.val_metrics.keys() == {'LanguageCrossEntropy', 'InContextLearningLMAccuracy'}
+
+
+@pytest.mark.parametrize('checkpoint_upload_folder', [None, 's3://checkpoints-bucket/'])
+@pytest.mark.parametrize('local_save_filename', [None, 'local-checkpoint.pt'])
+def test_write_hf_from_composer(checkpoint_upload_folder, local_save_filename, tiny_bert_model, tiny_bert_tokenizer,
+                                tmp_path):
+    transformers = pytest.importorskip('transformers')
+
+    from composer.models.huggingface import write_huggingface_pretrained_from_composer_checkpoint
+
+    if checkpoint_upload_folder is None:
+        checkpoint_upload_folder = tmp_path
+    trainer = get_lm_trainer(tiny_bert_model, tiny_bert_tokenizer, str(tmp_path))
+    trainer.fit()
+
+    # Just upload to a dummy object store outside of composer to make mocking easier
+    if str(checkpoint_upload_folder).startswith('s3://'):
+        parsed_uri = urlparse(checkpoint_upload_folder)
+        object_store = DummyObjectStore(Path(parsed_uri.netloc))
+        object_store.upload_object(parsed_uri.path + 'hf-checkpoint.pt', str(tmp_path / 'hf-checkpoint.pt'))
+
+    with patch('composer.utils.file_helpers.S3ObjectStore', DummyObjectStore):
+        checkpoint_path = os.path.join(checkpoint_upload_folder, 'hf-checkpoint.pt')
+        write_huggingface_pretrained_from_composer_checkpoint(checkpoint_path,
+                                                              tmp_path / 'hf-save-pretrained',
+                                                              local_checkpoint_save_location=local_save_filename)
+
+    assert os.path.exists(tmp_path / 'hf-save-pretrained' / 'config.json')
+    assert os.path.exists(tmp_path / 'hf-save-pretrained' / 'pytorch_model.bin')
+
+    loaded_hf_model = transformers.AutoModelForMaskedLM.from_pretrained(tmp_path / 'hf-save-pretrained')
+
+    # set _name_or_path so that the equivalence check passes. It is expected that these are different, because one is loaded from disk, while one is loaded from the hub
+    loaded_hf_model.config._name_or_path = tiny_bert_model.config._name_or_path
+
+    check_hf_model_equivalence(tiny_bert_model, loaded_hf_model)


### PR DESCRIPTION
# What does this PR do?
Adds a basic util function to load a composer checkpoint of a `HuggingFaceModel` and write out the `config.json` and `pytorch_model.bin` that are expected in a huggingface pretrained folder.

# What issue(s) does this change relate to?
[CO-1445](https://mosaicml.atlassian.net/browse/CO-1445)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1445]: https://mosaicml.atlassian.net/browse/CO-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ