### PR TITLE
Revert "Checkpoints Simplified (#2041)"

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -803,7 +803,7 @@ class Trainer:
 
             .. seealso:: :mod:`composer.utils.reproducibility` for more details on reproducibility.
         dist_timeout (float, optional): Timeout, in seconds, for initializing the distributed process group.
-            (default: ``600.0``)
+            (default: ``1800.0``)
         ddp_sync_strategy (str | DDPSyncStrategy, optional): The strategy to use for synchronizing gradients.
             Leave unset to let the trainer auto-configure this. See :class:`.DDPSyncStrategy`
             for more details.
@@ -907,7 +907,7 @@ class Trainer:
         deterministic_mode: bool = False,
 
         # Distributed Training
-        dist_timeout: float = 600.0,
+        dist_timeout: float = 1800.0,
         ddp_sync_strategy: Optional[Union[str, DDPSyncStrategy]] = None,
 
         # Profiling

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -351,7 +351,7 @@ def is_initialized():
     return dist.is_initialized()
 
 
-def initialize_dist(device: Union[str, Device], timeout: float = 600.0):
+def initialize_dist(device: Union[str, Device], timeout: float = 300.0):
     """Initialize the default PyTorch distributed process group.
 
     This function assumes that the following environment variables are set:
@@ -374,7 +374,7 @@ def initialize_dist(device: Union[str, Device], timeout: float = 600.0):
             interpreted. Either a string corresponding to a device (one of ``'cpu'``,
             ``'gpu'``, ``'mps'``, or ``'tpu'``) or a :class:`.Device`.
         timeout (float, optional): The timeout for operations executed against the process
-            group, expressed in seconds. (default: ``600.0``).
+            group, expressed in seconds. (default: ``300.0``).
     """
     # If device is string, get corresponding composer.devices.Device object
     device_obj = get_device(device)

--- a/composer/utils/inference.py
+++ b/composer/utils/inference.py
@@ -168,10 +168,10 @@ def export_for_inference(
         # download checkpoint and load weights only
         log.debug('Loading checkpoint at %s', load_path)
         with tempfile.TemporaryDirectory() as tempdir:
-            composer_states_filepath, _ = download_checkpoint(path=load_path,
-                                                              node_checkpoint_folder=tempdir,
-                                                              object_store=load_object_store,
-                                                              progress_bar=True)
+            composer_states_filepath, _, _ = download_checkpoint(path=load_path,
+                                                                 node_checkpoint_folder=tempdir,
+                                                                 object_store=load_object_store,
+                                                                 progress_bar=True)
             state_dict = safe_torch_load(composer_states_filepath)
             missing_keys, unexpected_keys = model.load_state_dict(state_dict['state']['model'], strict=load_strict)
             if len(missing_keys) > 0:

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -169,7 +169,7 @@ def test_extract_hparams_trainer():
         'deterministic_mode': False,
 
         # Distributed Training
-        'dist_timeout': 600.0,
+        'dist_timeout': 1800.0,
         'ddp_sync_strategy': None,
 
         # Profiling


### PR DESCRIPTION
This reverts commit 25c9a67014e23d655258bb241df0fe0748164c90.

# What does this PR do?
Reverts the recent checkpointing simplification because it seems to cause a hang in autoresume, blocking https://github.com/mosaicml/composer/pull/2054. Reverting until we can debug further

# What issue(s) does this change relate to?
N/A

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
