### PR TITLE
Fix broken image link for GLU

### DIFF
--- a/composer/algorithms/gated_linear_units/README.md
+++ b/composer/algorithms/gated_linear_units/README.md
@@ -6,7 +6,7 @@
 
 Gated Linear Units replaces the projection matricies in the feed-forward block with [Gated Linear Units](https://arxiv.org/abs/2002.05202).
 
-| ![GatedLinearUnits](https://storage.cloud.google.com/docs.mosaicml.com/images/methods/gated_linear_units.png)|
+| ![GatedLinearUnits](https://storage.googleapis.com/docs.mosaicml.com/images/methods/gated_linear_units.png)|
 |:--|
 |*These equations compare the projection matricies in a standard feed-forward network, and a Gated Linear Unit.
 Following [Shazeer, 2020](https://arxiv.org/abs/2002.05202), we omit the use of bias terms. $\cdot$ represents a dot product.*|


### PR DESCRIPTION
# What does this PR do?
Fix broken image link for GLU. This was caused by using `storage.cloud.google.com` instead of `storage.googleapis.com`
h/t to eagle eye @shinyfoil for finding this

# What issue(s) does this change relate to?
fix CO-2072
fix https://github.com/mosaicml/composer/issues/2106
