### PR TITLE
test and fix composer package name usage in composer_collect_env

### DIFF
--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -53,7 +53,7 @@ jobs:
       name: ${{ matrix.name }}
       pytest-command: ${{ matrix.pytest_command }}
       pytest-markers: ${{ matrix.markers }}
-      composer_package_name: ${{ matrix.composer_package_name}}
+      composer_package_name: ${{ matrix.composer_package_name }}
   coverage:
     uses: ./.github/workflows/coverage.yaml
     name: Coverage Results

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -20,22 +20,32 @@ jobs:
             container: mosaicml/pytorch:1.11.0_cpu-python3.8-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'mosaicml'
           - name: 'cpu-3.9-1.12'
             container: mosaicml/pytorch:1.12.1_cpu-python3.9-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'mosaicml'
           - name: 'cpu-3.10-1.13'
             container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'mosaicml'
+          - name: 'cpu-3.10-1.13-composer'
+            container: mosaicml/pytorch:1.13.1_cpu-python3.10-ubuntu20.04
+            markers: 'not daily and not remote and not gpu and not vision and not doctest'
+            pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'composer'
           - name: 'cpu-vision'
             container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and vision and not doctest'
             pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'mosaicml'
           - name: 'cpu-doctest'
             container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and doctest'
             pytest_command: 'coverage run -m pytest tests/test_docs.py'
+            composer_package_name: 'mosaicml'
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:
@@ -43,6 +53,7 @@ jobs:
       name: ${{ matrix.name }}
       pytest-command: ${{ matrix.pytest_command }}
       pytest-markers: ${{ matrix.markers }}
+      composer_package_name: ${{ matrix.composer_package_name}}
   coverage:
     uses: ./.github/workflows/coverage.yaml
     name: Coverage Results

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -11,6 +11,9 @@ on:
       pytest-command:
         required: true
         type: string
+      composer_package_name:
+        required: true
+        type: string
       pytest-markers:
         required: true
         type: string
@@ -42,6 +45,7 @@ jobs:
         run: |
           set -ex
           export PATH=/composer-python:$PATH
+          export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
           python -m pip install --upgrade 'pip<23' wheel
           python -m pip install --upgrade .[all]
       - name: Run Tests

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -44,7 +44,6 @@ import functools
 import json
 import sys
 import time
-from importlib import util as importlib_util
 from typing import NamedTuple, Optional, TextIO
 
 import cpuinfo
@@ -106,12 +105,13 @@ def get_composer_commit_hash() -> Optional[str]:
     # Use PEP-610 to get the commit hash
     # See https://packaging.python.org/en/latest/specifications/direct-url/
     # try both package names that composer is released under
-    if importlib_util.find_spec('mosaicml') is not None:
+    try:
         files = importlib_metadata.files('mosaicml')
-    elif importlib_util.find_spec('composer') is not None:
-        files = importlib_metadata.files('composer')
-    else:
-        return
+    except importlib_metadata.PackageNotFoundError:
+        try:
+            files = importlib_metadata.files('composer')
+        except importlib_metadata.PackageNotFoundError:
+            return
 
     if files is None:
         return

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -104,7 +104,7 @@ class ComposerEnv(NamedTuple):
 def get_composer_commit_hash() -> Optional[str]:
     # Use PEP-610 to get the commit hash
     # See https://packaging.python.org/en/latest/specifications/direct-url/
-    # try both package names that composer is released under
+    # Try both package names that Composer is released under
     try:
         files = importlib_metadata.files('mosaicml')
     except importlib_metadata.PackageNotFoundError:

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -44,6 +44,7 @@ import functools
 import json
 import sys
 import time
+from importlib import util as importlib_util
 from typing import NamedTuple, Optional, TextIO
 
 import cpuinfo
@@ -104,7 +105,14 @@ class ComposerEnv(NamedTuple):
 def get_composer_commit_hash() -> Optional[str]:
     # Use PEP-610 to get the commit hash
     # See https://packaging.python.org/en/latest/specifications/direct-url/
-    files = importlib_metadata.files('mosaicml')
+    # try both package names that composer is released under
+    if importlib_util.find_spec('mosaicml') is not None:
+        files = importlib_metadata.files('mosaicml')
+    elif importlib_util.find_spec('composer') is not None:
+        files = importlib_metadata.files('composer')
+    else:
+        return
+
     if files is None:
         return
     files = [f for f in files if str(f).endswith('direct_url.json')]


### PR DESCRIPTION
# What does this PR do?
We recently added the `composer` package in addition to `mosaicml` for the first time. We had one piece of code `get_composer_commit_hash` that relied on the `mosaicml` package name existing. This change makes the code robust to any package name (won't crash), and gives expected results for either `mosaicml` or `composer`.

Manually tested by doing `COMPOSER_PACKAGE_NAME=composer pip install .[all]` and verifying that `composer_collect_env` errors before this change, and does not error after this change. Also verified that the the tests suite fails when package is built as `composer`, so this new workflow would have caught this issue.

# What issue(s) does this change relate to?
Closes [CO-1901](https://mosaicml.atlassian.net/browse/CO-1901)
 https://github.com/mosaicml/composer/issues/2048 will be closed once re-released with this change

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1901]: https://mosaicml.atlassian.net/browse/CO-1901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ