### PR TITLE
Add some logic to pass the correct github ref to mcp script

### DIFF
--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -58,5 +58,19 @@ jobs:
         id: tests
         run: |
           set -ex
-          export PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          python .github/mcp/mcp_pytest.py --image '${{ inputs.container }}' --pr_number $PR_NUMBER --pytest_markers '${{ inputs.pytest-markers }}' --pytest_command '${{ inputs.pytest-command }}' --timeout ${{ inputs.mcloud-timeout }}
+
+          PR_NUMBER="$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
+          REF_ARGS=""
+
+          # Use the PR number if it exists, commit SHA for protected branches and the branch name otherwise
+          if [ -z "$PR_NUMBER" ]; then
+            if [[ "$GITHUB_REF" =~ "refs/heads/dev" || "$GITHUB_REF" =~ "refs/heads/main" || "$GITHUB_REF" =~ "refs/heads/release" ]]; then
+              REF_ARGS="--git_commit $GITHUB_SHA"
+            else
+              REF_ARGS="--git_branch $GITHUB_REF_NAME"
+            fi
+          else
+            REF_ARGS="--pr_number $PR_NUMBER"
+          fi
+
+          python .github/mcp/mcp_pytest.py --image '${{ inputs.container }}' --pytest_markers '${{ inputs.pytest-markers }}' --pytest_command '${{ inputs.pytest-command }}' --timeout ${{ inputs.mcloud-timeout }} ${REF_ARGS}


### PR DESCRIPTION
# What does this PR do?

Adds logic to the `pytest-gpu` workflow to pass the correct Github reference to the `mcp` test runner.  If the workflow is triggered by an event in a pull request, it will use the PR number.  Otherwise the commit SHA will be used if the run is on a protected branch, else the branch name is used.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
