### PR TITLE
Increase the flash attention version in the docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -291,6 +291,9 @@ RUN if [ -n "$CUDA_VERSION" ] ; then \
 RUN if [ -n "$CUDA_VERSION" ] ; then \
         pip${PYTHON_VERSION} install --no-cache-dir flash-attn==0.2.8; \
     fi
+RUN if [ -n "$CUDA_VERSION" ] ; then \
+        pip${PYTHON_VERSION} install --no-cache-dir flash-attn==1.0.3.post0; \
+    fi
 
 ###########################
 # Install Pandoc Dependency


### PR DESCRIPTION
# What does this PR do?
I still leave the old install as well so that both versions should be cached I think.

The increase is to match the new examples version: https://github.com/mosaicml/examples/pull/309
