### PR TITLE
HealthChecker should only send test message on global rank zero

### DIFF
--- a/composer/callbacks/health_checker.py
+++ b/composer/callbacks/health_checker.py
@@ -90,7 +90,7 @@ class HealthChecker(Callback):
         if self._check(state.timestamp):
             for metric in self.metrics:
                 message, alert = metric.check()
-                if self.test_mode and message:
+                if self.test_mode and message and dist.get_global_rank() == 0:
                     alert = True
                     message = '[**THIS IS A TEST**]' + message
                 if alert and not metric.alerted:


### PR DESCRIPTION
To reduce the verbosity of pings, the `HealthChecker` should only send the test message for global rank zero, not local rank zero.