### PR TITLE
Add torch.compile support for torch 2.0

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1358,6 +1358,7 @@ class Trainer:
             compiled_model = torch.compile(self.state.model, **compile_config)  # pyright: ignore
             self.state.model = compiled_model._orig_mod
             self.state.model.forward = compiled_model.dynamo_ctx(self.state.model.forward)
+            is_model_compiled = True
         elif not is_torch_2_0 and compile_config is not None:
             log.warning(f'`torch.compile()` is supported for PyTorch 2.0 or higher.' +
                         f'Either update your PyTorch version or disable parameter by providing ' +

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -903,7 +903,7 @@ class Trainer:
             if isinstance(model, OptimizedModule):
                 log.warning(f'Provided `model` is already compiled with `torch.compile`. Ignoring ' +
                             f'parameter `compile_config` if provided. If you would like `Trainer` ' +
-                            f'to takes care of model compilation, provide a un-compiled model and ' +
+                            f'to takes care of model compilation, provide a not-compiled model and ' +
                             f'`compile_config` parameter.')
                 # The `torch.compile` function returns an object of type `torch._dynamo.OptimizedModule`
                 # which wraps the original `nn.Module` object and later patches its forward method to
@@ -1366,9 +1366,9 @@ class Trainer:
             if self.auto_log_hparams:
                 self.local_hparams['is_model_compiled'] = is_model_compiled
         elif not is_torch_2_0 and compile_config is not None:
-            log.warning(f'`torch.compile` is supported for PyTorch 2.0 or higher.' +
-                        f'Either update your PyTorch version or disable parameter by providing ' +
-                        f'`compile_config` to `None`.')
+            warnings.warn(f'`torch.compile` is supported for PyTorch 2.0 or higher.' +
+                          f'Either update your PyTorch version or disable parameter by providing ' +
+                          f'`compile_config` to `None`.')
 
     @property
     def saved_checkpoints(self) -> List[str]:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -902,7 +902,7 @@ class Trainer:
             from torch._dynamo import OptimizedModule
             if isinstance(model, OptimizedModule):
                 log.warning(f'Provided `model` is already compiled with `torch.compile`. Ignoring ' +
-                            f'parameter `compile_config` if provided. If you would like `Trainer()` ' +
+                            f'parameter `compile_config` if provided. If you would like `Trainer` ' +
                             f'to takes care of model compilation, provide a un-compiled model and ' +
                             f'`compile_config` parameter.')
                 # The `torch.compile` function returns an object of type `torch._dynamo.OptimizedModule`
@@ -1363,7 +1363,8 @@ class Trainer:
             is_model_compiled = True
             # update local_hparams to ensure the `is_model_compiled` is set correctly for
             # debugging purpose and for unit test.
-            self.local_hparams['is_model_compiled'] = is_model_compiled
+            if self.auto_log_hparams:
+                self.local_hparams['is_model_compiled'] = is_model_compiled
         elif not is_torch_2_0 and compile_config is not None:
             log.warning(f'`torch.compile` is supported for PyTorch 2.0 or higher.' +
                         f'Either update your PyTorch version or disable parameter by providing ' +

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -913,7 +913,8 @@ class Trainer:
                 if not isinstance(compiled_model, ComposerModel):
                     raise ValueError(f'Provided `model` must be a subclass of ComposerModel. ' +
                                      f'Instead found as type `{type(compiled_model)}`')
-                compiled_model.forward = model.dynamo_ctx(compiled_model.forward)  # pyright: ignore
+                compiled_model.forward = model.dynamo_ctx(
+                    compiled_model.forward)  # pyright: ignore [reportGeneralTypeIssues]
                 model = compiled_model
 
         # Microbatching
@@ -1355,10 +1356,14 @@ class Trainer:
         # The model would need to be torch.compile()'d after being wrapped in a distributed strategy
         # to take advantage of any graph breaks.
         if is_torch_2_0 and not is_model_compiled and compile_config is not None:
-            compiled_model = torch.compile(self.state.model, **compile_config)  # pyright: ignore
+            compiled_model = torch.compile(  # pyright: ignore [reportGeneralTypeIssues]
+                self.state.model, **compile_config)
             self.state.model = compiled_model._orig_mod
             self.state.model.forward = compiled_model.dynamo_ctx(self.state.model.forward)
             is_model_compiled = True
+            # update local_hparams to ensure the `is_model_compiled` is set correctly for
+            # debugging purpose and for unit test.
+            self.local_hparams['is_model_compiled'] = is_model_compiled
         elif not is_torch_2_0 and compile_config is not None:
             log.warning(f'`torch.compile()` is supported for PyTorch 2.0 or higher.' +
                         f'Either update your PyTorch version or disable parameter by providing ' +

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1366,9 +1366,9 @@ class Trainer:
             if self.auto_log_hparams:
                 self.local_hparams['is_model_compiled'] = is_model_compiled
         elif not is_torch_2_0 and compile_config is not None:
-            warnings.warn(f'`torch.compile` is supported for PyTorch 2.0 or higher.' +
-                          f'Either update your PyTorch version or disable parameter by providing ' +
-                          f'`compile_config` to `None`.')
+            raise ValueError(f'`torch.compile` is supported for PyTorch 2.0 or higher.' +
+                             f'Either update your PyTorch version or disable parameter by providing ' +
+                             f'`compile_config` to `None`.')
 
     @property
     def saved_checkpoints(self) -> List[str]:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -901,7 +901,7 @@ class Trainer:
         if is_torch_2_0:
             from torch._dynamo import OptimizedModule
             if isinstance(model, OptimizedModule):
-                log.warning(f'Provided `model` is already compiled with `torch.compile(). Ignoring ' +
+                log.warning(f'Provided `model` is already compiled with `torch.compile`. Ignoring ' +
                             f'parameter `compile_config` if provided. If you would like `Trainer()` ' +
                             f'to takes care of model compilation, provide a un-compiled model and ' +
                             f'`compile_config` parameter.')
@@ -1365,7 +1365,7 @@ class Trainer:
             # debugging purpose and for unit test.
             self.local_hparams['is_model_compiled'] = is_model_compiled
         elif not is_torch_2_0 and compile_config is not None:
-            log.warning(f'`torch.compile()` is supported for PyTorch 2.0 or higher.' +
+            log.warning(f'`torch.compile` is supported for PyTorch 2.0 or higher.' +
                         f'Either update your PyTorch version or disable parameter by providing ' +
                         f'`compile_config` to `None`.')
 

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -84,8 +84,10 @@ def model_eval_mode(model: torch.nn.Module):
         model.train(mode=is_training)
 
 
-def using_torch_2_0():
-    is_torch_2_0 = False
-    if version.parse(torch.__version__) >= version.parse('2.0.0'):
-        is_torch_2_0 = True
-    return is_torch_2_0
+def using_torch_2_0() -> bool:
+    """Check the PyTorch version and compared it with version 2.0.0.
+
+    Returns:
+        bool: Return True if current version is greater than or equal to 2.0.0 else False
+    """
+    return version.parse(torch.__version__) >= version.parse('2.0.0')

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -5,8 +5,8 @@ import collections.abc
 import contextlib
 import copy
 import datetime
-import math
 import logging
+import math
 import os
 import pathlib
 import time

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -128,7 +128,7 @@ class TestTrainerInit():
                         optimizers=optimizer,
                         auto_log_hparams=True,
                         compile_config=None)
-            assert '`model` is already compiled with `torch.compile()' in caplog.text
+            assert '`model` is already compiled with `torch.compile`' in caplog.text
 
     @pytest.mark.skipif(version.parse(torch.__version__) >= version.parse('2.0.0'),
                         reason='requires PyTorch 1.13 or lower')
@@ -143,7 +143,7 @@ class TestTrainerInit():
                         optimizers=optimizer,
                         auto_log_hparams=True,
                         compile_config={})
-            assert '`torch.compile()` is supported for PyTorch 2.0 or higher.' in caplog.text
+            assert '`torch.compile` is supported for PyTorch 2.0 or higher.' in caplog.text
 
 
 def _assert_optimizer_is_on_device(optimizer: torch.optim.Optimizer):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -133,7 +133,7 @@ class TestTrainerInit():
     @pytest.mark.skipif(version.parse(torch.__version__) >= version.parse('2.0.0'),
                         reason='requires PyTorch 1.13 or lower')
     def test_compile_unsupported_torch_version_warning(self, caplog, model: ComposerModel):
-        with caplog.at_level(logging.WARNING):
+        with pytest.warns(Warning, match='`torch.compile` is supported for PyTorch 2.0 or higher.'):
             train_dataset = RandomClassificationDataset()
             optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
             max_duration = '2ba'
@@ -143,7 +143,6 @@ class TestTrainerInit():
                         optimizers=optimizer,
                         auto_log_hparams=True,
                         compile_config={})
-            assert '`torch.compile` is supported for PyTorch 2.0 or higher.' in caplog.text
 
 
 def _assert_optimizer_is_on_device(optimizer: torch.optim.Optimizer):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -550,11 +550,13 @@ class TestTrainerInitOrFit:
     @pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
                         reason='requires PyTorch 1.13 or higher')
     @pytest.mark.parametrize('precision', [Precision.FP32, Precision.AMP_BF16, Precision.AMP_FP16])
+    @pytest.mark.parametrize('compile_config', [None, {}])
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_fsdp(
         self,
         model: ComposerModel,
         precision: Precision,
+        compile_config: Optional[Dict[str, Any]],
         max_duration: Time[int],
         train_dataloader: DataLoader,
     ):
@@ -578,13 +580,12 @@ class TestTrainerInitOrFit:
         should_error = False
 
         with ctx:
-            trainer = Trainer(
-                model=model,
-                precision=precision,
-                fsdp_config=fsdp_config,
-                max_duration=max_duration,
-                train_dataloader=train_dataloader,
-            )
+            trainer = Trainer(model=model,
+                              precision=precision,
+                              fsdp_config=fsdp_config,
+                              max_duration=max_duration,
+                              train_dataloader=train_dataloader,
+                              compile_config=compile_config)
 
         if not should_error:
             assert is_model_fsdp(trainer.state.model)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -132,8 +132,8 @@ class TestTrainerInit():
 
     @pytest.mark.skipif(version.parse(torch.__version__) >= version.parse('2.0.0'),
                         reason='requires PyTorch 1.13 or lower')
-    def test_compile_unsupported_torch_version_warning(self, caplog, model: ComposerModel):
-        with pytest.warns(Warning, match='`torch.compile` is supported for PyTorch 2.0 or higher.'):
+    def test_compile_unsupported_torch_version_exception(self, caplog, model: ComposerModel):
+        with pytest.raises(ValueError, match='`torch.compile` is supported for PyTorch 2.0 or higher.'):
             train_dataset = RandomClassificationDataset()
             optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
             max_duration = '2ba'

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -134,6 +134,11 @@ def test_extract_hparams_trainer():
         'log_traces': False,
         'auto_log_hparams': True,
 
+        # Compile
+        'compile_config': None,
+        'is_model_compiled': False,
+        'is_torch_2_0': False,
+
         # Load Checkpoint
         'load_path': None,
         'load_object_store': None,


### PR DESCRIPTION
# What does this PR do?
- Support of `torch.compile` as part of Trainer argument.
- Add a new parameter `compile_config` in Trainer() which support model compilation based on the value of `compile_config` parameter.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?
CO-1956

# Testing
## End-to-end model training 

**Node:** 1
**GPUs:** 4

| Model    | Dataset  | With compile thoughput/samples_per_sec | Without compile thoughput/samples_per_sec | Performance % |
| -------- | -------- | -------------------------------------- | ----------------------------------------- | ------------- |
| HF BERT  | C4       | 4259                                   | 3360                                      | 26.75%        |
| ResNet50 | ImageNet | 7424                                   | 5557                                      | 33.60%        |


### FSDP
- Some known FSDP Torch 2.0 issues when doing eval (Training works fine): https://github.com/pytorch/pytorch/issues/93288

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
