### PR TITLE
Patch EMA with FSDP

### DIFF
--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -402,22 +402,28 @@ class EMAParameters:
 
             for name, param in model.named_parameters():
                 if name in ema_params:
-                    param.data, ema_params[name] = ema_params[name], param.data
+                    # Use copy instead of raw data access (eg .data) doesn't work with FSDP
+                    dummy_param = param.clone()
+                    param.copy_(ema_params[name])
+                    ema_params[name].copy_(dummy_param)
 
             for name, buffer in model.named_buffers():
                 if name in ema_buffers:
-                    buffer.data, ema_buffers[name] = ema_buffers[name], buffer.data
+                    # Use copy instead of raw data access (eg .data) doesn't work with FSDP
+                    dummy_buffer = buffer.clone()
+                    buffer.copy_(ema_buffers[name])
+                    ema_buffers[name].copy_(dummy_buffer)
 
     def transfer_ema_params(self, model: torch.nn.Module):
         """Transfers the parameters and buffers from the ema model to the supplied model."""
         with torch.no_grad():
             for name, param in model.named_parameters():
                 if name in self.named_parameters_dict:
-                    param.data = self.named_parameters_dict[name]
+                    param.copy_(self.named_parameters_dict[name])
 
             for name, buffer in model.named_buffers():
                 if name in self.named_buffers_dict:
-                    buffer.data = self.named_buffers_dict[name]
+                    buffer.copy_(self.named_buffers_dict[name])
 
     def move_params_to_device(self, destination_model: torch.nn.Module):
         """Moves the ema parameters and buffers to the device of a destination model."""

--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -428,10 +428,10 @@ class EMAParameters:
     def move_params_to_device(self, destination_model: torch.nn.Module):
         """Moves the ema parameters and buffers to the device of a destination model."""
         model_state_dict = destination_model.state_dict()
-        for name, param in self.named_parameters_dict.items():
-            if name in model_state_dict:
-                self.named_parameters_dict[name] = param.to(model_state_dict[name].device)
+        for name, param in destination_model.named_parameters():
+            if name in self.named_parameters_dict:
+                self.named_parameters_dict[name] = param.to(param.device)
 
-        for name, buffer in self.named_buffers_dict.items():
-            if name in model_state_dict:
-                self.named_buffers_dict[name] = buffer.to(model_state_dict[name].device)
+        for name, buffer in destination_model.named_buffers():
+            if name in self.named_buffers_dict:
+                self.named_buffers_dict[name] = buffer.to(param.device)

--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -427,11 +427,10 @@ class EMAParameters:
 
     def move_params_to_device(self, destination_model: torch.nn.Module):
         """Moves the ema parameters and buffers to the device of a destination model."""
-        model_state_dict = destination_model.state_dict()
         for name, param in destination_model.named_parameters():
             if name in self.named_parameters_dict:
-                self.named_parameters_dict[name] = param.to(param.device)
+                self.named_parameters_dict[name] = self.named_parameters_dict[name].to(param.device)
 
         for name, buffer in destination_model.named_buffers():
             if name in self.named_buffers_dict:
-                self.named_buffers_dict[name] = buffer.to(param.device)
+                self.named_buffers_dict[name] = self.named_buffers_dict[name].to(buffer.device)

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -209,6 +209,12 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     for obj_name, obj in model.named_children():
         if not isinstance(obj, (Metric, MetricCollection)):
 
+            # Skip wrapping submodules which are explicitly marked with no wrap
+            print(f'Name: {obj_name}, hasattr: {hasattr(obj, "_fsdp_wrap")}')
+            if hasattr(obj, '_fsdp_wrap') and not bool(obj._fsdp_wrap):
+                print(f'Not wrapping {obj_name} because it is marked with _fsdp_wrap=False')
+                continue
+
             def _param_init_fn(module: torch.nn.Module) -> None:
                 # A dictionary of all tied parameter pointers to module names
                 tied_pointers = {}


### PR DESCRIPTION
# What does this PR do?

Fixes EMA to work with FSDP. FSDP doesn't like directly accessing torch tensors -- instead we have to use copy. This has a small memory impact, but since it's not during a fwd/backward, it should be fine

Confirmed with manual test curves are same w or w/o FSDP:
```
Eval batch=1/1] Eval on eval data:
	 Eval metrics/eval/FrechetInceptionDistance-scale-0p0: 418.2500
	 Eval metrics/eval/MeanSquaredError: 1.1608
	 Eval metrics/eval/MeanSquaredError-bin-0-to-1: 1.1608
```
```
[Eval batch=1/1] Eval on eval data:
	 Eval metrics/eval/FrechetInceptionDistance-scale-0p0: 418.2500
	 Eval metrics/eval/MeanSquaredError: 1.1608
	 Eval metrics/eval/MeanSquaredError-bin-0-to-1: 1.1608
```

# What issue(s) does this change relate to?

[CO-1943](https://mosaicml.atlassian.net/browse/CO-1943)

[CO-1943]: https://mosaicml.atlassian.net/browse/CO-1943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ