### PR TITLE
switch code quality workflow to dev target and smoketest

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -30,7 +30,7 @@ jobs:
           - "3.9"
           - "3.10"
         pip_deps:
-          - "[all]"
+          - "[dev]"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -1,4 +1,4 @@
-name: Code Quality Checks
+name: Smoketest
 on:
   push:
     branches:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -1,0 +1,45 @@
+name: Code Quality Checks
+on:
+  push:
+    branches:
+      - dev
+      - main
+      - release/**
+  pull_request:
+    branches:
+      - dev
+      - main
+      - release/**
+  workflow_call:
+  workflow_dispatch:
+# Cancel old runs when a new commit is pushed to the same branch if not on main or dev
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+defaults:
+  run:
+    working-directory: .
+jobs:
+  smoketest:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        python_version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Setup
+        run: |
+          set -ex
+          python -m pip install --upgrade 'pip<23' wheel
+          python -m pip install --upgrade .
+      - name: Run checks
+        run: |
+          pre-commit run --all-files
+          pytest tests/test_smoketest.py

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -39,7 +39,7 @@ jobs:
           set -ex
           python -m pip install --upgrade 'pip<23' wheel
           python -m pip install --upgrade .
-          python -m pip install pytest
+          python -m pip install pytest==7.2.1 pytest_codeblocks==0.16.1
       - name: Run checks
         run: |
           pytest tests/test_smoketest.py

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -39,6 +39,7 @@ jobs:
           set -ex
           python -m pip install --upgrade 'pip<23' wheel
           python -m pip install --upgrade .
+          python -m pip install pytest
       - name: Run checks
         run: |
           pytest tests/test_smoketest.py

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -41,5 +41,4 @@ jobs:
           python -m pip install --upgrade .
       - name: Run checks
         run: |
-          pre-commit run --all-files
           pytest tests/test_smoketest.py

--- a/composer/models/timm/model.py
+++ b/composer/models/timm/model.py
@@ -52,15 +52,16 @@ def composer_timm(model_name: str,
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='timm', conda_package='timm>=0.5.4',
                                             conda_channel=None) from e
-    model = timm.create_model(model_name=model_name,
-                              pretrained=pretrained,
-                              num_classes=num_classes,
-                              drop_rate=drop_rate,
-                              drop_path_rate=drop_path_rate,
-                              drop_block_rate=drop_block_rate,
-                              global_pool=global_pool,
-                              bn_momentum=bn_momentum,
-                              bn_eps=bn_eps)
+    model = timm.create_model(
+        model_name=model_name,  # type: ignore (third-party)
+        pretrained=pretrained,
+        num_classes=num_classes,
+        drop_rate=drop_rate,
+        drop_path_rate=drop_path_rate,
+        drop_block_rate=drop_block_rate,
+        global_pool=global_pool,
+        bn_momentum=bn_momentum,
+        bn_eps=bn_eps)
 
     composer_model = ComposerClassifier(module=model)
     return composer_model

--- a/composer/models/timm/model.py
+++ b/composer/models/timm/model.py
@@ -52,8 +52,8 @@ def composer_timm(model_name: str,
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='timm', conda_package='timm>=0.5.4',
                                             conda_channel=None) from e
-    model = timm.create_model(
-        model_name=model_name,  # type: ignore (third-party)
+    model = timm.create_model(  # type: ignore (third-party)
+        model_name=model_name,
         pretrained=pretrained,
         num_classes=num_classes,
         drop_rate=drop_rate,

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -1,0 +1,25 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+from composer import (algorithms, callbacks, core, datasets, devices, functional, loggers, loss, metrics, models, optim,
+                      profiler, trainer, utils)
+
+
+# this very simple test is just to use the above imports, which check and make sure we can import all the top-level
+# modules from composer. This is mainly useful for checking that we have correctly conditionally imported all optional
+# dependencies.
+def test_smoketest():
+    assert callbacks
+    assert algorithms
+    assert core
+    assert datasets
+    assert devices
+    assert functional
+    assert loggers
+    assert loss
+    assert metrics
+    assert models
+    assert optim
+    assert profiler
+    assert trainer
+    assert utils

--- a/tests/test_smoketest.py
+++ b/tests/test_smoketest.py
@@ -5,7 +5,7 @@ from composer import (algorithms, callbacks, core, datasets, devices, functional
                       profiler, trainer, utils)
 
 
-# this very simple test is just to use the above imports, which check and make sure we can import all the top-level
+# This very simple test is just to use the above imports, which check and make sure we can import all the top-level
 # modules from composer. This is mainly useful for checking that we have correctly conditionally imported all optional
 # dependencies.
 def test_smoketest():


### PR DESCRIPTION
# What does this PR do?
This PR does two things:
- switches our code quality workflow back to dev target to avoid forcing install all for linting to pass
- adds a smoketest workflow that just imports the top level composer modules to avoid accidentally missing conditional imports

# What issue(s) does this change relate to?
Closes [CO-1866](https://mosaicml.atlassian.net/browse/CO-1866)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1866]: https://mosaicml.atlassian.net/browse/CO-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ