### PR TITLE
Upgrade ipython installed in Docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,9 @@ ARG AWS_OFI_NCCL_VERSION=v1.5.0-aws
 # Upgrade certifi to resolve CVE-2022-23491
 ARG CERTIFI_VERSION='>=2022.12.7'
 
+# Upgrade ipython to resolve CVE-2023-24816
+ARG IPYTHON_VERSION='>=8.10.0'
+
 # Upgrade urllib to resolve CVE-2021-33503
 ARG URLLIB3_VERSION='>=1.26.5,<2'
 
@@ -340,8 +343,10 @@ RUN apt-get update && \
 #########################
 # Upgrade pip packages
 #########################
-RUN pip install --no-cache-dir --upgrade urllib3${URLLIB3_VERSION} \
-        certifi${CERTIFI_VERSION}
+RUN pip install --no-cache-dir --upgrade \
+        certifi${CERTIFI_VERSION} \
+        ipython${IPYTHON_VERSION} \
+        urllib3${URLLIB3_VERSION}
 
 
 ######################


### PR DESCRIPTION
# What does this PR do?

Follow on to PR #2007, previous PR upgraded the `ipython` package in Composer's `setup.py`.  However the `mosaicml/pytorch*` images are failing because the version already installed in the image needs to be upgraded as well.

This should resolve CVE-2023-24816.

# What issue(s) does this change relate to?

[CO-1844](https://mosaicml.atlassian.net/browse/CO-1844)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1844]: https://mosaicml.atlassian.net/browse/CO-1844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ