### PR TITLE
Activation monitor

### DIFF
--- a/composer/callbacks/__init__.py
+++ b/composer/callbacks/__init__.py
@@ -6,6 +6,7 @@
 Each callback inherits from the :class:`.Callback` base class. See detailed description and
 examples for writing your own callbacks at the :class:`.Callback` base class.
 """
+from composer.callbacks.activation_monitor import ActivationMonitor
 from composer.callbacks.checkpoint_saver import CheckpointSaver
 from composer.callbacks.early_stopper import EarlyStopper
 from composer.callbacks.export_for_inference import ExportForInferenceCallback
@@ -20,6 +21,7 @@ from composer.callbacks.speed_monitor import SpeedMonitor
 from composer.callbacks.threshold_stopper import ThresholdStopper
 
 __all__ = [
+    'ActivationMonitor',
     'OptimizerMonitor',
     'LRMonitor',
     'MemoryMonitor',

--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -199,8 +199,8 @@ class ActivationMonitor(Callback):
     def compute_kurtosis(self, value: torch.Tensor):
         mean = value.mean()
         diffs = value - mean
-        m_4 = torch.pow(diffs, 4).sum()
-        var = torch.pow(diffs, 2).sum()
+        m_4 = torch.pow(diffs, 4).mean()
+        var = torch.pow(diffs, 2).mean()
         return m_4 / (var**2)
 
     def create_module_names(self, model: torch.nn.Module):

--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -48,7 +48,6 @@ class ActivationMonitor(Callback):
 
         """
 
-        self.interval = interval
         self.recompute_attention_softmax = recompute_attention_softmax
         self.ignore_module_types = ignore_module_types
         self.only_log_wandb = only_log_wandb
@@ -58,8 +57,10 @@ class ActivationMonitor(Callback):
         # Check that the interval timestring is parsable and convert into time object
         if isinstance(interval, int):
             self.interval = Time(interval, TimeUnit.BATCH)
-        if isinstance(interval, str):
+        elif isinstance(interval, str):
             self.interval = Time.from_timestring(interval)
+        elif isinstance(interval, Time):
+            self.interval = interval
 
         # Verify that the interval has supported units
         if self.interval.unit not in [TimeUnit.BATCH, TimeUnit.EPOCH]:

--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -104,18 +104,18 @@ class ActivationMonitor(Callback):
             if ignore_module_type in module_name:
                 return
 
-        metric_name = f'activation/{module_name}'
+        metric_name = f'activations/{module_name}'
         metrics = {}
 
         for i, val in enumerate(input):
             if val is None or isinstance(val, dict):
                 continue
-            self.add_metrics(metrics, f'{metric_name}/input_{i}', val)
+            self.add_metrics(metrics, f'{metric_name}_input_{i}', val)
 
         for i, val in enumerate(output):
             if val is None or isinstance(val, dict):
                 continue
-            self.add_metrics(metrics, f'{metric_name}/output_{i}', val)
+            self.add_metrics(metrics, f'{metric_name}_output_{i}', val)
 
         logger.log_metrics(metrics)
 

--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -197,7 +197,7 @@ class ActivationMonitor(Callback):
         metrics[f'activations/max/{name}{suffix}'] = value.max().item()
 
     def compute_kurtosis(self, value: torch.Tensor):
-        # Computes the kurtosis over the last dimension's subspace
+        # Computes the kurtosis over the last dimension
         mean = torch.mean(value, dim=-1).unsqueeze(-1)
         diffs = value - mean
         m_4 = torch.mean(torch.pow(diffs, 4), dim=-1)

--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -107,9 +107,9 @@ class ActivationMonitor(Callback):
 
         if self.interval.unit == TimeUnit.BATCH and self.interval < Time.from_timestring('10ba'):
             warnings.warn(f'Currently the ActivationMonitor`s interval is set to {self.interval} '
-                          f'this is below our recommended value of 10ba. We recommend you raise '
+                          f'which is below our recommended value of 10ba. We recommend you raise '
                           f'the interval to at least 10ba, as the activation monitor adds extra overhead '
-                          f'and is currently adversely impacting throughput performance.')
+                          f'and decreases throughput.')
 
         # Verify that the interval has supported units
         if self.interval.unit not in [TimeUnit.BATCH, TimeUnit.EPOCH]:

--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -197,11 +197,12 @@ class ActivationMonitor(Callback):
         metrics[f'activations/max/{name}{suffix}'] = value.max().item()
 
     def compute_kurtosis(self, value: torch.Tensor):
-        mean = value.mean()
+        # Computes the kurtosis over the last dimension's subspace
+        mean = torch.mean(value, dim=-1).unsqueeze(-1)
         diffs = value - mean
-        m_4 = torch.pow(diffs, 4).mean()
-        var = torch.pow(diffs, 2).mean()
-        return m_4 / (var**2)
+        m_4 = torch.mean(torch.pow(diffs, 4), dim=-1)
+        var = torch.mean(torch.pow(diffs, 2), dim=-1)
+        return (m_4 / (var**2)).mean()
 
     def create_module_names(self, model: torch.nn.Module):
         self.module_names = {m: name for name, m in model.named_modules()}

--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -1,0 +1,129 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Monitor activation values during training."""
+
+from functools import partial
+from typing import List, Optional, Sequence, Union
+
+import torch
+
+from composer.core import Callback, State, Time, TimeUnit
+from composer.loggers import Logger
+
+__all__ = ['ActivationMonitor']
+
+
+class ActivationMonitor(Callback):
+
+    def __init__(self,
+                 recompute_attention_softmax: bool = True,
+                 interval: Union[int, str, Time] = '100ba',
+                 ignore_module_types: Optional[List[str]] = []):
+        """Logs stats of activation inputs and outputs.
+
+        This callback triggers at a user defined interval, and logs some simple statistics of the inputs, outputs for every
+        torch module. This is done by attaching a forward hook to the module. Additionally, when we are not logging
+        we detach the forwards hook.
+
+        Example:
+            .. doctest::
+
+                >>> from composer import Trainer
+                >>> from composer.callbacks import ActivationMonitor
+                >>> # constructing trainer object with this callback
+                >>> trainer = Trainer(
+                ...     model=model,
+                ...     train_dataloader=train_dataloader,
+                ...     eval_dataloader=eval_dataloader,
+                ...     optimizers=optimizer,
+                ...     max_duration="1ep",
+                ...     callbacks=[ActivationMonitor()],
+                ... )
+
+        The metrics are logged by the :class:`.Logger` to the following keys described below. For convenience we have included
+        example metrics logged below:
+
+        """
+
+        self.interval = interval
+        self.recompute_attention_softmax = recompute_attention_softmax
+        self.ignore_module_types = ignore_module_types
+
+        self.handles = []
+
+        # Check that the interval timestring is parsable and convert into time object
+        if isinstance(interval, int):
+            self.interval = Time(interval, TimeUnit.BATCH)
+        if isinstance(interval, str):
+            self.interval = Time.from_timestring(interval)
+
+        # Verify that the interval has supported units
+        if self.interval.unit not in [TimeUnit.BATCH, TimeUnit.EPOCH]:
+            raise ValueError(f'Invalid time unit for parameter interval: '
+                             f'{self.interval.unit}')
+
+        self.last_train_time_value_logged = -1
+        self.module_names = {}
+
+    def before_forward(self, state: State, logger: Logger):
+        current_time_value = state.timestamp.get(self.interval.unit).value
+
+        if current_time_value % self.interval.value == 0 and current_time_value != self.last_train_time_value_logged:
+            if not self.module_names:
+                self.create_module_names(state.model)
+
+            self.attach_forward_hook(state, logger)
+
+    def after_forward(self, state: State, logger: Logger):
+        current_time_value = state.timestamp.get(self.interval.unit).value
+
+        if current_time_value % self.interval.value == 0 and current_time_value != self.last_train_time_value_logged:
+            self.last_train_time_value_logged = current_time_value
+            self.remove_forward_hooks()
+
+    def attach_forward_hook(self, state: State, logger: Logger):
+        self.register_forward_hook(state.model, logger)
+
+    def remove_forward_hooks(self):
+        for handle in self.handles:
+            handle.remove()
+        # Resetting handles we track
+        self.handles = []
+
+    def register_forward_hook(self, model: torch.nn.Module, logger: Logger):
+        model.apply(partial(self._register_forward_hook, logger))
+
+    def _register_forward_hook(self, logger: Logger, module: torch.nn.Module):
+        self.handles.append(module.register_forward_hook(partial(self.forward_hook, logger)))
+
+    def forward_hook(self, logger: Logger, module: torch.nn.Module, input: Sequence, output: Sequence):
+        module_name = self.module_names[module]
+
+        for ignore_module_type in self.ignore_module_types:
+            if ignore_module_type in module_name:
+                return
+
+        metric_name = f'activation/{module_name}'
+        metrics = {}
+
+        for i, val in enumerate(input):
+            if val is None or isinstance(val, dict):
+                continue
+            self.add_metrics(metrics, f'{metric_name}/input_{i}', val)
+
+        for i, val in enumerate(output):
+            if val is None or isinstance(val, dict):
+                continue
+            self.add_metrics(metrics, f'{metric_name}/output_{i}', val)
+
+        logger.log_metrics(metrics)
+
+    def create_module_names(self, model: torch.nn.Module):
+        self.module_names = {m: name for name, m in model.named_modules()}
+
+    def add_metrics(self, metrics: dict, name: str, value: torch.Tensor):
+        if value.is_floating_point() or value.is_complex():
+            metrics[f'{name}_l2_norm'] = torch.linalg.vector_norm(value).item()
+            metrics[f'{name}_average'] = value.mean().item()
+        metrics[f'{name}_max'] = value.max().item()

--- a/tests/callbacks/test_activation_monitor.py
+++ b/tests/callbacks/test_activation_monitor.py
@@ -1,10 +1,14 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import numpy as np
 import pytest
+import scipy
+import torch
 from torch.utils.data import DataLoader
 
 from composer.callbacks import ActivationMonitor
+from composer.callbacks.activation_monitor import compute_kurtosis
 from composer.loggers import InMemoryLogger
 from composer.optim import DecoupledAdamW
 from composer.trainer import Trainer
@@ -39,3 +43,10 @@ def test_activation_monitor():
     assert 'activations/max/module.0_input.0' in in_memory_logger.data.keys()
     assert 'activations/average/module.0_input.0' in in_memory_logger.data.keys()
     assert 'activations/kurtosis/module.0_input.0' in in_memory_logger.data.keys()
+
+
+def test_kurtosis_computation():
+    x = torch.randn((2, 3, 4))
+    res = compute_kurtosis(x)
+    scipy_res = scipy.stats.kurtosis(x.numpy(), axis=-1, fisher=False).mean()
+    assert np.allclose(res.numpy(), scipy_res, rtol=1e-4)

--- a/tests/callbacks/test_activation_monitor.py
+++ b/tests/callbacks/test_activation_monitor.py
@@ -38,3 +38,4 @@ def test_activation_monitor():
     assert 'activations/l2_norm/module.0_input.0' in in_memory_logger.data.keys()
     assert 'activations/max/module.0_input.0' in in_memory_logger.data.keys()
     assert 'activations/average/module.0_input.0' in in_memory_logger.data.keys()
+    assert 'activations/kurtosis/module.0_input.0' in in_memory_logger.data.keys()

--- a/tests/callbacks/test_activation_monitor.py
+++ b/tests/callbacks/test_activation_monitor.py
@@ -1,0 +1,40 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+from torch.utils.data import DataLoader
+
+from composer.callbacks import ActivationMonitor
+from composer.loggers import InMemoryLogger
+from composer.optim import DecoupledAdamW
+from composer.trainer import Trainer
+from tests.common.datasets import RandomClassificationDataset
+from tests.common.models import SimpleModel
+
+
+def test_activation_monitor():
+
+    # Log every batch for debugging purposes
+    activation_monitor = ActivationMonitor(interval='1ba')
+    in_memory_logger = InMemoryLogger()  # track the logged metrics in the in_memory_logger
+    model = SimpleModel()
+
+    trainer = Trainer(
+        model=model,
+        callbacks=activation_monitor,
+        loggers=in_memory_logger,
+        train_dataloader=DataLoader(RandomClassificationDataset()),
+        optimizers=DecoupledAdamW(model.parameters()),
+        max_duration='3ba',
+    )
+    trainer.fit()
+
+    num_max_calls = len(in_memory_logger.data['activations/max/_output.0'])
+    num_average_calls = len(in_memory_logger.data['activations/average/_output.0'])
+
+    assert num_max_calls == num_average_calls
+    assert num_max_calls == 3
+
+    # Checking to make sure existing keys are in the memory logger dict
+    assert 'activations/l2_norm/module.0_input.0' in in_memory_logger.data.keys()
+    assert 'activations/max/module.0_input.0' in in_memory_logger.data.keys()
+    assert 'activations/average/module.0_input.0' in in_memory_logger.data.keys()

--- a/tests/callbacks/test_activation_monitor.py
+++ b/tests/callbacks/test_activation_monitor.py
@@ -1,6 +1,7 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from torch.utils.data import DataLoader
 
 from composer.callbacks import ActivationMonitor
@@ -13,11 +14,10 @@ from tests.common.models import SimpleModel
 
 def test_activation_monitor():
 
-    # Log every batch for debugging purposes
-    activation_monitor = ActivationMonitor(interval='1ba')
+    with pytest.warns(Warning):
+        activation_monitor = ActivationMonitor(interval='1ba')
     in_memory_logger = InMemoryLogger()  # track the logged metrics in the in_memory_logger
     model = SimpleModel()
-
     trainer = Trainer(
         model=model,
         callbacks=activation_monitor,


### PR DESCRIPTION
# What does this PR do?
Adds a callback that monitors activations in the network. Every `interval` batches it will attach a forwards hook and logs the `max`, `average`, `l2 norm`, and `kurtosis` for the input and output activations.

the output in wandb looks sth like:
<img width="630" alt="image" src="https://user-images.githubusercontent.com/15602962/226694265-0f76401b-91cb-4e84-a997-8eccea13bfe5.png">

Also as a sanity check the average kurtosis is ~3 at initialization:
<img width="636" alt="image" src="https://user-images.githubusercontent.com/15602962/226695568-fd85f673-073b-4298-878f-14f64fac3517.png">



And it doesn't impact throughput that heavily:
<img width="995" alt="image" src="https://user-images.githubusercontent.com/15602962/226051315-c84105d6-5b9d-42de-a65a-32dffe8a5160.png">

In particular every `interval` batches it looks like we take maybe a ~5% throughput hit. However, making `interval` say 25ba or 50ba should alleviate the issues.


# What issue(s) does this change relate to?

[CO-1915](https://mosaicml.atlassian.net/browse/CO-1915)

# Before submitting
- [x ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x ] Did you update any related docs and document your change?
- [ x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ x] Did you run the tests locally to make sure they pass?
- [ x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1915]: https://mosaicml.atlassian.net/browse/CO-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ