### PR TITLE
Update FFCV 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -381,7 +381,7 @@ ARG CUDA_VERSION
 RUN CUDA_VERSION_TAG=$(python${PYTHON_VERSION} -c "print('cu' + ''.join('${CUDA_VERSION}'.split('.')[:2]) if '${CUDA_VERSION}' else 'cpu')") && \
     MMCV_TORCH_VERSION=$(python -c "print('torch' + ''.join('${PYTORCH_VERSION}'.split('.')[:2]) + '.0')") && \
     sudo pip${PYTHON_VERSION} install --no-cache-dir \
-        "https://github.com/libffcv/ffcv/archive/f9726ce2be6c36d57ed596b94e1e855131f0d732.zip" \
+        "ffcv" \
         "opencv-python${OPENCV_VERSION}" \
         "numba${NUMBA_VERSION}" \
         "mmsegmentation${MMSEGMENTATION_VERSION}" && \


### PR DESCRIPTION
# What does this PR do?

We use an old version of FFCV. With their latest versions, they loosen pins (eg for numpy/numba) which lets us avoid some nasty issues. Otherwise, if we upgrade numpy on vision / composer images, everything breaks. We've seen a few customers hit issues related to this upgrade.

Note: We don't add ffcv as a target because then [all] fails on CPU instances (eg no opencv) and it's not worth the headache

# What issue(s) does this change relate to?

[CO-2069](https://mosaicml.atlassian.net/browse/CO-2069)

[CO-2069]: https://mosaicml.atlassian.net/browse/CO-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ