### PR TITLE
Fix Broken Training Loop Image Link

### DIFF
--- a/examples/custom_speedup_methods.ipynb
+++ b/examples/custom_speedup_methods.ipynb
@@ -366,20 +366,23 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "<a id=\"events-and-state-in-composer\"></a>\n",
+    "\n",
     "## Events and State in Composer"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "The training loop Composer uses provides multiple different locations where method code can be inserted and run. These are called events. Diagramatically, the training loop looks as follows:\n",
     "\n",
-    "![Training Loop](https://storage.googleapis.com/docs.mosaicml.com/projects/composer/images/training_loop.png)"
+    "![Training Loop](https://storage.googleapis.com/docs.mosaicml.com/images/training_loop.png)"
    ]
   },
   {
@@ -394,10 +397,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "<a id=\"implementing-a-method-with-composer\"></a>\n",
+    "\n",
     "## Implementing a method with Composer"
    ]
   },
@@ -584,10 +589,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "<a id=\"composing-multiple-methods\"></a>\n",
+    "\n",
     "## Composing multiple methods\n",
     "\n",
     "Now that we've implemented ColOut as a Composer algorithm, composing it with other methods is easy!"

--- a/examples/custom_speedup_methods.ipynb
+++ b/examples/custom_speedup_methods.ipynb
@@ -54,10 +54,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "<a id='implementing-a-method-with-pytorch'></a>\n",
+    "\n",
     "## Implementing a Method with PyTorch"
    ]
   },


### PR DESCRIPTION
# What does this PR do?
Fixes broken image link with composer training loop
Also, fixes broken markdown headings

# What issue(s) does this change relate to?
Fix CO-2071
Fix https://github.com/mosaicml/composer/issues/2168

