### PR TITLE
Add support + test for autoresume with FSDP sharded checkpoints

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1456,7 +1456,7 @@ class Trainer:
             f'Looking for autoresume checkpoint: {save_latest_remote_file_name} (remote), {latest_checkpoint_path} (local)'
         )
 
-        if self.deepspeed_enabled:
+        if self.deepspeed_enabled or self.state.fsdp_sharded_state_dict_enabled:
             # If latest checkpoint is not saved locally, try to fetch from loggers
             if not os.path.exists(latest_checkpoint_path):
                 log.debug(f'Attempting to download the checkpoint on to rank {dist.get_global_rank()}')
@@ -1464,15 +1464,19 @@ class Trainer:
                 self._try_checkpoint_download(latest_checkpoint_path, save_latest_remote_file_name, loggers,
                                               load_progress_bar)
 
-            # list of whether the checkpoint exists on each rank
+            # List of whether the checkpoint exists on each rank
             latest_checkpoint_exists = dist.all_gather_object(os.path.exists(latest_checkpoint_path))
 
-            # Require all ranks to have their own local checkpoint if we wish to restore from it for deepspeed
-            if not all(latest_checkpoint_exists):
+            if all(latest_checkpoint_exists):  # All paths exist, so return the path.
+                return latest_checkpoint_path
+            # Require all ranks to have their own local checkpoint if we wish to restore from it for
+            # deepspeed or fsdp + sharding
+            elif any(latest_checkpoint_exists):  # Some but not all exist, which is very bad.
                 missing_ranks = [n for (n, exist) in enumerate(latest_checkpoint_exists) if not exist]
-                raise RuntimeError(f'Deepspeed was enabled, but checkpoints missing on ranks: {missing_ranks}')
-
-            return latest_checkpoint_path
+                mode = 'Deepspeed' if self.deepspeed_enabled else 'FSDP sharding'
+                raise RuntimeError(f'{mode} was enabled, but checkpoints missing on ranks: {missing_ranks}')
+            else:  # None of the paths exists, so no autoresume necessary.
+                return None
         else:
             # broadcast the local checkpoint path to all ranks
             latest_checkpoint_path_list = [os.path.abspath(latest_checkpoint_path)]


### PR DESCRIPTION
# What does this PR do?
Adds support for FSDP sharded checkpoints in the autoresume code path.

[Passes](https://wandb.ai/mosaic-ml/evan-v13-2-resumption-tests/runs/fxsiqran) [manual test](https://wandb.ai/mosaic-ml/evan-v13-2-resumption-tests/runs/1qe6lc7f/overview)

# What issue(s) does this change relate to?
Closes [CO-1906](https://mosaicml.atlassian.net/browse/CO-1906)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1906]: https://mosaicml.atlassian.net/browse/CO-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ