### PR TITLE
Tag surgery algorithms LPLN and LPGN

### DIFF
--- a/composer/algorithms/low_precision_groupnorm/low_precision_groupnorm.py
+++ b/composer/algorithms/low_precision_groupnorm/low_precision_groupnorm.py
@@ -55,6 +55,13 @@ class LowPrecisionGroupNorm(Algorithm):
         if self.apply_at not in {Event.INIT, Event.AFTER_LOAD}:
             raise ValueError('LowPrecisionGroupNorm only supports application on Event.INIT and Event.AFTER_LOAD.')
 
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(apply_at={self.apply_at})'
+
+    @staticmethod
+    def required_on_load() -> bool:
+        return True
+
     def match(self, event: Event, state: State) -> bool:
         del state  # unused
         return event == self.apply_at

--- a/composer/algorithms/low_precision_layernorm/low_precision_layernorm.py
+++ b/composer/algorithms/low_precision_layernorm/low_precision_layernorm.py
@@ -70,6 +70,13 @@ class LowPrecisionLayerNorm(Algorithm):
         if self.apply_at not in {Event.INIT, Event.AFTER_LOAD}:
             raise ValueError('LowPrecisionLayerNorm only supports application on Event.INIT and Event.AFTER_LOAD.')
 
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(apply_at={self.apply_at})'
+
+    @staticmethod
+    def required_on_load() -> bool:
+        return True
+
     def match(self, event: Event, state: State) -> bool:
         del state  # unused
         return event == self.apply_at


### PR DESCRIPTION
# What does this PR do?

LowPrecisionLayernorm and LowPrecisionGroupnorm are surgery algorithms that should be tagged accordingly to ensure they trigger the right unit tests and are baked into the checkpoints.