### PR TITLE
Fix Issue of duplicate downloads to every node for Multinode FSDP when loading from a monolithic checkpoint.

### DIFF
--- a/tests/trainer/test_sharded_checkpoint.py
+++ b/tests/trainer/test_sharded_checkpoint.py
@@ -322,3 +322,19 @@ def test_fsdp_partitioned_state_dict_load(world_size, tmp_path: pathlib.Path, st
     _compare_model_params_between_state_dicts(state_dict_from_trainer1, state_dict_from_trainer2)
 
     _compare_optims_between_state_dicts(state_dict_from_trainer1, state_dict_from_trainer2)
+
+
+@pytest.mark.gpu
+@world_size(2)
+def test_fsdp_full_downloads_one_file_only(world_size, tmp_path: pathlib.Path):
+    pytest.skip()
+    # save_folder = tmp_path
+    # save_filename = 'rank{rank}.pt'
+    # trainer1 = get_trainer(save_folder=str(save_folder), save_filename=save_filename, fsdp_state_dict_type='full')
+    # trainer1.fit()
+    # state_dict_from_trainer1 = trainer1.state.state_dict()
+    # trainer1.close()
+    # load_path = str(save_folder / pathlib.Path('rank{rank}.pt'))
+    # trainer2 = get_trainer(fsdp_state_dict_type='full', load_path=load_path)
+    # state_dict_from_trainer2 = trainer2.state.state_dict()
+


### PR DESCRIPTION
# What does this PR do?

## Background
Loading in a checkpoint for a multinode workload was designed with distributed data parallel workloads in mind. This means that it was designed to do the following when loading in a single monolithic checkpoint file:

* Download a copy of the checkpoint file to every node

* Every rank loads in the checkpoint from the copy of the file that is available on their node’s local storage

This avoids a situation where one rank loads in the model and broadcasts it to all the other ranks, which incurs extra communication

## Nature of the Bug

In FSDP, global rank 0 does a scatter of all the model weights no matter what, so there is no need to communicate each rank’s model weights by having them read the same file in parallel. The same communication cost is incurred if instead just global rank 0 reads in the monolithic file. In fact, there is a large extra networking cost of downloading N copies of the same file at the same time from an external object store (and there are potentially extra egress fees depending on the object store).

## Resolution

We check if fsdp is enabled and non-sharded checkpoint loading is occurring and if so, we restrict the checkpoint file download and subsequent checkpoint load to ONLY global rank 0. This should speed up load times for large checkpoints in an fsdp multinode setting.


# Tests
WIP. Working on creating a unit test that simulates 2 nodes. Will do manual test too.


# What issue(s) does this change relate to?

fixes CO-1833
