### PR TITLE
Allow FX graph mode post-training dynamic quantisation of BlurConv2d operations.

### DIFF
--- a/composer/algorithms/blurpool/blurpool_layers.py
+++ b/composer/algorithms/blurpool/blurpool_layers.py
@@ -30,11 +30,15 @@ def _padding_for_filt_2d_same(filt: torch.Tensor):
     return int(torch.div(h, 2)), int(torch.div(w, 2))
 
 
-def blur_2d(input: torch.Tensor, stride: _size_2_t = 1, filter: Optional[torch.Tensor] = None) -> torch.Tensor:
+def blur_2d(input: torch.Tensor, channels: int = 0, stride: _size_2_t = 1, filter: Optional[torch.Tensor] = None) -> torch.Tensor:
     """Applies a spatial low-pass filter.
 
     Args:
         input (torch.Tensor): A 4d tensor of shape NCHW
+        channels (int, optional): The number of channels in the input tensor.
+            If non-positive, then dynamic control flow is used to determine the number of channels.
+            If positive, then static control flow is used and the filter dimensions should be appropriate for
+            the input size (note: this condition is always satisfied for the default filter and non-zero input size).
         stride (int | tuple, optional): Stride(s) along H and W axes. If a single value is passed, this
             value is used for both dimensions.
         filter (torch.Tensor, optional): A 2d or 4d tensor to be cross-correlated with the input tensor
@@ -54,24 +58,29 @@ def blur_2d(input: torch.Tensor, stride: _size_2_t = 1, filter: Optional[torch.T
     Returns:
         The blurred input
     """
-    _, c, h, w = input.shape
-    n_in_channels = c
 
     if filter is None:
         filter = _default_2d_filter()
-    if (filter.shape[0] == 1) and (n_in_channels > 1):
-        # filt is already a rank 4 tensor
-        filter = filter.repeat((n_in_channels, 1, 1, 1))
 
-    _, _, filter_h, filter_w = filter.shape
+    if channels < 1:  # Use Dynamic Control Flow
+        _, c, h, w = input.shape
+        n_in_channels = c
+        if (filter.shape[0] == 1) and (n_in_channels > 1):
+            # filt is already a rank 4 tensor
+            filter = filter.repeat((n_in_channels, 1, 1, 1))
+
     padding = _padding_for_filt_2d_same(filter)
 
-    if h + 2 * padding[0] < filter_h:
-        return input
-    if w + 2 * padding[1] < filter_w:
-        return input
+    if channels < 1:  # Use Dynamic Control Flow
+        _, _, filter_h, filter_w = filter.shape
+        if h + 2 * padding[0] < filter_h:
+            return input
+        if w + 2 * padding[1] < filter_w:
+            return input
 
-    return F.conv2d(input, filter, stride=stride, padding=padding, groups=n_in_channels, bias=None)
+        return F.conv2d(input, filter, stride=stride, padding=padding, groups=n_in_channels, bias=None)  # Use Dynamic Control Flow
+
+    return F.conv2d(input, filter, stride=stride, padding=padding, groups=channels, bias=None)  # Use Static Control Flow
 
 
 def blurmax_pool2d(input: torch.Tensor,
@@ -138,7 +147,7 @@ def blurmax_pool2d(input: torch.Tensor,
                         padding=padding,
                         dilation=dilation,
                         ceil_mode=ceil_mode)
-    return blur_2d(maxs, stride=stride, filter=filter)
+    return blur_2d(maxs, channels=0, stride=stride, filter=filter)
 
 
 class BlurMaxPool2d(nn.Module):
@@ -240,11 +249,11 @@ class BlurConv2d(nn.Module):
             assert stride is not None
             conv_stride = stride
             self.blur_stride = 1
-            blur_nchannels = in_channels
+            self.blur_nchannels = in_channels
         else:
             conv_stride = 1
             self.blur_stride = kernel_size if (stride is None) else stride
-            blur_nchannels = out_channels
+            self.blur_nchannels = out_channels
 
         self.conv = torch.nn.Conv2d(
             in_channels=in_channels,
@@ -261,7 +270,7 @@ class BlurConv2d(nn.Module):
         # this is the full 4d tensor we want; materialize it once, instead
         # of just-in-time during forward; we can do this in this class but
         # not the others because we know in_channels during __init__
-        filt = _default_2d_filter().repeat(blur_nchannels, 1, 1, 1)
+        filt = _default_2d_filter().repeat(self.blur_nchannels, 1, 1, 1)
         self.register_buffer('blur_filter', filt)
 
     def forward(self, input: torch.Tensor):
@@ -269,14 +278,14 @@ class BlurConv2d(nn.Module):
             # blur in place, then apply (probably strided) conv
             # this is roughly the same number of flops as just applying
             # the original conv (though has some memory bandwidth cost)
-            blurred = blur_2d(input, filter=self.blur_filter, stride=self.blur_stride)
+            blurred = blur_2d(input, channels=self.blur_nchannels, filter=self.blur_filter, stride=self.blur_stride)
             return self.conv.forward(blurred)
         else:
             # apply conv with stride of 1, then blur and (probably) downsample;
             # this is much more costly than a strided conv, at least in the
             # compute-bound regime
             activations = self.conv.forward(input)
-            return blur_2d(activations, filter=self.blur_filter, stride=self.blur_stride)
+            return blur_2d(activations, channels=self.blur_nchannels, filter=self.blur_filter, stride=self.blur_stride)
 
     @staticmethod
     def from_conv2d(module: torch.nn.Conv2d, module_index: int = -1, blur_first: bool = True):
@@ -304,11 +313,12 @@ class BlurConv2d(nn.Module):
 class BlurPool2d(nn.Module):
     """This module just calls :func:`.blur_2d` in ``forward`` using the provided arguments."""
 
-    def __init__(self, stride: _size_2_t = 2, padding: _size_2_t = 1) -> None:
+    def __init__(self, channels: int = 0, stride: _size_2_t = 2, padding: _size_2_t = 1) -> None:
         super(BlurPool2d, self).__init__()
+        self.channels = channels
         self.stride = stride
         self.padding = padding
-        self.register_buffer('filt2d', _default_2d_filter())
+        self.register_buffer('filt2d', _default_2d_filter().repeat(channels, 1, 1, 1))
 
     def forward(self, input: torch.Tensor):
-        return blur_2d(input, stride=self.stride, filter=self.filt2d)
+        return blur_2d(input, channels=self.channels, stride=self.stride, filter=self.filt2d)

--- a/composer/algorithms/blurpool/blurpool_layers.py
+++ b/composer/algorithms/blurpool/blurpool_layers.py
@@ -318,7 +318,9 @@ class BlurPool2d(nn.Module):
         self.channels = channels
         self.stride = stride
         self.padding = padding
-        self.register_buffer('filt2d', _default_2d_filter().repeat(channels, 1, 1, 1))
+        self.register_buffer('filt2d', _default_2d_filter())
+        if self.channels > 0:
+            self.filt2d = self.filt2d.repeat(channels, 1, 1, 1)
 
     def forward(self, input: torch.Tensor):
         return blur_2d(input, channels=self.channels, stride=self.stride, filter=self.filt2d)

--- a/composer/algorithms/blurpool/blurpool_layers.py
+++ b/composer/algorithms/blurpool/blurpool_layers.py
@@ -64,8 +64,8 @@ def blur_2d(input: torch.Tensor,
 
     if filter is None:
         filter = _default_2d_filter()
-    padding = _padding_for_filt_2d_same(
-        filter)  # The dynamic control flow branch below does not affect this as only h and w are used.
+    # The dynamic control flow branch below does not affect the padding as only h and w are used.
+    padding = _padding_for_filt_2d_same(filter)
 
     if channels < 1:  # Use Dynamic Control Flow
         _, c, h, w = input.shape
@@ -81,11 +81,11 @@ def blur_2d(input: torch.Tensor,
         if w + 2 * padding[1] < filter_w:
             return input
 
-        return F.conv2d(input, filter, stride=stride, padding=padding, groups=n_in_channels,
-                        bias=None)  # Use Dynamic Control Flow
+        # Use Dynamic Control Flow
+        return F.conv2d(input, filter, stride=stride, padding=padding, groups=n_in_channels, bias=None)
 
-    return F.conv2d(input, filter, stride=stride, padding=padding, groups=channels,
-                    bias=None)  # Use Static Control Flow
+    # Use Static Control Flow
+    return F.conv2d(input, filter, stride=stride, padding=padding, groups=channels, bias=None)
 
 
 def blurmax_pool2d(input: torch.Tensor,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2554,7 +2554,7 @@ class Trainer:
                 for evaluation.  If not provided, defaults to using the
                 ``eval_dataloader`` provided to the trainer init().
             subset_num_batches (int, optional): Evaluate on this many batches. Default to ``-1`` (the entire
-                dataloader. Can also be provided in the trainer init()as ``eval_subset_num_batches``.
+                dataloader. Can also be provided in the trainer.__init__() as ``eval_subset_num_batches``.
 
         """
         if eval_dataloader is not None:


### PR DESCRIPTION
# What does this PR do?

This PR extracts the dynamic control flow operations in `blur_2d` into static control flow operations in the `BlurConv2d` class while leaving the dynamic control flow operations in place for `BlurMaxPool2d`. This allows FX graph mode post-training dynamic quantisation to be applied to models where blurpool has been applied to convolutions (though not max pooling).

There still seems to be an issue with static quantisation however, which I'm unsure of how to fix:
```
RuntimeError: quantized::conv2d_prepack() is missing value for argument 'bias'. Declaration: quantized::conv2d_prepack(Tensor weight, Tensor? bias, int[] stride, int[] padding, int[] dilation, int groups) -> __torch__.torch.classes.quantized.Conv2dPackedParamsBase
```

# What issue(s) does this change relate to?
This PR partially fixes issue #1985 in that blurpool applied to convolutions uses static control flow and no longer prevents FX graph mode post-training dynamic quantisation. Blurpool applied to max pool continues to use dynamic control flow as before.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [n] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [n/a] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))
