### PR TITLE
Skip extra downloads when not using a format string

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -211,7 +211,8 @@ def load_checkpoint(
                 object_store=object_store,
                 progress_bar=progress_bar,
                 fsdp_sharded_state_dict_enabled=state.fsdp_sharded_state_dict_enabled,
-                deepspeed_sharded_checkpoint=is_model_deepspeed(state.model))
+                deepspeed_sharded_checkpoint=is_model_deepspeed(state.model),
+            )
             rng_state_dicts = _restore_checkpoint(
                 state,
                 logger,


### PR DESCRIPTION
# What does this PR do?
Previously, if the `load_path` was specified as a _not_ format string, all ranks would download the same checkpoint, resulting in 8x the ingress to the node. This PR gates the downloads behind a check for whether sharded checkpoints are used so that only local rank 0 downloads the checkpoint.

Before and after of network usage for a resumption:
<img width="273" alt="Screen Shot 2023-03-14 at 11 54 59 PM" src="https://user-images.githubusercontent.com/43149077/225230269-e8ec6225-25e1-4d10-ba58-6caa301313c7.png">

# What issue(s) does this change relate to?
Closes [CO-1883](https://mosaicml.atlassian.net/browse/CO-1883)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1883]: https://mosaicml.atlassian.net/browse/CO-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ