### PR TITLE
Patch Speed Monitor MFU

### DIFF
--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -294,7 +294,6 @@ class SpeedMonitor(Callback):
             if not isinstance(model_flops_per_batch, Callable):
                 raise TypeError('flops_per_batch must a callable accepting a batch and '
                                 f'returning an int or float. Instead, got {type(model_flops_per_batch)}.')
-            print(state.batch['input_ids'].shape)
             device_flops_per_batch = model_flops_per_batch(state.batch)
 
             # Sum flops across all ranks since each rank computes the flops for its own batch
@@ -303,7 +302,6 @@ class SpeedMonitor(Callback):
             dist.all_reduce(flops_per_batch_tensor, reduce_operation='SUM')
             flops_per_batch = flops_per_batch_tensor.item()
 
-            print(f'flops_per_batch: {flops_per_batch}, device_flops_per_batch: {device_flops_per_batch}')
             self.history_flops.append(flops_per_batch)
 
         # Log the flops throughput

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -304,7 +304,7 @@ class SpeedMonitor(Callback):
             flops_per_batch = flops_per_batch_tensor.item()
 
             print(f'flops_per_batch: {flops_per_batch}, device_flops_per_batch: {device_flops_per_batch}')
-            self.history_flops.append(flops_per_batch)
+            self.history_flops.append(flops_per_batch + self.history_flops[-1])
 
         # Log the flops throughput
         if len(self.history_flops) == self.history_flops.maxlen:

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -304,7 +304,8 @@ class SpeedMonitor(Callback):
             flops_per_batch = flops_per_batch_tensor.item()
 
             print(f'flops_per_batch: {flops_per_batch}, device_flops_per_batch: {device_flops_per_batch}')
-            self.history_flops.append(flops_per_batch + self.history_flops[-1])
+            cur_flop_sum = self.history_flops[-1] if len(self.history_flops) > 0 else 0
+            self.history_flops.append(flops_per_batch + cur_flop_sum)
 
         # Log the flops throughput
         if len(self.history_flops) == self.history_flops.maxlen:

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -272,6 +272,7 @@ class SpeedMonitor(Callback):
             if not isinstance(model_flops_per_batch, Callable):
                 raise TypeError('flops_per_batch must a callable accepting a batch and '
                                 f'returning an int or float. Instead, got {type(model_flops_per_batch)}.')
+            print(state.batch['input_ids'].shape)
             device_flops_per_batch = model_flops_per_batch(state.batch)
 
             # Sum flops across all ranks since each rank computes the flops for its own batch

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -275,7 +275,7 @@ class SpeedMonitor(Callback):
 
                 # Sum flops across all ranks since each rank computes the flops for its own batch
                 flops_per_batch_tensor = state.device.tensor_to_device(
-                    torch.tensor(device_flops_per_batch, dtype=torch.int))
+                    torch.tensor(device_flops_per_batch, dtype=torch.float))
                 dist.all_reduce(flops_per_batch_tensor, reduce_operation='SUM')
                 flops_per_batch = flops_per_batch_tensor.item()
 

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -304,13 +304,12 @@ class SpeedMonitor(Callback):
             flops_per_batch = flops_per_batch_tensor.item()
 
             print(f'flops_per_batch: {flops_per_batch}, device_flops_per_batch: {device_flops_per_batch}')
-            cur_flop_sum = self.history_flops[-1] if len(self.history_flops) > 0 else 0
-            self.history_flops.append(flops_per_batch + cur_flop_sum)
+            self.history_flops.append(flops_per_batch)
 
         # Log the flops throughput
         if len(self.history_flops) == self.history_flops.maxlen:
             world_size = dist.get_world_size()
-            elapsed_flops = self.history_flops[-1] - self.history_flops[0]
+            elapsed_flops = sum(self.history_flops) - self.history_flops[0]
             elapsed_wct = self.history_wct[-1] - self.history_wct[0]
             flops_per_sec = elapsed_flops / elapsed_wct
             device_flops_per_sec = flops_per_sec / world_size


### PR DESCRIPTION
# What does this PR do?

As title. Fixes speed monitor bug which has a problem with flops/MFU. We now keep a record of flop utilization, as the values might be different depending on the level of padding in the batch. We also correctly sum the flop counts from all the devices

<img width="477" alt="image" src="https://user-images.githubusercontent.com/17102158/222006754-014b71dd-9d71-438b-a194-c1e26aa7ae5e.png">

# What issue(s) does this change relate to?

[CO-1838](https://mosaicml.atlassian.net/browse/CO-1838)

[CO-1838]: https://mosaicml.atlassian.net/browse/CO-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ