### PR TITLE
Pin transformers package to <4.27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ extra_deps['coco'] = [
 ]
 
 extra_deps['nlp'] = [
-    'transformers>=4.11,<5',
+    'transformers>=4.11,<4.27',
     'datasets>=2.4,<3',
 ]
 


### PR DESCRIPTION
# What does this PR do?
Pins transformers to <4.27 (the version released today)

# What issue(s) does this change relate to?
N/A


<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
