### PR TITLE
Remove python-version input from Daily CPU tests

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -66,7 +66,6 @@ jobs:
       pytest-command: ${{ matrix.pytest_command }}
       pytest-markers: ${{ matrix.markers }}
       pytest-s3-bucket: 'mosaicml-internal-integration-testing'
-      python-version: 3.9
       pytest-wandb-entity: 'mosaicml-public-integration-tests'
       pytest-wandb-project: "integration-tests-${{ github.sha }}"
     secrets:


### PR DESCRIPTION
# What does this PR do?

The `python-version` input was removed from the `pytest-cpu` workflow as a last minute change before #1968 was merged.  However we missed removing the `python-version` input in the `daily` workflow, this PR removes the vestigial input since it breaks the workflow.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
