### PR TITLE
Add flag to Composer Launcher that will kill all python processes at the end of the launcher

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -83,8 +83,10 @@ def _get_parser():
     parser.add_argument('-k',
                         '--kill_python_zombies',
                         action='store_true',
-                        help=('If set, at the end of composer, it will run ``kill python``'
-                              'which will kill all python processes.'))
+                        help=('If set, at the end of composer, it will run ``kill python`` '
+                              'which will kill all python processes. This can help in the case '
+                              'of NCCL timeouts where child processes become zombies and are '
+                              'not cleaned up.'))
 
     multinode_args = parser.add_argument_group(
         'multi-node arguments',

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -80,6 +80,10 @@ def _get_parser():
         help=('If set, run the training script as a command (i.e. without `python`). '
               'Cannot be used in conjunction with `module_mode`.'),
     )
+    parser.add_argument('-k',
+                        '--kill_python_zombies',
+                        action='store_true',
+                        help=('If set, at the end of composer, it will run '))
 
     multinode_args = parser.add_argument_group(
         'multi-node arguments',
@@ -494,11 +498,12 @@ def main():
         # what failed. No need to re-raise the exception, as `aggregate_process_returncode`
         # will return an appropriate error code, which will cause the script to exit.
         traceback.print_exc()
-        print('Killing training processes')
     finally:
         _cleanup_processes(processes)
         log_tmpdir.cleanup()
-        return _aggregate_process_returncode(processes)
+        return_code = _aggregate_process_returncode(processes)
+        os.system('pkill python')
+        return return_code
 
 
 if __name__ == '__main__':

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -502,7 +502,8 @@ def main():
         _cleanup_processes(processes)
         log_tmpdir.cleanup()
         return_code = _aggregate_process_returncode(processes)
-        os.system('pkill python')
+        if args.kill_python_zombies:
+            os.system('pkill python')
         return return_code
 
 

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -83,7 +83,8 @@ def _get_parser():
     parser.add_argument('-k',
                         '--kill_python_zombies',
                         action='store_true',
-                        help=('If set, at the end of composer, it will run '))
+                        help=('If set, at the end of composer, it will run ``kill python``'
+                              'which will kill all python processes.'))
 
     multinode_args = parser.add_argument_group(
         'multi-node arguments',

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -322,12 +322,15 @@ def download_checkpoint(
                     pass
 
     finally:
-        # Wait for all checkpoints on the node to finish downloading
-        # Putting the barrier in a finally so the rank will always block on the barrier,
-        # even if it has an exception.
-        # Any exception will be re-raised after the barrier passes. The launcher script
-        # will detect the process crash and terminate the other ranks
-        dist.barrier()
+        # Wait for all checkpoints on the node to finish downloading. First, we busy wait until
+        # file exists, ensuring synchronization intra-node. Next, we use `dist.barrier()` to
+        # sync across nodes. This is necessary to avoid timing out on the barrier when downloading
+        # large checkpoints, which may exceed the normal timeout. Now, a timeout is only
+        # encountered if the difference between checkpoint download times on the slowest and
+        # fastest nodes exceeds the timeout.
+        with dist.local_rank_zero_download_and_wait(composer_states_filepath):
+            print('composer filepath is: ', composer_states_filepath, os.path.exists(composer_states_filepath))
+            dist.barrier()
 
     return composer_states_filepath, extracted_checkpoint_folder, extracted_rank_n
 


### PR DESCRIPTION
# What does this PR do?
Adds a flag to the composer launcher, which will run `pkill python` at the end of the launcher. This will kill off all python zombie processes at the end.

Running a test in MCloud we get:
```
composer-kill-zombies-CtNmn6  r1z1     a100_80gb  8        2023-03-10 04:19 PM  2023-03-10 04:20 PM  2023-03-10 04:22 PM  Failed (Exit code: 1. Reason: Error)
```

and here are the logs 
![image](https://user-images.githubusercontent.com/15602962/224447130-e7c77c36-aba3-4c78-9cdd-370fc3fdc8ca.png)

showing it exited cleanly.


# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
