### PR TITLE
Add cmake to the docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -292,6 +292,11 @@ RUN if [ -n "$CUDA_VERSION" ] ; then \
         pip${PYTHON_VERSION} install --no-cache-dir flash-attn==1.0.3.post0; \
     fi
 
+###############
+# Install cmake
+###############
+RUN pip${PYTHON_VERSION} install --no-cache-dir cmake==3.26.3
+
 ###########################
 # Install Pandoc Dependency
 ###########################


### PR DESCRIPTION
# What does this PR do?
This is for llm-foundry, which needs to depend on a fork of triton that @vchiley has created until torch2 and triton work out their issues that prevent us from fully using the new triton.

