### PR TITLE
Update SpeedMonitor short-description for docs table

### DIFF
--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -130,7 +130,7 @@ def get_gpu_flops_available(state: State):
 
 
 class SpeedMonitor(Callback):
-    """Logs the training throughput.
+    """Logs the training throughput and utilization.
 
     The training throughput is logged on the :attr:`.Event.BATCH_END` event once we have reached
     the `window_size` threshold. If a model has `flops_per_batch` attribute, then flops per second


### PR DESCRIPTION
# What does this PR do?

Updates SpeedMonitor description to mention utilization. This means the table in the docs will include it (as the table takes the first line of the docstring). Minor nit from @bandish-shah 
