### PR TITLE
Upgrade to mcli0.4, smaller mcli improvements

### DIFF
--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -1,17 +1,17 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run pytest using MCP."""
+"""Run pytest using MCLI."""
 
 import argparse
 import time
 
-from mcli.sdk import RunConfig, RunStatus, create_run, follow_run_logs, stop_run, wait_for_run_status
+from mcli import RunConfig, RunStatus, create_run, follow_run_logs, stop_run, wait_for_run_status
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--name', type=str, default='mcp-pytest', help='Base name of run')
+    parser.add_argument('--name', type=str, default='mcli-pytest', help='Base name of run')
     parser.add_argument('--cluster', type=str, default='r1z4', help='Cluster to use')
     parser.add_argument('--gpu_type', type=str, default='a100_40gb', help='Type of GPU to use')
     parser.add_argument('--gpu_num', type=int, default=2, help='Number of the GPU to use')

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -55,7 +55,6 @@ jobs:
         run: |
           set -ex
           python -m pip install mosaicml-cli
-          mcli init --mcloud
           mcli version
       - name: Submit Run
         id: tests
@@ -76,4 +75,4 @@ jobs:
             REF_ARGS="--pr_number $PR_NUMBER"
           fi
 
-          python .github/mcp/mcp_pytest.py --image '${{ inputs.container }}' --pip_package_name '${{ inputs.composer_package_name }}' --pytest_markers '${{ inputs.pytest-markers }}' --pytest_command '${{ inputs.pytest-command }}' --timeout ${{ inputs.mcloud-timeout }} ${REF_ARGS}
+          python .github/mcli/mcli_pytest.py --image '${{ inputs.container }}' --pip_package_name '${{ inputs.composer_package_name }}' --pytest_markers '${{ inputs.pytest-markers }}' --pytest_command '${{ inputs.pytest-command }}' --timeout ${{ inputs.mcloud-timeout }} ${REF_ARGS}

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -113,8 +113,8 @@ class MosaicMLLogger(LoggerDestination):
     def _flush_metadata(self, force_flush: bool = False) -> None:
         """Flush buffered metadata to MosaicML if enough time has passed since last flush."""
         if self._enabled and (time.time() - self.time_last_logged > self.log_interval or force_flush):
+            from mcli import update_run_metadata
             from mcli.api.exceptions import MAPIException
-            from mcli.sdk import update_run_metadata
             try:
                 update_run_metadata(self.run_name, self.buffered_metadata)
                 self.buffered_metadata = {}

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -14,8 +14,8 @@ import time
 from functools import reduce
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+import mcli
 import torch
-from mcli import MAPIException, update_run_metadata
 
 from composer.loggers.logger import Logger
 from composer.loggers.logger_destination import LoggerDestination
@@ -108,10 +108,10 @@ class MosaicMLLogger(LoggerDestination):
         """Flush buffered metadata to MosaicML if enough time has passed since last flush."""
         if self._enabled and (time.time() - self.time_last_logged > self.log_interval or force_flush):
             try:
-                update_run_metadata(self.run_name, self.buffered_metadata)
+                mcli.update_run_metadata(self.run_name, self.buffered_metadata)
                 self.buffered_metadata = {}
                 self.time_last_logged = time.time()
-            except MAPIException as e:
+            except mcli.MAPIException as e:
                 log.error(f'Failed to log metadata to Mosaic with error: {e}')
 
 

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ install_requires = [
     'py-cpuinfo>=8.0.0,<10',
     'packaging>=21.3.0,<23',
     'importlib-metadata>=5.0.0,<7',
+    'mosaicml-cli>=0.4.0,<0.5',
 ]
 extra_deps = {}
 
@@ -217,7 +218,7 @@ extra_deps['mlflow'] = [
 ]
 
 extra_deps['mcli'] = [
-    'mosaicml-cli>=0.3.6,<0.4',
+    'mosaicml-cli>=0.4.0,<0.5',
 ]
 
 extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)

--- a/setup.py
+++ b/setup.py
@@ -217,10 +217,6 @@ extra_deps['mlflow'] = [
     'mlflow>=2.0.1,<3.0',
 ]
 
-extra_deps['mcli'] = [
-    'mosaicml-cli>=0.4.0,<0.5',
-]
-
 extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
 
 composer_data_files = ['py.typed']

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -38,8 +38,8 @@ def test_logged_data_is_json_serializable(monkeypatch, callback_cls: Type[Callba
     pytest.importorskip('mcli')
 
     mock_mapi = MockMAPI()
-    import mcli.sdk
-    monkeypatch.setattr(mcli.sdk, 'update_run_metadata', mock_mapi.update_run_metadata)
+    import mcli
+    monkeypatch.setattr(mcli, 'update_run_metadata', mock_mapi.update_run_metadata)
     run_name = 'small_chungus'
     monkeypatch.setenv('RUN_NAME', run_name)
 
@@ -69,8 +69,8 @@ def test_metric_partial_filtering(monkeypatch):
     pytest.importorskip('mcli')
 
     mock_mapi = MockMAPI()
-    import mcli.sdk
-    monkeypatch.setattr(mcli.sdk, 'update_run_metadata', mock_mapi.update_run_metadata)
+    import mcli
+    monkeypatch.setattr(mcli, 'update_run_metadata', mock_mapi.update_run_metadata)
     run_name = 'small_chungus'
     monkeypatch.setenv('RUN_NAME', run_name)
 
@@ -91,8 +91,8 @@ def test_metric_full_filtering(monkeypatch):
     pytest.importorskip('mcli')
 
     mock_mapi = MockMAPI()
-    import mcli.sdk
-    monkeypatch.setattr(mcli.sdk, 'update_run_metadata', mock_mapi.update_run_metadata)
+    import mcli
+    monkeypatch.setattr(mcli, 'update_run_metadata', mock_mapi.update_run_metadata)
     run_name = 'small_chungus'
     monkeypatch.setenv('RUN_NAME', run_name)
 

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -4,6 +4,7 @@
 import json
 from typing import Type
 
+import mcli
 import pytest
 import torch
 from torch.utils.data import DataLoader
@@ -35,10 +36,8 @@ class MockMAPI:
 @world_size(1, 2)
 def test_logged_data_is_json_serializable(monkeypatch, callback_cls: Type[Callback], world_size):
     """Test that all logged data is json serializable, which is a requirement to use MAPI."""
-    pytest.importorskip('mcli')
 
     mock_mapi = MockMAPI()
-    import mcli
     monkeypatch.setattr(mcli, 'update_run_metadata', mock_mapi.update_run_metadata)
     run_name = 'small_chungus'
     monkeypatch.setenv('RUN_NAME', run_name)
@@ -66,10 +65,7 @@ def test_logged_data_is_json_serializable(monkeypatch, callback_cls: Type[Callba
 
 
 def test_metric_partial_filtering(monkeypatch):
-    pytest.importorskip('mcli')
-
     mock_mapi = MockMAPI()
-    import mcli
     monkeypatch.setattr(mcli, 'update_run_metadata', mock_mapi.update_run_metadata)
     run_name = 'small_chungus'
     monkeypatch.setenv('RUN_NAME', run_name)
@@ -88,10 +84,7 @@ def test_metric_partial_filtering(monkeypatch):
 
 
 def test_metric_full_filtering(monkeypatch):
-    pytest.importorskip('mcli')
-
     mock_mapi = MockMAPI()
-    import mcli
     monkeypatch.setattr(mcli, 'update_run_metadata', mock_mapi.update_run_metadata)
     run_name = 'small_chungus'
     monkeypatch.setenv('RUN_NAME', run_name)


### PR DESCRIPTION
# What does this PR do?

Upgrades to mcli 0.4.0

Small changes:
* Uses root import instead of `mcli.sdk` (This is not required, but feels nicer 🙂)
* Renames mcp to mcli
* Removes `mcli init --mcloud` for CI testing - this is only user facing, not actually needed if api key env variable is set

# What issue(s) does this change relate to?

Dependabot wants to update since we recently pushed 0.4.0 https://github.com/mosaicml/composer/pull/2220
