### PR TITLE
fix name_or_path usage in HF save/load usage

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -284,9 +284,8 @@ class HuggingFaceModel(ComposerModel):
                 hf_tokenizer = transformers.AutoTokenizer.from_pretrained(_tmp_dir)
 
                 # we need to set the name_or_path back because otherwise it is the tmp dir we are loading from here
-                hf_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content']['name_or_path']
-                hf_tokenizer.init_kwargs['name_or_path'] = hf_tokenizer_state['tokenizer_config']['content'][
-                    'name_or_path']
+                hf_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content'].get('name_or_path', '')
+                hf_tokenizer.init_kwargs['name_or_path'] = hf_tokenizer.name_or_path
 
                 # for an unknown reason this key is missing when loading the saved tokenizer, but present with a value of None
                 # for the original tokenizer, so we default it to None

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ extra_deps['coco'] = [
 ]
 
 extra_deps['nlp'] = [
-    'transformers>=4.11,<5',
+    'transformers>=4.11,<4.27.2',
     'datasets>=2.4,<3',
 ]
 

--- a/tests/datasets/test_in_context_learning_datasets.py
+++ b/tests/datasets/test_in_context_learning_datasets.py
@@ -15,6 +15,7 @@ from composer.loggers import InMemoryLogger
 from composer.metrics import InContextLearningLMAccuracy, InContextLearningMultipleChoiceAccuracy
 from composer.models import HuggingFaceModel
 from composer.trainer import Trainer
+from composer.utils import reproducibility
 from tests.common import device
 
 
@@ -246,20 +247,23 @@ def test_lm_task_evaluation(device, dataset_uri, num_fewshot, tiny_gpt2_tokenize
 
 
 @pytest.mark.parametrize('dataset_uri', ['piqa_small.jsonl', 'hellaswag_small.jsonl'])
-@device('gpu')
+# @device('cpu')
 @pytest.mark.parametrize('num_fewshot', [0, 5])
-def test_mc_task_evaluation(device, num_fewshot, dataset_uri, tiny_gpt2_tokenizer, tmp_path):
+def test_mc_task_evaluation(num_fewshot, dataset_uri, tiny_gpt2_tokenizer, tmp_path, tiny_gpt2_model):
     pytest.importorskip('datasets')
     in_memory_logger = InMemoryLogger()  # track the logged metrics in the in_memory_logger
     local_data = os.path.join(os.path.dirname(__file__), 'local_data')
     dataset_uri = f'{local_data}/{dataset_uri}'
     tokenizer = tiny_gpt2_tokenizer
+
+    # seed because the fewshot selection is currently unseeded
+    reproducibility.seed_all(1234)
     dl = get_icl_task_dataloader(
         'multiple_choice',
         dataset_uri,
         tokenizer,
         8,
-        max_seq_len=2048,
+        max_seq_len=1024,
         pad_tok_id=tokenizer.eos_token_id,
         num_fewshot=num_fewshot,
         prompt_string='',
@@ -270,10 +274,10 @@ def test_mc_task_evaluation(device, num_fewshot, dataset_uri, tiny_gpt2_tokenize
 
     evaluator = Evaluator(label='lambada', dataloader=dl, metric_names=['InContextLearningMultipleChoiceAccuracy'])
 
-    config = transformers.AutoConfig.from_pretrained('EleutherAI/gpt-neo-125M')
-    model = transformers.AutoModelForCausalLM.from_config(config)
+    # config = transformers.AutoConfig.from_pretrained('EleutherAI/gpt-neo-125M')
+    # model = transformers.AutoModelForCausalLM.from_config(config)
     model = HuggingFaceModel(
-        model=model,
+        model=tiny_gpt2_model,
         tokenizer=None,
         eval_metrics=[InContextLearningMultipleChoiceAccuracy()],
         use_logits=True,

--- a/tests/datasets/test_in_context_learning_datasets.py
+++ b/tests/datasets/test_in_context_learning_datasets.py
@@ -249,7 +249,7 @@ def test_lm_task_evaluation(device, dataset_uri, num_fewshot, tiny_gpt2_tokenize
 @pytest.mark.parametrize('dataset_uri', ['piqa_small.jsonl', 'hellaswag_small.jsonl'])
 @device('gpu')
 @pytest.mark.parametrize('num_fewshot', [0, 5])
-def test_mc_task_evaluation(num_fewshot, dataset_uri, tiny_gpt2_tokenizer, tmp_path, tiny_gpt2_model):
+def test_mc_task_evaluation(device, num_fewshot, dataset_uri, tiny_gpt2_tokenizer, tmp_path, tiny_gpt2_model):
     pytest.importorskip('datasets')
     in_memory_logger = InMemoryLogger()  # track the logged metrics in the in_memory_logger
     local_data = os.path.join(os.path.dirname(__file__), 'local_data')

--- a/tests/datasets/test_in_context_learning_datasets.py
+++ b/tests/datasets/test_in_context_learning_datasets.py
@@ -247,7 +247,7 @@ def test_lm_task_evaluation(device, dataset_uri, num_fewshot, tiny_gpt2_tokenize
 
 
 @pytest.mark.parametrize('dataset_uri', ['piqa_small.jsonl', 'hellaswag_small.jsonl'])
-# @device('cpu')
+@device('gpu')
 @pytest.mark.parametrize('num_fewshot', [0, 5])
 def test_mc_task_evaluation(num_fewshot, dataset_uri, tiny_gpt2_tokenizer, tmp_path, tiny_gpt2_model):
     pytest.importorskip('datasets')
@@ -274,8 +274,6 @@ def test_mc_task_evaluation(num_fewshot, dataset_uri, tiny_gpt2_tokenizer, tmp_p
 
     evaluator = Evaluator(label='lambada', dataloader=dl, metric_names=['InContextLearningMultipleChoiceAccuracy'])
 
-    # config = transformers.AutoConfig.from_pretrained('EleutherAI/gpt-neo-125M')
-    # model = transformers.AutoModelForCausalLM.from_config(config)
     model = HuggingFaceModel(
         model=tiny_gpt2_model,
         tokenizer=None,

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -108,8 +108,8 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     # the reloaded tokenizer
     tokenizer1.__dict__.pop('name_or_path')
     tokenizer2.__dict__.pop('name_or_path')
-    model_max_length_1 = tokenizer1.init_kwargs.pop('name_or_path', None)
-    model_max_length_2 = tokenizer2.init_kwargs.pop('name_or_path', None)
+    tokenizer1.init_kwargs.pop('name_or_path', None)
+    tokenizer2.init_kwargs.pop('name_or_path', None)
 
     # tokenizer.init_kwargs['model_max_length'] is unset when the tokenizer does not specify it, but is set
     # to a very large number when you save and reload, so here we just check that its the same if it is present in

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -87,7 +87,13 @@ def test_hf_train_eval_predict(num_classes: int, tiny_bert_config):
 
 
 def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
-    # below is a best effort attempt to compare two tokenizers for equivalence
+    """This is a best effort attempt to compare two tokenizers for equivalence
+
+    This is not a perfect test, but it should catch most issues. We first check that the vocab is identical
+    and that a string is tokenized the same one. Then we compare the __dict__ of the tokenizers, but we remove
+    some keys that are not important for equivalence. See the inline explanations for each one.
+    """
+    #
     assert tokenizer1.vocab == tokenizer2.vocab
     assert type(tokenizer1) == type(tokenizer2)
 
@@ -104,8 +110,8 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     tokenizer1.__dict__.pop('deprecation_warnings')
     tokenizer2.__dict__.pop('deprecation_warnings')
 
-    # Name or path will be the path that the tokenizer was loaded from, which will just be a temporary directory for
-    # the reloaded tokenizer
+    # name_or_path will be the path that the tokenizer was loaded from, which will just be a temporary directory for
+    # the reloaded tokenizer, so we remove it and don't compare it between the two tokenizers
     tokenizer1.__dict__.pop('name_or_path')
     tokenizer2.__dict__.pop('name_or_path')
     tokenizer1.init_kwargs.pop('name_or_path', None)

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -218,11 +218,6 @@ def test_hf_state_dict_info(tmp_path: Path, pass_in_tokenizer: bool, modify_toke
                             _tmp_file.write(line)
                             _tmp_file.write('\n')
             loaded_tokenizer = transformers.AutoTokenizer.from_pretrained(_tmp_dir)
-            # we need to set the name_or_path back because otherwise it is the tmp dir we are loading from here
-            loaded_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content'].get('name_or_path', '')
-            if 'name_or_path' in loaded_tokenizer.init_kwargs:
-                loaded_tokenizer.init_kwargs['name_or_path'] = hf_tokenizer_state['tokenizer_config']['content'].get(
-                    'name_or_path', '')
 
         # for an unknown reason this key is missing when loading the saved tokenizer, but present with a value of None
         # for the original tokenizer

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -104,7 +104,7 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     tokenizer1.__dict__.pop('deprecation_warnings')
     tokenizer2.__dict__.pop('deprecation_warnings')
 
-    # name or path will be the path that the tokenizer was loaded from, which will just be a temporary directory for
+    # Name or path will be the path that the tokenizer was loaded from, which will just be a temporary directory for
     # the reloaded tokenizer
     tokenizer1.__dict__.pop('name_or_path')
     tokenizer2.__dict__.pop('name_or_path')

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -104,6 +104,8 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     tokenizer1.__dict__.pop('deprecation_warnings')
     tokenizer2.__dict__.pop('deprecation_warnings')
 
+    # name or path will be the path that the tokenizer was loaded from, which will just a temporary directory for
+    # the reloaded tokenizer
     tokenizer1.__dict__.pop('name_or_path')
     tokenizer2.__dict__.pop('name_or_path')
     model_max_length_1 = tokenizer1.init_kwargs.pop('name_or_path', None)

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -104,6 +104,11 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     tokenizer1.__dict__.pop('deprecation_warnings')
     tokenizer2.__dict__.pop('deprecation_warnings')
 
+    tokenizer1.__dict__.pop('name_or_path')
+    tokenizer2.__dict__.pop('name_or_path')
+    model_max_length_1 = tokenizer1.init_kwargs.pop('name_or_path', None)
+    model_max_length_2 = tokenizer2.init_kwargs.pop('name_or_path', None)
+
     # tokenizer.init_kwargs['model_max_length'] is unset when the tokenizer does not specify it, but is set
     # to a very large number when you save and reload, so here we just check that its the same if it is present in
     # both tokenizers. There is a separate tokenizer.model_max_length that will still get checked for equivalence
@@ -212,9 +217,10 @@ def test_hf_state_dict_info(tmp_path: Path, pass_in_tokenizer: bool, modify_toke
                             _tmp_file.write('\n')
             loaded_tokenizer = transformers.AutoTokenizer.from_pretrained(_tmp_dir)
             # we need to set the name_or_path back because otherwise it is the tmp dir we are loading from here
-            loaded_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content']['name_or_path']
-            loaded_tokenizer.init_kwargs['name_or_path'] = hf_tokenizer_state['tokenizer_config']['content'][
-                'name_or_path']
+            loaded_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content'].get('name_or_path', '')
+            if 'name_or_path' in loaded_tokenizer.init_kwargs:
+                loaded_tokenizer.init_kwargs['name_or_path'] = hf_tokenizer_state['tokenizer_config']['content'].get(
+                    'name_or_path', '')
 
         # for an unknown reason this key is missing when loading the saved tokenizer, but present with a value of None
         # for the original tokenizer

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -104,7 +104,7 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     tokenizer1.__dict__.pop('deprecation_warnings')
     tokenizer2.__dict__.pop('deprecation_warnings')
 
-    # name or path will be the path that the tokenizer was loaded from, which will just a temporary directory for
+    # name or path will be the path that the tokenizer was loaded from, which will just be a temporary directory for
     # the reloaded tokenizer
     tokenizer1.__dict__.pop('name_or_path')
     tokenizer2.__dict__.pop('name_or_path')


### PR DESCRIPTION
# What does this PR do?
This PR fixes the usage of `name_or_path` in the saving/loading of the HuggingFace tokenizer to be resilient to the key not existing, as apparently it was removed in a minor release. It also pins transformers so this does not happen again.

# What issue(s) does this change relate to?
Closes [CO-1942](https://mosaicml.atlassian.net/browse/CO-1942)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1942]: https://mosaicml.atlassian.net/browse/CO-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ