### PR TITLE
Add backwards compatible checkpoint loading for EMA

### DIFF
--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -286,29 +286,44 @@ class EMA(Algorithm):
                 state_dict[attribute_name] = getattr(self, attribute_name)
         return state_dict
 
-    def load_old_state_dict_format(self, state: Dict[str, Any]):
-        self.ema_started = state['ema_started']
-        self.ema_weights_active = state['ema_weights_active']
+    def ensure_compatible_state_dict(self, state: Dict[str, Any]):
+        """Ensure state dicts created prior to Composer 0.13.0 are compatible with later versions."""
+        # Version 0.13.0 and later state dicts will not include training_model.
+        if 'training_model' not in state:
+            return state
 
-        # If EMA weights are active, load training weights into the ema_model storage
+        # Prior to version 0.13.0, the state dict contained a separate training_model and ema_model.
+        # Only one of these needs to be loaded as the ema_model.
         if state['ema_weights_active'] is True:
+            # If EMA weights are active, load training weights into the ema_model storage
             state_dict = state['training_model']
-        # If EMA weights are not active, load the ema weights into the ema_model storage
         else:
+            # If EMA weights are not active, load the ema weights into the ema_model storage
             state_dict = state['ema_model']
 
-        # Verify that the ema_model has been initialized. If not, state_dict cannot be loaded correctly.
+        named_parameters_dict = {}
+        named_buffers_dict = {}
+        # Rewrite the state dict in the newer format.
         if isinstance(self.ema_model, EMAParameters):
-            for key, value in state_dict.items():
-                if key in self.ema_model.named_parameters_dict:
-                    self.ema_model.named_parameters_dict[key] = value
-                elif key in self.ema_model.named_buffers_dict:
-                    self.ema_model.named_buffers_dict[key] = value
+            for key in self.ema_model.named_parameters_dict.keys():
+                if key in state_dict:
+                    named_parameters_dict[key] = state_dict[key]
+            for key in self.ema_model.named_buffers_dict.keys():
+                if key in state_dict:
+                    named_buffers_dict[key] = state_dict[key]
         else:
-            ValueError(f'ema_model must be initialized before loading an old state_dict format.')
+            ValueError(f'ema_model must be initialized before loading state dicts from versions earlier than 0.13.0')
 
-    def load_new_state_dict_format(self, state: Dict[str, Any]):
-        for attribute_name, serialized_value in state.items():
+        # Update the state dict with the new format
+        del state['training_model']
+        state['ema_model'] = {}
+        state['ema_model']['named_parameters_dict'] = named_parameters_dict
+        state['ema_model']['named_buffers_dict'] = named_buffers_dict
+        return state
+
+    def load_state_dict(self, state: Dict[str, Any], strict: bool = False):
+        state_dict = self.ensure_compatible_state_dict(state)
+        for attribute_name, serialized_value in state_dict.items():
             if attribute_name != 'repr':  # skip attribute added by parent class
                 if attribute_name == 'ema_model':
                     self.ema_model = EMAParameters(None)
@@ -316,13 +331,6 @@ class EMA(Algorithm):
                     self.ema_model.named_buffers_dict = serialized_value['named_buffers_dict']
                 else:
                     setattr(self, attribute_name, serialized_value)
-
-    def load_state_dict(self, state: Dict[str, Any], strict: bool = False):
-        # Old state dicts also contained the training model, so check for that and load accordingly.
-        if 'training_model' in state:
-            self.load_old_state_dict_format(state)
-        else:
-            self.load_new_state_dict_format(state)
 
     def get_ema_model(self, model: torch.nn.Module) -> torch.nn.Module:
         """Replaces the parameters of the supplied model with the ema parameters if they are not already active.


### PR DESCRIPTION
This PR adds backwards compatibility for loading checkpoints saved with the EMA algorithm from composer 0.12.1 and earlier. 

Here is a plot showing a checkpoint saved on composer 0.12.1 resuming training on this PR branch.
<img width="1080" alt="Screen Shot 2023-02-27 at 10 56 55 PM" src="https://user-images.githubusercontent.com/83666378/221778215-47770604-7512-4ae4-b481-481c85bd0076.png">
