### PR TITLE
Eval subset num batches bug fix

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2604,10 +2604,11 @@ class Trainer:
             evaluators = self.state.evaluators
 
         for evaluator in evaluators:
+            eval_subset_num_batches = evaluator.subset_num_batches if subset_num_batches == -1 else subset_num_batches
             self._eval_loop(
                 dataloader=evaluator.dataloader,
                 dataloader_label=evaluator.label,
-                subset_num_batches=subset_num_batches,
+                subset_num_batches=eval_subset_num_batches,
                 metrics=self.state.eval_metrics[evaluator.label],
             )
             if eval_passed_in:


### PR DESCRIPTION
# What does this PR do?

Currently, trainer ignores `eval_subset_num_batches` when passed into init when calling `trainer.eval()` and always uses `subset_num_batches`. Instead, we should use `subset_num_batches` if specified, or otherwise fall back on what is already specified in the evaluator (either through trainer or in evaluator constructor). This PR fixes this and adds a unit test for it.

# What issue(s) does this change relate to?

[CO-1753](https://mosaicml.atlassian.net/browse/CO-1753)

[CO-1753]: https://mosaicml.atlassian.net/browse/CO-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ