### PR TITLE
Runtime estimator

### DIFF
--- a/composer/callbacks/runtime_estimator.py
+++ b/composer/callbacks/runtime_estimator.py
@@ -137,7 +137,7 @@ class RuntimeEstimator(Callback):
                 else:
                     eval_wct_avg = sum(eval_wcts) / num_evals_finished
                 eval_rate = self.eval_frequency_per_label[dataloader_label]
-                num_total_evals = 1 / eval_rate
+                num_total_evals = 1 / eval_rate * (1 - self.start_dur)
                 remaining_calls = num_total_evals - num_evals_finished
                 remaining_time += eval_wct_avg * remaining_calls
 


### PR DESCRIPTION
# What does this PR do?

The runtime estimator currently over estimates the number of evals left when resuming. This fixes the num evals left correction.

Manual test:
Before: After first eval, we see 26 hr ETA
<img width="443" alt="image" src="https://user-images.githubusercontent.com/17102158/230458211-45bca334-5d08-4c6b-8521-46f797e894cd.png">
After: After first eval, we see 13.5 hr ETA
<img width="545" alt="image" src="https://user-images.githubusercontent.com/17102158/230473845-cf893317-31c4-4b8e-81e4-eb9b529a86cf.png">


# What issue(s) does this change relate to?

[CP-1978](https://mosaicml.atlassian.net/browse/CO-1978)