### PR TITLE
Add support for `eval_interval` and `save_interval` in tokens

### DIFF
--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -229,7 +229,7 @@ class EMA(Algorithm):
             checkpoint_savers = [cb for cb in state.callbacks if isinstance(cb, CheckpointSaver)]
             for checkpoint_saver in checkpoint_savers:
                 assert callable(checkpoint_saver.save_interval)
-                if checkpoint_saver.save_interval(state, event, will_actually_checkpoint=False) is True:
+                if checkpoint_saver.save_interval(state, event) is True:
                     return True
 
         # Otherwise, always run on events where ema params must be moved after ema has started

--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -228,6 +228,7 @@ class EMA(Algorithm):
         if event in [Event.BATCH_CHECKPOINT, Event.EPOCH_CHECKPOINT] and self.ema_started:
             checkpoint_savers = [cb for cb in state.callbacks if isinstance(cb, CheckpointSaver)]
             for checkpoint_saver in checkpoint_savers:
+                assert callable(checkpoint_saver.save_interval)
                 if checkpoint_saver.save_interval(state, event) is True:
                     return True
 

--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -229,7 +229,7 @@ class EMA(Algorithm):
             checkpoint_savers = [cb for cb in state.callbacks if isinstance(cb, CheckpointSaver)]
             for checkpoint_saver in checkpoint_savers:
                 assert callable(checkpoint_saver.save_interval)
-                if checkpoint_saver.save_interval(state, event) is True:
+                if checkpoint_saver.save_interval(state, event, will_actually_checkpoint=False) is True:
                     return True
 
         # Otherwise, always run on events where ema params must be moved after ema has started

--- a/composer/callbacks/__init__.py
+++ b/composer/callbacks/__init__.py
@@ -7,7 +7,7 @@ Each callback inherits from the :class:`.Callback` base class. See detailed desc
 examples for writing your own callbacks at the :class:`.Callback` base class.
 """
 from composer.callbacks.activation_monitor import ActivationMonitor
-from composer.callbacks.checkpoint_saver import CheckpointSaver
+from composer.callbacks.checkpoint_saver import CheckpointSaver, SaveIntervalCallable
 from composer.callbacks.early_stopper import EarlyStopper
 from composer.callbacks.export_for_inference import ExportForInferenceCallback
 from composer.callbacks.health_checker import HealthChecker
@@ -27,6 +27,7 @@ __all__ = [
     'MemoryMonitor',
     'SpeedMonitor',
     'CheckpointSaver',
+    'SaveIntervalCallable',
     'MLPerfCallback',
     'EarlyStopper',
     'ExportForInferenceCallback',

--- a/composer/callbacks/__init__.py
+++ b/composer/callbacks/__init__.py
@@ -7,7 +7,7 @@ Each callback inherits from the :class:`.Callback` base class. See detailed desc
 examples for writing your own callbacks at the :class:`.Callback` base class.
 """
 from composer.callbacks.activation_monitor import ActivationMonitor
-from composer.callbacks.checkpoint_saver import CheckpointSaver, SaveIntervalCallable
+from composer.callbacks.checkpoint_saver import CheckpointSaver
 from composer.callbacks.early_stopper import EarlyStopper
 from composer.callbacks.export_for_inference import ExportForInferenceCallback
 from composer.callbacks.health_checker import HealthChecker
@@ -27,7 +27,6 @@ __all__ = [
     'MemoryMonitor',
     'SpeedMonitor',
     'CheckpointSaver',
-    'SaveIntervalCallable',
     'MLPerfCallback',
     'EarlyStopper',
     'ExportForInferenceCallback',

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -72,6 +72,21 @@ def checkpoint_periodically(interval: Union[str, int, Time],
             event: Event,
             will_actually_checkpoint: bool = True,  # determines whether to update the last_value_checkpointed state
     ):
+        """The save interval function that determines whether to save a checkpoint.
+
+        Args:
+            state (State): The current :class:`.State` object
+            event (Event): The :class:`.Event` that has is being checked for checkpointing
+            will_actually_checkpoint (bool, optional): Whether or not the call to this function will actually write a checkpoint.
+                This determines whether or not to update the `last_value_checkpointed` state that keeps track of when the last checkpointing occurred.
+                Defaults to True.
+
+        Raises:
+            NotImplementedError: _description_
+
+        Returns:
+            _type_: _description_
+        """
         nonlocal last_value_checkpointed
 
         elapsed_duration = state.get_elapsed_duration()
@@ -350,6 +365,7 @@ class CheckpointSaver(Callback):  # noqa: D101
         os.makedirs(folder, exist_ok=True)
 
     def after_load(self, state: State, logger: Logger) -> None:
+        # This is done here to set the starting timestamp when we are resuming
         if not callable(self.save_interval):
             self.save_interval = checkpoint_periodically(self.save_interval, state.timestamp)
 

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -51,7 +51,7 @@ def checkpoint_periodically(interval: Union[str, int, Time]) -> Callable[[State,
         raise NotImplementedError(
             f'Unknown checkpointing interval: {interval.unit}. Must be TimeUnit.EPOCH or TimeUnit.BATCH.')
 
-    last_value_checkpointed = -1
+    last_value_checkpointed = 0
 
     def save_interval(state: State, event: Event):
         elapsed_duration = state.get_elapsed_duration()

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -6,13 +6,14 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import pathlib
 import tempfile
 import textwrap
-from typing import List, Optional, Protocol, Union
+from typing import Callable, List, Optional, Union
 
-from composer.core import Callback, Event, State, Time, Timestamp, TimeUnit
+from composer.core import Callback, Event, State, Time, TimeUnit
 from composer.loggers import Logger
 from composer.utils import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, FORMAT_NAME_WITH_DIST_TABLE, PartialFilePath,
                             checkpoint, create_symlink_file, dist, ensure_folder_has_no_conflicting_files,
@@ -23,14 +24,7 @@ log = logging.getLogger(__name__)
 __all__ = ['CheckpointSaver', 'checkpoint_periodically']
 
 
-class SaveIntervalCallable(Protocol):
-
-    def __call__(self, state: State, event: Event, will_actually_checkpoint: bool) -> bool:
-        ...
-
-
-def checkpoint_periodically(interval: Union[str, int, Time],
-                            starting_timestamp: Optional[Timestamp] = None) -> SaveIntervalCallable:
+def checkpoint_periodically(interval: Union[str, int, Time]) -> Callable[[State, Event], bool]:
     r"""Helper function to create a checkpoint scheduler according to a specified interval.
 
     Args:
@@ -41,9 +35,6 @@ def checkpoint_periodically(interval: Union[str, int, Time],
 
             Checkpoints will be saved every ``n`` batches or epochs (depending on the unit),
             and at the end of training.
-        starting_timestamp (optional, :class:`.Timestamp`): The timestamp at which to initialize the save interval.
-            This will just be a timestamp with value zero unless resuming, in which case it will be the timestamp
-            that resumption is occurring from. If ``None``, will default to value zero. (default: ``None``)
 
     Returns:
         Callable[[State, Event], bool]: A function that can be passed as the ``save_interval``
@@ -63,32 +54,7 @@ def checkpoint_periodically(interval: Union[str, int, Time],
             f'Unknown checkpointing interval: {interval.unit}. Must be TimeUnit.EPOCH, TimeUnit.BATCH, TimeUnit.TOKEN, or TimeUnit.SAMPLE.'
         )
 
-    last_value_checkpointed = 0
-    if starting_timestamp is not None:
-        last_value_checkpointed = starting_timestamp.get(interval.unit)
-
-    def save_interval(
-            state: State,
-            event: Event,
-            will_actually_checkpoint: bool = True,  # determines whether to update the last_value_checkpointed state
-    ):
-        """The save interval function that determines whether to save a checkpoint.
-
-        Args:
-            state (State): The current :class:`.State` object
-            event (Event): The :class:`.Event` that has is being checked for checkpointing
-            will_actually_checkpoint (bool, optional): Whether or not the call to this function will actually write a checkpoint.
-                This determines whether or not to update the `last_value_checkpointed` state that keeps track of when the last checkpointing occurred.
-                Defaults to True.
-
-        Raises:
-            NotImplementedError: _description_
-
-        Returns:
-            _type_: _description_
-        """
-        nonlocal last_value_checkpointed
-
+    def save_interval(state: State, event: Event):
         elapsed_duration = state.get_elapsed_duration()
         assert elapsed_duration is not None, 'elapsed_duration is set on the BATCH_CHECKPOINT and EPOCH_CHECKPOINT'
 
@@ -96,22 +62,26 @@ def checkpoint_periodically(interval: Union[str, int, Time],
         if elapsed_duration >= 1.0:
             return True
 
+        assert state.previous_timestamp is not None
         if interval.unit == TimeUnit.EPOCH:
+            previous_count = state.previous_timestamp.epoch
             count = state.timestamp.epoch
         elif interval.unit == TimeUnit.BATCH:
+            previous_count = state.previous_timestamp.batch
             count = state.timestamp.batch
         elif interval.unit == TimeUnit.TOKEN:
+            previous_count = state.previous_timestamp.token
             count = state.timestamp.token
         elif interval.unit == TimeUnit.SAMPLE:
+            previous_count = state.previous_timestamp.sample
             count = state.timestamp.sample
         else:
             raise NotImplementedError(
                 f'Unknown checkpointing interval: {interval.unit}. Must be TimeUnit.EPOCH, TimeUnit.BATCH, TimeUnit.TOKEN, or TimeUnit.SAMPLE.'
             )
 
-        if event == save_event and count - last_value_checkpointed >= interval.value:
-            if will_actually_checkpoint:
-                last_value_checkpointed = count
+        threshold_passed = math.floor(previous_count / interval.value) != math.floor(count / interval.value)
+        if event == save_event and threshold_passed:
             return True
 
         return False
@@ -275,7 +245,7 @@ class CheckpointSaver(Callback):  # noqa: D101
             If ``False`` (the default), then the ``folder`` must not exist or must not contain checkpoints which may conflict
             with the current run. Default: ``False``.
 
-        save_interval (Time | str | int | (State, Event, bool) -> bool): A :class:`.Time`, time-string, integer (in epochs),
+        save_interval (Time | str | int | (State, Event) -> bool): A :class:`.Time`, time-string, integer (in epochs),
             or a function that takes (state, event) and returns a boolean whether a checkpoint should be saved.
 
             If an integer, checkpoints will be saved every n epochs.
@@ -284,11 +254,9 @@ class CheckpointSaver(Callback):  # noqa: D101
             .. seealso:: :func:`.checkpoint_periodically`
 
             If a function, then this function should take three arguments (:class:`.State`, :class:`.Event`, ``bool``).
-            The first argument will be the current state of the trainer, the second argument will be
+            The first argument will be the current state of the trainer, and the second argument will be
             be :attr:`.Event.BATCH_CHECKPOINT` or :attr:`.Event.EPOCH_CHECKPOINT` (depending on the current training
-            progress), and the third argument is a bool (defaults to ``True``) that indicates whether the function call will actually result
-            in writing a checkpoint if it returns ``True``. The third argument is necessary to determine whether to update the state that is kept
-            for checkpointing based on tokens or samples. It should return ``True`` if a checkpoint should be saved given the current state and
+            progress). It should return ``True`` if a checkpoint should be saved given the current state and
             event.
 
         weights_only (bool): If ``True``, save only the model weights instead of the entire training state.
@@ -330,7 +298,7 @@ class CheckpointSaver(Callback):  # noqa: D101
                                          pathlib.Path]] = '{run_name}/checkpoints/ep{epoch}-ba{batch}-rank{rank}.pt',
         latest_filename: Optional[Union[str, pathlib.Path]] = 'latest-rank{rank}.pt',
         latest_remote_file_name: Optional[Union[str, pathlib.Path]] = '{run_name}/checkpoints/latest-rank{rank}.pt',
-        save_interval: Union[Time, str, int, SaveIntervalCallable] = '1ep',
+        save_interval: Union[Time, str, int, Callable[[State, Event], bool]] = '1ep',
         *,
         overwrite: bool = False,
         num_checkpoints_to_keep: int = -1,
@@ -342,6 +310,8 @@ class CheckpointSaver(Callback):  # noqa: D101
         latest_filename = str(latest_filename) if latest_filename is not None else None
         latest_remote_file_name = str(latest_remote_file_name) if latest_remote_file_name is not None else None
 
+        if not callable(save_interval):
+            save_interval = checkpoint_periodically(save_interval)
         self.save_interval = save_interval
         self.last_checkpoint_batch: Optional[Time] = None
 
@@ -364,11 +334,6 @@ class CheckpointSaver(Callback):  # noqa: D101
         folder = format_name_with_dist(self.folder, state.run_name)
         os.makedirs(folder, exist_ok=True)
 
-    def after_load(self, state: State, logger: Logger) -> None:
-        # This is done here to set the starting timestamp when we are resuming
-        if not callable(self.save_interval):
-            self.save_interval = checkpoint_periodically(self.save_interval, state.timestamp)
-
     def fit_start(self, state: State, logger: Logger) -> None:
         if not self.overwrite:
             # checks that save_folder contains no files with a timestamp after the current timestamp,
@@ -385,8 +350,7 @@ class CheckpointSaver(Callback):  # noqa: D101
 
     def batch_checkpoint(self, state: State, logger: Logger):
         assert callable(self.save_interval)
-        if self.save_interval(state, Event.BATCH_CHECKPOINT,
-                              will_actually_checkpoint=True) and self.last_checkpoint_batch != state.timestamp.batch:
+        if self.save_interval(state, Event.BATCH_CHECKPOINT) and self.last_checkpoint_batch != state.timestamp.batch:
             self._save_checkpoint(
                 state,
                 logger,
@@ -394,8 +358,7 @@ class CheckpointSaver(Callback):  # noqa: D101
 
     def epoch_checkpoint(self, state: State, logger: Logger):
         assert callable(self.save_interval)
-        if self.save_interval(state, Event.EPOCH_CHECKPOINT,
-                              will_actually_checkpoint=True) and self.last_checkpoint_batch != state.timestamp.batch:
+        if self.save_interval(state, Event.EPOCH_CHECKPOINT) and self.last_checkpoint_batch != state.timestamp.batch:
             self._save_checkpoint(
                 state,
                 logger,

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -72,10 +72,7 @@ def checkpoint_periodically(interval: Union[str, int, Time]) -> Callable[[State,
             )
 
         threshold_passed = math.floor(previous_count / interval.value) != math.floor(count / interval.value)
-        if event == save_event and threshold_passed:
-            return True
-
-        return False
+        return event == save_event and threshold_passed:
 
     return save_interval
 

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -72,7 +72,7 @@ def checkpoint_periodically(interval: Union[str, int, Time]) -> Callable[[State,
             )
 
         threshold_passed = math.floor(previous_count / interval.value) != math.floor(count / interval.value)
-        return event == save_event and threshold_passed:
+        return event == save_event and threshold_passed
 
     return save_interval
 

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -62,7 +62,11 @@ def checkpoint_periodically(interval: Union[str, int, Time]) -> Callable[[State,
         if elapsed_duration >= 1.0:
             return True
 
-        assert state.previous_timestamp is not None
+        # previous timestamp will only be None if training has not started, but we are returning False
+        # in this case, just to be safe
+        if state.previous_timestamp is None:
+            return False
+
         if interval.unit in {TimeUnit.EPOCH, TimeUnit.BATCH, TimeUnit.TOKEN, TimeUnit.SAMPLE}:
             previous_count = state.previous_timestamp.get(interval.unit)
             count = state.timestamp.get(interval.unit)

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -24,7 +24,7 @@ __all__ = ['CheckpointSaver', 'checkpoint_periodically']
 
 
 def checkpoint_periodically(interval: Union[str, int, Time],
-                            starting_timestamp: Timestamp) -> Callable[[State, Event], bool]:
+                            starting_timestamp: Optional[Timestamp] = None) -> Callable[[State, Event], bool]:
     r"""Helper function to create a checkpoint scheduler according to a specified interval.
 
     Args:
@@ -35,9 +35,9 @@ def checkpoint_periodically(interval: Union[str, int, Time],
 
             Checkpoints will be saved every ``n`` batches or epochs (depending on the unit),
             and at the end of training.
-        starting_timestamp (:class:`.Timestamp`): The timestamp at which to initialize the save interval.
+        starting_timestamp (optional, :class:`.Timestamp`): The timestamp at which to initialize the save interval.
             This will just be a timestamp with value zero unless resuming, in which case it will be the timestamp
-            that resumption is occurring from.
+            that resumption is occurring from. If ``None``, will default to value zero. (default: ``None``)
 
     Returns:
         Callable[[State, Event], bool]: A function that can be passed as the ``save_interval``
@@ -57,7 +57,9 @@ def checkpoint_periodically(interval: Union[str, int, Time],
             f'Unknown checkpointing interval: {interval.unit}. Must be TimeUnit.EPOCH, TimeUnit.BATCH, TimeUnit.TOKEN, or TimeUnit.SAMPLE.'
         )
 
-    last_value_checkpointed = starting_timestamp.get(interval.unit)
+    last_value_checkpointed = 0
+    if starting_timestamp is not None:
+        last_value_checkpointed = starting_timestamp.get(interval.unit)
 
     def save_interval(state: State, event: Event):
         nonlocal last_value_checkpointed

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -244,7 +244,7 @@ class CheckpointSaver(Callback):  # noqa: D101
 
             .. seealso:: :func:`.checkpoint_periodically`
 
-            If a function, then this function should take three arguments (:class:`.State`, :class:`.Event`, ``bool``).
+            If a function, then this function should take two arguments (:class:`.State`, :class:`.Event`).
             The first argument will be the current state of the trainer, and the second argument will be
             be :attr:`.Event.BATCH_CHECKPOINT` or :attr:`.Event.EPOCH_CHECKPOINT` (depending on the current training
             progress). It should return ``True`` if a checkpoint should be saved given the current state and

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -63,18 +63,9 @@ def checkpoint_periodically(interval: Union[str, int, Time]) -> Callable[[State,
             return True
 
         assert state.previous_timestamp is not None
-        if interval.unit == TimeUnit.EPOCH:
-            previous_count = state.previous_timestamp.epoch
-            count = state.timestamp.epoch
-        elif interval.unit == TimeUnit.BATCH:
-            previous_count = state.previous_timestamp.batch
-            count = state.timestamp.batch
-        elif interval.unit == TimeUnit.TOKEN:
-            previous_count = state.previous_timestamp.token
-            count = state.timestamp.token
-        elif interval.unit == TimeUnit.SAMPLE:
-            previous_count = state.previous_timestamp.sample
-            count = state.timestamp.sample
+        if interval.unit in {TimeUnit.EPOCH, TimeUnit.BATCH, TimeUnit.TOKEN, TimeUnit.SAMPLE}:
+            previous_count = state.previous_timestamp.get(interval.unit)
+            count = state.timestamp.get(interval.unit)
         else:
             raise NotImplementedError(
                 f'Unknown checkpointing interval: {interval.unit}. Must be TimeUnit.EPOCH, TimeUnit.BATCH, TimeUnit.TOKEN, or TimeUnit.SAMPLE.'

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -56,6 +56,7 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
         if eval_interval.unit in {TimeUnit.EPOCH, TimeUnit.BATCH, TimeUnit.TOKEN, TimeUnit.SAMPLE}:
             previous_count = state.previous_timestamp.get(eval_interval.unit)
             count = state.timestamp.get(eval_interval.unit)
+        # If the eval_interval is a duration, we will track progress in terms of the unit of max_duration
         else:
             assert state.max_duration is not None
             previous_count = state.previous_timestamp.get(state.max_duration.unit)

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -48,7 +48,11 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
         if eval_at_fit_end and event == Event.FIT_END and state.timestamp.batch != last_batch_seen:
             return True
 
-        assert state.previous_timestamp is not None
+        # previous timestamp will only be None if training has not started, but we are returning False
+        # in this case, just to be safe
+        if state.previous_timestamp is None:
+            return False
+
         if eval_interval.unit in {TimeUnit.EPOCH, TimeUnit.BATCH, TimeUnit.TOKEN, TimeUnit.SAMPLE}:
             previous_count = state.previous_timestamp.get(eval_interval.unit)
             count = state.timestamp.get(eval_interval.unit)

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -57,10 +57,12 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
             previous_count = state.previous_timestamp.get(eval_interval.unit)
             count = state.timestamp.get(eval_interval.unit)
         # If the eval_interval is a duration, we will track progress in terms of the unit of max_duration
-        else:
+        elif eval_interval.unit == TimeUnit.DURATION:
             assert state.max_duration is not None
             previous_count = state.previous_timestamp.get(state.max_duration.unit)
             count = state.timestamp.get(state.max_duration.unit)
+        else:
+            raise ValueError(f'Invalid eval_interval unit: {eval_interval.unit}')
 
         threshold_passed = math.floor(previous_count / eval_interval.value) != math.floor(count / eval_interval.value)
 

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -48,7 +48,7 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
         if eval_at_fit_end and event == Event.FIT_END and state.timestamp.batch != last_batch_seen:
             return True
 
-        # previous timestamp will only be None if training has not started, but we are returning False
+        # Previous timestamp will only be None if training has not started, but we are returning False
         # in this case, just to be safe
         if state.previous_timestamp is None:
             return False

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -88,14 +88,12 @@ def evaluate_periodically(eval_interval: Union[str, Time, int], eval_at_fit_end:
                 last_batch_seen = state.timestamp.batch
                 return True
             elif state.max_duration.unit == TimeUnit.SAMPLE and event == Event.BATCH_END:
-                # If last sample in batch is not evenly divisible by eval_interval, perform evaluation in next batch
-                if int(state.timestamp.batch) > 0:
-                    samples_in_a_batch = int(state.timestamp.sample) // int(state.timestamp.batch)
-                    if int(state.timestamp.sample) // math.ceil(state.max_duration.value * eval_interval) != int(
-                            state.timestamp.sample - samples_in_a_batch) // math.ceil(
-                                state.max_duration.value * eval_interval):
-                        last_batch_seen = state.timestamp.batch
-                        return True
+                samples_per_interval = math.ceil(state.max_duration.value * eval_interval)
+                threshold_passed = math.floor(previous_count / samples_per_interval) != math.floor(
+                    count / samples_per_interval)
+                if threshold_passed:
+                    last_batch_seen = state.timestamp.batch
+                    return True
             elif state.max_duration.unit == TimeUnit.TOKEN and event == Event.BATCH_END:
                 tokens_per_interval = math.ceil(state.max_duration.value * eval_interval)
                 threshold_passed = math.floor(previous_count / tokens_per_interval) != math.floor(

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -416,6 +416,7 @@ class State(Serializable):
         self._train_dataloader = train_dataloader
         self._evaluators = list(ensure_tuple(evaluators))
 
+        self.starting_timestamp = Timestamp()
         self.timestamp = Timestamp()
         self.eval_timestamp = Timestamp()
         self.predict_timestamp = Timestamp()
@@ -1077,6 +1078,8 @@ class State(Serializable):
                         continue
                     source = serialized_value[type(target).__qualname__]
                     target.load_state_dict(source)
+                if attribute_name == 'timestamp':
+                    self.starting_timestamp = self.timestamp
             else:
                 # direct serialization
                 try:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -416,7 +416,7 @@ class State(Serializable):
         self._train_dataloader = train_dataloader
         self._evaluators = list(ensure_tuple(evaluators))
 
-        self.starting_timestamp = Timestamp()
+        self.previous_timestamp: Optional[Timestamp] = None
         self.timestamp = Timestamp()
         self.eval_timestamp = Timestamp()
         self.predict_timestamp = Timestamp()
@@ -1078,8 +1078,6 @@ class State(Serializable):
                         continue
                     source = serialized_value[type(target).__qualname__]
                     target.load_state_dict(source)
-                if attribute_name == 'timestamp':
-                    self.starting_timestamp = self.timestamp
             else:
                 # direct serialization
                 try:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -31,7 +31,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data import DataLoader, DistributedSampler
 from torchmetrics import Metric
 
-from composer.callbacks import CheckpointSaver, OptimizerMonitor
+from composer.callbacks import CheckpointSaver, OptimizerMonitor, SaveIntervalCallable
 from composer.core import (Algorithm, AlgorithmPass, Batch, BreakEpochException, Callback, DataSpec, Engine, Evaluator,
                            Event, Precision, PyTorchScheduler, State, Time, Timestamp, TimeUnit, TrainerMode,
                            ensure_data_spec, ensure_evaluator, ensure_time, get_precision_context,
@@ -668,8 +668,8 @@ class Trainer:
             This parameter has no effect if ``save_folder`` is None. (default: ``False``)
 
             .. seealso:: :class:`~.CheckpointSaver`
-        save_interval (Time | str | int | (State, Event) -> bool): A :class:`Time`, time-string, integer (in epochs),
-            or a function that takes (state, event) and returns a boolean whether a checkpoint should be saved.
+        save_interval (Time | str | int | (State, Event, bool) -> bool): A :class:`Time`, time-string, integer (in epochs),
+            or a function that takes (state, event, will_actually_checkpoint) and returns a boolean whether a checkpoint should be saved.
             This parameter has no effect if ``save_folder`` is ``None``. (default: ``'1ep'``)
 
             .. seealso:: :class:`~.CheckpointSaver`
@@ -835,7 +835,7 @@ class Trainer:
         save_filename: str = 'ep{epoch}-ba{batch}-rank{rank}.pt',
         save_latest_filename: Optional[str] = 'latest-rank{rank}.pt',
         save_overwrite: bool = False,
-        save_interval: Union[str, int, Time, Callable[[State, Event], bool]] = '1ep',
+        save_interval: Union[str, int, Time, SaveIntervalCallable] = '1ep',
         save_weights_only: bool = False,
         save_num_checkpoints_to_keep: int = -1,
 

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import copy
+import math
 import os
 import pathlib
 import shutil
@@ -30,8 +31,8 @@ from composer.utils import dist, is_tar
 from composer.utils.checkpoint import glob_filter
 from composer.utils.object_store.object_store import ObjectStore
 from composer.utils.object_store.s3_object_store import S3ObjectStore
-from tests.common import (RandomClassificationDataset, RandomImageDataset, SimpleConvModel, SimpleModel, deep_compare,
-                          device)
+from tests.common import (RandomClassificationDataset, RandomImageDataset, RandomTextLMDataset, SimpleConvModel,
+                          SimpleModel, SimpleTransformerMaskedLM, deep_compare, device)
 from tests.common.markers import world_size
 
 
@@ -247,6 +248,75 @@ class TestCheckpointSaving:
         }
         expected_folder = expected_path.rstrip('/') if expected_path != '' else '.'
         mock_checkpoint_saver.assert_called_once_with(folder=expected_folder, **rest_of_checkpoint_saver_kwargs)
+
+    @pytest.mark.parametrize('save_interval', ['1tok', '64tok', '65tok'])
+    @pytest.mark.parametrize('batch_size', [4])
+    @pytest.mark.parametrize('sequence_length', [16, 17, 18])
+    def test_checkpoint_save_token_interval(self, tiny_bert_tokenizer, save_interval: str, batch_size: int,
+                                            sequence_length: int, tmp_path: pathlib.Path):
+        tokens_per_batch = batch_size * sequence_length
+        max_duration_time = Time.from_timestring('5ba')
+        save_interval_time = Time.from_timestring(save_interval)
+        max_duration_tokens = max_duration_time.value * tokens_per_batch
+        token_save_multiple = math.ceil(save_interval_time.value / tokens_per_batch) * tokens_per_batch
+        expected_num_checkpoints = math.ceil(max_duration_tokens / token_save_multiple)
+
+        transformers = pytest.importorskip('transformers')
+        model = SimpleTransformerMaskedLM(vocab_size=tiny_bert_tokenizer.vocab_size)
+        pretraining_train_dataset = RandomTextLMDataset(size=100,
+                                                        vocab_size=tiny_bert_tokenizer.vocab_size,
+                                                        sequence_length=sequence_length,
+                                                        use_keys=True)
+
+        collator = transformers.DataCollatorForLanguageModeling(tokenizer=tiny_bert_tokenizer, mlm_probability=0.15)
+        dataloader = DataLoader(pretraining_train_dataset,
+                                batch_size=batch_size,
+                                sampler=dist.get_sampler(pretraining_train_dataset),
+                                collate_fn=collator)
+
+        trainer = Trainer(model=model,
+                          train_dataloader=dataloader,
+                          max_duration=max_duration_time,
+                          save_interval=save_interval_time,
+                          save_folder=str(tmp_path / 'checkpoints'))
+        trainer.fit()
+
+        assert trainer._checkpoint_saver is not None
+        assert len(trainer._checkpoint_saver.saved_checkpoints) == expected_num_checkpoints
+
+    @pytest.mark.parametrize('save_interval', ['1sp', '4sp', '5sp'])
+    @pytest.mark.parametrize('batch_size', [4, 5, 6])
+    @pytest.mark.parametrize('sequence_length', [16])
+    def test_checkpoint_save_sample_interval(self, tiny_bert_tokenizer, save_interval: str, batch_size: int,
+                                             sequence_length: int, tmp_path: pathlib.Path):
+        max_duration_time = Time.from_timestring('5ba')
+        save_interval_time = Time.from_timestring(save_interval)
+        max_duration_samples = max_duration_time.value * batch_size
+        sample_save_multiple = math.ceil(save_interval_time.value / batch_size) * batch_size
+        expected_num_checkpoints = math.ceil(max_duration_samples / sample_save_multiple)
+
+        transformers = pytest.importorskip('transformers')
+        model = SimpleTransformerMaskedLM(vocab_size=tiny_bert_tokenizer.vocab_size)
+        pretraining_train_dataset = RandomTextLMDataset(size=100,
+                                                        vocab_size=tiny_bert_tokenizer.vocab_size,
+                                                        sequence_length=sequence_length,
+                                                        use_keys=True)
+
+        collator = transformers.DataCollatorForLanguageModeling(tokenizer=tiny_bert_tokenizer, mlm_probability=0.15)
+        dataloader = DataLoader(pretraining_train_dataset,
+                                batch_size=batch_size,
+                                sampler=dist.get_sampler(pretraining_train_dataset),
+                                collate_fn=collator)
+
+        trainer = Trainer(model=model,
+                          train_dataloader=dataloader,
+                          max_duration=max_duration_time,
+                          save_interval=save_interval_time,
+                          save_folder=str(tmp_path / 'checkpoints'))
+        trainer.fit()
+
+        assert trainer._checkpoint_saver is not None
+        assert len(trainer._checkpoint_saver.saved_checkpoints) == expected_num_checkpoints
 
 
 class TestCheckpointLoading:

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -250,8 +250,8 @@ class TestCheckpointSaving:
         mock_checkpoint_saver.assert_called_once_with(folder=expected_folder, **rest_of_checkpoint_saver_kwargs)
 
     @pytest.mark.parametrize('save_interval', ['1tok', '64tok', '65tok'])
-    @pytest.mark.parametrize('batch_size', [4])
-    @pytest.mark.parametrize('sequence_length', [16, 17, 18])
+    @pytest.mark.parametrize('batch_size', [1, 4])
+    @pytest.mark.parametrize('sequence_length', [1, 16])
     def test_checkpoint_save_token_interval(self, tiny_bert_tokenizer, save_interval: str, batch_size: int,
                                             sequence_length: int, tmp_path: pathlib.Path):
         tokens_per_batch = batch_size * sequence_length
@@ -285,8 +285,8 @@ class TestCheckpointSaving:
         assert len(trainer._checkpoint_saver.saved_checkpoints) == expected_num_checkpoints
 
     @pytest.mark.parametrize('save_interval', ['1sp', '4sp', '5sp'])
-    @pytest.mark.parametrize('batch_size', [4, 5, 6])
-    @pytest.mark.parametrize('sequence_length', [16])
+    @pytest.mark.parametrize('batch_size', [1, 4])
+    @pytest.mark.parametrize('sequence_length', [1, 16])
     def test_checkpoint_save_sample_interval(self, tiny_bert_tokenizer, save_interval: str, batch_size: int,
                                              sequence_length: int, tmp_path: pathlib.Path):
         max_duration_time = Time.from_timestring('5ba')

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -151,6 +151,7 @@ def test_trainer_eval_timestamp():
 @pytest.mark.parametrize('sequence_length', [1, 16])
 def test_eval_token_interval(tiny_bert_tokenizer, eval_interval: str, batch_size: int, sequence_length: int,
                              tmp_path: pathlib.Path):
+    """Tests that the trainer evaluates the model at the correct intervals when using token-based intervals."""
     tokens_per_batch = batch_size * sequence_length
     max_duration_time = Time.from_timestring('5ba')
     eval_interval_time = Time.from_timestring(eval_interval)
@@ -197,6 +198,7 @@ def test_eval_token_interval(tiny_bert_tokenizer, eval_interval: str, batch_size
 @pytest.mark.parametrize('sequence_length', [1, 16])
 def test_eval_sample_interval(tiny_bert_tokenizer, eval_interval: str, batch_size: int, sequence_length: int,
                               tmp_path: pathlib.Path):
+    """Tests that the trainer evaluates the model at the correct intervals when using sample-based intervals."""
     max_duration_time = Time.from_timestring('5ba')
     eval_interval_time = Time.from_timestring(eval_interval)
     max_duration_samples = max_duration_time.value * batch_size
@@ -243,6 +245,7 @@ def test_eval_sample_interval(tiny_bert_tokenizer, eval_interval: str, batch_siz
 @pytest.mark.parametrize('sequence_length', [1, 16])
 def test_eval_dur_interval_token_max(tiny_bert_tokenizer, eval_interval: str, max_duration: str, batch_size: int,
                                      sequence_length: int):
+    """Tests that the trainer evaluates the model at the correct intervals when using duration-based intervals, with max_duration in tokens."""
     max_duration_time = Time.from_timestring(max_duration)
     eval_interval_time = Time.from_timestring(eval_interval)
     tokens_per_batch = batch_size * sequence_length
@@ -397,7 +400,6 @@ def test_eval_params_init(
     assert event_counter_callback.event_to_num_calls[Event.EVAL_BATCH_START] == 1
 
 
-# TODO: token test
 def test_eval_params_evaluator():
     """Test the `eval_subset_num_batches` and `eval_interval` works when specified as part of an evaluator."""
     # Construct the trainer


### PR DESCRIPTION
# What does this PR do?
Adds support for specifying `eval_interval` and `save_interval` in tokens, as well as the combination of `max_duration` in tokens and `eval_interval` in `dur`.

Manual test:

```
GLOBAL_BATCH_SIZE = 512
MAX_SEQ_LEN = 2048
DURATION_INT = 104_857_600
MAX_DURATION = f'{DURATION_INT}tok'
EVAL_INT = 12_582_912
EVAL_INTERVAL = f'{EVAL_INT}tok'
SAVE_INT = 41_943_041
SAVE_INTERVAL = f'{SAVE_INT}tok'
```

<img width="622" alt="Screen Shot 2023-04-18 at 10 47 29 PM" src="https://user-images.githubusercontent.com/43149077/232978350-1c8f3221-a2ee-4def-ba49-30650e718843.png">
<img width="463" alt="Screen Shot 2023-04-18 at 10 47 41 PM" src="https://user-images.githubusercontent.com/43149077/232978357-f819f5ea-30f6-44b2-8518-e87fb009f5a8.png">


TODO:
- [x] update docs
- [x] manual test

# What issue(s) does this change relate to?
Closes [CO-1877](https://mosaicml.atlassian.net/browse/CO-1877)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1877]: https://mosaicml.atlassian.net/browse/CO-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ