### PR TITLE
update fsdp mixed precision

### DIFF
--- a/composer/trainer/mosaic_fsdp.py
+++ b/composer/trainer/mosaic_fsdp.py
@@ -84,8 +84,8 @@ def get_mixed_precision(precision, mixed_precision='DEFAULT', keep_low_precision
         if mixed_precision == 'FULL':
             pass
         elif mixed_precision == 'DEFAULT':
-            reduce_dtype = get_torch_dtype(precision)
-            buffer_dtype = torch.float32
+            param_dtype = get_torch_dtype(precision)
+            buffer_dtype = get_torch_dtype(precision)
         elif mixed_precision == 'PURE':
             param_dtype = get_torch_dtype(precision)
             reduce_dtype = get_torch_dtype(precision)

--- a/docs/source/notes/distributed_training.rst
+++ b/docs/source/notes/distributed_training.rst
@@ -202,7 +202,7 @@ One Composer-specific pattern is that if :code:`mixed_precision` is provided as 
     )
     # If mixed_precision = 'default'; emulates automatic mixed precision training.
     mixed_precision = MixedPrecision(
-      param_dtype=autocast_precision,  # Master weigths stored in fp32 but are downcast to autocast_precision before the dist all_gather
+      param_dtype=autocast_precision,  # Master weights stored in fp32 but are downcast to autocast_precision before the dist all_gather
       reduce_dtype=torch.float32,  # gradient dist all_reduce in fp32
       buffer_dtype=autocast_precision,  # Buffers stored in fp32 but are downcast to autocast_precision before the dist all_gather
     )

--- a/docs/source/notes/distributed_training.rst
+++ b/docs/source/notes/distributed_training.rst
@@ -200,18 +200,17 @@ One Composer-specific pattern is that if :code:`mixed_precision` is provided as 
       reduce_dtype=torch.float32,
       buffer_dtype=torch.float32,
     )
-    # If mixed_precision = 'default'
+    # If mixed_precision = 'default'; emulates automatic mixed precision training.
     mixed_precision = MixedPrecision(
-      param_dtype=torch.float32,
-      reduce_dtype=autocast_precision, # Low precision gradient communication
-      buffer_dtype=torch.float32,
+      param_dtype=autocast_precision,  # Master weigths stored in fp32 but are downcast to autocast_precision before the dist all_gather
+      reduce_dtype=torch.float32,  # gradient dist all_reduce in fp32
+      buffer_dtype=autocast_precision,  # Buffers stored in fp32 but are downcast to autocast_precision before the dist all_gather
     )
-
     # If mixed_precision = 'pure'
     mixed_precision = MixedPrecision(
-      param_dtype=autocast_precision, # Low precision master weights
-      reduce_dtype=autocast_precision, # Low precision gradient communication
-      buffer_dtype=autocast_precision, # Low precision buffers
+      param_dtype=autocast_precision,  # Master weigths stored in fp32 but are downcast to autocast_precision before the dist all_gather
+      reduce_dtype=autocast_precision,  # gradient dist all_reduce in autocast_precision
+      buffer_dtype=autocast_precision,  # Buffers stored in fp32 but are downcast to autocast_precision before the dist all_gather
     )
 
 An example code snippet for using FSDP with composer is provided below:

--- a/docs/source/notes/distributed_training.rst
+++ b/docs/source/notes/distributed_training.rst
@@ -208,7 +208,7 @@ One Composer-specific pattern is that if :code:`mixed_precision` is provided as 
     )
     # If mixed_precision = 'pure'
     mixed_precision = MixedPrecision(
-      param_dtype=autocast_precision,  # Master weigths stored in fp32 but are downcast to autocast_precision before the dist all_gather
+      param_dtype=autocast_precision,  # Master weights stored in fp32 but are downcast to autocast_precision before the dist all_gather
       reduce_dtype=autocast_precision,  # gradient dist all_reduce in autocast_precision
       buffer_dtype=autocast_precision,  # Buffers stored in fp32 but are downcast to autocast_precision before the dist all_gather
     )

--- a/docs/source/notes/distributed_training.rst
+++ b/docs/source/notes/distributed_training.rst
@@ -203,13 +203,13 @@ One Composer-specific pattern is that if :code:`mixed_precision` is provided as 
     # If mixed_precision = 'default'; emulates automatic mixed precision training.
     mixed_precision = MixedPrecision(
       param_dtype=autocast_precision,  # Master weights stored in fp32 but are downcast to autocast_precision before the dist all_gather
-      reduce_dtype=torch.float32,  # gradient dist all_reduce in fp32
+      reduce_dtype=torch.float32,  # Gradient dist all_reduce in fp32
       buffer_dtype=autocast_precision,  # Buffers stored in fp32 but are downcast to autocast_precision before the dist all_gather
     )
     # If mixed_precision = 'pure'
     mixed_precision = MixedPrecision(
       param_dtype=autocast_precision,  # Master weights stored in fp32 but are downcast to autocast_precision before the dist all_gather
-      reduce_dtype=autocast_precision,  # gradient dist all_reduce in autocast_precision
+      reduce_dtype=autocast_precision,  # Gradient dist all_reduce in autocast_precision
       buffer_dtype=autocast_precision,  # Buffers stored in fp32 but are downcast to autocast_precision before the dist all_gather
     )
 


### PR DESCRIPTION
# What does this PR do?

Our MixedPrecision setting 'DEFAULT' should be updated to:
```
# If mixed_precision = 'default'
mixed_precision = MixedPrecision(
  param_dtype=autocast_precision,
  reduce_dtype=torch.float32,
  buffer_dtype=autocast_precision,
)
```
This will make 'DEFAULT' emulate AMP behavior.

use FULL if you need
use PURE if you want to live dangerously
standard AMP should be the 'DEFAULT' MixedPrecision setting (see above)

The current 'DEFAULT' shouldn't really be used.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

Fixes https://mosaicml.atlassian.net/browse/CO-1896

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in an issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [ ] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
