### PR TITLE
Updating gradient clipping to be torch 2.0 compatible

### DIFF
--- a/composer/algorithms/gradient_clipping/gradient_clipping.py
+++ b/composer/algorithms/gradient_clipping/gradient_clipping.py
@@ -14,6 +14,7 @@ from packaging import version
 from composer.core import Algorithm, Event, State
 from composer.loggers import Logger
 from composer.models import ComposerModel
+from composer.utils import using_torch_2_0
 
 log = logging.getLogger(__name__)
 
@@ -43,9 +44,7 @@ def apply_gradient_clipping(model: Union[ComposerModel, torch.nn.Module], clippi
             raise RuntimeError('To use FSDP with Composer, you must use torch>=1.13.0.')
         from torch.distributed.fsdp import FullyShardedDataParallel
 
-        is_torch_2_0 = False
-        if version.parse(torch.__version__) >= version.parse('2.0.0'):
-            is_torch_2_0 = True
+        is_torch_2_0 = using_torch_2_0()
 
         for module in model.modules():
             if isinstance(module, FullyShardedDataParallel):
@@ -59,14 +58,11 @@ def apply_gradient_clipping(model: Union[ComposerModel, torch.nn.Module], clippi
                         module.clip_grad_norm_(max_norm=clipping_threshold, norm_type=float('inf'))
                     else:
                         raise ValueError(f"clipping type must be 'norm' or 'value' with FSDP not {clipping_type}")
-                except AssertionError as e:
-                    # Catches the error message from PyTorch 1.13
-                    if 'clip_grad_norm should only be called on the root (parent) instance' == str(
-                            e) and not is_torch_2_0:
-                        continue
-                except RuntimeError as e:
-                    # Torch 2.0 has a different error message than 1.13, so we have to catch a different error message.
-                    if '`clip_grad_norm_()` should only be called on the root FSDP instance' == str(e) and is_torch_2_0:
+                except (AssertionError, RuntimeError) as e:
+                    if (('clip_grad_norm should only be called on the root (parent) instance' == str(e) and
+                         not is_torch_2_0) or
+                        ('`clip_grad_norm_()` should only be called on the root FSDP instance' == str(e) and
+                         is_torch_2_0)):
                         continue
                     else:
                         raise

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -134,13 +134,17 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
         fsdp_config (Dict[str, Any]): The FSDP config.
         precision: (Precision): The precision being used by the Trainer, used to fill in defaults for FSDP `mixed_precision` settings.
     """
+    is_torch_2_0 = False
+    if version.parse(torch.__version__) >= version.parse('2.0.0'):
+        is_torch_2_0 = True
     if version.parse(torch.__version__) < version.parse('1.13.0'):
         raise RuntimeError('To use FSDP with Composer, you must use torch>=1.13.0.')
     from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (CheckpointImpl,
                                                                              apply_activation_checkpointing,
                                                                              checkpoint_wrapper)
     from torch.distributed.fsdp import FullyShardedDataParallel
-    from torch.distributed.fsdp.flatten_params_wrapper import FlattenParamsWrapper
+    if not is_torch_2_0:
+        from torch.distributed.fsdp.flatten_params_wrapper import FlattenParamsWrapper
 
     from composer.trainer.mosaic_fsdp import (MosaicFullyShardedDataParallel, backward_prefetch_map, get_cpu_offload,
                                               get_mixed_precision, sharding_map)
@@ -275,18 +279,32 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
             # If module has attribute `module._fsdp_wrap = ...`, always respect it
             # Otherwise wrap if root object `obj.fsdp_wrap_fn(module)` is true
             # Or if unwrapped params in module in greater than or equal to fsdp_config.min_params
-            def _auto_wrap_policy(module: torch.nn.Module, recurse: bool, unwrapped_params: int) -> bool:
+            def __auto_wrap_policy(module: torch.nn.Module, recurse: bool, nonwrapped_numel: int) -> bool:
                 if recurse:
                     return True
                 else:
                     if hasattr(module, '_fsdp_wrap'):
                         return bool(module._fsdp_wrap)
 
-                    is_large = unwrapped_params >= min_params
+                    is_large = nonwrapped_numel >= min_params
                     if hasattr(obj, 'fsdp_wrap_fn') and isinstance(obj.fsdp_wrap_fn, Callable):
                         return obj.fsdp_wrap_fn(module) or is_large
                     else:
                         return is_large
+
+            if is_torch_2_0:
+
+                def _auto_wrap_policy_new(module: torch.nn.Module, recurse: bool, nonwrapped_numel: int) -> bool:
+                    return __auto_wrap_policy(module, recurse, nonwrapped_numel)
+
+                _auto_wrap_policy = _auto_wrap_policy_new
+
+            else:
+
+                def _auto_wrap_policy_old(module: torch.nn.Module, recurse: bool, unwrapped_params: int) -> bool:
+                    return __auto_wrap_policy(module, recurse, unwrapped_params)
+
+                _auto_wrap_policy = _auto_wrap_policy_old
 
             fsdp_obj = MosaicFullyShardedDataParallel(
                 obj,
@@ -325,7 +343,9 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
                 # If module has attribute `module._activation_checkpointing = ...`, always respect it
                 # Otherwise checkpoint if root object `obj.activation_checkpointing_fn(module)` is true
                 def _check_fn(module: torch.nn.Module) -> bool:
-                    if isinstance(module, (FullyShardedDataParallel, FlattenParamsWrapper)):
+                    if not is_torch_2_0 and isinstance(module, FlattenParamsWrapper):
+                        return False
+                    if isinstance(module, FullyShardedDataParallel):
                         return False
                     if hasattr(module, '_activation_checkpointing'):
                         return bool(module._activation_checkpointing)

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -17,7 +17,7 @@ from torchmetrics import Metric, MetricCollection
 from composer.core import Precision
 from composer.core.state import State
 from composer.trainer.meta_safe_apply import meta_safe_apply
-from composer.utils import StringEnum, dist, ensure_tuple
+from composer.utils import StringEnum, dist, ensure_tuple, using_torch_2_0
 
 __all__ = ['DDPSyncStrategy', 'ddp_sync_context', 'prepare_ddp_module', 'prepare_fsdp_module']
 
@@ -134,11 +134,9 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
         fsdp_config (Dict[str, Any]): The FSDP config.
         precision: (Precision): The precision being used by the Trainer, used to fill in defaults for FSDP `mixed_precision` settings.
     """
-    is_torch_2_0 = False
-    if version.parse(torch.__version__) >= version.parse('2.0.0'):
-        is_torch_2_0 = True
     if version.parse(torch.__version__) < version.parse('1.13.0'):
         raise RuntimeError('To use FSDP with Composer, you must use torch>=1.13.0.')
+    is_torch_2_0 = using_torch_2_0()
     from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (CheckpointImpl,
                                                                              apply_activation_checkpointing,
                                                                              checkpoint_wrapper)

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -18,7 +18,8 @@ from composer.utils.file_helpers import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, F
 from composer.utils.import_helpers import MissingConditionalImportError, import_object
 from composer.utils.inference import ExportFormat, Transform, export_for_inference, export_with_logger, quantize_dynamic
 from composer.utils.iter_helpers import IteratorFileStream, ensure_tuple, map_collection
-from composer.utils.misc import get_free_tcp_port, is_model_deepspeed, is_model_fsdp, is_notebook, model_eval_mode
+from composer.utils.misc import (get_free_tcp_port, is_model_deepspeed, is_model_fsdp, is_notebook, model_eval_mode,
+                                 using_torch_2_0)
 from composer.utils.object_store import (LibcloudObjectStore, ObjectStore, ObjectStoreTransientError, OCIObjectStore,
                                          S3ObjectStore, SFTPObjectStore)
 from composer.utils.retrying import retry
@@ -77,4 +78,5 @@ __all__ = [
     'extract_hparams',
     'convert_nested_dict_to_flat_dict',
     'convert_flat_dict_to_nested_dict',
+    'using_torch_2_0',
 ]

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from typing import Type
 
 import torch
+from packaging import version
 from torch.nn.parallel import DistributedDataParallel
 
 __all__ = [
@@ -78,3 +79,10 @@ def model_eval_mode(model: torch.nn.Module):
         yield
     finally:
         model.train(mode=is_training)
+
+
+def using_torch_2_0():
+    is_torch_2_0 = False
+    if version.parse(torch.__version__) >= version.parse('2.0.0'):
+        is_torch_2_0 = True
+    return is_torch_2_0


### PR DESCRIPTION
# What does this PR do?
In torch 2.0 they change the error message that is thrown for gradient clipping. This PR adds code to catch this new error message.

ran locally with torch 2.0:
https://wandb.ai/mosaic-ml/examples_fork-examples_llm/runs/prr9w4gb?workspace=user-bcui

link to PyTorch 2.0 new error message:
https://github.com/pytorch/pytorch/blob/master/torch/distributed/fsdp/fully_sharded_data_parallel.py#L1000

# What issue(s) does this change relate to?
[CO-1955](https://mosaicml.atlassian.net/browse/CO-1955)

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1955]: https://mosaicml.atlassian.net/browse/CO-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ