### PR TITLE
Flush checkpoint on kill

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -343,6 +343,13 @@ class CheckpointSaver(Callback):  # noqa: D101
                 logger,
             )
 
+    def close(self, state: State, logger: Logger):
+        if self.last_checkpoint_batch != state.timestamp.batch:
+            self._save_checkpoint(
+                state,
+                logger,
+            )
+
     def get_state_dict(self, state):
         return {
             'state': state.state_dict(),

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -69,6 +69,8 @@ import atexit
 import contextlib
 import logging
 import os
+import signal
+import sys
 import textwrap
 import weakref
 from collections import OrderedDict
@@ -112,6 +114,15 @@ def _set_atexit_ran():
 # Since atexit calls hooks in LIFO order, this hook will always be invoked after all atexit-triggered
 # _close() calls are invoked
 atexit.register(_set_atexit_ran)
+
+
+# Catch SIGTERM/SIGINT and instead exit via `sys.exit` using same error code, ensuring atexit
+# functions still run. Composer CLI launcher will give a 30 second grace period before sending
+# SIGKILL.
+def sigterm_handler(signal, frame):
+    sys.exit(128+signal)
+signal.signal(signal.SIGTERM, sigterm_handler)
+signal.signal(signal.SIGINT, sigterm_handler)
 
 
 def _get_default_passes():

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -120,7 +120,9 @@ atexit.register(_set_atexit_ran)
 # functions still run. Composer CLI launcher will give a 30 second grace period before sending
 # SIGKILL.
 def sigterm_handler(signal, frame):
-    sys.exit(128+signal)
+    sys.exit(128 + signal)
+
+
 signal.signal(signal.SIGTERM, sigterm_handler)
 signal.signal(signal.SIGINT, sigterm_handler)
 


### PR DESCRIPTION
# What does this PR do?

Flushes checkpoint on kill. Adds signal handling to ensure atexit fns run. Notes:
1. cloud doesn't currently support this -- theyre fixign a bug to ensure it actually sends SIGINT
2. this leads to some nasty traces when ctrl + Cing... I'm not really sure if we can handle this any better. Open to ideas, but I think this is ok for a v1?
<img width="1295" alt="image" src="https://user-images.githubusercontent.com/17102158/230654302-7c645540-f973-4339-9535-f3b0f8ef636a.png">

Manual test:
1) I kill with ctrl C
<img width="694" alt="image" src="https://user-images.githubusercontent.com/17102158/230653894-c0b178ed-bab9-491a-b3dd-b8bc9e7db622.png">
2) Checkpoint exists
<img width="491" alt="image" src="https://user-images.githubusercontent.com/17102158/230653907-c91e3ab7-f869-4e85-bfa4-10a42a15da34.png">


# What issue(s) does this change relate to?

[CO-1987](https://mosaicml.atlassian.net/browse/CO-1987)

[CO-1987]: https://mosaicml.atlassian.net/browse/CO-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ