### PR TITLE
Make sure the timestamps of the checkpoints are the same when loading

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -492,15 +492,15 @@ def _restore_checkpoint(
         dist.all_reduce(max_step_to_resume_from, reduce_operation='MAX')
         dist.all_reduce(min_step_to_resume_from, reduce_operation='MIN')
         if max_step_to_resume_from.data != min_step_to_resume_from.data:
-            raise RuntimeError(textwrap.dedent(
-                f'Timestamp mismatch error: batch to resume from {step_to_resume_from} is not the same on all ranks. '
-                'This usually occurs when at least one rank fails to save the last checkpoint '
-                'while using sharded checkpointing + autoresume. '
-                'Please manually resume by disabling autoresume and explicitly setting load_path '
-                'to the most recent checkpoints that all ranks have saved. '
-                'E.g. for the 10th batch: trainer = Trainer(autoresume=False, load_path="/path/to/checkpoint/ba10-rank{rank}.pt", ...). '
-                'Remember to keep the {rank} placeholder!' 
-            ))
+            raise RuntimeError(
+                textwrap.dedent(
+                    f'Timestamp mismatch error: batch to resume from {step_to_resume_from} is not the same on all ranks. '
+                    'This usually occurs when at least one rank fails to save the last checkpoint '
+                    'while using sharded checkpointing + autoresume. '
+                    'Please manually resume by disabling autoresume and explicitly setting load_path '
+                    'to the most recent checkpoints that all ranks have saved. '
+                    'E.g. for the 10th batch: trainer = Trainer(autoresume=False, load_path="/path/to/checkpoint/ba10-rank{rank}.pt", ...). '
+                    'Remember to keep the {rank} placeholder!'))
         return state_dict['rng']
 
 

--- a/tests/trainer/test_sharded_checkpoint.py
+++ b/tests/trainer/test_sharded_checkpoint.py
@@ -4,13 +4,13 @@
 import os
 import pathlib
 import textwrap
-
+import shutil
 import numpy as np
 import pytest
 import torch
 from packaging import version
 from torch.utils.data import DataLoader
-
+import contextlib
 from composer.trainer.trainer import Trainer
 from composer.utils import dist
 from tests.common import RandomClassificationDataset, SimpleModel
@@ -24,7 +24,9 @@ def get_trainer(save_folder=None,
                 fsdp_state_dict_type='full',
                 load_path=None,
                 autoresume=False,
-                run_name=None):
+                run_name=None,
+                max_duration='2ba',
+                save_interval='2ba',):
     model = SimpleModel(num_features=num_features, num_classes=num_classes)
     dataset = RandomClassificationDataset(shape=(num_features, 1, 1), size=128)
     dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset), batch_size=32)
@@ -39,8 +41,8 @@ def get_trainer(save_folder=None,
             'sharding_strategy': 'FULL_SHARD'
         },
         save_folder=save_folder,
-        max_duration='2ba',
-        save_interval='2ba',
+        max_duration=max_duration,
+        save_interval=save_interval,
         save_filename=save_filename,
         save_overwrite=False,
         load_path=load_path,
@@ -48,6 +50,7 @@ def get_trainer(save_folder=None,
         log_to_console=False,
         autoresume=autoresume,
         run_name=run_name,
+        save_latest_filename='latest-rank{rank}.pt',
     )
     return trainer
 
@@ -357,3 +360,47 @@ def test_fsdp_partitioned_state_dict_load(world_size, tmp_path: pathlib.Path, st
     _compare_model_params_between_state_dicts(state_dict_from_trainer1, state_dict_from_trainer2)
 
     _compare_optims_between_state_dicts(state_dict_from_trainer1, state_dict_from_trainer2)
+
+
+@pytest.mark.gpu
+@world_size(2)
+@pytest.mark.parametrize('state_dict_type', ['local', 'sharded'])
+@pytest.mark.parametrize('autoresume', [True])
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
+                    reason='requires PyTorch 1.13 or higher')
+def test_mismatch_timestamp_error(world_size, tmp_path: pathlib.Path, state_dict_type: str, autoresume: bool):
+    run_name = 'my-run-ar' if autoresume else 'my-run'
+    save_folder = str(tmp_path / pathlib.Path(run_name))
+    save_filename = 'ba{batch}-rank{rank}.pt'
+    trainer1 = get_trainer(save_folder=save_folder,
+                           save_filename=save_filename,
+                           fsdp_state_dict_type=state_dict_type,
+                           run_name=run_name,
+                           autoresume=autoresume,
+                           max_duration='2ba',
+                           save_interval='1ba')
+    trainer1.fit()
+    trainer1.close()
+    # Corrupt latest checkpoint symlink for rank1 by changing it from batch 2 checkpoint to the batch 1 one
+    # and removing batch 2 checkpoint.
+    if dist.get_global_rank() == 1:
+        latest_symlink = str(pathlib.Path(save_folder) / pathlib.Path('latest-rank1.pt'))
+        latest_checkpoint_path = pathlib.Path(save_folder) / pathlib.Path(save_filename.format(batch=2, rank=1))
+        assert os.readlink(latest_symlink) == latest_checkpoint_path.name
+        oldest_checkpoint_path = pathlib.Path(save_folder) / pathlib.Path(save_filename.format(batch=1, rank=1))
+        os.remove(latest_symlink)
+        os.symlink(src=oldest_checkpoint_path.name, dst=latest_symlink)
+        os.remove(latest_checkpoint_path)
+        assert os.readlink(latest_symlink) == oldest_checkpoint_path.name
+    
+    expected_error = pytest.raises(RuntimeError, match='Timestamp mismatch error:*')
+
+    with expected_error:
+        get_trainer(
+            save_folder=save_folder,
+            save_filename=save_filename,
+            fsdp_state_dict_type=state_dict_type,
+            autoresume=autoresume,
+            run_name=run_name,
+        )
+

--- a/tests/trainer/test_sharded_checkpoint.py
+++ b/tests/trainer/test_sharded_checkpoint.py
@@ -4,13 +4,13 @@
 import os
 import pathlib
 import textwrap
-import shutil
+
 import numpy as np
 import pytest
 import torch
 from packaging import version
 from torch.utils.data import DataLoader
-import contextlib
+
 from composer.trainer.trainer import Trainer
 from composer.utils import dist
 from tests.common import RandomClassificationDataset, SimpleModel
@@ -406,7 +406,7 @@ def test_mismatch_timestamp_error(world_size, tmp_path: pathlib.Path, state_dict
         os.symlink(src=oldest_checkpoint_path.name, dst=latest_symlink)
         os.remove(latest_checkpoint_path)
         assert os.readlink(latest_symlink) == oldest_checkpoint_path.name
-    
+
     expected_error = pytest.raises(RuntimeError, match='Timestamp mismatch error:*')
 
     with expected_error:
@@ -416,6 +416,4 @@ def test_mismatch_timestamp_error(world_size, tmp_path: pathlib.Path, state_dict
             fsdp_state_dict_type=state_dict_type,
             autoresume=autoresume,
             run_name=run_name,
-            
         )
-


### PR DESCRIPTION
# What does this PR do?
In the edge case where one is using sharded checkpointing + autoresume and one rank's save checkpoint operation fails, then that rank will resume from an older checkpoint than the other ranks and this will be a silent error. 

This PR fixes that by checking to make sure that all timestamps loaded in match. If they don't it errors out


### Manual Test
```image: mosaicml/pytorch:latest
integrations:
- git_branch: release/v0.0.4
  git_repo: mosaicml/examples
  integration_type: git_repo
  pip_install: .[llm]
- git_branch: ckpt-timestamp
  git_repo: eracah/evan-composer
  integration_type: git_repo
  pip_install: .[all]
parameters:
  load_path: s3://mosaicml-internal-checkpoints-test/evan-test/checkpoints/gpt_125m/sharded-ws-8/125m-ws-8-save-FYeuN0/ep0-ba1-rank{rank}.pt
  max_duration: 4ba
```
logs:
```
Starting training...
******************************
Config:
enabled_algorithms/GradientClipping: true
node_name: a100-80sxm-h10-03
num_gpus_per_node: 8
num_nodes: 1
rank_zero_seed: 17

******************************
[batch=2/4]:
         ...
[batch=3/4]:
         ....
[batch=4/4]:
         ...
```


# What issue(s) does this change relate to?
fix CO-2017
