### PR TITLE
Protect for missing `slack_sdk` import

### DIFF
--- a/composer/callbacks/health_checker.py
+++ b/composer/callbacks/health_checker.py
@@ -65,7 +65,8 @@ class HealthChecker(Callback):
         if self.slack_webhook_url:
             # fail fast if missing import
             try:
-                import slack_sdk as slack_sdk
+                import slack_sdk
+                del slack_sdk
             except ImportError as e:
                 raise MissingConditionalImportError('health_checker', 'slack_sdk', None) from e
 

--- a/composer/callbacks/health_checker.py
+++ b/composer/callbacks/health_checker.py
@@ -14,7 +14,7 @@ import torch
 from composer.core import Callback, State
 from composer.core.time import Timestamp
 from composer.loggers import Logger
-from composer.utils import dist, MissingConditionalImportError
+from composer.utils import MissingConditionalImportError, dist
 
 log = logging.getLogger(__name__)
 

--- a/composer/callbacks/health_checker.py
+++ b/composer/callbacks/health_checker.py
@@ -14,8 +14,7 @@ import torch
 from composer.core import Callback, State
 from composer.core.time import Timestamp
 from composer.loggers import Logger
-from composer.utils import dist
-from composer.utils.import_helpers import MissingConditionalImportError
+from composer.utils import dist, MissingConditionalImportError
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #2030 . `slack_sdk` is not in the base install, so the `HealthChecker` needs to check the import.

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
