### PR TITLE
Fix typo in evaluation docs

### DIFF
--- a/docs/source/trainer/evaluation.rst
+++ b/docs/source/trainer/evaluation.rst
@@ -23,7 +23,7 @@ To provide a deeper intuition, here's pseudocode for the evaluation logic that o
 
 .. code:: python
 
-    metrics = model.get_metrics(train=False)
+    metrics = model.get_metrics(is_train=False)
 
     for batch in eval_dataloader:
         outputs, targets = model.eval_forward(batch)
@@ -35,7 +35,7 @@ To provide a deeper intuition, here's pseudocode for the evaluation logic that o
 - Outputs of ``model.eval_forward`` are used to update the metrics (a :class:`torchmetrics.Metric` returned by :meth:`.ComposerModel.get_metrics <model.get_metrics(train=False)>`).
 - Finally, metrics over the whole validation dataset are computed.
 
-Note that the tuple returned by :meth:`.ComposerModel.eval_forward` provide the positional arguments to ``metric.update``.
+Note that the tuple returned by :meth:`.ComposerModel.eval_forward` provides the positional arguments to ``metric.update``.
 Please keep this in mind when using custom models and/or metrics.
 
 Multiple Datasets


### PR DESCRIPTION
# What does this PR do?
Fixes a couple typos in the evaluation docs.

# What issue(s) does this change relate to?
Fixes the typo raised by #2219

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
