### PR TITLE
Better defaults for `get_num_tokens_in_batch`

### DIFF
--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -260,13 +260,13 @@ class DataSpec:
                     Please use a DataSpec and specify `get_num_samples_in_batch`."""))
 
     def _default_get_num_tokens_in_batch(self, batch: Batch) -> int:
-        samples_per_batch = self.get_num_samples_in_batch(batch)
-
         # first try HuggingFace-style input dicts
         if isinstance(batch, dict) and 'input_ids' in batch:
-            return batch['input_ids'].shape[1] * batch['input_ids'].shape[0]
+            samples_per_batch = batch['input_ids'].shape[0]
+            return batch['input_ids'].shape[1] * samples_per_batch
         # then try dataset.max_seq_len
         elif hasattr(self.dataloader, 'dataset') and hasattr(self.dataloader.dataset, 'max_seq_len'):  # type: ignore
+            samples_per_batch = self.get_num_samples_in_batch(batch)
             return self.dataloader.dataset.max_seq_len * samples_per_batch  # type: ignore
         return 0
 

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -8,7 +8,6 @@ import collections.abc
 import math
 import textwrap
 import warnings
-from collections import UserDict
 from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import torch
@@ -262,7 +261,7 @@ class DataSpec:
 
     def _default_get_num_tokens_in_batch(self, batch: Batch) -> int:
         # First try HuggingFace-style input dicts
-        if (isinstance(batch, dict) or isinstance(batch, UserDict)) and 'input_ids' in batch:
+        if isinstance(batch, Mapping) and 'input_ids' in batch:
             samples_per_batch = batch['input_ids'].shape[0]
             return batch['input_ids'].shape[1] * samples_per_batch
         # Then try dataset.max_seq_len

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -260,7 +260,14 @@ class DataSpec:
                     Please use a DataSpec and specify `get_num_samples_in_batch`."""))
 
     def _default_get_num_tokens_in_batch(self, batch: Batch) -> int:
-        del batch  # unused
+        samples_per_batch = self.get_num_samples_in_batch(batch)
+
+        # first try dataset.max_seq_len
+        if hasattr(self.dataloader, 'dataset') and hasattr(self.dataloader.dataset, 'max_seq_len'):  # type: ignore
+            return self.dataloader.dataset.max_seq_len * samples_per_batch  # type: ignore
+        # then try HuggingFace-style input dicts
+        elif isinstance(batch, dict) and 'input_ids' in batch:
+            return batch['input_ids'].shape[1] * samples_per_batch
         return 0
 
 

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -265,7 +265,7 @@ class DataSpec:
         if (isinstance(batch, dict) or isinstance(batch, UserDict)) and 'input_ids' in batch:
             samples_per_batch = batch['input_ids'].shape[0]
             return batch['input_ids'].shape[1] * samples_per_batch
-        # then try dataset.max_seq_len
+        # Then try dataset.max_seq_len
         elif hasattr(self.dataloader, 'dataset') and hasattr(self.dataloader.dataset, 'max_seq_len'):  # type: ignore
             samples_per_batch = self.get_num_samples_in_batch(batch)
             return self.dataloader.dataset.max_seq_len * samples_per_batch  # type: ignore

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -168,7 +168,7 @@ class DataSpec:
         get_num_tokens_in_batch ((Batch) -> int, optional): Function that is called by the :class:`.Trainer` to
             get the number of tokens in the provided batch.
 
-            By default, it checks for HuggingFace-style dictionary batches with ``input_ids``, and then checks ``dataset.max_seq_len``, and then returns 0
+            By default, it checks for HuggingFace-style dictionary batches with ``input_ids``, and then checks ``dataset.max_seq_len``, and returns 0
             if both of those fail, meaning that number of tokens processed will not be tracked as a part of the training progress tracking.
             This function must be specified to track the number of tokens processed during training in a non-default way.
     """

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -8,6 +8,7 @@ import collections.abc
 import math
 import textwrap
 import warnings
+from collections import UserDict
 from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
 
 import torch
@@ -261,7 +262,7 @@ class DataSpec:
 
     def _default_get_num_tokens_in_batch(self, batch: Batch) -> int:
         # first try HuggingFace-style input dicts
-        if isinstance(batch, dict) and 'input_ids' in batch:
+        if isinstance(batch, dict) or isinstance(batch, UserDict) and 'input_ids' in batch:
             samples_per_batch = batch['input_ids'].shape[0]
             return batch['input_ids'].shape[1] * samples_per_batch
         # then try dataset.max_seq_len

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -169,6 +169,7 @@ class DataSpec:
 
             By default, it checks for HuggingFace-style dictionary batches with ``input_ids``, and then checks ``dataset.max_seq_len``, and returns 0
             if both of those fail, meaning that number of tokens processed will not be tracked as a part of the training progress tracking.
+            Note that the defaults do NOT take padding into account, so if you want the token calculation to exclude padding, you should specify this function.
             This function must be specified to track the number of tokens processed during training in a non-default way.
     """
 

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -262,7 +262,7 @@ class DataSpec:
 
     def _default_get_num_tokens_in_batch(self, batch: Batch) -> int:
         # first try HuggingFace-style input dicts
-        if isinstance(batch, dict) or isinstance(batch, UserDict) and 'input_ids' in batch:
+        if (isinstance(batch, dict) or isinstance(batch, UserDict)) and 'input_ids' in batch:
             samples_per_batch = batch['input_ids'].shape[0]
             return batch['input_ids'].shape[1] * samples_per_batch
         # then try dataset.max_seq_len

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -167,7 +167,7 @@ class DataSpec:
         get_num_tokens_in_batch ((Batch) -> int, optional): Function that is called by the :class:`.Trainer` to
             get the number of tokens in the provided batch.
 
-            By default, it checks ``dataset.max_seq_len``, and then checks for HuggingFace-style dictionary batches with ``input_ids``, and then returns 0
+            By default, it checks for HuggingFace-style dictionary batches with ``input_ids``, and then checks ``dataset.max_seq_len``, and then returns 0
             if both of those fail, meaning that number of tokens processed will not be tracked as a part of the training progress tracking.
             This function must be specified to track the number of tokens processed during training in a non-default way.
     """

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -261,7 +261,7 @@ class DataSpec:
                     Please use a DataSpec and specify `get_num_samples_in_batch`."""))
 
     def _default_get_num_tokens_in_batch(self, batch: Batch) -> int:
-        # first try HuggingFace-style input dicts
+        # First try HuggingFace-style input dicts
         if (isinstance(batch, dict) or isinstance(batch, UserDict)) and 'input_ids' in batch:
             samples_per_batch = batch['input_ids'].shape[0]
             return batch['input_ids'].shape[1] * samples_per_batch

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -167,9 +167,9 @@ class DataSpec:
         get_num_tokens_in_batch ((Batch) -> int, optional): Function that is called by the :class:`.Trainer` to
             get the number of tokens in the provided batch.
 
-            By default, it returns 0, meaning that number of tokens processed will not be tracked as a part of the
-            training progress tracking. This function must be specified to track the number of tokens processed during
-            training.
+            By default, it checks ``dataset.max_seq_len``, and then checks for HuggingFace-style dictionary batches with ``input_ids``, and then returns 0
+            if both of those fail, meaning that number of tokens processed will not be tracked as a part of the training progress tracking.
+            This function must be specified to track the number of tokens processed during training in a non-default way.
     """
 
     def __init__(

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -262,12 +262,12 @@ class DataSpec:
     def _default_get_num_tokens_in_batch(self, batch: Batch) -> int:
         samples_per_batch = self.get_num_samples_in_batch(batch)
 
-        # first try dataset.max_seq_len
-        if hasattr(self.dataloader, 'dataset') and hasattr(self.dataloader.dataset, 'max_seq_len'):  # type: ignore
+        # first try HuggingFace-style input dicts
+        if isinstance(batch, dict) and 'input_ids' in batch:
+            return batch['input_ids'].shape[1] * batch['input_ids'].shape[0]
+        # then try dataset.max_seq_len
+        elif hasattr(self.dataloader, 'dataset') and hasattr(self.dataloader.dataset, 'max_seq_len'):  # type: ignore
             return self.dataloader.dataset.max_seq_len * samples_per_batch  # type: ignore
-        # then try HuggingFace-style input dicts
-        elif isinstance(batch, dict) and 'input_ids' in batch:
-            return batch['input_ids'].shape[1] * samples_per_batch
         return 0
 
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -10,9 +10,8 @@ import json
 import logging
 import tempfile
 import textwrap
-from collections import UserDict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 import torch
 from torchmetrics import Metric
@@ -308,7 +307,7 @@ class HuggingFaceModel(ComposerModel):
         return hf_model, hf_tokenizer
 
     def forward(self, batch):
-        if isinstance(batch, dict) or isinstance(batch, UserDict):
+        if isinstance(batch, Mapping):
             # Further input validation is left to the huggingface forward call
             batch = {k: v for k, v in batch.items() if k in self.model_forward_args}
             output = self.model(**batch)  # type: ignore (thirdparty)

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -11,7 +11,8 @@ from tests.common.datasets import (InfiniteClassificationDataset, RandomClassifi
 from tests.common.events import EventCounterCallback
 from tests.common.markers import device, world_size
 from tests.common.models import (ConvModel, EmbeddedWeightTiedModel, SimpleConvModel, SimpleModel,
-                                 SimpleModelWithDropout, SimpleTransformerClassifier, SimpleWeightTiedModel)
+                                 SimpleModelWithDropout, SimpleTransformerClassifier, SimpleTransformerMaskedLM,
+                                 SimpleWeightTiedModel)
 from tests.common.state import assert_state_equivalent
 
 
@@ -31,6 +32,7 @@ __all__ = [
     'SimpleConvModel',
     'SimpleModel',
     'SimpleTransformerClassifier',
+    'SimpleTransformerMaskedLM',
     'EmbeddedWeightTiedModel',
     'SimpleWeightTiedModel',
     'EventCounterCallback',

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -6,7 +6,8 @@ from typing import List, Type
 
 from tests.common.compare import deep_compare
 from tests.common.datasets import (InfiniteClassificationDataset, RandomClassificationDataset, RandomImageDataset,
-                                   RandomSegmentationDataset, RandomTextClassificationDataset, SimpleDataset)
+                                   RandomSegmentationDataset, RandomTextClassificationDataset, RandomTextLMDataset,
+                                   SimpleDataset)
 from tests.common.events import EventCounterCallback
 from tests.common.markers import device, world_size
 from tests.common.models import (ConvModel, EmbeddedWeightTiedModel, SimpleConvModel, SimpleModel,
@@ -23,6 +24,7 @@ __all__ = [
     'assert_state_equivalent',
     'RandomClassificationDataset',
     'RandomTextClassificationDataset',
+    'RandomTextLMDataset',
     'RandomImageDataset',
     'RandomSegmentationDataset',
     'ConvModel',


### PR DESCRIPTION
# What does this PR do?
Adds better defaults for `get_num_tokens_in_batch`, so that `max_duration` in tokens is supported by default.

Manual tested a gpt run with

```
GLOBAL_BATCH_SIZE = 512
MAX_SEQ_LEN = 2048
DURATION_INT = 104_857_600
MAX_DURATION = f'{DURATION_INT}tok'
```

and it ran for 100 batches

<img width="406" alt="Screen Shot 2023-04-13 at 3 33 13 PM" src="https://user-images.githubusercontent.com/43149077/231897464-303d01af-d00c-496d-b53f-3f7c6685dc85.png">


# What issue(s) does this change relate to?
Closes [CO-1876](https://mosaicml.atlassian.net/browse/CO-1876)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1876]: https://mosaicml.atlassian.net/browse/CO-1876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ