### PR TITLE
Fix broken URLs due to docs site refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 
 <h4><p align='center'>
 <a href="https://www.mosaicml.com">[Website]</a>
-- <a href="https://docs.mosaicml.com/en/stable/getting_started/installation.html">[Getting Started]</a>
-- <a href="https://docs.mosaicml.com/">[Docs]</a>
-- <a href="https://docs.mosaicml.com/en/stable/method_cards/methods_overview.html">[Methods]</a>
+- <a href="https://docs.mosaicml.com/projects/composer/en/stable/getting_started/installation.html">[Getting Started]</a>
+- <a href="https://docs.mosaicml.com/projects/composer/">[Docs]</a>
+- <a href="https://docs.mosaicml.com/projects/composer/en/stable/method_cards/methods_overview.html">[Methods]</a>
 - <a href="https://www.mosaicml.com/team">[We're Hiring!]</a>
 </p></h4>
 
@@ -31,7 +31,7 @@
     <a href="https://pepy.tech/project/mosaicml/">
         <img alt="PyPi Downloads" src="https://static.pepy.tech/personalized-badge/mosaicml?period=month&units=international_system&left_color=grey&right_color=blue&left_text=Downloads/month">
     </a>
-    <a href="https://docs.mosaicml.com/en/stable/">
+    <a href="https://docs.mosaicml.com/projects/composer/en/stable/">
         <img alt="Documentation" src="https://readthedocs.org/projects/composer/badge/?version=stable">
     </a>
     <a href="https://join.slack.com/t/mosaicml-community/shared_invite/zt-w0tiddn9-WGTlRpfjcO9J5jyrMub1dg">
@@ -102,7 +102,7 @@ You can use Composer's speedup methods in two ways:
 
 ### Example: Functional API [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mosaicml/composer/blob/dev/examples/functional_api.ipynb)
 
-Integrate our speedup methods into your training loop with just a few lines of code, and see the results. Here we easily apply [BlurPool](https://docs.mosaicml.com/en/stable/method_cards/blurpool.html) and [SqueezeExcite](https://docs.mosaicml.com/en/stable/method_cards/squeeze_excite.html):
+Integrate our speedup methods into your training loop with just a few lines of code, and see the results. Here we easily apply [BlurPool](https://docs.mosaicml.com/projects/composer/en/stable/method_cards/blurpool.html) and [SqueezeExcite](https://docs.mosaicml.com/projects/composer/en/stable/method_cards/squeeze_excite.html):
 
 <!-- begin_example_1 --->
 ```python
@@ -119,7 +119,7 @@ cf.apply_squeeze_excite(my_model)
 ```
 <!-- end_example_1 --->
 
-For more examples, see the [Composer Functional API Colab notebook](https://colab.research.google.com/github/mosaicml/composer/blob/dev/examples/functional_api.ipynb) and [Functional API guide](https://docs.mosaicml.com/en/latest/functional_api.html).
+For more examples, see the [Composer Functional API Colab notebook](https://colab.research.google.com/github/mosaicml/composer/blob/dev/examples/functional_api.ipynb) and [Functional API guide](https://docs.mosaicml.com/projects/composer/en/latest/functional_api.html).
 
 ### Example: Trainer [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mosaicml/composer/blob/dev/examples/getting_started.ipynb)
 
@@ -167,23 +167,23 @@ trainer.fit()
 ```
 <!-- end_example_2 -->
 
-Composer's built-in [trainer](https://docs.mosaicml.com/en/stable/trainer/using_the_trainer.html) makes it easy to **add multiple speedup methods in a single line of code!**
+Composer's built-in [trainer](https://docs.mosaicml.com/projects/composer/en/stable/trainer/using_the_trainer.html) makes it easy to **add multiple speedup methods in a single line of code!**
 Trying out new methods or combinations of methods is as easy as changing a single list.
 
-Here are some examples of methods available in Composer ([_see here for the full list_](https://docs.mosaicml.com/en/latest/trainer/algorithms.html)):
+Here are some examples of methods available in Composer ([_see here for the full list_](https://docs.mosaicml.com/projects/composer/en/latest/trainer/algorithms.html)):
 
 Name|Attribution|tl;dr|Example Benchmark|Speed Up*|
 ----|-----------|-----|---------|---------|
 [Alibi](https://github.com/mosaicml/composer/tree/dev/composer/algorithms/alibi)|[Press et al, 2021](https://arxiv.org/abs/2108.12409)|Replace attention with AliBi.|GPT-2|1.5x
 [BlurPool](https://github.com/mosaicml/composer/tree/dev/composer/algorithms/blurpool)|[Zhang, 2019](https://arxiv.org/abs/1904.11486)|Applies an anti-aliasing filter before every downsampling operation.|ResNet-101|1.2x
 [ChannelsLast](https://github.com/mosaicml/composer/tree/dev/composer/algorithms/channels_last)|[PyTorch](https://pytorch.org/tutorials/intermediate/memory_format_tutorial.html)|Uses channels last memory format (NHWC).|ResNet-101|1.5x
-[CutOut](https://docs.mosaicml.com/en/latest/method_cards/cutout.html)|[DeVries et al, 2017](https://arxiv.org/abs/1708.04552)|Randomly erases rectangular blocks from the image.|ResNet-101|1.2x
+[CutOut](https://docs.mosaicml.com/projects/composer/en/latest/method_cards/cutout.html)|[DeVries et al, 2017](https://arxiv.org/abs/1708.04552)|Randomly erases rectangular blocks from the image.|ResNet-101|1.2x
 [LabelSmoothing](https://github.com/mosaicml/composer/tree/dev/composer/algorithms/label_smoothing)|[Szegedy et al, 2015](https://arxiv.org/abs/1512.00567)|Smooths the labels with a uniform prior|ResNet-101|1.5x
 [MixUp](https://github.com/mosaicml/composer/tree/dev/composer/algorithms/mixup)|[Zhang et al, 2017](https://arxiv.org/abs/1710.09412)|Blends pairs of examples and labels.|ResNet-101|1.5x
 [RandAugment](https://github.com/mosaicml/composer/tree/dev/composer/algorithms/randaugment)|[Cubuk et al, 2020](https://openaccess.thecvf.com/content_CVPRW_2020/html/w40/Cubuk_Randaugment_Practical_Automated_Data_Augmentation_With_a_Reduced_Search_Space_CVPRW_2020_paper.html)|Applies a series of random augmentations to each image.|ResNet-101|1.3x
 [SAM](https://github.com/mosaicml/composer/tree/dev/composer/algorithms/sam)|[Foret et al, 2021](https://arxiv.org/abs/2010.01412)|An optimization strategy that seeks flatter minima.|ResNet-101|1.4x
 [SeqLengthWarmup](https://github.com/mosaicml/composer/tree/dev/composer/algorithms/seq_length_warmup)|[Li et al, 2021](https://arxiv.org/abs/2108.06084)|Progressively increase sequence length.|GPT-2|1.2x
-[Stochastic Depth](https://docs.mosaicml.com/en/latest/method_cards/stochastic_depth.html)|[Huang et al, 2016](https://arxiv.org/abs/1603.09382)|Replaces a specified layer with a stochastic version that randomly drops the layer or samples during training|ResNet-101|1.1x
+[Stochastic Depth](https://docs.mosaicml.com/projects/composer/en/latest/method_cards/stochastic_depth.html)|[Huang et al, 2016](https://arxiv.org/abs/1603.09382)|Replaces a specified layer with a stochastic version that randomly drops the layer or samples during training|ResNet-101|1.1x
 <p align="right">* = time-to-train to the same quality as the baseline.</p>
 
 ## 🛠 Building Speedup Recipes

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -257,7 +257,7 @@ class State(Serializable):
         eval_metrics (Dict[str, Dict[str, Metric]]): The current evaluation metrics, organized
             by dataloader label and then by metric name. If not using an :class:`.Evaluator`,
             the eval dataloader is labeled ``'eval'``. Otherwise, in the case of having multiple evaluation datasets,
-            the evaluator label is used. See the `Multiple Datasets Documentation <https://docs.mosaicml.com/en/stable/trainer/evaluation.html#multiple-datasets>`_
+            the evaluator label is used. See the `Multiple Datasets Documentation <https://docs.mosaicml.com/projects/composer/en/stable/trainer/evaluation.html#multiple-datasets>`_
             for more information. ``eval_metrics`` will be deep-copied to ensure that each evaluator updates only its ``eval_metrics``.
 
             For example:

--- a/composer/models/resnet/README.md
+++ b/composer/models/resnet/README.md
@@ -42,7 +42,7 @@ ResNet family members are identified by their number of layers. Parameter count,
 | ResNet-152           | 60.2M           | TBA          | TBA                      |
 
 
-> ❗ **Note**: Please see the [CIFAR ResNet model card](https://docs.mosaicml.com/en/stable/model_cards/cifar_resnet.html#architecture) for the differences between CIFAR and ImageNet ResNets.
+> ❗ **Note**: Please see the [CIFAR ResNet model card](https://docs.mosaicml.com/projects/composer/en/stable/model_cards/cifar_resnet.html#architecture) for the differences between CIFAR and ImageNet ResNets.
 
 ## Default Training Hyperparameters
 

--- a/examples/TPU_Training_in_composer.ipynb
+++ b/examples/TPU_Training_in_composer.ipynb
@@ -21,7 +21,7 @@
     "Let's get started!\n",
     "\n",
     "[torch_xla]: https://github.com/pytorch/xla\n",
-    "[getting_started]: https://docs.mosaicml.com/en/stable/examples/getting_started.html"
+    "[getting_started]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html"
    ]
   },
   {
@@ -188,11 +188,11 @@
     "\n",
     "* Keep it custom with our [custom speedups][custom_speedups_tutorial] tutorial.\n",
     "\n",
-    "[autograd]: https://docs.mosaicml.com/en/stable/examples/auto_microbatching.html\n",
-    "[autoresume]: https://docs.mosaicml.com/en/stable/examples/checkpoint_autoresume.html\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[huggingface_tutorial]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html\n",
-    "[custom_speedups_tutorial]: https://docs.mosaicml.com/en/stable/examples/custom_speedup_methods.html"
+    "[autograd]: https://docs.mosaicml.com/projects/composer/en/stable/examples/auto_microbatching.html\n",
+    "[autoresume]: https://docs.mosaicml.com/projects/composer/en/stable/examples/checkpoint_autoresume.html\n",
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[huggingface_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html\n",
+    "[custom_speedups_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/custom_speedup_methods.html"
    ]
   },
   {

--- a/examples/auto_microbatching.ipynb
+++ b/examples/auto_microbatching.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "Let's get started!\n",
     "\n",
-    "[docs]: https://docs.mosaicml.com/en/stable/notes/auto_microbatching.html"
+    "[docs]: https://docs.mosaicml.com/projects/composer/en/stable/notes/auto_microbatching.html"
    ]
   },
   {
@@ -183,11 +183,11 @@
     "\n",
     "\n",
     "\n",
-    "[docs]: https://docs.mosaicml.com/en/stable/notes/auto_microbatching.html\n",
-    "[autoresume]: https://docs.mosaicml.com/en/stable/examples/checkpoint_autoresume.html\n",
-    "[exporting]: https://docs.mosaicml.com/en/stable/examples/exporting_for_inference.html\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[huggingface_tutorial]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html"
+    "[docs]: https://docs.mosaicml.com/projects/composer/en/stable/notes/auto_microbatching.html\n",
+    "[autoresume]: https://docs.mosaicml.com/projects/composer/en/stable/examples/checkpoint_autoresume.html\n",
+    "[exporting]: https://docs.mosaicml.com/projects/composer/en/stable/examples/exporting_for_inference.html\n",
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[huggingface_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html"
    ]
   },
   {

--- a/examples/checkpoint_autoresume.ipynb
+++ b/examples/checkpoint_autoresume.ipynb
@@ -20,8 +20,8 @@
     "\n",
     "For a deeper look into the way autoresume works, check out our more in depth [notes][autoresume].\n",
     "\n",
-    "[checkpointing]: https://docs.mosaicml.com/en/stable/trainer/checkpointing.html\n",
-    "[autoresume]: https://docs.mosaicml.com/en/stable/notes/resumption.html"
+    "[checkpointing]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/checkpointing.html\n",
+    "[autoresume]: https://docs.mosaicml.com/projects/composer/en/stable/notes/resumption.html"
    ]
   },
   {
@@ -151,10 +151,10 @@
     "\n",
     "* Learn how to [train without local storage][no_local_storage_tutorial].\n",
     "\n",
-    "[autograd]: https://docs.mosaicml.com/en/stable/examples/auto_microbatching.html\n",
-    "[autoresume]: https://docs.mosaicml.com/en/stable/notes/resumption.html\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[huggingface_tutorial]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html\n"
+    "[autograd]: https://docs.mosaicml.com/projects/composer/en/stable/examples/auto_microbatching.html\n",
+    "[autoresume]: https://docs.mosaicml.com/projects/composer/en/stable/notes/resumption.html\n",
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[huggingface_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html\n"
    ]
   },
   {

--- a/examples/custom_speedup_methods.ipynb
+++ b/examples/custom_speedup_methods.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "We will see that getting a method working with Composer is not very different from getting it working with vanilla PyTorch. With just a couple extra steps we can use our algorithm while enjoying the flexibility and simplicity of Composer!\n",
     "\n",
-    "[getting_started]: https://docs.mosaicml.com/en/stable/examples/getting_started.html"
+    "[getting_started]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html"
    ]
   },
   {
@@ -210,11 +210,11 @@
     "### Implementing ColOut\n",
     "\n",
     "\n",
-    "For this tutorial, we'll look at how to implement one of the simpler speedup methods currently in our composer library: [ColOut](https://docs.mosaicml.com/en/stable/method_cards/colout.html). This method works on image data by dropping random rows and columns from the training images. This reduces the size of the training images, which reduces the time per training iteration and hopefully does not alter the semantic content of the image too much. Additionally, dropping a small fraction of random rows and columns can also slightly distort objects and perhaps provide a data augmentation effect.\n",
+    "For this tutorial, we'll look at how to implement one of the simpler speedup methods currently in our composer library: [ColOut](https://docs.mosaicml.com/projects/composer/en/stable/method_cards/colout.html). This method works on image data by dropping random rows and columns from the training images. This reduces the size of the training images, which reduces the time per training iteration and hopefully does not alter the semantic content of the image too much. Additionally, dropping a small fraction of random rows and columns can also slightly distort objects and perhaps provide a data augmentation effect.\n",
     "\n",
     "To start our implementation, we'll write a function to drop random rows and columns from a batch of input images. We'll assume that these are torch tensors and operate on a batch, rather than individual images, for simplicity here.\n",
     "\n",
-    "[colout]: https://docs.mosaicml.com/en/stable/method_cards/colout.html"
+    "[colout]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/colout.html"
    ]
   },
   {
@@ -379,7 +379,7 @@
    "source": [
     "The training loop Composer uses provides multiple different locations where method code can be inserted and run. These are called events. Diagramatically, the training loop looks as follows:\n",
     "\n",
-    "![Training Loop](https://storage.googleapis.com/docs.mosaicml.com/images/training_loop.png)"
+    "![Training Loop](https://storage.googleapis.com/docs.mosaicml.com/projects/composer/images/training_loop.png)"
    ]
   },
   {
@@ -686,11 +686,11 @@
     "* [SelectiveBackprop][selectivebackprop] changes which samples are used to compute gradients.\n",
     "* [SAM][sam] changes the optimizer used for training.\n",
     "\n",
-    "[blurpool]: https://docs.mosaicml.com/en/stable/method_cards/blurpool.html\n",
-    "[layerfreezing]: https://docs.mosaicml.com/en/stable/method_cards/layer_freezing.html\n",
-    "[randaugment]: https://docs.mosaicml.com/en/stable/method_cards/randaugment.html\n",
-    "[selectivebackprop]: https://docs.mosaicml.com/en/stable/method_cards/selective_backprop.html\n",
-    "[sam]: https://docs.mosaicml.com/en/stable/method_cards/sam.html\n",
+    "[blurpool]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/blurpool.html\n",
+    "[layerfreezing]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/layer_freezing.html\n",
+    "[randaugment]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/randaugment.html\n",
+    "[selectivebackprop]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/selective_backprop.html\n",
+    "[sam]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/sam.html\n",
     "\n",
     "In addition, please continue to explore our tutorials! Here's a couple suggestions:\n",
     "\n",
@@ -700,10 +700,10 @@
     "\n",
     "* A [transition guide][ptl_tutorial] for switching from PyTorch Lightening to Composer.\n",
     "\n",
-    "[ptl_tutorial]: https://docs.mosaicml.com/en/stable/examples/migrate_from_ptl.html\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[huggingface_tutorial]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html\n",
-    "[early_stopping_tutorial]: https://docs.mosaicml.com/en/stable/examples/early_stopping.html"
+    "[ptl_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/migrate_from_ptl.html\n",
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[huggingface_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html\n",
+    "[early_stopping_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/early_stopping.html"
    ]
   },
   {

--- a/examples/early_stopping.ipynb
+++ b/examples/early_stopping.ipynb
@@ -33,10 +33,10 @@
     "\n",
     "Let's get started!\n",
     "\n",
-    "[earlystopper]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.callbacks.EarlyStopper.html\n",
-    "[thresholdstopper]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.callbacks.ThresholdStopper.html\n",
-    "[getting_started]: https://docs.mosaicml.com/en/stable/examples/getting_started.html\n",
-    "[welcome_tour]: https://docs.mosaicml.com/en/stable/getting_started/welcome_tour.html"
+    "[earlystopper]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.callbacks.EarlyStopper.html\n",
+    "[thresholdstopper]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.callbacks.ThresholdStopper.html\n",
+    "[getting_started]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html\n",
+    "[welcome_tour]: https://docs.mosaicml.com/projects/composer/en/stable/getting_started/welcome_tour.html"
    ]
   },
   {
@@ -49,7 +49,7 @@
     "\n",
     "In this tutorial, we'll train a `ComposerModel` and halt training for criteria that we'll set. We'll use the same basic setup as in the [Getting Started][tutorial] tutorial. If you want to better understand the details of the setup, that's a good place to review.\n",
     "\n",
-    "[tutorial]: https://docs.mosaicml.com/en/stable/examples/getting_started.html"
+    "[tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html"
    ]
   },
   {
@@ -136,7 +136,7 @@
     "\n",
     "Finally, set up the model, optimizer, scheduler, and an [evaluator][evaluator].\n",
     "\n",
-    "[evaluator]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.Evaluator.html#evaluator"
+    "[evaluator]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Evaluator.html#evaluator"
    ]
   },
   {
@@ -197,10 +197,10 @@
     "\n",
     "See the [API Reference][api] for more information.\n",
     "\n",
-    "[evaluator]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.Evaluator.html#evaluator\n",
-    "[trainer]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.Trainer.html#trainer\n",
-    "[time]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.Time.html#time\n",
-    "[api]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.callbacks.EarlyStopper.html\n",
+    "[evaluator]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Evaluator.html#evaluator\n",
+    "[trainer]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Trainer.html#trainer\n",
+    "[time]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Time.html#time\n",
+    "[api]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.callbacks.EarlyStopper.html\n",
     "\n",
     "Here, we'll use our callback to track the MulticlassAccuracy metric over one epoch on the test dataset:"
    ]
@@ -270,7 +270,7 @@
     "-   `threshold`: The float threshold that dictates when to halt training.\n",
     "-   `stop_on_batch`: If `True`, training can halt in the middle of an epoch, rather than just add the end.\n",
     "\n",
-    "[thresholdstopper]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.callbacks.ThresholdStopper.html"
+    "[thresholdstopper]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.callbacks.ThresholdStopper.html"
    ]
   },
   {
@@ -325,11 +325,11 @@
     "\n",
     "* Give your model life after training with Composer's [export for inference tools][exporting]\n",
     "\n",
-    "[docs]: https://docs.mosaicml.com/en/stable/trainer/callbacks.html\n",
-    "[api]: https://docs.mosaicml.com/en/stable/api_reference/composer.callbacks.html#module-composer.callbacks\n",
-    "[autograd]: https://docs.mosaicml.com/en/stable/examples/auto_microbatching.html\n",
-    "[autoresume]: https://docs.mosaicml.com/en/stable/examples/checkpoint_autoresume.html\n",
-    "[exporting]: https://docs.mosaicml.com/en/stable/examples/exporting_for_inference.html"
+    "[docs]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/callbacks.html\n",
+    "[api]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/composer.callbacks.html#module-composer.callbacks\n",
+    "[autograd]: https://docs.mosaicml.com/projects/composer/en/stable/examples/auto_microbatching.html\n",
+    "[autoresume]: https://docs.mosaicml.com/projects/composer/en/stable/examples/checkpoint_autoresume.html\n",
+    "[exporting]: https://docs.mosaicml.com/projects/composer/en/stable/examples/exporting_for_inference.html"
    ]
   },
   {

--- a/examples/exporting_for_inference.ipynb
+++ b/examples/exporting_for_inference.ipynb
@@ -31,8 +31,8 @@
     "\n",
     "[onnx]: https://onnx.ai/\n",
     "[torchscript]: https://pytorch.org/docs/stable/jit.html\n",
-    "[callback_docs]: https://docs.mosaicml.com/en/stable/trainer/callbacks.html\n",
-    "[checkpointing_docs]: https://docs.mosaicml.com/en/stable/trainer/checkpointing.html\n",
+    "[callback_docs]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/callbacks.html\n",
+    "[checkpointing_docs]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/checkpointing.html\n",
     "\n",
     "Let's get started!"
    ]
@@ -118,7 +118,7 @@
    "id": "5668ffed",
    "metadata": {},
    "source": [
-    "Now we run export using our standalone export API. Composer also supports exporting to an object store such as S3. For more info on using an object store, please checkout our full [documentation](https://docs.mosaicml.com/en/stable/api_reference/composer.utils.inference.html) for the `export_for_inference` API."
+    "Now we run export using our standalone export API. Composer also supports exporting to an object store such as S3. For more info on using an object store, please checkout our full [documentation](https://docs.mosaicml.com/projects/composer/en/stable/api_reference/composer.utils.inference.html) for the `export_for_inference` API."
    ]
   },
   {
@@ -420,7 +420,7 @@
    "id": "0bc52f62",
    "metadata": {},
    "source": [
-    "If our input is a dictionary, as if often the case when using a Composer [HuggingFaceModel](https://docs.mosaicml.com/en/stable/examples/huggingface_models.html), we'll need to make sure all the elements of our input dictionary are numpy arrays before calling `ort_session.run()`."
+    "If our input is a dictionary, as if often the case when using a Composer [HuggingFaceModel](https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html), we'll need to make sure all the elements of our input dictionary are numpy arrays before calling `ort_session.run()`."
    ]
   },
   {
@@ -444,8 +444,8 @@
     "\n",
     "Some of our algorithms alter the model architecture. For example, [SqueezeExcite][squeezeexcite] adds a channel-wise attention operator in CNNs and modifies the model architecure. Therefore, we need to provide a function that takes the mode and applies the algorithm before we can load the model weights from a checkpoint. The functional form of SqueezeExcite does exactly that, and we pass this function in the `surgery_algs` argument to the `export_for_inference` API. \n",
     "\n",
-    "[docs]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.utils.export_for_inference.html\n",
-    "[squeezeexcite]: https://docs.mosaicml.com/en/stable/method_cards/squeeze_excite.html"
+    "[docs]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.utils.export_for_inference.html\n",
+    "[squeezeexcite]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/squeeze_excite.html"
    ]
   },
   {
@@ -637,7 +637,7 @@
     "\n",
     "* Check out our beta support for [training on TPUs][tpu_training].\n",
     "\n",
-    "[tpu_training]: https://docs.mosaicml.com/en/stable/examples/TPU_Training_in_composer.html\n"
+    "[tpu_training]: https://docs.mosaicml.com/projects/composer/en/stable/examples/TPU_Training_in_composer.html\n"
    ]
   },
   {

--- a/examples/ffcv_dataloaders.ipynb
+++ b/examples/ffcv_dataloaders.ipynb
@@ -27,7 +27,7 @@
     "Let's get started!\n",
     "\n",
     "[ffcv]: https://ffcv.io/\n",
-    "[getting_started]: https://docs.mosaicml.com/en/stable/examples/getting_started.html"
+    "[getting_started]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html"
    ]
   },
   {
@@ -154,7 +154,7 @@
     "\n",
     "Next, we create our model. We'll use Composer's built-in ResNet18. To use your own custom model, please see the [custom models tutorial][tutorial].\n",
     "\n",
-    "[tutorial]: https://docs.mosaicml.com/en/stable/tutorials/adding_models_datasets.html#models"
+    "[tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/tutorials/adding_models_datasets.html#models"
    ]
   },
   {
@@ -455,7 +455,7 @@
     "* Computer vision for [medical imaging][medical_imaging] with Composer.\n",
     "\n",
     "[ffcv]: https://ffcv.io/\n",
-    "[medical_imaging]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html"
+    "[medical_imaging]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html"
    ]
   },
   {

--- a/examples/finetune_huggingface.ipynb
+++ b/examples/finetune_huggingface.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "Let's do this 🚀\n",
     "\n",
-    "[getting_started]: https://docs.mosaicml.com/en/stable/examples/getting_started.html"
+    "[getting_started]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html"
    ]
   },
   {
@@ -160,7 +160,7 @@
     "\n",
     "See the [API Reference][api] for additional details.\n",
     "\n",
-    "[api]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.models.HuggingFaceModel.html"
+    "[api]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.models.HuggingFaceModel.html"
    ]
   },
   {
@@ -223,7 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will now specify a Composer `Trainer` object and run our training! `Trainer` has many arguments that are described in our [documentation](https://docs.mosaicml.com/en/stable/api_reference/generated/composer.Trainer.html#trainer), so we'll discuss only the less-obvious arguments used below:\n",
+    "We will now specify a Composer `Trainer` object and run our training! `Trainer` has many arguments that are described in our [documentation](https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Trainer.html#trainer), so we'll discuss only the less-obvious arguments used below:\n",
     "\n",
     "- `max_duration` - a string specifying how long to train. This can be in terms of batches (e.g., `'10ba'` is 10 batches) or epochs (e.g., `'1ep'` is 1 epoch), [among other options][time].\n",
     "- `schedulers` - a (list of) PyTorch or Composer learning rate scheduler(s) that will be composed together.\n",
@@ -232,7 +232,7 @@
     "- `precision` - whether to do the training in full precision (`'fp32'`) or mixed precision (`'amp'`). Mixed precision can provide a ~2x training speedup on recent NVIDIA GPUs.\n",
     "- `seed` - sets the random seed for the training run, so the results are reproducible!\n",
     "\n",
-    "[time]: https://docs.mosaicml.com/en/stable/trainer/time.html"
+    "[time]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/time.html"
    ]
   },
   {
@@ -362,10 +362,10 @@
     "\n",
     "* Check out the [examples][examples] repo for full examples of training large language models like GPT and BERT, image segmentation models like DeepLab, and more!\n",
     "\n",
-    "[tutorial]: https://docs.mosaicml.com/en/stable/examples/pretrain_finetune_huggingface.html\n",
+    "[tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/pretrain_finetune_huggingface.html\n",
     "[examples]: https://github.com/mosaicml/examples\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[early_stopping_tutorial]: https://docs.mosaicml.com/en/stable/examples/early_stopping.html"
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[early_stopping_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/early_stopping.html"
    ]
   },
   {

--- a/examples/functional_api.ipynb
+++ b/examples/functional_api.ipynb
@@ -18,8 +18,8 @@
     "\n",
     "We'll be training a simple model on CIFAR-10, similar to the [PyTorch classifier tutorial][pytorch_tutorial]. Because we'll be using a toy model trained for only a few epochs, we won't get the same speed or accuracy gains we might expect from a more realistic problem. However, this tutorial should still serve as a useful illustration of how to use various algorithms. For examples of more realistic results, see the MosaicML [Explorer][explorer].\n",
     "\n",
-    "[algorithm_docs]: https://docs.mosaicml.com/en/stable/trainer/algorithms.html\n",
-    "[api_docs]: https://docs.mosaicml.com/en/stable/functional_api.html\n",
+    "[algorithm_docs]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/algorithms.html\n",
+    "[api_docs]: https://docs.mosaicml.com/projects/composer/en/stable/functional_api.html\n",
     "[pytorch_tutorial]: https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html\n",
     "[explorer]: https://app.mosaicml.com/explorer/imagenet"
    ]
@@ -199,7 +199,7 @@
    "source": [
     "Now that we have this baseline, let's add algorithms to improve our data pipeline and model. We'll start by adding some data augmentation, accessed via `cf.colout_batch`. (We can ignore the details on how `ColOut` works for the sake of this tutorial; you can check out the [docs][colout] if you'd like to learn more.)\n",
     "\n",
-    "[colout]: https://docs.mosaicml.com/en/stable/method_cards/colout.html"
+    "[colout]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/colout.html"
    ]
   },
   {
@@ -260,7 +260,7 @@
     "\n",
     "Let's try using some algorithms that modify the model. We're going to keep things simple and just add a [Squeeze-and-Excitation][squeezeexcite] module after the larger of the two `Conv2d` operations in our model. (Again, we can ignore what `SqueezeExcite` actually does, but feel free to check the docs to learn more.)\n",
     "\n",
-    "[squeezeexcite]: https://docs.mosaicml.com/en/stable/method_cards/squeeze_excite.html"
+    "[squeezeexcite]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/squeeze_excite.html"
    ]
   },
   {
@@ -317,9 +317,9 @@
     "\n",
     "* A [transition guide][ptl_tutorial] for switching from PyTorch Lightning to Composer.\n",
     "\n",
-    "[docs]: https://docs.mosaicml.com/en/stable/functional_api.html\n",
-    "[custom_speedups_tutorial]: https://docs.mosaicml.com/en/stable/examples/custom_speedup_methods.html\n",
-    "[ptl_tutorial]: https://docs.mosaicml.com/en/stable/examples/migrate_from_ptl.html\n"
+    "[docs]: https://docs.mosaicml.com/projects/composer/en/stable/functional_api.html\n",
+    "[custom_speedups_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/custom_speedup_methods.html\n",
+    "[ptl_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/migrate_from_ptl.html\n"
    ]
   },
   {

--- a/examples/getting_started.ipynb
+++ b/examples/getting_started.ipynb
@@ -36,9 +36,9 @@
     "Let's get started!\n",
     "\n",
     "\n",
-    "[welcome_tour]: https://docs.mosaicml.com/en/stable/getting_started/welcome_tour.html\n",
+    "[welcome_tour]: https://docs.mosaicml.com/projects/composer/en/stable/getting_started/welcome_tour.html\n",
     "[pytorch_basics]: https://pytorch.org/tutorials/beginner/basics/intro.html\n",
-    "[trainer]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.Trainer.html#trainer"
+    "[trainer]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Trainer.html#trainer"
    ]
   },
   {
@@ -115,7 +115,7 @@
     "\n",
     "As a bit of extra detail, there are [three ways][composer_dataloaders] of passing training and/or evaluation dataloaders to the Trainer. If you're used to working with [PyTorch dataloaders][pytorch_dataloaders], good news—that's one of the ways! The below code should look pretty familiar if you're coming from PyTorch, but if not, now may be a good time to familiarize yourself with those basics.\n",
     "\n",
-    "[composer_dataloaders]: https://docs.mosaicml.com/en/stable/trainer/dataloaders.html\n",
+    "[composer_dataloaders]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/dataloaders.html\n",
     "[pytorch_dataloaders]: https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"
    ]
   },
@@ -154,8 +154,8 @@
     "\n",
     "**Note**: The model below is an instance of a [ComposerModel][composer_model]. Models need to be wrapped in this class, which provides a convenient interface between the underlying PyTorch model and the Trainer.\n",
     "\n",
-    "[custom_model_example]: https://docs.mosaicml.com/en/stable/composer_model.html#using-your-own-model\n",
-    "[composer_model]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.ComposerModel.html#composer.ComposerModel"
+    "[custom_model_example]: https://docs.mosaicml.com/projects/composer/en/stable/composer_model.html#using-your-own-model\n",
+    "[composer_model]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.ComposerModel.html#composer.ComposerModel"
    ]
   },
   {
@@ -202,7 +202,7 @@
     "\n",
     "**Note**: Composer provides a handful of different [schedulers][schedulers] to help customize your training!\n",
     "\n",
-    "[schedulers]: https://docs.mosaicml.com/en/stable/trainer/schedulers.html"
+    "[schedulers]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/schedulers.html"
    ]
   },
   {
@@ -227,7 +227,7 @@
     "\n",
     "Finally, we instantiate an [InMemoryLogger][in_memory_logger] that records all the data from the Composer Trainer. We will use this logger to generate data plots after we complete training.\n",
     "\n",
-    "[in_memory_logger]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.loggers.InMemoryLogger.html"
+    "[in_memory_logger]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.loggers.InMemoryLogger.html"
    ]
   },
   {
@@ -270,14 +270,14 @@
     "-   `loggers`: Any loggers to use during training. More info [here][loggers].\n",
     "\n",
     "\n",
-    "[trainer_docs]: https://docs.mosaicml.com/en/stable/trainer/using_the_trainer.html\n",
-    "[api]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.Trainer.html#trainer\n",
-    "[composer_model]: https://docs.mosaicml.com/en/stable/composer_model.html\n",
-    "[dataloaders]: https://docs.mosaicml.com/en/stable/trainer/dataloaders.html\n",
-    "[time]: https://docs.mosaicml.com/en/stable/trainer/time.html\n",
-    "[optimizers]: https://docs.mosaicml.com/en/stable/api_reference/composer.optim.html\n",
-    "[schedulers]: https://docs.mosaicml.com/en/stable/trainer/schedulers.html\n",
-    "[loggers]: https://docs.mosaicml.com/en/stable/trainer/logging.html\n"
+    "[trainer_docs]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/using_the_trainer.html\n",
+    "[api]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Trainer.html#trainer\n",
+    "[composer_model]: https://docs.mosaicml.com/projects/composer/en/stable/composer_model.html\n",
+    "[dataloaders]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/dataloaders.html\n",
+    "[time]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/time.html\n",
+    "[optimizers]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/composer.optim.html\n",
+    "[schedulers]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/schedulers.html\n",
+    "[loggers]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/logging.html\n"
    ]
   },
   {
@@ -337,7 +337,7 @@
     "\n",
     "Now, you might be thinking, \"I don't remember logging any validation accuracy!\" And you'd be right—sort of. That's because all the logging happened automatically during the `trainer.fit()` call. The values that we'll plot were set up by the model, which defines which metric(s) to measure during evaluation (and possibly also during training). Check out the [documentation][loggers] for a deeper dive on the loggers Composer offers and how to interact with them!\n",
     "\n",
-    "[loggers]: https://docs.mosaicml.com/en/stable/trainer/logging.html"
+    "[loggers]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/logging.html"
    ]
   },
   {
@@ -372,9 +372,9 @@
     "\n",
     "For our first algorithm here, let's start with [Label Smoothing][label_smoothing], which serves as a form of regularization by interpolating between the target distribution and another distribution that usually has higher entropy.\n",
     "\n",
-    "[algorithms]: https://docs.mosaicml.com/en/stable/trainer/algorithms.html\n",
+    "[algorithms]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/algorithms.html\n",
     "[explorer]: https://app.mosaicml.com/explorer/imagenet\n",
-    "[label_smoothing]: https://docs.mosaicml.com/en/stable/method_cards/label_smoothing.html"
+    "[label_smoothing]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/label_smoothing.html"
    ]
   },
   {
@@ -392,7 +392,7 @@
    "source": [
     "Let's also use [BlurPool][blurpool], which increases accuracy by applying a spatial low-pass filter before the pool in max pooling and whenever using a strided convolution.\n",
     "\n",
-    "[blurpool]: https://docs.mosaicml.com/en/stable/method_cards/blurpool.html"
+    "[blurpool]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/blurpool.html"
    ]
   },
   {
@@ -414,7 +414,7 @@
    "source": [
     "Our final algorithm in our improved training recipe is [Progressive Image Resizing][progressive_image_resizing]. Progressive Image Resizing initially shrinks the size of training images and slowly scales them back to their full size over the course of training. It increases throughput during the early phase of training, when the network may learn coarse-grained features that do not require the details lost by reducing image resolution.\n",
     "\n",
-    "[progressive_image_resizing]: https://docs.mosaicml.com/en/stable/method_cards/progressive_resizing.html"
+    "[progressive_image_resizing]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/progressive_resizing.html"
    ]
   },
   {
@@ -659,10 +659,10 @@
     "\n",
     "* Learn about callbacks and how to apply [early stopping][early_stopping_tutorial].\n",
     "\n",
-    "[functional_tutorial]: https://docs.mosaicml.com/en/stable/examples/functional_api.html\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[huggingface_tutorial]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html\n",
-    "[early_stopping_tutorial]: https://docs.mosaicml.com/en/stable/examples/early_stopping.html"
+    "[functional_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/functional_api.html\n",
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[huggingface_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html\n",
+    "[early_stopping_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/early_stopping.html"
    ]
   },
   {

--- a/examples/medical_image_segmentation.ipynb
+++ b/examples/medical_image_segmentation.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "[kaggle]: https://www.kaggle.com/c/siim-acr-pneumothorax-segmentation/overview\n",
     "[siim]: https://siim.org/\n",
-    "[getting_started]: https://docs.mosaicml.com/en/stable/examples/getting_started.html"
+    "[getting_started]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html"
    ]
   },
   {
@@ -679,10 +679,10 @@
     "\n",
     "* See how dataloading bottlenecks in computer vision can be addressed using [FFCV][ffcv].\n",
     "\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[huggingface_tutorial]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html\n",
-    "[early_stopping_tutorial]: https://docs.mosaicml.com/en/stable/examples/early_stopping.html\n",
-    "[ffcv]: https://docs.mosaicml.com/en/stable/examples/ffcv_dataloaders.html"
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[huggingface_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html\n",
+    "[early_stopping_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/early_stopping.html\n",
+    "[ffcv]: https://docs.mosaicml.com/projects/composer/en/stable/examples/ffcv_dataloaders.html"
    ]
   },
   {

--- a/examples/migrate_from_ptl.ipynb
+++ b/examples/migrate_from_ptl.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# ⚡ Migrating from PTL\n",
     "\n",
-    "[PyTorch Lightning][ptl] is a popular and well-designed framework for training deep neural networks. You can use Composer's algorithms in your Pytorch Lightning code via the [functional API](https://docs.mosaicml.com/en/stable/functional_api.html) with no additional code changes.\n",
+    "[PyTorch Lightning][ptl] is a popular and well-designed framework for training deep neural networks. You can use Composer's algorithms in your Pytorch Lightning code via the [functional API](https://docs.mosaicml.com/projects/composer/en/stable/functional_api.html) with no additional code changes.\n",
     "\n",
-    "However, if you are interested in features like [automatic gradient accumulation](https://docs.mosaicml.com/en/stable/examples/auto_microbatching.html), a [clean time abstraction](https://docs.mosaicml.com/en/stable/trainer/time.html), and the easiest path to trying out different combinations of algorithms, you will need to switch from the PTL trainer to the Composer trainer.\n",
+    "However, if you are interested in features like [automatic gradient accumulation](https://docs.mosaicml.com/projects/composer/en/stable/examples/auto_microbatching.html), a [clean time abstraction](https://docs.mosaicml.com/projects/composer/en/stable/trainer/time.html), and the easiest path to trying out different combinations of algorithms, you will need to switch from the PTL trainer to the Composer trainer.\n",
     "\n",
     "The below is a quick guide on how to adapt your `LightningModule` to our simple interface.\n",
     "\n",
@@ -24,7 +24,7 @@
     "\n",
     "We'll primarily focus on the different ways **models** are structured in each framework, in order to illustrate how one maps on to the other.\n",
     "\n",
-    "[getting_started]: https://docs.mosaicml.com/en/stable/examples/getting_started.html\n",
+    "[getting_started]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html\n",
     "[ptl]: https://www.pytorchlightning.ai/\n",
     "\n",
     "Let's get started!"
@@ -234,7 +234,7 @@
     "\n",
     "For more information about the `ComposerModel` format, see our [documentation][composer_model].\n",
     "\n",
-    "[composer_model]: https://docs.mosaicml.com/en/stable/composer_model.html"
+    "[composer_model]: https://docs.mosaicml.com/projects/composer/en/stable/composer_model.html"
    ]
   },
   {
@@ -289,8 +289,8 @@
     "\n",
     "Now you are ready to insert your algorithms! As an example, here we add the [BlurPool][blurpool] algorithm.\n",
     "\n",
-    "[trainer]: https://docs.mosaicml.com/en/stable/trainer/using_the_trainer.html\n",
-    "[blurpool]: https://docs.mosaicml.com/en/stable/method_cards/blurpool.html"
+    "[trainer]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/using_the_trainer.html\n",
+    "[blurpool]: https://docs.mosaicml.com/projects/composer/en/stable/method_cards/blurpool.html"
    ]
   },
   {
@@ -358,11 +358,11 @@
     "\n",
     "* Learn about implementing your own [custom speedup methods in Composer][custom_methods].\n",
     "\n",
-    "[trainer]: https://docs.mosaicml.com/en/stable/trainer/using_the_trainer.html\n",
-    "[functional_tutorial]: https://docs.mosaicml.com/en/stable/examples/functional_api.html\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[huggingface_tutorial]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html\n",
-    "[custom_methods]: https://docs.mosaicml.com/en/stable/examples/custom_speedup_methods.html"
+    "[trainer]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/using_the_trainer.html\n",
+    "[functional_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/functional_api.html\n",
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[huggingface_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html\n",
+    "[custom_methods]: https://docs.mosaicml.com/projects/composer/en/stable/examples/custom_speedup_methods.html"
    ]
   },
   {

--- a/examples/pretrain_finetune_huggingface.ipynb
+++ b/examples/pretrain_finetune_huggingface.ipynb
@@ -37,8 +37,8 @@
     "\n",
     "Let's do this 🚀\n",
     "\n",
-    "[huggingface]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html\n",
-    "[getting_started]: https://docs.mosaicml.com/en/stable/examples/getting_started.html\n",
+    "[huggingface]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html\n",
+    "[getting_started]: https://docs.mosaicml.com/projects/composer/en/stable/examples/getting_started.html\n",
     "[downstream]: https://arxiv.org/abs/2209.14389\n",
     "[agnews]: https://paperswithcode.com/sota/text-classification-on-ag-news\n",
     "[electra]: https://arxiv.org/abs/2003.10555"
@@ -174,7 +174,7 @@
     "\n",
     "See the [API Reference][api] for additional details.\n",
     "\n",
-    "[api]: https://docs.mosaicml.com/en/stable/api_reference/generated/composer.models.HuggingFaceModel.html"
+    "[api]: https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.models.HuggingFaceModel.html"
    ]
   },
   {
@@ -207,8 +207,8 @@
    "source": [
     "The last setup step is to create an optimizer and a learning rate scheduler. We will use Composer's [DecoupledAdamW][optimizer] optimizer and [LinearWithWarmupScheduler][scheduler].\n",
     "\n",
-    "[optimizer]: https://docs.mosaicml.com/en/latest/api_reference/generated/composer.optim.DecoupledAdamW.html\n",
-    "[scheduler]: https://docs.mosaicml.com/en/latest/api_reference/generated/composer.optim.LinearWithWarmupScheduler.html"
+    "[optimizer]: https://docs.mosaicml.com/projects/composer/en/latest/api_reference/generated/composer.optim.DecoupledAdamW.html\n",
+    "[scheduler]: https://docs.mosaicml.com/projects/composer/en/latest/api_reference/generated/composer.optim.LinearWithWarmupScheduler.html"
    ]
   },
   {
@@ -234,7 +234,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will now specify a Composer `Trainer` object and run our training! `Trainer` has many arguments that are described in our [documentation](https://docs.mosaicml.com/en/stable/api_reference/generated/composer.Trainer.html#trainer), so we'll discuss only the less-obvious arguments used below:\n",
+    "We will now specify a Composer `Trainer` object and run our training! `Trainer` has many arguments that are described in our [documentation](https://docs.mosaicml.com/projects/composer/en/stable/api_reference/generated/composer.Trainer.html#trainer), so we'll discuss only the less-obvious arguments used below:\n",
     "\n",
     "- `max_duration` - a string specifying how long to train. This can be in terms of batches (e.g., `'10ba'` is 10 batches) or epochs (e.g., `'1ep'` is 1 epoch), [among other options][time].\n",
     "- `save_folder` - a string specifying where to save checkpoints to\n",
@@ -244,7 +244,7 @@
     "- `precision` - whether to do the training in full precision (`'fp32'`) or mixed precision (`'amp_fp16'` or `'amp_bf16'`). Mixed precision can provide a ~2x training speedup on recent NVIDIA GPUs.\n",
     "- `seed` - sets the random seed for the training run, so the results are reproducible!\n",
     "\n",
-    "[time]: https://docs.mosaicml.com/en/stable/trainer/time.html"
+    "[time]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/time.html"
    ]
   },
   {
@@ -316,7 +316,7 @@
    "source": [
     "The next part should look very familiar if you have already gone through the [tutorial][huggingface], as it is exactly the same except using a different dataset and starting model!\n",
     "\n",
-    "[huggingface]: https://docs.mosaicml.com/en/stable/examples/huggingface_models.html"
+    "[huggingface]: https://docs.mosaicml.com/projects/composer/en/stable/examples/huggingface_models.html"
    ]
   },
   {
@@ -431,7 +431,7 @@
    "source": [
     "There are many possibilities for how to improve performance. Using a larger model and training for longer are often the first thing to try to improve performance (given a fixed dataset). You can also tweak the hyperparameters, try a different model class, start from pretrained weights instead of randomly initialized, or try adding some of Composer's [algorithms][algorithms]. We encourage you to play around with these and other things to get familiar with training in Composer.\n",
     "\n",
-    "[algorithms]: https://docs.mosaicml.com/en/stable/trainer/algorithms.html"
+    "[algorithms]: https://docs.mosaicml.com/projects/composer/en/stable/trainer/algorithms.html"
    ]
   },
   {
@@ -453,8 +453,8 @@
     "* Check out the [benchmarks][benchmarks] repo for full examples of training large language models like GPT and BERT, image segmentation models like DeepLab, and more!\n",
     "\n",
     "[benchmarks]: https://github.com/mosaicml/benchmarks\n",
-    "[image_segmentation_tutorial]: https://docs.mosaicml.com/en/stable/examples/medical_image_segmentation.html\n",
-    "[early_stopping_tutorial]: https://docs.mosaicml.com/en/stable/examples/early_stopping.html"
+    "[image_segmentation_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/medical_image_segmentation.html\n",
+    "[early_stopping_tutorial]: https://docs.mosaicml.com/projects/composer/en/stable/examples/early_stopping.html"
    ]
   },
   {

--- a/examples/training_with_submitit.ipynb
+++ b/examples/training_with_submitit.ipynb
@@ -208,7 +208,7 @@
     "deepnote_cell_type": "markdown"
    },
    "source": [
-    "For more details about model wrapping, see [🛻 ComposerModel](https://docs.mosaicml.com/en/stable/composer_model.html). "
+    "For more details about model wrapping, see [🛻 ComposerModel](https://docs.mosaicml.com/projects/composer/en/stable/composer_model.html). "
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

* Updates "docs.mosaicml.com/en" to "docs.mosaicml.com/projects/composer/en" project URL

# What issue(s) does this change relate to?

 N/A

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
