### PR TITLE
Adjust auto microbatch size when hitting cuda alloc retries

### DIFF
--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -288,6 +288,7 @@ class SeqLengthWarmup(Algorithm):
             model_inputs = {k: v[:per_gpu_batch] for k, v in batch_clone.items()}
 
             found_cuda_oom = 0  # int since bool BOR not supported on all torch.distributed backends
+            num_alloc_retries = torch.cuda.memory_stats()['num_alloc_retries']
             try:
                 # start by running a forward and backward pass
                 # of the maximum sequence length to allocate cache.
@@ -304,6 +305,11 @@ class SeqLengthWarmup(Algorithm):
                 for optimizer in state.optimizers:
                     optimizer.zero_grad()
 
+                # Raise error if automicrobatching and num_alloc_retries increased, as thrashing
+                # often leads to throughput slowdown
+                if state.auto_microbatching and torch.cuda.memory_stats()['num_alloc_retries'] > num_alloc_retries:
+                    raise RuntimeError(
+                        'num_alloc_retries > 1, which leads to memory thrashing and throughput decrease.')
             # This error/state.grad_accum handling mimics the logic in trainer._train_batch().
             except RuntimeError as e:
                 if state.auto_microbatching and _is_cuda_oom(e):

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -309,7 +309,7 @@ class SeqLengthWarmup(Algorithm):
                 # Raise error if automicrobatching and num_alloc_retries increased, as thrashing
                 # often leads to throughput slowdown
                 if state.auto_microbatching and _get_num_alloc_retries() > num_alloc_retries:
-                    raise RuntimeError('num_alloc_retries > 1 which causes memory thrashing and throughput decrease')
+                    raise RuntimeError('num_alloc_retries > 0 which causes memory thrashing and throughput decrease')
             # This error/state.grad_accum handling mimics the logic in trainer._train_batch().
             except RuntimeError as e:
                 if state.auto_microbatching and _is_cuda_oom(e):

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -308,8 +308,7 @@ class SeqLengthWarmup(Algorithm):
                 # Raise error if automicrobatching and num_alloc_retries increased, as thrashing
                 # often leads to throughput slowdown
                 if state.auto_microbatching and torch.cuda.memory_stats()['num_alloc_retries'] > num_alloc_retries:
-                    raise RuntimeError(
-                        'num_alloc_retries > 1, which leads to memory thrashing and throughput decrease.')
+                    raise RuntimeError('num_alloc_retries > 1 which causes memory thrashing and throughput decrease.')
             # This error/state.grad_accum handling mimics the logic in trainer._train_batch().
             except RuntimeError as e:
                 if state.auto_microbatching and _is_cuda_oom(e):

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -308,7 +308,7 @@ class SeqLengthWarmup(Algorithm):
                 # Raise error if automicrobatching and num_alloc_retries increased, as thrashing
                 # often leads to throughput slowdown
                 if state.auto_microbatching and torch.cuda.memory_stats()['num_alloc_retries'] > num_alloc_retries:
-                    raise RuntimeError('num_alloc_retries > 1 which causes memory thrashing and throughput decrease.')
+                    raise RuntimeError('num_alloc_retries > 1 which causes memory thrashing and throughput decrease')
             # This error/state.grad_accum handling mimics the logic in trainer._train_batch().
             except RuntimeError as e:
                 if state.auto_microbatching and _is_cuda_oom(e):

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -260,7 +260,6 @@ def _adjust_grad_accum(state: State, device_batch_size: int):
         del state.loss
     for optimizer in state.optimizers:
         optimizer.zero_grad(set_to_none=True)
-    print('reset state')
     if state.scaler is not None:
         state.scaler._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
     torch.cuda.empty_cache()
@@ -291,6 +290,8 @@ def _adjust_device_train_microbatch_size(state: State):
         del state.loss
     for optimizer in state.optimizers:
         optimizer.zero_grad(set_to_none=True)
+    if state.scaler is not None:
+        state.scaler._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
     torch.cuda.empty_cache()
 
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2115,6 +2115,7 @@ class Trainer:
             total_loss_dict = {'loss/train/total': self.state.device.tensor_to_device(torch.zeros(size=(1,)))}
             found_cuda_oom = 0  # int since bool BOR not supported on all torch.distributed backends
             num_alloc_retries = torch.cuda.memory_stats()['num_alloc_retries']
+            print(f'num_alloc_retries: {num_alloc_retries}')
             try:
                 assert self.state.scaler is not None
                 if self.state.using_device_microbatch_size:
@@ -2147,6 +2148,7 @@ class Trainer:
                                     optimizer.step()
                 # Raise error if automicrobatching and num_alloc_retries increased, as thrashing
                 # often leads to throughput slowdown
+                print(torch.cuda.memory_stats()['num_alloc_retries'], num_alloc_retries)
                 if self.state.auto_microbatching and torch.cuda.memory_stats()['num_alloc_retries'] > num_alloc_retries:
                     raise RuntimeError('num_alloc_retries > 1 which causes memory thrashing and throughput decrease')
             except RuntimeError as e:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -260,7 +260,7 @@ def _adjust_grad_accum(state: State, device_batch_size: int):
         del state.loss
     for optimizer in state.optimizers:
         optimizer.zero_grad(set_to_none=True)
-    if hasattr(state, 'scaler') and state.scaler is not None:
+    if state.scaler is not None:
         state.scaler._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
     torch.cuda.empty_cache()
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -227,7 +227,7 @@ def _is_cuda_oom(e: RuntimeError):
     """Determines if error is CUDA Out of Memory and if auto_microbatching is enabled."""
     if 'CUDA out of memory' in str(e):
         return True
-    if 'num_alloc_retries > 1' in str(e):
+    if 'num_alloc_retries > 0' in str(e):
         return True
     # With batch_norm, large batch sizes sometimes result in cuDNN instead of Cuda OOMs.
     if 'cuDNN error: CUDNN_STATUS_NOT_SUPPORTED. This error may appear if you passed in a non-contiguous input.' in str(
@@ -2161,7 +2161,7 @@ class Trainer:
                 # Raise error if automicrobatching and num_alloc_retries increased, as thrashing
                 # often leads to throughput slowdown
                 if self.state.auto_microbatching and _get_num_alloc_retries() > num_alloc_retries:
-                    raise RuntimeError('num_alloc_retries > 1 which causes memory thrashing and throughput decrease')
+                    raise RuntimeError('num_alloc_retries > 0 which causes memory thrashing and throughput decrease')
             except RuntimeError as e:
                 if self.state.auto_microbatching and _is_cuda_oom(e):
                     log.debug((f"Rank {dist.get_global_rank()} OOM'd."))
@@ -2746,7 +2746,7 @@ class Trainer:
                         # often leads to throughput slowdown
                         if self.state.auto_microbatching and _get_num_alloc_retries() > num_alloc_retries:
                             raise RuntimeError(
-                                'num_alloc_retries > 1 which causes memory thrashing and throughput decrease')
+                                'num_alloc_retries > 0 which causes memory thrashing and throughput decrease')
                     except RuntimeError as e:
                         if self.state.auto_microbatching and _is_cuda_oom(e):
                             log.debug((f"Rank {dist.get_global_rank()} OOM'd."))

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -260,6 +260,7 @@ def _adjust_grad_accum(state: State, device_batch_size: int):
         del state.loss
     for optimizer in state.optimizers:
         optimizer.zero_grad(set_to_none=True)
+    print('reset state')
     if state.scaler is not None:
         state.scaler._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
     torch.cuda.empty_cache()

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2148,8 +2148,7 @@ class Trainer:
                 # Raise error if automicrobatching and num_alloc_retries increased, as thrashing
                 # often leads to throughput slowdown
                 if self.state.auto_microbatching and torch.cuda.memory_stats()['num_alloc_retries'] > num_alloc_retries:
-                    raise RuntimeError(
-                        'num_alloc_retries > 1, which leads to memory thrashing and throughput decrease.')
+                    raise RuntimeError('num_alloc_retries > 1 which causes memory thrashing and throughput decrease')
             except RuntimeError as e:
                 if self.state.auto_microbatching and _is_cuda_oom(e):
                     log.debug((f"Rank {dist.get_global_rank()} OOM'd."))
@@ -2735,7 +2734,7 @@ class Trainer:
                         if self.state.auto_microbatching and torch.cuda.memory_stats(
                         )['num_alloc_retries'] > num_alloc_retries:
                             raise RuntimeError(
-                                'num_alloc_retries > 1, which leads to memory thrashing and throughput decrease.')
+                                'num_alloc_retries > 1 which causes memory thrashing and throughput decrease')
                     except RuntimeError as e:
                         if self.state.auto_microbatching and _is_cuda_oom(e):
                             log.debug((f"Rank {dist.get_global_rank()} OOM'd."))

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2120,7 +2120,6 @@ class Trainer:
             total_loss_dict = {'loss/train/total': self.state.device.tensor_to_device(torch.zeros(size=(1,)))}
             found_cuda_oom = 0  # int since bool BOR not supported on all torch.distributed backends
             num_alloc_retries = torch.cuda.memory_stats()['num_alloc_retries']
-            print(f'num_alloc_retries: {num_alloc_retries}')
             try:
                 assert self.state.scaler is not None
                 if self.state.using_device_microbatch_size:
@@ -2153,7 +2152,6 @@ class Trainer:
                                     optimizer.step()
                 # Raise error if automicrobatching and num_alloc_retries increased, as thrashing
                 # often leads to throughput slowdown
-                print(torch.cuda.memory_stats()['num_alloc_retries'], num_alloc_retries)
                 if self.state.auto_microbatching and torch.cuda.memory_stats()['num_alloc_retries'] > num_alloc_retries:
                     raise RuntimeError('num_alloc_retries > 1 which causes memory thrashing and throughput decrease')
             except RuntimeError as e:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -15,6 +15,7 @@ import random
 import re
 import time
 import warnings
+from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Callable, ContextManager, Dict, Iterable, List, Optional, Sequence, TextIO, Tuple, Union, cast
@@ -24,7 +25,7 @@ import torch
 import torch.distributed
 import torch.nn as nn
 import torch.utils.data
-from torch.cuda.amp.grad_scaler import GradScaler
+from torch.cuda.amp.grad_scaler import GradScaler, _refresh_per_optimizer_state
 from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader, DistributedSampler
 from torchmetrics import Metric
@@ -259,6 +260,8 @@ def _adjust_grad_accum(state: State, device_batch_size: int):
         del state.loss
     for optimizer in state.optimizers:
         optimizer.zero_grad(set_to_none=True)
+    if hasattr(state, 'scaler') and state.scaler is not None:
+        state.scaler._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
     torch.cuda.empty_cache()
 
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2554,7 +2554,7 @@ class Trainer:
                 for evaluation.  If not provided, defaults to using the
                 ``eval_dataloader`` provided to the trainer init().
             subset_num_batches (int, optional): Evaluate on this many batches. Default to ``-1`` (the entire
-                dataloader. Can also be provided in the trainer init()as ``eval_subset_num_batches``.
+                dataloader. Can also be provided in the trainer.__init__() as ``eval_subset_num_batches``.
 
         """
         if eval_dataloader is not None:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2112,6 +2112,7 @@ class Trainer:
 
             total_loss_dict = {'loss/train/total': self.state.device.tensor_to_device(torch.zeros(size=(1,)))}
             found_cuda_oom = 0  # int since bool BOR not supported on all torch.distributed backends
+            print(f'Retries: {torch.cuda.memory_stats()["num_alloc_retries"]}')
             try:
                 assert self.state.scaler is not None
                 if self.state.using_device_microbatch_size:
@@ -2148,6 +2149,7 @@ class Trainer:
                     found_cuda_oom = 1
                 else:
                     raise
+            print(f'After Retries: {torch.cuda.memory_stats()["num_alloc_retries"]}')
 
             if self.state.auto_microbatching:
                 # Propagate across all ranks if any rank hit CUDA OOM

--- a/tests/trainer/test_sharded_checkpoint.py
+++ b/tests/trainer/test_sharded_checkpoint.py
@@ -90,8 +90,9 @@ def _compare_model_params_between_state_dicts(state_dict1, state_dict2):
 
 @pytest.mark.gpu
 @world_size(2)
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
+                    reason='requires PyTorch 1.13 or higher')
 def test_fsdp_full_state_dict_save(world_size, tmp_path: pathlib.Path):
-
     save_folder = tmp_path
     save_filename = 'rank{rank}.pt'
     num_features = 3
@@ -176,8 +177,9 @@ def test_fsdp_full_state_dict_save(world_size, tmp_path: pathlib.Path):
 
 @pytest.mark.gpu
 @world_size(2)
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
+                    reason='requires PyTorch 1.13 or higher')
 def test_fsdp_full_state_dict_load(world_size, tmp_path: pathlib.Path):
-
     save_folder = tmp_path
     save_filename = 'rank{rank}.pt'
     trainer1 = get_trainer(save_folder=str(save_folder), save_filename=save_filename, fsdp_state_dict_type='full')
@@ -197,10 +199,9 @@ def test_fsdp_full_state_dict_load(world_size, tmp_path: pathlib.Path):
 @pytest.mark.gpu
 @world_size(2)
 @pytest.mark.parametrize('state_dict_type', ['local', 'sharded'])
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
+                    reason='requires PyTorch 1.13 or higher')
 def test_fsdp_partitioned_state_dict_save(world_size, tmp_path: pathlib.Path, state_dict_type: str):
-
-    if version.parse(torch.__version__) < version.parse('1.13.0'):
-        pytest.skip()
     pytest.importorskip('torch.distributed.fsdp.fully_sharded_data_parallel')
     from torch.distributed.fsdp.fully_sharded_data_parallel import ShardedTensor
     save_folder = tmp_path
@@ -304,8 +305,9 @@ def test_fsdp_partitioned_state_dict_save(world_size, tmp_path: pathlib.Path, st
 @pytest.mark.gpu
 @world_size(2)
 @pytest.mark.parametrize('state_dict_type', ['local', 'sharded'])
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
+                    reason='requires PyTorch 1.13 or higher')
 def test_fsdp_partitioned_state_dict_load(world_size, tmp_path: pathlib.Path, state_dict_type: str):
-
     save_folder = tmp_path
     save_filename = 'rank{rank}.pt'
     trainer1 = get_trainer(save_folder=str(save_folder),


### PR DESCRIPTION
# What does this PR do?

If a run is repeatedly hitting cuda alloc retries, throughput will collapse due to memory thrashing. I finally found a reliable repro of this, which has let me update auto grad accum to catch this case and lower the microbatch size to fix it.

Along for the ride, correctly resets grad scaler which was missing in original implementation

Blue is before, green is after
<img width="391" alt="image" src="https://user-images.githubusercontent.com/17102158/221093944-b77e0acc-20a3-46a1-990f-64c81cddc3ad.png">


# What issue(s) does this change relate to?

[CO-1827](https://mosaicml.atlassian.net/browse/CO-1827)

[CO-1827]: https://mosaicml.atlassian.net/browse/CO-1827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ