### PR TITLE
Add merge_group event trigger to GHA daily workflow

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,8 +1,8 @@
 name: Code Quality Checks
 on:
+  merge_group:
   push:
     branches:
-      - dev
       - main
       - release/**
   pull_request:

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -1,17 +1,17 @@
 name: Daily
 on:
-  schedule:
-    - cron: '30 2 * * *' # 2:30 every day
+  merge_group:
   push:
     branches:
-      - dev
       - main
       - release/**
+  schedule:
+    - cron: '30 2 * * *' # 2:30 every day
   workflow_dispatch:
 # Cancel old runs when a new commit is pushed to the same branch if not on main or dev
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   daily-pytest-cpu:
     uses: ./.github/workflows/pytest-cpu.yaml


### PR DESCRIPTION
# What does this PR do?

This PR modifies the `daily.yaml` workflow by adding the `merge_group` event trigger and removing the `push` trigger for the `dev` branch.  Merge queues were just enabled for `dev` so the intent is that the `daily` workflow will run on PR's pushed to the merge queue.  For more information on merge queues, please see:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue

The `daily` workflow is now triggered as follows:
* Run workflow on merge_group event
* Run workflow on pushes to main and release branches
* Run workflow at 2:30am every day on dev
* Run workflow manually

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
