### PR TITLE
Bump version to 0.13.5

### DIFF
--- a/composer/_version.py
+++ b/composer/_version.py
@@ -3,4 +3,4 @@
 
 """The Composer Version."""
 
-__version__ = '0.13.4'
+__version__ = '0.13.5'

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,8 +15,8 @@ all dependencies for both NLP and Vision models. They are built on top of the
 <!-- BEGIN_COMPOSER_BUILD_MATRIX -->
 | Composer Version   | CUDA Support   | Docker Tag                                                     |
 |--------------------|----------------|----------------------------------------------------------------|
-| 0.13.4             | Yes            | `mosaicml/composer:latest`, `mosaicml/composer:0.13.4`         |
-| 0.13.4             | No             | `mosaicml/composer:latest_cpu`, `mosaicml/composer:0.13.4_cpu` |
+| 0.13.5             | Yes            | `mosaicml/composer:latest`, `mosaicml/composer:0.13.5`         |
+| 0.13.5             | No             | `mosaicml/composer:latest_cpu`, `mosaicml/composer:0.13.5_cpu` |
 <!-- END_COMPOSER_BUILD_MATRIX -->
 
 **Note**: For a lightweight installation, we recommended using a [MosaicML PyTorch Image](#pytorch-images) and manually

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -126,28 +126,28 @@
   TORCHVISION_VERSION: 0.14.1
 - AWS_OFI_NCCL_VERSION: ''
   BASE_IMAGE: nvidia/cuda:11.7.1-cudnn8-devel-ubuntu20.04
-  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.13.4
+  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.13.5
   CUDA_VERSION: 11.7.1
-  IMAGE_NAME: composer-0-13-4
+  IMAGE_NAME: composer-0-13-5
   MOFED_VERSION: 5.5-1.0.3.2
   PYTHON_VERSION: '3.10'
   PYTORCH_VERSION: 1.13.1
   TAGS:
-  - mosaicml/composer:0.13.4
+  - mosaicml/composer:0.13.5
   - mosaicml/composer:latest
   TARGET: composer_stage
   TORCHTEXT_VERSION: 0.14.1
   TORCHVISION_VERSION: 0.14.1
 - AWS_OFI_NCCL_VERSION: ''
   BASE_IMAGE: ubuntu:20.04
-  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.13.4
+  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.13.5
   CUDA_VERSION: ''
-  IMAGE_NAME: composer-0-13-4-cpu
+  IMAGE_NAME: composer-0-13-5-cpu
   MOFED_VERSION: 5.5-1.0.3.2
   PYTHON_VERSION: '3.10'
   PYTORCH_VERSION: 1.13.1
   TAGS:
-  - mosaicml/composer:0.13.4_cpu
+  - mosaicml/composer:0.13.5_cpu
   - mosaicml/composer:latest_cpu
   TARGET: composer_stage
   TORCHTEXT_VERSION: 0.14.1

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -195,7 +195,7 @@ def _main():
     composer_entries = []
 
     # The `GIT_COMMIT` is a placeholder and Jenkins will substitute it with the actual git commit for the `composer_staging` images
-    composer_versions = ['0.13.4']  # Only build images for the latest composer version
+    composer_versions = ['0.13.5']  # Only build images for the latest composer version
     composer_python_versions = [LATEST_PYTHON_VERSION]  # just build composer against the latest
 
     for product in itertools.product(composer_python_versions, composer_versions, cuda_options):


### PR DESCRIPTION
# What does this PR do?

Bumps version to 0.13.5, which we'll release with EMA + FSDP fixes