### PR TITLE
Fix ICL eval for sentencepiece tokenizers

### DIFF
--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -296,8 +296,6 @@ class InContextLearningLMTaskDataset(Dataset):
         self.max_seq_len = max_seq_len
         self.pad_tok_id = pad_tok_id
         fewshot_rng = random.Random(fewshot_random_seed)
-        self.encoded_dataset = self.prep_examples(num_fewshot, prompt_string, example_delimiter, continuation_delimiter,
-                                                  fewshot_rng)
 
         # Test for whether a prefix space is needed before the continuation
         # sentencepiece tokenization should not have a prefix space, but gpt2 style BPE should
@@ -305,6 +303,9 @@ class InContextLearningLMTaskDataset(Dataset):
         test = self.tokenizer(' a', add_special_tokens=False)['input_ids']
         if len(test) > 1:
             self.prefix_space = False
+
+        self.encoded_dataset = self.prep_examples(num_fewshot, prompt_string, example_delimiter, continuation_delimiter,
+                                                  fewshot_rng)
 
     def prep_examples(self, num_fewshot: int, prompt_string: str, example_delimiter: str, continuation_delimiter: str,
                       fewshot_rng: random.Random):
@@ -459,8 +460,6 @@ class InContextLearningMultipleChoiceTaskDataset(Dataset):
         self.max_seq_len = max_seq_len
         self.pad_tok_id = pad_tok_id
         fewshot_rng = random.Random(fewshot_random_seed)
-        self.encoded_dataset = self.prep_examples(num_fewshot, prompt_string, example_delimiter, continuation_delimiter,
-                                                  fewshot_rng)
 
         # Test for whether a prefix space is needed before the continuation
         # sentencepiece tokenization should not have a prefix space, but gpt2 style BPE should
@@ -468,6 +467,9 @@ class InContextLearningMultipleChoiceTaskDataset(Dataset):
         test = self.tokenizer(' a', add_special_tokens=False)['input_ids']
         if len(test) > 1:
             self.prefix_space = False
+
+        self.encoded_dataset = self.prep_examples(num_fewshot, prompt_string, example_delimiter, continuation_delimiter,
+                                                  fewshot_rng)
 
     def prep_examples(self, num_fewshot: int, prompt_string: str, example_delimiter: str, continuation_delimiter: str,
                       fewshot_rng: random.Random):

--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
 __all__ = ['InContextLearningLMTaskDataset', 'InContextLearningMultipleChoiceTaskDataset', 'get_icl_task_dataloader']
 
 
+def _tokenizer_needs_prefix_space(tokenizer) -> bool:
+    # Test for whether a prefix space is needed before the continuation.
+    # sentencepiece tokenization should not have a prefix space, but gpt2 style BPE should
+    return len(tokenizer(' a', add_special_tokens=False)['input_ids']) == 1
+
+
 def _make_padded_input(context_enc, continuation_enc, max_seq_len, pad_tok_id, padding_side='right'):
     if len(continuation_enc) + len(context_enc) > max_seq_len:
         # clip from the end
@@ -297,12 +303,7 @@ class InContextLearningLMTaskDataset(Dataset):
         self.pad_tok_id = pad_tok_id
         fewshot_rng = random.Random(fewshot_random_seed)
 
-        # Test for whether a prefix space is needed before the continuation
-        # sentencepiece tokenization should not have a prefix space, but gpt2 style BPE should
-        self.prefix_space = True
-        test = self.tokenizer(' a', add_special_tokens=False)['input_ids']
-        if len(test) > 1:
-            self.prefix_space = False
+        self.prefix_space = _tokenizer_needs_prefix_space(self.tokenizer)
 
         self.encoded_dataset = self.prep_examples(num_fewshot, prompt_string, example_delimiter, continuation_delimiter,
                                                   fewshot_rng)
@@ -461,12 +462,7 @@ class InContextLearningMultipleChoiceTaskDataset(Dataset):
         self.pad_tok_id = pad_tok_id
         fewshot_rng = random.Random(fewshot_random_seed)
 
-        # Test for whether a prefix space is needed before the continuation
-        # sentencepiece tokenization should not have a prefix space, but gpt2 style BPE should
-        self.prefix_space = True
-        test = self.tokenizer(' a', add_special_tokens=False)['input_ids']
-        if len(test) > 1:
-            self.prefix_space = False
+        self.prefix_space = _tokenizer_needs_prefix_space(self.tokenizer)
 
         self.encoded_dataset = self.prep_examples(num_fewshot, prompt_string, example_delimiter, continuation_delimiter,
                                                   fewshot_rng)

--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -337,8 +337,8 @@ class InContextLearningLMTaskDataset(Dataset):
             if continuation_delimiter.endswith(' '):
                 continuation_delimiter = continuation_delimiter.rstrip(' ')
 
-            if not cont.startswith(' '):
-                cont = f' {cont}'
+            # if not cont.startswith(' '):
+            #     cont = f' {cont}'
             ctxt += continuation_delimiter
 
             encoded_example['preamble'] = self.tokenizer(
@@ -496,7 +496,7 @@ class InContextLearningMultipleChoiceTaskDataset(Dataset):
 
             if continuation_delimiter.endswith(' '):
                 continuation_delimiter = continuation_delimiter.rstrip(' ')
-            choices = [(f' {choice}' if not choice.startswith(' ') else choice) for choice in choices]
+            # choices = [(f' {choice}' if not choice.startswith(' ') else choice) for choice in choices]
             query += continuation_delimiter
             encoded_example['preamble'] = self.tokenizer(
                 preamble

--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -661,6 +661,9 @@ class InContextLearningSchemaTaskDataset(InContextLearningMultipleChoiceTaskData
         self.max_seq_len = max_seq_len
         self.pad_tok_id = pad_tok_id
         fewshot_rng = random.Random(fewshot_random_seed)
+
+        self.prefix_space = _tokenizer_needs_prefix_space(self.tokenizer)
+
         self.encoded_dataset = self.prep_examples(num_fewshot, prompt_string, example_delimiter, continuation_delimiter,
                                                   fewshot_rng)
 
@@ -716,6 +719,9 @@ class InContextLearningSchemaTaskDataset(InContextLearningMultipleChoiceTaskData
 
             encoded_example['gold_idx'] = gold_idx
             encoded_example['context_options'] = [self.tokenizer(c, add_special_tokens=False) for c in context_options]
+
+            if self.prefix_space:
+                continuation = f' {continuation}' if not continuation.startswith(' ') else continuation
             encoded_example['continuation'] = self.tokenizer(
                 f' {continuation}' if not continuation.startswith(' ') else continuation, add_special_tokens=False)
             examples.append(encoded_example)


### PR DESCRIPTION
# What does this PR do?
This PR fixes the setting of a prefix space for the continuation for ICL eval. some tokenizers don't want this and some do. I am not aware of a property to check directly, so instead we run a simple string through ` a` and see what happens.
