### PR TITLE
Delete composer package GPU workflow

### DIFF
--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -21,11 +21,11 @@ jobs:
             markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
-          - name: 'gpu-3.10-1.13-vision-doctest-composer'
-            container: mosaicml/pytorch_vision:1.13.1_cu117-python3.10-ubuntu20.04
-            markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
-            pytest_command: 'coverage run -m pytest'
-            composer_package_name: 'composer'
+          # - name: 'gpu-3.10-1.13-vision-doctest-composer'
+          #   container: mosaicml/pytorch_vision:1.13.1_cu117-python3.10-ubuntu20.04
+          #   markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
+          #   pytest_command: 'coverage run -m pytest'
+          #   composer_package_name: 'composer'
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -21,11 +21,6 @@ jobs:
             markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
-          # - name: 'gpu-3.10-1.13-vision-doctest-composer'
-          #   container: mosaicml/pytorch_vision:1.13.1_cu117-python3.10-ubuntu20.04
-          #   markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
-          #   pytest_command: 'coverage run -m pytest'
-          #   composer_package_name: 'composer'
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:


### PR DESCRIPTION
# What does this PR do?
Comments out the GPU workflow for the `composer` package due to it causing GPU tests to fail. Also, increases load substantially for GPU CI and is not necessary. Note: the GPU tests are still run, just only for the `mosaicml` package build.

# What issue(s) does this change relate to?
N/A
