### PR TITLE
gate the extra forward call specifically for fsdp

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -19,7 +19,7 @@ from torchmetrics import Metric
 
 from composer.metrics import InContextLearningMetric
 from composer.models.base import ComposerModel
-from composer.utils import MissingConditionalImportError, dist, get_file, import_object, safe_torch_load
+from composer.utils import MissingConditionalImportError, dist, get_file, import_object, is_model_fsdp, safe_torch_load
 
 if TYPE_CHECKING:
     import transformers
@@ -434,7 +434,7 @@ class HuggingFaceModel(ComposerModel):
         # We need to call forward once in order for FSDP + generate to work
         # See https://github.com/huggingface/accelerate/issues/570, https://github.com/huggingface/accelerate/issues/947,
         # and https://github.com/pytorch/pytorch/issues/82461 for more info
-        if not self.dummy_forward_called:
+        if not self.dummy_forward_called and is_model_fsdp(self.model):
             with torch.no_grad():
                 maybe_decoder_input_ids = {}
                 if self.model.config.is_encoder_decoder:

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -35,12 +35,12 @@ def is_model_fsdp(model: torch.nn.Module) -> bool:
     """Whether ``model`` is an instance of a :class:`.FullyShardedDataParallel`."""
     try:
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-        is_fsdp = False
+
         # Check if model is wrapped with FSDP
         for _, obj in model.named_children():
             if isinstance(obj, FSDP):
-                is_fsdp = True
-        return is_fsdp
+                return True
+        return False
     except ImportError:
         return False
 

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -36,6 +36,9 @@ def is_model_fsdp(model: torch.nn.Module) -> bool:
     try:
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
+        if isinstance(model, FSDP):
+            return True
+
         # Check if model is wrapped with FSDP
         for _, obj in model.named_children():
             if isinstance(obj, FSDP):


### PR DESCRIPTION
# What does this PR do?
This PR gates the extra forward call to get generate to work with fsdp on the model actually being fsdp so it is not called when not necessary.

# What issue(s) does this change relate to?
N/A

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
