### PR TITLE
Add multi-gpu testing to test_algorithm_resumption

### DIFF
--- a/composer/algorithms/gyro_dropout/gyro_dropout.py
+++ b/composer/algorithms/gyro_dropout/gyro_dropout.py
@@ -121,6 +121,8 @@ class GyroDropout(Algorithm):
         self.sigma = sigma
         self.tau = tau
 
+        log.warning('GyroDropout is not implemented in a way that allows correct resumption from checkpoint.')
+
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}()'
 

--- a/composer/algorithms/gyro_dropout/gyro_dropout.py
+++ b/composer/algorithms/gyro_dropout/gyro_dropout.py
@@ -121,7 +121,9 @@ class GyroDropout(Algorithm):
         self.sigma = sigma
         self.tau = tau
 
-        log.warning('GyroDropout is not implemented in a way that allows correct resumption from checkpoint, which may lead to incorrect behavior.')
+        log.warning(
+            'GyroDropout is not implemented in a way that allows correct resumption from checkpoint, which may lead to incorrect behavior.'
+        )
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}()'

--- a/composer/algorithms/gyro_dropout/gyro_dropout.py
+++ b/composer/algorithms/gyro_dropout/gyro_dropout.py
@@ -121,7 +121,7 @@ class GyroDropout(Algorithm):
         self.sigma = sigma
         self.tau = tau
 
-        log.warning('GyroDropout is not implemented in a way that allows correct resumption from checkpoint.')
+        log.warning('GyroDropout is not implemented in a way that allows correct resumption from checkpoint, which may lead to incorrect behavior.')
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}()'

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -147,10 +147,12 @@ class SAM(Algorithm):
         epsilon: float = 1.0e-12,
         interval: int = 1,
     ):
+        log.warning('SAM has known issues of weight mismatch when loading from a checkpoint')
         """__init__ is constructed from the same fields as in hparams."""
         self.rho = rho
         self.epsilon = epsilon
         self.interval = interval
+
 
     def match(self, event: Event, state: State) -> bool:
         return event == Event.INIT

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -147,7 +147,9 @@ class SAM(Algorithm):
         epsilon: float = 1.0e-12,
         interval: int = 1,
     ):
-        log.warning('SAM has known issues of weight mismatch when loading from a checkpoint, which will cause an error when resuming without `load_weights_only=True`.')
+        log.warning(
+            'SAM has known issues of weight mismatch when loading from a checkpoint, which will cause an error when resuming without `load_weights_only=True`.'
+        )
         """__init__ is constructed from the same fields as in hparams."""
         self.rho = rho
         self.epsilon = epsilon

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -147,7 +147,7 @@ class SAM(Algorithm):
         epsilon: float = 1.0e-12,
         interval: int = 1,
     ):
-        log.warning('SAM has known issues of weight mismatch when loading from a checkpoint')
+        log.warning('SAM has known issues of weight mismatch when loading from a checkpoint, which will cause an error when resuming without `load_weights_only=True`.')
         """__init__ is constructed from the same fields as in hparams."""
         self.rho = rho
         self.epsilon = epsilon

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -153,7 +153,6 @@ class SAM(Algorithm):
         self.epsilon = epsilon
         self.interval = interval
 
-
     def match(self, event: Event, state: State) -> bool:
         return event == Event.INIT
 

--- a/composer/algorithms/stochastic_depth/stochastic_depth.py
+++ b/composer/algorithms/stochastic_depth/stochastic_depth.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import functools
 import logging
 from typing import Optional, Type, Union
-import warnings
+
 import torch
 from torchvision.models.resnet import Bottleneck
 
@@ -138,7 +138,7 @@ class StochasticDepth(Algorithm):
                  drop_rate: float = 0.2,
                  drop_distribution: str = 'linear',
                  drop_warmup: Union[float, Time, str] = 0.0):
-        
+
         log.warning('Stochastic depth has known issues of weight mismatch when loading from a checkpoint')
 
         if drop_rate == 0.0:
@@ -159,8 +159,6 @@ class StochasticDepth(Algorithm):
                                      drop_rate=self.drop_rate,
                                      drop_distribution=self.drop_distribution,
                                      drop_warmup=str(self.drop_warmup))
-        
-
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(target_layer_name='{self.target_layer_name}',stochastic_method='{self.stochastic_method}',drop_rate={self.drop_rate},drop_distribution='{self.drop_distribution}',drop_warmup={repr(self.drop_warmup)})"

--- a/composer/algorithms/stochastic_depth/stochastic_depth.py
+++ b/composer/algorithms/stochastic_depth/stochastic_depth.py
@@ -139,7 +139,7 @@ class StochasticDepth(Algorithm):
                  drop_distribution: str = 'linear',
                  drop_warmup: Union[float, Time, str] = 0.0):
 
-        log.warning('Stochastic depth has known issues of weight mismatch when loading from a checkpoint')
+        log.warning('Stochastic depth has known issues of weight mismatch when loading from a checkpoint, which will cause an error when resuming without `load_weights_only=True`.')
 
         if drop_rate == 0.0:
             log.warning('Stochastic Depth will have no effect when drop_rate set to 0')

--- a/composer/algorithms/stochastic_depth/stochastic_depth.py
+++ b/composer/algorithms/stochastic_depth/stochastic_depth.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import functools
 import logging
 from typing import Optional, Type, Union
-
+import warnings
 import torch
 from torchvision.models.resnet import Bottleneck
 
@@ -138,6 +138,8 @@ class StochasticDepth(Algorithm):
                  drop_rate: float = 0.2,
                  drop_distribution: str = 'linear',
                  drop_warmup: Union[float, Time, str] = 0.0):
+        
+        log.warning('Stochastic depth has known issues of weight mismatch when loading from a checkpoint')
 
         if drop_rate == 0.0:
             log.warning('Stochastic Depth will have no effect when drop_rate set to 0')
@@ -157,6 +159,8 @@ class StochasticDepth(Algorithm):
                                      drop_rate=self.drop_rate,
                                      drop_distribution=self.drop_distribution,
                                      drop_warmup=str(self.drop_warmup))
+        
+
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(target_layer_name='{self.target_layer_name}',stochastic_method='{self.stochastic_method}',drop_rate={self.drop_rate},drop_distribution='{self.drop_distribution}',drop_warmup={repr(self.drop_warmup)})"

--- a/composer/algorithms/stochastic_depth/stochastic_depth.py
+++ b/composer/algorithms/stochastic_depth/stochastic_depth.py
@@ -139,7 +139,9 @@ class StochasticDepth(Algorithm):
                  drop_distribution: str = 'linear',
                  drop_warmup: Union[float, Time, str] = 0.0):
 
-        log.warning('Stochastic depth has known issues of weight mismatch when loading from a checkpoint, which will cause an error when resuming without `load_weights_only=True`.')
+        log.warning(
+            'Stochastic depth has known issues of weight mismatch when loading from a checkpoint, which will cause an error when resuming without `load_weights_only=True`.'
+        )
 
         if drop_rate == 0.0:
             log.warning('Stochastic Depth will have no effect when drop_rate set to 0')

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -115,7 +115,9 @@ class SWA(Algorithm):
                  anneal_steps: int = 10,
                  swa_lr: Optional[float] = None):
 
-        log.warning('SWA has known issues when resuming from a checkpoint on multiple GPUs, which will cause an error when resuming without `load_weights_only=True`.')
+        log.warning(
+            'SWA has known issues when resuming from a checkpoint on multiple GPUs, which will cause an error when resuming without `load_weights_only=True`.'
+        )
         self.schedule_swa_lr = schedule_swa_lr
         self.anneal_strategy = anneal_strategy
         self.anneal_steps = anneal_steps

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Dict, List, Optional
-
+import warnings
 import torch
 from torch.optim.swa_utils import SWALR, AveragedModel
 
@@ -114,6 +114,8 @@ class SWA(Algorithm):
                  anneal_strategy: str = 'linear',
                  anneal_steps: int = 10,
                  swa_lr: Optional[float] = None):
+        
+        log.warning('Using SWA when saving then resuming from a checkpoint on multiple gpu''s has issues. To avoid this remove SWA on resumption or set load_weights_only to True')
         self.schedule_swa_lr = schedule_swa_lr
         self.anneal_strategy = anneal_strategy
         self.anneal_steps = anneal_steps

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Dict, List, Optional
-import warnings
+
 import torch
 from torch.optim.swa_utils import SWALR, AveragedModel
 
@@ -114,8 +114,9 @@ class SWA(Algorithm):
                  anneal_strategy: str = 'linear',
                  anneal_steps: int = 10,
                  swa_lr: Optional[float] = None):
-        
-        log.warning('Using SWA when saving then resuming from a checkpoint on multiple gpu''s has issues. To avoid this remove SWA on resumption or set load_weights_only to True')
+
+        log.warning('Using SWA when saving then resuming from a checkpoint on multiple gpu'
+                    's has issues. To avoid this remove SWA on resumption or set load_weights_only to True')
         self.schedule_swa_lr = schedule_swa_lr
         self.anneal_strategy = anneal_strategy
         self.anneal_steps = anneal_steps

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -115,8 +115,7 @@ class SWA(Algorithm):
                  anneal_steps: int = 10,
                  swa_lr: Optional[float] = None):
 
-        log.warning('Using SWA when saving then resuming from a checkpoint on multiple gpu'
-                    's has issues. To avoid this remove SWA on resumption or set load_weights_only to True')
+        log.warning('SWA has known issues when resuming from a checkpoint on multiple GPUs, which will cause an error when resuming without `load_weights_only=True`.')
         self.schedule_swa_lr = schedule_swa_lr
         self.anneal_strategy = anneal_strategy
         self.anneal_steps = anneal_steps

--- a/tests/algorithms/algorithm_settings.py
+++ b/tests/algorithms/algorithm_settings.py
@@ -24,6 +24,7 @@ from composer.algorithms import (EMA, SAM, SWA, Alibi, AugMix, BlurPool, Channel
                                  WeightStandardization)
 from composer.models import composer_resnet
 from composer.models.base import ComposerModel
+from composer.utils import dist
 from tests.common import get_module_subclasses
 from tests.common.datasets import RandomImageDataset, SimpleDataset, dummy_bert_lm_dataloader, dummy_gpt_lm_dataloader
 from tests.common.models import (SimpleConvModel, SimpleModelWithDropout, configure_tiny_bert_hf_model,
@@ -215,25 +216,29 @@ def get_alg_model(alg_cls: Type[Algorithm]) -> ComposerModel:
     return cls(**kwargs)
 
 
-def get_alg_dataloader(alg_cls: Type[Algorithm]) -> DataLoader:
+def get_alg_dataloader(alg_cls: Type[Algorithm], multigpu=False) -> DataLoader:
     """Return an instance of the dataset for an algorithm."""
     settings = _get_alg_settings(alg_cls)
 
     if 'dataloader' in settings:
-        settings = settings['dataloader']
+        dataloader_cls, kwargs = settings['dataloader']
+        if 'dataset' in kwargs and multigpu:
+            kwargs['sampler'] = dist.get_sampler(kwargs['dataset'])
+
+        dataloader = dataloader_cls(**kwargs)
+
     elif 'dataset' in settings:
-        settings = settings['dataset']
+        if isinstance(settings['dataset'], tuple):
+            dataset_cls, kwargs = settings['dataset']
+        else:
+            dataset_cls = settings['dataset']
+            kwargs = {}
+        dataset = dataset_cls(**kwargs)
+        sampler = dist.get_sampler(dataset) if multigpu else None
+        dataloader = DataLoader(dataset=dataset, batch_size=4, sampler=sampler)
     else:
         raise ValueError(f'Neither dataset nor dataloader have been provided for algorithm {alg_cls}')
 
-    if isinstance(settings, tuple):
-        (cls, kwargs) = settings
-    else:
-        (cls, kwargs) = (settings, {})
-
-    dataloader = cls(**kwargs)
-    if isinstance(dataloader, Dataset):
-        dataloader = DataLoader(dataset=dataloader, batch_size=2)
     return dataloader
 
 

--- a/tests/algorithms/algorithm_settings.py
+++ b/tests/algorithms/algorithm_settings.py
@@ -11,7 +11,7 @@ Each algorithm is keyed based on its name in the algorithm registry.
 from typing import Any, Dict, Optional, Type
 
 import pytest
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import DataLoader
 
 import composer
 import composer.algorithms

--- a/tests/algorithms/test_algorithm_resumption.py
+++ b/tests/algorithms/test_algorithm_resumption.py
@@ -10,22 +10,27 @@ import pytest
 import torch
 
 from composer import Algorithm, Trainer
-from composer.algorithms import SAM, GyroDropout, LayerFreezing, SeqLengthWarmup, StochasticDepth
+from composer.algorithms import SAM, SWA, GyroDropout, LayerFreezing, SeqLengthWarmup, StochasticDepth
+from composer.utils import dist
 from tests.algorithms.algorithm_settings import get_alg_dataloader, get_alg_kwargs, get_alg_model, get_algs_with_marks
 from tests.common import deep_compare
+from tests.common.markers import world_size
 
 
 @pytest.mark.gpu
 @pytest.mark.parametrize('alg_cls', get_algs_with_marks())
 @pytest.mark.filterwarnings('ignore:Detected call of `lr_scheduler.step()'
                            )  # optimizer.step() sometimes skipped when NaN/inf on low batch size
-@world_size(1,2)
+@world_size(1, 2)
 def test_algorithm_resumption(
     tmp_path: pathlib.Path,
     alg_cls: Type[Algorithm],
+    world_size,
 ):
     folder1 = os.path.join(tmp_path, 'folder1')
     folder2 = os.path.join(tmp_path, 'folder2')
+    os.makedirs(folder1, exist_ok=True)
+    os.makedirs(folder2, exist_ok=True)
 
     model = get_alg_model(alg_cls)
     alg_kwargs = get_alg_kwargs(alg_cls)
@@ -41,20 +46,24 @@ def test_algorithm_resumption(
     if alg_cls is GyroDropout:
         pytest.xfail('GyroDropoutLayer is not implemented in a way that allows correct resumption.')
 
+    if alg_cls is SWA and world_size > 1:
+        pytest.xfail('SWA is not implemented in a way that is compatible correct resumption on multiple devices.')
+
     optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=5)
 
     shared_config = {
         'max_duration': '2ep',
         'save_filename': 'ep{epoch}-rank{rank}',
-        'train_subset_num_batches': 4,
+        'save_interval': '1ep',
+        'train_subset_num_batches': 2,
         'precision': 'amp_fp16',
     }
-
+    train_dataloader = get_alg_dataloader(alg_cls) if world_size == 1 else get_alg_dataloader(alg_cls, multigpu=True)
     # train model once, saving checkpoints every epoch
     trainer1 = Trainer(
         model=model,
-        train_dataloader=get_alg_dataloader(alg_cls),
+        train_dataloader=train_dataloader,
         optimizers=optimizer,
         schedulers=scheduler,
         save_folder=folder1,
@@ -75,9 +84,11 @@ def test_algorithm_resumption(
     # when reloading.
     if alg_cls is SeqLengthWarmup:
         alg._activated = True  # type: ignore
+
+    train_dataloader = get_alg_dataloader(alg_cls) if world_size == 1 else get_alg_dataloader(alg_cls, multigpu=True)
     trainer2 = Trainer(
         model=copied_model,
-        train_dataloader=get_alg_dataloader(alg_cls),
+        train_dataloader=train_dataloader,
         load_path=os.path.join(folder1, 'ep1-rank{rank}'),
         load_weights_only=False,
         load_strict_model_weights=False,
@@ -88,20 +99,21 @@ def test_algorithm_resumption(
         **shared_config,
     )
     trainer2.fit()
-
     # check that the checkpoints are equal
-    _assert_checkpoints_equal(
-        file1=os.path.join(folder1, 'ep2-rank0'),
-        file2=os.path.join(folder2, 'ep2-rank0'),
-    )
+    if world_size == 1 or dist.get_global_rank() == 0:
+        _assert_checkpoints_equal(
+            file1=os.path.join(folder1, 'ep2-rank0'),
+            file2=os.path.join(folder2, 'ep2-rank0'),
+        )
 
     # check that different epoch checkpoints are _not_ equal
     # this ensures that the model weights are being updated.
-    with pytest.raises(AssertionError):
-        _assert_model_weights_equal(
-            file1=os.path.join(folder1, 'ep1-rank0'),
-            file2=os.path.join(folder1, 'ep2-rank0'),
-        )
+    if world_size == 1 or dist.get_global_rank() == 0:
+        with pytest.raises(AssertionError):
+            _assert_model_weights_equal(
+                file1=os.path.join(folder1, 'ep1-rank0'),
+                file2=os.path.join(folder1, 'ep2-rank0'),
+            )
 
 
 def _assert_checkpoints_equal(file1, file2):

--- a/tests/algorithms/test_algorithm_resumption.py
+++ b/tests/algorithms/test_algorithm_resumption.py
@@ -19,6 +19,7 @@ from tests.common import deep_compare
 @pytest.mark.parametrize('alg_cls', get_algs_with_marks())
 @pytest.mark.filterwarnings('ignore:Detected call of `lr_scheduler.step()'
                            )  # optimizer.step() sometimes skipped when NaN/inf on low batch size
+@world_size(1,2)
 def test_algorithm_resumption(
     tmp_path: pathlib.Path,
     alg_cls: Type[Algorithm],


### PR DESCRIPTION
# What does this PR do?

Resuming some model-surgery algorithms using DDP in multi-gpu settings can cause issues due to module renaming.
There is a unit test (`test_algorithm_resumption.py::test_algorithm_resumption`) that checks for every algorithm whether you can train a model with that algorithm, save a checkpoint, then resume the training from that checkpoint with the algorithm. However, that unit test only checks when using one gpu. 

In this PR, we:
*  extend `test_algorithm_resumption.py::test_algorithm_resumption` to include a 2 gpu setting. 
* To enable that setting, we also modify `algorithm_settings.get_alg_dataloader` to include support for distributed samplers
* Add an xfail for the algorithm SWA for the 2-gpu setting since it has a known issue that we won't fix at the moment


# What issue(s) does this change relate to?
fix CO-1848