### PR TITLE
Another attempt to fix the daily tests

### DIFF
--- a/.github/mcp/mcp_pytest.py
+++ b/.github/mcp/mcp_pytest.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
 
     pip install --upgrade --user .[all]
 
-    export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}'"
+    export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' --s3_bucket mosaicml-internal-integration-testing"
 
     make test PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
 

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -8,6 +8,7 @@ import collections.abc
 import logging
 import textwrap
 import warnings
+from collections import OrderedDict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Sequence, Union, cast
 
@@ -1117,6 +1118,8 @@ class State(Serializable):
                     if isinstance(serialized_value[metric_name], Metric):
                         # For checkpoints saved using Composer <= 0.13.5
                         serialized_value[metric_name].persistent(mode=True)
+                        # Add new attr in torch2
+                        serialized_value[metric_name]._state_dict_pre_hooks = OrderedDict()
                         metric_state_dict = serialized_value[metric_name].state_dict()
                         metric_computed_field = serialized_value[metric_name]._computed
                     elif isinstance(serialized_value[metric_name], dict):
@@ -1155,6 +1158,8 @@ class State(Serializable):
                         if isinstance(serialized_value[eval_key][metric_name], Metric):
                             # For checkpoints saved using Composer <= 0.13.5
                             serialized_value[eval_key][metric_name].persistent(mode=True)
+                            # Add new attr in torch2
+                            serialized_value[eval_key][metric_name]._state_dict_pre_hooks = OrderedDict()
                             eval_metric_state_dict = serialized_value[eval_key][metric_name].state_dict()
                             eval_metric_computed_field = serialized_value[eval_key][metric_name]._computed
                         elif isinstance(serialized_value[eval_key][metric_name], dict):

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -123,7 +123,7 @@ def fsdp_get_optim_state_dict(model: torch.nn.Module,
         optim_state_dict = _legacy_fsdp_get_optim_state_dict(model, optim, state_dict_type)
     else:
         with fsdp_state_dict_type_context(module=model, state_dict_type=state_dict_type):
-            optim_state_dict = FSDP.optim_state_dict(model, optim)
+            optim_state_dict = FSDP.optim_state_dict(model, optim)  # type: ignore
     return optim_state_dict
 
 
@@ -1018,9 +1018,8 @@ class State(Serializable):
                                                                         state_dict_type=self.fsdp_state_dict_type)
                 else:
                     with fsdp_state_dict_type_context(module=self.model, state_dict_type=self.fsdp_state_dict_type):
-                        optim_state_dict = FSDP.optim_state_dict_to_load(optim_state_dict=optim_state_dict,
-                                                                         model=self.model,
-                                                                         optim=optimizer)
+                        optim_state_dict = FSDP.optim_state_dict_to_load(  #  type: ignore
+                            optim_state_dict=optim_state_dict, model=self.model, optim=optimizer)
                 optimizer.load_state_dict(optim_state_dict)
             else:
                 log.debug(f'Loading optimizer state dict')

--- a/composer/core/types.py
+++ b/composer/core/types.py
@@ -29,7 +29,7 @@ Dataset = torch.utils.data.Dataset[Batch]
 
 try:
     # This is correct for PyTorch >= 2.0
-    PyTorchScheduler = torch.optim.lr_scheduler.LRScheduler
+    PyTorchScheduler = torch.optim.lr_scheduler.LRScheduler  # type: ignore
 except:
     # This is correct for PyTorch < 2.0
     PyTorchScheduler = torch.optim.lr_scheduler._LRScheduler

--- a/tests/common/compare.py
+++ b/tests/common/compare.py
@@ -80,7 +80,7 @@ def _check_dict_recursively(dict1: Dict[str, Any], dict2: Dict[str, Any], path: 
         val2 = dict2[k]
 
         # special case fused optimizer to allow comparing a GPU checkpoint with a CPU checkpoint
-        if k == 'fused':
+        if k == 'fused' and path == '/state/optimizers/Adam/param_groups/0':
             assert bool(val1) == bool(val2)
             continue
         _check_item(val1, val2, path=f'{path}/{k}', atol=atol, rtol=rtol)

--- a/tests/common/compare.py
+++ b/tests/common/compare.py
@@ -80,7 +80,7 @@ def _check_dict_recursively(dict1: Dict[str, Any], dict2: Dict[str, Any], path: 
         val2 = dict2[k]
 
         # special case fused optimizer to allow comparing a GPU checkpoint with a CPU checkpoint
-        if k == 'fused' and path == '/state/optimizers/Adam/param_groups/0':
+        if isinstance(k, str) and k == 'fused' and path == '/state/optimizers/Adam/param_groups/0':
             assert bool(val1) == bool(val2)
             continue
         _check_item(val1, val2, path=f'{path}/{k}', atol=atol, rtol=rtol)

--- a/tests/common/compare.py
+++ b/tests/common/compare.py
@@ -78,4 +78,9 @@ def _check_dict_recursively(dict1: Dict[str, Any], dict2: Dict[str, Any], path: 
     assert len(dict1) == len(dict2), f'{path} differs: {dict1} != {dict2}'
     for k, val1 in dict1.items():
         val2 = dict2[k]
+
+        # special case fused optimizer to allow comparing a GPU checkpoint with a CPU checkpoint
+        if k == 'fused':
+            assert bool(val1) == bool(val2)
+            continue
         _check_item(val1, val2, path=f'{path}/{k}', atol=atol, rtol=rtol)

--- a/tests/common/compare.py
+++ b/tests/common/compare.py
@@ -53,7 +53,8 @@ def _check_item(item1: Any, item2: Any, path: str, rtol: float = 0.0, atol: floa
         # Increase update count so Torchmetrics doesn't throw warning when computing two metrics which haven't been updated
         item1._update_count += 1
         item2._update_count += 1
-        assert item1.compute() == item2.compute(), f'{path} differs: {item1.compute()} != {item2.compute()}'
+        assert item1.compute().allclose(item2.compute(), atol=atol,
+                                        rtol=rtol), f'{path} differs: {item1.compute()} != {item2.compute()}'
         item1._update_count -= 1
         item2._update_count -= 1
         return


### PR DESCRIPTION
# What does this PR do?
1. Adds the `s3_bucket` config option to the GPU tests
2. Adjusts the precision for the old torchmetrics checkpoint test
3. Adds an attr to the loaded metric that needs to be present for torch 2
4. Special cases an equivalence tests for fused adam, because the loaded checkpoint has `False` and the CPU trained checkpoint has `None`
5. Ignores a few types so that precommit passes locally

