### PR TITLE
add logic for direct instantiation

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -510,7 +510,16 @@ def get_hf_config_from_composer_state_dict(state_dict: Dict[str, Any],
     if 'id2label' in hf_config_dict:
         hf_config_dict['id2label'] = {int(k): v for k, v in hf_config_dict['id2label'].items()}
 
-    return transformers.AutoConfig.from_pretrained(hf_config_dict['_name_or_path'], **hf_config_dict)
+    try:
+        return transformers.AutoConfig.for_model(**hf_config_dict)
+    except ValueError:
+        try:
+            return transformers.AutoConfig.from_pretrained(hf_config_dict['_name_or_path'], **hf_config_dict)
+        except KeyError:
+            raise Exception(
+                f'Could not load config from state dict using either `for_model` or `from_pretrained`.'
+                f'Please make sure that the model_type={hf_config_dict.get("model_type")} is valid, or that the'
+                f'config has a valid `_name_or_path`.')
 
 
 def write_huggingface_pretrained_from_composer_checkpoint(

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -647,6 +647,50 @@ def test_write_hf_from_composer(checkpoint_upload_folder, local_save_filename, t
     check_hf_model_equivalence(tiny_bert_model, loaded_hf_model)
 
 
+def test_write_hf_from_composer_direct(tiny_bert_tokenizer, tmp_path):
+    # tests that the logic to write out a huggingface checkpoint from a composer checkpoint
+    # still works when the huggingface model is instantiated directly rather than using from_pretrained
+    transformers = pytest.importorskip('transformers')
+
+    from composer.models.huggingface import write_huggingface_pretrained_from_composer_checkpoint
+
+    checkpoint_upload_folder = tmp_path
+
+    tiny_overrides = {
+        'hidden_size': 128,
+        'num_attention_heads': 2,
+        'num_hidden_layers': 2,
+        'intermediate_size': 512,
+    }
+    tiny_bert_config = transformers.BertConfig(**tiny_overrides)
+    tiny_bert_model = transformers.BertForMaskedLM(tiny_bert_config)
+    trainer = get_lm_trainer(tiny_bert_model, tiny_bert_tokenizer, str(tmp_path))
+    trainer.fit()
+
+    # Just upload to a dummy object store outside of composer to make mocking easier
+    if str(checkpoint_upload_folder).startswith('s3://'):
+        parsed_uri = urlparse(checkpoint_upload_folder)
+        object_store = DummyObjectStore(Path(parsed_uri.netloc))
+        object_store.upload_object(parsed_uri.path + 'hf-checkpoint.pt', str(tmp_path / 'hf-checkpoint.pt'))
+
+    with patch('composer.utils.file_helpers.S3ObjectStore', DummyObjectStore):
+        checkpoint_path = os.path.join(checkpoint_upload_folder, 'hf-checkpoint.pt')
+        write_huggingface_pretrained_from_composer_checkpoint(
+            checkpoint_path,
+            tmp_path / 'hf-save-pretrained',
+        )
+
+    assert os.path.exists(tmp_path / 'hf-save-pretrained' / 'config.json')
+    assert os.path.exists(tmp_path / 'hf-save-pretrained' / 'pytorch_model.bin')
+
+    loaded_hf_model = transformers.AutoModelForMaskedLM.from_pretrained(tmp_path / 'hf-save-pretrained')
+
+    # set _name_or_path so that the equivalence check passes. It is expected that these are different, because one is loaded from disk, while one is loaded from the hub
+    loaded_hf_model.config._name_or_path = tiny_bert_model.config._name_or_path
+
+    check_hf_model_equivalence(tiny_bert_model, loaded_hf_model)
+
+
 @pytest.mark.parametrize('embedding_resize', ['higher', 'lower', 'no_resize'])
 @pytest.mark.parametrize('allow_embedding_resizing', [True, False])
 def test_embedding_resizing(tiny_bert_model, tiny_bert_tokenizer, embedding_resize, allow_embedding_resizing, caplog):

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -667,18 +667,11 @@ def test_write_hf_from_composer_direct(tiny_bert_tokenizer, tmp_path):
     trainer = get_lm_trainer(tiny_bert_model, tiny_bert_tokenizer, str(tmp_path))
     trainer.fit()
 
-    # Just upload to a dummy object store outside of composer to make mocking easier
-    if str(checkpoint_upload_folder).startswith('s3://'):
-        parsed_uri = urlparse(checkpoint_upload_folder)
-        object_store = DummyObjectStore(Path(parsed_uri.netloc))
-        object_store.upload_object(parsed_uri.path + 'hf-checkpoint.pt', str(tmp_path / 'hf-checkpoint.pt'))
-
-    with patch('composer.utils.file_helpers.S3ObjectStore', DummyObjectStore):
-        checkpoint_path = os.path.join(checkpoint_upload_folder, 'hf-checkpoint.pt')
-        write_huggingface_pretrained_from_composer_checkpoint(
-            checkpoint_path,
-            tmp_path / 'hf-save-pretrained',
-        )
+    checkpoint_path = os.path.join(checkpoint_upload_folder, 'hf-checkpoint.pt')
+    write_huggingface_pretrained_from_composer_checkpoint(
+        checkpoint_path,
+        tmp_path / 'hf-save-pretrained',
+    )
 
     assert os.path.exists(tmp_path / 'hf-save-pretrained' / 'config.json')
     assert os.path.exists(tmp_path / 'hf-save-pretrained' / 'pytorch_model.bin')


### PR DESCRIPTION
# What does this PR do?
The utility function to write out a huggingface checkpoint from a composer checkpoint relied on `_name_or_path`, which only exists if the huggingface model was created using `from_pretrained`. This PR adds the necessary code to load the config using `model_type` instead. It first tries to use `model_type`, then tries to use `_name_or_path`, then crashes if neither of those work.

# What issue(s) does this change relate to?
Closes [CO-1984](https://mosaicml.atlassian.net/browse/CO-1984)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1984]: https://mosaicml.atlassian.net/browse/CO-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ