### PR TITLE
Adding checks for weight tying s.t. we don't think `None` attributes are weight tied

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -219,7 +219,10 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
                 for name, mod in module.named_modules():
                     for attr in ['weight', 'bias']:
                         if hasattr(mod, attr):
-                            ptr = id(getattr(mod, attr))
+                            mod_attr = getattr(mod, attr)
+                            if mod_attr is None:
+                                continue
+                            ptr = id(mod_attr)
                             ptr_attr = (ptr, attr)
                             name_list = tied_pointers.get(ptr_attr, [])
                             name_list.append(name)

--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -23,7 +23,7 @@ class SimpleModel(ComposerClassifier):
         num_classes (int): number of classes (default: 2)
     """
 
-    def __init__(self, num_features: int = 1, num_classes: int = 2, device: str = 'cpu', bias: bool = False) -> None:
+    def __init__(self, num_features: int = 1, num_classes: int = 2, device: str = 'cpu', bias: bool = True) -> None:
 
         self.num_features = num_features
         self.num_classes = num_classes

--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -23,13 +23,13 @@ class SimpleModel(ComposerClassifier):
         num_classes (int): number of classes (default: 2)
     """
 
-    def __init__(self, num_features: int = 1, num_classes: int = 2) -> None:
+    def __init__(self, num_features: int = 1, num_classes: int = 2, device: str = 'cpu', bias: bool = False) -> None:
 
         self.num_features = num_features
         self.num_classes = num_classes
 
-        fc1 = torch.nn.Linear(num_features, 5)
-        fc2 = torch.nn.Linear(5, num_classes)
+        fc1 = torch.nn.Linear(num_features, 5, device=device, bias=bias)
+        fc2 = torch.nn.Linear(5, num_classes, device=device, bias=bias)
 
         net = torch.nn.Sequential(
             torch.nn.AdaptiveAvgPool2d(1),
@@ -39,6 +39,7 @@ class SimpleModel(ComposerClassifier):
             fc2,
             torch.nn.Softmax(dim=-1),
         )
+        net.param_init_fn = self.param_init_fn
         super().__init__(module=net, num_classes=num_classes)
 
         # Important: It is crucial that the FC layers are bound to `self`
@@ -48,6 +49,14 @@ class SimpleModel(ComposerClassifier):
         # as self.net[1]
         self.fc1 = fc1
         self.fc2 = fc2
+
+    def param_init_fn(self, module):
+        init_fn = partial(torch.nn.init.normal_, mean=0.0, std=0.1)
+
+        if isinstance(module, torch.nn.Linear):
+            init_fn(module.weight)
+            if module.bias is not None:
+                torch.nn.init.zeros_(module.bias)
 
 
 class SimpleMLP(torch.nn.Module):

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -19,7 +19,7 @@ from tests.common import EmbeddedWeightTiedModel, RandomClassificationDataset, S
 @pytest.mark.filterwarnings('ignore::UserWarning')
 @pytest.mark.gpu
 @pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
-                    reason='requires PyTorch 1.13 or higher')
+                    reason='FSDP requires PyTorch 1.13 or higher')
 def test_fsdp_device_initialization(model: ComposerClassifier, mixed_precision: str, device: str, reentrant: bool):
     """test FSDP device initialization for a simple model with weight tying and a model where two modules
     from separate submodules have weight tying applied. This test also covers both 'cpu' and
@@ -63,11 +63,11 @@ def test_fsdp_device_initialization(model: ComposerClassifier, mixed_precision: 
 @pytest.mark.parametrize('mixed_precision', ['FULL', 'DEFAULT', 'PURE'])
 @pytest.mark.gpu
 @pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
-                    reason='requires PyTorch 1.13 or higher')
+                    reason='FSDP requires PyTorch 1.13 or higher')
 def test_fsdp_meta_initialization_none(model: ComposerClassifier, mixed_precision: 'str', device: str = 'meta'):
     """
     This test is intedned to test FSDP for meta initialization when there are attributes
-    that are `None` and ensure we don't raise naster UserWarnings.
+    that are `None` and ensure we don't raise nasty UserWarnings.
     """
     num_classes = 2
     model = model(num_features=1, num_classes=num_classes, device=device, bias=False)
@@ -75,12 +75,10 @@ def test_fsdp_meta_initialization_none(model: ComposerClassifier, mixed_precisio
     dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
 
-    trainer = Trainer(
+    Trainer(
         model=model,
         optimizers=optimizer,
         train_dataloader=dataloader,
         fsdp_config={'mixed_precision': mixed_precision},
         max_duration='3ba',
     )
-
-    trainer.fit()

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader
 from composer.models import ComposerClassifier
 from composer.trainer.trainer import Trainer
 from composer.utils import dist
-from tests.common import EmbeddedWeightTiedModel, RandomClassificationDataset, SimpleWeightTiedModel
+from tests.common import EmbeddedWeightTiedModel, RandomClassificationDataset, SimpleModel, SimpleWeightTiedModel
 
 
 @pytest.mark.parametrize('model', [SimpleWeightTiedModel, EmbeddedWeightTiedModel])
@@ -57,3 +57,30 @@ def test_fsdp_device_initialization(model: ComposerClassifier, mixed_precision: 
             weight_2 = model.net2.fc1.weight
             assert (id(weight_1) == id(weight_2))
             assert (torch.equal(weight_1, weight_2))
+
+
+@pytest.mark.parametrize('model', [SimpleModel])
+@pytest.mark.parametrize('mixed_precision', ['FULL', 'DEFAULT', 'PURE'])
+@pytest.mark.gpu
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
+                    reason='requires PyTorch 1.13 or higher')
+def test_fsdp_meta_initialization_none(model: ComposerClassifier, mixed_precision: 'str', device: str = 'meta'):
+    """
+    This test is intedned to test FSDP for meta initialization when there are attributes
+    that are `None` and ensure we don't raise naster UserWarnings.
+    """
+    num_classes = 2
+    model = model(num_features=1, num_classes=num_classes, device=device, bias=False)
+    dataset = RandomClassificationDataset(shape=(num_classes,), size=2, num_classes=num_classes)
+    dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    trainer = Trainer(
+        model=model,
+        optimizers=optimizer,
+        train_dataloader=dataloader,
+        fsdp_config={'mixed_precision': mixed_precision},
+        max_duration='3ba',
+    )
+
+    trainer.fit()


### PR DESCRIPTION
# What does this PR do?
Adding checks, tests for on `meta` initialization with FSDP s.t. when we check for weight tying, `None` attributes aren't added to the list of attributes to check.

Before we added all `None` attributes and it would raise a scary error. 

# What issue(s) does this change relate to?
[CO-1968](https://mosaicml.atlassian.net/jira/software/c/projects/CO/issues/CO-1968)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1968]: https://mosaicml.atlassian.net/browse/CO-1968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ