### PR TITLE
Adjust HuggingFaceModel token embedding resizing to only occur when necessary

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -104,7 +104,7 @@ class HuggingFaceModel(ComposerModel):
                 f'The number of tokens in the tokenizer is less than the number of tokens in the model.'
                 f' You may want to resize the model embeddings to {len(tokenizer)} from {self.config.vocab_size}'
                 f' by calling `model.resize_token_embeddings(len(tokenizer))` before calling the `HuggingFaceModel`'
-                f' gconstructor.')
+                f' constructor.')
 
         self.use_logits = use_logits
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -93,7 +93,7 @@ class HuggingFaceModel(ComposerModel):
             # when the embedding size is smaller than the tokenizer vocab size,
             # the embeddings should get resized to match the tokenizer vocab size
             log.warning(f'The number of tokens in the tokenizer is greater than the number of tokens in the model'
-                        f'This would cause an error during training.'
+                        f' This would cause an error during training.'
                         f' Resizing the model embeddings to {len(tokenizer)} from {self.config.vocab_size}.')
             self.model.resize_token_embeddings(len(tokenizer))
         elif tokenizer is not None and self.config.vocab_size > len(tokenizer):
@@ -102,9 +102,9 @@ class HuggingFaceModel(ComposerModel):
             # and should be done by the user if desired
             log.warning(
                 f'The number of tokens in the tokenizer is less than the number of tokens in the model.'
-                f'You may want to resize the model embeddings to {len(tokenizer)} from {self.config.vocab_size}'
-                f'by calling `model.resize_token_embeddings(len(tokenizer))` before calling the `HuggingFaceModel`'
-                f'constructor.')
+                f' You may want to resize the model embeddings to {len(tokenizer)} from {self.config.vocab_size}'
+                f' by calling `model.resize_token_embeddings(len(tokenizer))` before calling the `HuggingFaceModel`'
+                f' constructor.')
 
         self.use_logits = use_logits
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -92,7 +92,7 @@ class HuggingFaceModel(ComposerModel):
         if tokenizer is not None and self.config.vocab_size < len(tokenizer):
             # when the embedding size is smaller than the tokenizer vocab size,
             # the embeddings should get resized to match the tokenizer vocab size
-            log.warning(f'The number of tokens in the tokenizer is greater than the number of tokens in the model'
+            log.warning(f'The number of tokens in the tokenizer is greater than the number of tokens in the model.'
                         f' This would cause an error during training.'
                         f' Resizing the model embeddings to {len(tokenizer)} from {self.config.vocab_size}.')
             self.model.resize_token_embeddings(len(tokenizer))
@@ -104,7 +104,7 @@ class HuggingFaceModel(ComposerModel):
                 f'The number of tokens in the tokenizer is less than the number of tokens in the model.'
                 f' You may want to resize the model embeddings to {len(tokenizer)} from {self.config.vocab_size}'
                 f' by calling `model.resize_token_embeddings(len(tokenizer))` before calling the `HuggingFaceModel`'
-                f' constructor.')
+                f' gconstructor.')
 
         self.use_logits = use_logits
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -102,7 +102,9 @@ class HuggingFaceModel(ComposerModel):
             # and should be done by the user if desired
             log.warning(
                 f'The number of tokens in the tokenizer is less than the number of tokens in the model.'
-                f'You may want to resize the model embeddings to {len(tokenizer)} from {self.config.vocab_size}.')
+                f'You may want to resize the model embeddings to {len(tokenizer)} from {self.config.vocab_size}'
+                f'by calling `model.resize_token_embeddings(len(tokenizer))` before calling the `HuggingFaceModel`'
+                f'constructor.')
 
         self.use_logits = use_logits
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -95,6 +95,10 @@ class HuggingFaceModel(ComposerModel):
                         f'This would cause an error during training.'
                         f' Resizing the model embeddings to {len(tokenizer)} from {self.config.vocab_size}.')
             self.model.resize_token_embeddings(len(tokenizer))
+        elif tokenizer is not None and self.config.vocab_size > len(tokenizer):
+            log.warning(
+                f'The number of tokens in the tokenizer is less than the number of tokens in the model.'
+                f'You may want to resize the model embeddings to {len(tokenizer)} from {self.config.vocab_size}.')
 
         self.use_logits = use_logits
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -89,10 +89,11 @@ class HuggingFaceModel(ComposerModel):
             log.warning(
                 'The tokenizer was not provided. This means the tokenizer config will not be saved in the checkpoint.')
 
-        if tokenizer is not None and self.config.vocab_size != len(tokenizer):
+        if tokenizer is not None and self.config.vocab_size < len(tokenizer):
             # set model's word embedding matrix and final lm_head to vocab size according to tokenizer
-            log.warning(f'The number of tokens in the tokenizer and the number of tokens in the model are different.'
-                        f' Resizing the model tokenizer to {len(tokenizer)} from {self.config.vocab_size}.')
+            log.warning(f'The number of tokens in the tokenizer is greater than the number of tokens in the model'
+                        f'This would cause an error during training.'
+                        f' Resizing the model embeddings to {len(tokenizer)} from {self.config.vocab_size}.')
             self.model.resize_token_embeddings(len(tokenizer))
 
         self.use_logits = use_logits

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -90,12 +90,16 @@ class HuggingFaceModel(ComposerModel):
                 'The tokenizer was not provided. This means the tokenizer config will not be saved in the checkpoint.')
 
         if tokenizer is not None and self.config.vocab_size < len(tokenizer):
-            # set model's word embedding matrix and final lm_head to vocab size according to tokenizer
+            # when the embedding size is smaller than the tokenizer vocab size,
+            # the embeddings should get resized to match the tokenizer vocab size
             log.warning(f'The number of tokens in the tokenizer is greater than the number of tokens in the model'
                         f'This would cause an error during training.'
                         f' Resizing the model embeddings to {len(tokenizer)} from {self.config.vocab_size}.')
             self.model.resize_token_embeddings(len(tokenizer))
         elif tokenizer is not None and self.config.vocab_size > len(tokenizer):
+            # when the embedding size is greater than the tokenizer vocab size,
+            # the embeddings do not _need_ to be resized to match the tokenizer vocab size,
+            # and should be done by the user if desired
             log.warning(
                 f'The number of tokens in the tokenizer is less than the number of tokens in the model.'
                 f'You may want to resize the model embeddings to {len(tokenizer)} from {self.config.vocab_size}.')

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -175,6 +175,7 @@ def tiny_gpt2_config_helper():
         'n_embd': 2,
         'n_head': 2,
         'n_layer': 2,
+        'vocab_size': 50258  # 50257 + 1 for pad token
     }
     return transformers.AutoConfig.from_pretrained('gpt2', **tiny_overrides)
 

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -526,6 +526,7 @@ def test_hf_causal_shift_labels(tiny_gpt2_model, tiny_gpt2_tokenizer):
     pytest.importorskip('transformers')
 
     from composer.models import HuggingFaceModel
+    tiny_gpt2_model.resize_token_embeddings(len(tiny_gpt2_tokenizer))
     model = HuggingFaceModel(tiny_gpt2_model, tokenizer=tiny_gpt2_tokenizer, use_logits=True)
 
     batch = tiny_gpt2_tokenizer('a b c d e f g h i j k', return_tensors='pt')

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -4,6 +4,7 @@ import copy
 import json
 import os
 import tempfile
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import patch
@@ -649,7 +650,8 @@ def test_write_hf_from_composer(checkpoint_upload_folder, local_save_filename, t
 
 
 @pytest.mark.parametrize('embedding_resize', ['higher', 'lower', 'no_resize'])
-def test_embedding_resizing(tiny_bert_model, tiny_bert_tokenizer, embedding_resize, caplog):
+@pytest.mark.parametrize('allow_embedding_resizing', [True, False])
+def test_embedding_resizing(tiny_bert_model, tiny_bert_tokenizer, embedding_resize, allow_embedding_resizing, caplog):
     pytest.importorskip('transformers')
 
     import logging
@@ -662,14 +664,20 @@ def test_embedding_resizing(tiny_bert_model, tiny_bert_tokenizer, embedding_resi
     elif embedding_resize == 'lower':
         tiny_bert_model.resize_token_embeddings(original_size - 100)
 
+    error_context = pytest.raises(ValueError) if (not allow_embedding_resizing and
+                                                  embedding_resize == 'lower') else nullcontext()
     with caplog.at_level(logging.WARNING, logger='composer'):
-        _ = HuggingFaceModel(tiny_bert_model, tokenizer=tiny_bert_tokenizer)
+        with error_context:
+            _ = HuggingFaceModel(tiny_bert_model,
+                                 tokenizer=tiny_bert_tokenizer,
+                                 allow_embedding_resizing=allow_embedding_resizing)
         if embedding_resize == 'lower':
-            # when the embedding size is smaller than the tokenizer vocab size,
-            # the embeddings should get resized to match the tokenizer vocab size
-            assert tiny_bert_model.config.vocab_size == len(tiny_bert_tokenizer)
-            assert caplog.messages[0].startswith(
-                'The number of tokens in the tokenizer is greater than the number of tokens in the model')
+            if allow_embedding_resizing:
+                # when the embedding size is smaller than the tokenizer vocab size,
+                # the embeddings should get resized to match the tokenizer vocab size
+                assert tiny_bert_model.config.vocab_size == len(tiny_bert_tokenizer)
+                assert caplog.messages[0].startswith(
+                    'The number of tokens in the tokenizer is greater than the number of tokens in the model')
         elif embedding_resize == 'higher':
             # when the embedding size is greater than the tokenizer vocab size,
             # no adjustment is needed. Some embeddings will simply not be used

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -674,7 +674,8 @@ def test_embedding_resizing(tiny_bert_model, tiny_bert_tokenizer, embedding_resi
             # when the embedding size is greater than the tokenizer vocab size,
             # no adjustment is needed. Some embeddings will simply not be used
             assert tiny_bert_model.config.vocab_size == original_size + 100
-            assert len(caplog.messages) == 0
+            assert caplog.messages[0].startswith(
+                'The number of tokens in the tokenizer is less than the number of tokens in the model.')
         elif embedding_resize == 'no_resize':
             assert tiny_bert_model.config.vocab_size == original_size
             assert len(caplog.messages) == 0

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -646,3 +646,37 @@ def test_write_hf_from_composer(checkpoint_upload_folder, local_save_filename, t
     loaded_hf_model.config._name_or_path = tiny_bert_model.config._name_or_path
 
     check_hf_model_equivalence(tiny_bert_model, loaded_hf_model)
+
+
+@pytest.mark.parametrize('embedding_resize', ['higher', 'lower', 'no_resize'])
+def test_embedding_resizing(tiny_bert_model, tiny_bert_tokenizer, embedding_resize, caplog):
+    pytest.importorskip('transformers')
+
+    import logging
+
+    from composer.models import HuggingFaceModel
+
+    original_size = tiny_bert_model.config.vocab_size
+    if embedding_resize == 'higher':
+        tiny_bert_model.resize_token_embeddings(original_size + 100)
+    elif embedding_resize == 'lower':
+        tiny_bert_model.resize_token_embeddings(original_size - 100)
+
+    with caplog.at_level(logging.WARNING, logger='composer'):
+        _ = HuggingFaceModel(tiny_bert_model, tokenizer=tiny_bert_tokenizer)
+        if embedding_resize == 'lower':
+            # when the embedding size is smaller than the tokenizer vocab size,
+            # the embeddings should get resized to match the tokenizer vocab size
+            assert tiny_bert_model.config.vocab_size == len(tiny_bert_tokenizer)
+            assert caplog.messages[0].startswith(
+                'The number of tokens in the tokenizer is greater than the number of tokens in the model')
+        elif embedding_resize == 'higher':
+            # when the embedding size is greater than the tokenizer vocab size,
+            # no adjustment is needed. Some embeddings will simply not be used
+            assert tiny_bert_model.config.vocab_size == original_size + 100
+            assert len(caplog.messages) == 0
+        elif embedding_resize == 'no_resize':
+            assert tiny_bert_model.config.vocab_size == original_size
+            assert len(caplog.messages) == 0
+        else:
+            raise ValueError(f'Unknown embedding_resize: {embedding_resize}')


### PR DESCRIPTION
# What does this PR do?
Previously, `HuggingFaceModel` automatically resizes the model vocab size to match whatever the tokenizer vocab size is. This can cause an issue when the model vocab size is rounded to a multiple of 8 or 64 and _intentionally_ does not match the tokenizer vocab size. This PR changes our behavior to only resize the model vocab size when it is _necessary_, meaning when the model vocab size is less than the tokenizer vocab size. When the tokenizer vocab size is less than the model vocab size, we just raise a warning now.

# What issue(s) does this change relate to?
Closes [CO-1861](https://mosaicml.atlassian.net/browse/CO-1861)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1861]: https://mosaicml.atlassian.net/browse/CO-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ