### PR TITLE
Fix Logger During Predict

### DIFF
--- a/composer/loggers/logger.py
+++ b/composer/loggers/logger.py
@@ -52,6 +52,11 @@ class Logger:
         self.destinations = ensure_tuple(destinations)
         self._state = state
 
+    def get_step(self):
+        if self._state.dataloader_label == 'predict':
+            return self._state.predict_timestamp.batch.value
+        return self._state.timestamp.batch.value
+
     def log_traces(self, traces: Dict[str, Any]):
         for destination in self.destinations:
             destination.log_traces(traces)
@@ -62,7 +67,7 @@ class Logger:
 
     def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None) -> None:
         if step is None:
-            step = self._state.timestamp.batch.value
+            step = self.get_step()
         for destination in self.destinations:
             destination.log_metrics(metrics, step)
 
@@ -96,7 +101,7 @@ class Logger:
                 with WandB.
         """
         if step is None:
-            step = self._state.timestamp.batch.value
+            step = self.get_step()
         for destination in self.destinations:
             destination.log_images(images, name, channels_last, step, masks, mask_class_labels, use_table)
 


### PR DESCRIPTION
# What does this PR do?

During predict, we currently use `self._state.timestamp`. This always returns the same value, so all logged metrics are overridden by the latest version. Instead, we should be using the predict timestamp during predict (which we know because predict always sets a fixed dataloader label).

Before (crouching crab) and after (tunneling macaw)
<img width="405" alt="image" src="https://user-images.githubusercontent.com/17102158/219706566-1c16b367-c78b-46c6-927c-df7037d517f1.png">


# What issue(s) does this change relate to?

[CO-1797](https://mosaicml.atlassian.net/browse/CO-1797)

[CO-1797]: https://mosaicml.atlassian.net/browse/CO-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ