### PR TITLE
Fix early stopper docs links

### DIFF
--- a/examples/early_stopping.ipynb
+++ b/examples/early_stopping.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -24,9 +25,9 @@
     "\n",
     "We'll demonstrate:\n",
     "\n",
-    "* [Basic training setup with Composer](#setup)\n",
-    "* [Using the EarlyStopper](#earlystopper), and\n",
-    "* [Using the ThresholdStopper](#thresholdstopper)\n",
+    "* [Basic training setup with Composer](#Setup)\n",
+    "* [Using the EarlyStopper](#Earlystopper), and\n",
+    "* [Using the ThresholdStopper](#Thresholdstopper)\n",
     "\n",
     "A comprehensive overview of Composer callbacks is outside the scope of this tutorial, but this should introduce you to some useful tools and give you a sense for the ways callbacks can be used to modify training behavior.\n",
     "\n",
@@ -39,11 +40,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"setup\"></a>\n",
     "## Setup\n",
+    "<a id=\"Setup\"></a>\n",
     "\n",
     "In this tutorial, we'll train a `ComposerModel` and halt training for criteria that we'll set. We'll use the same basic setup as in the [Getting Started][tutorial] tutorial. If you want to better understand the details of the setup, that's a good place to review.\n",
     "\n",
@@ -170,11 +172,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"earlystopper\"></a>\n",
-    "## EarlyStopper"
+    "## EarlyStopper\n",
+    "<a id=\"Earlystopper\"></a>"
    ]
   },
   {
@@ -247,11 +250,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id=\"thresholdstopper\"></a>\n",
-    "## ThresholdStopper"
+    "## ThresholdStopper\n",
+    "<a id=\"Thresholdstopper\"></a>"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

The hyperlinks are wrong and messed up in current docs.
<img width="345" alt="image" src="https://user-images.githubusercontent.com/17102158/230466836-7a08f0f3-8a19-481f-8fe5-68343b410274.png">
This PR fixes it as we've done in other notebooks.

Now, it's fixed:
<img width="356" alt="image" src="https://user-images.githubusercontent.com/17102158/230475175-248a1c05-45e3-40f8-bf9a-6b9e0be0c97f.png">
