### PR TITLE
Skip backward compatible checkpointing test on older torch versions

### DIFF
--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 import torch.distributed
+from packaging import version
 from pytest import MonkeyPatch
 from torch.utils.data import DataLoader
 
@@ -522,6 +523,8 @@ class TestCheckpointLoading:
         ],
     )
     @pytest.mark.filterwarnings('ignore:.*The checkpoint included CUDA RNG state.*')
+    @pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
+                        reason='requires PyTorch 1.13 or higher')
     def test_load_remote_checkpoint(self, device, tmp_path: pathlib.Path, load_weights_only, remote_checkpoint_uri,
                                     remote_checkpoint_name, continue_training_dur, final_checkpoint_name, s3_bucket):
         """


### PR DESCRIPTION
# What does this PR do?
Skips the backwards compatibility test on torch versions prior to 1.13. The checkpoint in question was saved using torch 1.13, and there are some minor differences when loading on older torch versions (like pytorch changes to the optimizer). They should not _actually_ break backwards compatibility, but they break the way we check if two checkpoints are equal. We are going to stop supporting pytorch versions before 1.13 in the next release anyway, so I am just skipping that test on older torch versions.

