### PR TITLE
Log nodename information in composer

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1103,7 +1103,6 @@ class Trainer:
 
         # Logger
         self.logger = Logger(state=self.state, destinations=loggers)
-        self.logger.log_hyperparameters({'NODENAME': os.environ.get('NODENAME', '')})
 
         if save_latest_filename is not None:
             remote_ud_has_format_string = [
@@ -1175,7 +1174,8 @@ class Trainer:
         self.logger.log_hyperparameters({
             'num_nodes': int(dist.get_world_size() / dist.get_local_world_size()),
             f'num_{device_name}s_per_node': dist.get_local_world_size(),
-        })
+            'node_name': os.environ.get('NODENAME', 'unknown because NODENAME env variable not set')
+            })
 
         if not isinstance(self.state.model, ComposerModel):
             raise ValueError('Provided model should be a subclass of ComposerModel.')

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1103,6 +1103,7 @@ class Trainer:
 
         # Logger
         self.logger = Logger(state=self.state, destinations=loggers)
+        self.logger.log_hyperparameters({'NODENAME': os.environ.get('NODENAME', '')})
 
         if save_latest_filename is not None:
             remote_ud_has_format_string = [

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1175,7 +1175,7 @@ class Trainer:
             'num_nodes': int(dist.get_world_size() / dist.get_local_world_size()),
             f'num_{device_name}s_per_node': dist.get_local_world_size(),
             'node_name': os.environ.get('NODENAME', 'unknown because NODENAME env variable not set')
-            })
+        })
 
         if not isinstance(self.state.model, ComposerModel):
             raise ValueError('Provided model should be a subclass of ComposerModel.')

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1174,7 +1174,7 @@ class Trainer:
         self.logger.log_hyperparameters({
             'num_nodes': int(dist.get_world_size() / dist.get_local_world_size()),
             f'num_{device_name}s_per_node': dist.get_local_world_size(),
-            'node_name': os.environ.get('NODENAME', 'unknown because NODENAME env variable not set')
+            'node_name': os.environ.get('NODENAME', 'unknown because NODENAME environment variable not set')
         })
 
         if not isinstance(self.state.model, ComposerModel):

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -104,5 +104,6 @@ def test_mlflow_logging_works(tmp_path):
     param_path = run_file_path / Path('params')
     actual_params_list = [param_filepath.stem for param_filepath in param_path.iterdir()]
 
-    expected_params_list = ['num_cpus_per_node', 'node_name' 'num_nodes', 'rank_zero_seed']
+    expected_params_list = ['num_cpus_per_node', 'node_name'
+                            'num_nodes', 'rank_zero_seed']
     assert set(expected_params_list) == set(actual_params_list)

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -104,6 +104,5 @@ def test_mlflow_logging_works(tmp_path):
     param_path = run_file_path / Path('params')
     actual_params_list = [param_filepath.stem for param_filepath in param_path.iterdir()]
 
-    expected_params_list = ['num_cpus_per_node', 'node_name',
-                            'num_nodes', 'rank_zero_seed']
+    expected_params_list = ['num_cpus_per_node', 'node_name', 'num_nodes', 'rank_zero_seed']
     assert set(expected_params_list) == set(actual_params_list)

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -104,6 +104,6 @@ def test_mlflow_logging_works(tmp_path):
     param_path = run_file_path / Path('params')
     actual_params_list = [param_filepath.stem for param_filepath in param_path.iterdir()]
 
-    expected_params_list = ['num_cpus_per_node', 'node_name'
+    expected_params_list = ['num_cpus_per_node', 'node_name',
                             'num_nodes', 'rank_zero_seed']
     assert set(expected_params_list) == set(actual_params_list)

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -104,5 +104,5 @@ def test_mlflow_logging_works(tmp_path):
     param_path = run_file_path / Path('params')
     actual_params_list = [param_filepath.stem for param_filepath in param_path.iterdir()]
 
-    expected_params_list = ['num_cpus_per_node', 'num_nodes', 'rank_zero_seed']
-    assert set(expected_params_list).issubset(set(actual_params_list))
+    expected_params_list = ['num_cpus_per_node', 'node_name' 'num_nodes', 'rank_zero_seed']
+    assert set(expected_params_list) == set(actual_params_list)

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -105,4 +105,4 @@ def test_mlflow_logging_works(tmp_path):
     actual_params_list = [param_filepath.stem for param_filepath in param_path.iterdir()]
 
     expected_params_list = ['num_cpus_per_node', 'num_nodes', 'rank_zero_seed']
-    assert set(actual_params_list) == set(expected_params_list)
+    assert set(expected_params_list).issubset(set(actual_params_list))


### PR DESCRIPTION
# What does this PR do?
It would be good if we had Composer logging print relevant node information as part of the logs for all ranks so that this is possible, and consistent, for all users.


## Manual test output:

```bash
Starting training...
******************************
Config:
enabled_algorithms/GradientClipping: true
node_name: inst-iqyol-r7z2-workers
num_gpus_per_node: 8
num_nodes: 2
rank_zero_seed: 17

******************************
/usr/lib/python3/dist-packages/torch/distributed/distributed_c10d.py:2387: UserWarning: torch.distributed._all_gather_base is a private function and will be deprecated. Please use torch.distributed.all_gather_into_tensor instead.
  warnings.warn(
/usr/lib/python3/dist-packages/torch/distributed/distributed_c10d.py:2849: UserWarning: torch.distributed._reduce_scatter_base is a private function and will be deprecated. Please use torch.distributed.reduce_scatter_tensor instead.
  warnings.warn(
[batch=1/10]:
	 Train trainer/epoch: 0
	 Train trainer/global_step: 0
	 Train trainer/batch_idx: 0
....
```

# What issue(s) does this change relate to?

fix CO-1890


