### PR TITLE
Add flexibility for FSDP Auto Wrap in Composer

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -205,7 +205,15 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     # may make calls to sharded submodules. If we only wrap the submodules, then any call that ComposerModel makes
     # to a FSDP-wrapped submodule's `forward()` function will be safe and all-gather the necessary weights before `forward()`.
     for obj_name, obj in model.named_children():
-        if not isinstance(obj, (Metric, MetricCollection)):
+        if not isinstance(obj, (Metric, MetricCollection, FullyShardedDataParallel)):
+            has_wrapped_child = False
+            # Don't wrap already wrapped children
+            for _, child_mod in obj.named_children():
+                if isinstance(child_mod, FullyShardedDataParallel):
+                    has_wrapped_child = True
+            if has_wrapped_child:
+                print('skipping already wrapped child: ', obj_name)
+                continue
 
             # Skip wrapping submodules which are explicitly marked with no wrap
             if hasattr(obj, '_fsdp_wrap') and not bool(obj._fsdp_wrap):

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -206,15 +206,6 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     # to a FSDP-wrapped submodule's `forward()` function will be safe and all-gather the necessary weights before `forward()`.
     for obj_name, obj in model.named_children():
         if not isinstance(obj, (Metric, MetricCollection, FullyShardedDataParallel)):
-            has_wrapped_child = False
-            # Don't wrap already wrapped children
-            for _, child_mod in obj.named_children():
-                if isinstance(child_mod, FullyShardedDataParallel):
-                    has_wrapped_child = True
-            if has_wrapped_child:
-                print('skipping already wrapped child: ', obj_name)
-                continue
-
             # Skip wrapping submodules which are explicitly marked with no wrap
             if hasattr(obj, '_fsdp_wrap') and not bool(obj._fsdp_wrap):
                 continue

--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -205,7 +205,8 @@ def prepare_fsdp_module(model: torch.nn.Module, optimizers: Optional[Union[torch
     # may make calls to sharded submodules. If we only wrap the submodules, then any call that ComposerModel makes
     # to a FSDP-wrapped submodule's `forward()` function will be safe and all-gather the necessary weights before `forward()`.
     for obj_name, obj in model.named_children():
-        if not isinstance(obj, (Metric, MetricCollection, FullyShardedDataParallel)):
+        if not isinstance(obj, (Metric, MetricCollection)):
+
             # Skip wrapping submodules which are explicitly marked with no wrap
             if hasattr(obj, '_fsdp_wrap') and not bool(obj._fsdp_wrap):
                 continue

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -711,7 +711,7 @@ class Trainer:
             To use FSDP with default values, set to the empty dictionary ``{}``. To
             disable FSDP, set to ``None``. (default: ``None``)
         fsdp_auto_wrap (bool, optional): option to let trainer wrap the module, or if
-            the module is already wrapped outside, then don't wrap.
+            the module is already wrapped outside, allow the user to disable auto-wrapping. 
 
         device (Device | str, optional): The device to use for training, which can be ``'cpu'``, ``'gpu'``,
             ``'tpu'``, or ``'mps'``. (default: ``None``)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -710,7 +710,7 @@ class Trainer:
             See :doc:`FSDP Documentation </notes/distributed_training>` for more details.
             To use FSDP with default values, set to the empty dictionary ``{}``. To
             disable FSDP, set to ``None``. (default: ``None``)
-        wrap_fsdp (bool, optional): option to let trainer wrap the module, or if
+        fsdp_auto_wrap (bool, optional): option to let trainer wrap the module, or if
             the module is already wrapped outside, then don't wrap.
 
         device (Device | str, optional): The device to use for training, which can be ``'cpu'``, ``'gpu'``,
@@ -839,7 +839,7 @@ class Trainer:
         # DeepSpeed
         deepspeed_config: Optional[Dict[str, Any]] = None,
         fsdp_config: Optional[Dict[str, Any]] = None,
-        wrap_fsdp: Optional[bool] = True,
+        fsdp_auto_wrap: Optional[bool] = True,
 
         # System/Numerics
         device: Optional[Union[str, Device]] = None,
@@ -898,8 +898,8 @@ class Trainer:
             # And torch.distributed is always required for multi-rank training
             dist.initialize_dist(device, dist_timeout)
 
-        # Handle FSDP sharding
-        if self.fsdp_config is not None and wrap_fsdp:
+        # Handle FSDP wrapping
+        if self.fsdp_config is not None and fsdp_auto_wrap:
             prepare_fsdp_module(model, optimizers, self.fsdp_config, precision)
 
         # Reproducibility

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -916,7 +916,7 @@ class Trainer:
 
         # Handle FSDP wrapping
         if self.fsdp_config is not None and fsdp_auto_wrap:
-            prepare_fsdp_module(model, optimizers, self.fsdp_config, precision)
+            prepare_fsdp_module(model, optimizers, self.fsdp_config, precision, device, auto_microbatching)
 
         # Reproducibility
         rank_zero_seed, seed = _distribute_and_get_random_seed(seed, device)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1841,6 +1841,7 @@ class Trainer:
                             reproducibility.load_rng_state(self._rng_state)
                             self._rng_state = None
                         continue
+
                     self.state.batch = self.state.device.batch_to_device(self.state.batch)
                     self.state.batch = self._train_data_spec.device_transforms(self.state.batch)
                     rank_num_samples = self._train_data_spec.get_num_samples_in_batch(self.state.batch)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -711,7 +711,7 @@ class Trainer:
             To use FSDP with default values, set to the empty dictionary ``{}``. To
             disable FSDP, set to ``None``. (default: ``None``)
         fsdp_auto_wrap (bool, optional): option to let trainer wrap the module, or if
-            the module is already wrapped outside, allow the user to disable auto-wrapping. 
+            the module is already wrapped outside, allow the user to disable auto-wrapping.
 
         device (Device | str, optional): The device to use for training, which can be ``'cpu'``, ``'gpu'``,
             ``'tpu'``, or ``'mps'``. (default: ``None``)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1841,8 +1841,6 @@ class Trainer:
                             reproducibility.load_rng_state(self._rng_state)
                             self._rng_state = None
                         continue
-                    # print ("state batch is: ", self.state.batch)
-                    # assert False
                     self.state.batch = self.state.device.batch_to_device(self.state.batch)
                     self.state.batch = self._train_data_spec.device_transforms(self.state.batch)
                     rank_num_samples = self._train_data_spec.get_num_samples_in_batch(self.state.batch)

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -158,6 +158,7 @@ def test_extract_hparams_trainer():
         # DeepSpeed
         'deepspeed_config': None,
         'fsdp_config': None,
+        'fsdp_auto_wrap': True,
 
         # System/Numerics
         'device': 'DeviceCPU',


### PR DESCRIPTION
# What does this PR do?
Adds a flag to enable a user to disable FSDP auto wrapping in composer.

This is necessary, since if a user pre-wraps their modules, then auto-wrap will see there are already pre-wrapped modules and it will raise an error. 

# What issue(s) does this change relate to?
https://mosaicml.atlassian.net/browse/CO-2004

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
