### PR TITLE
Deprecate healthchecker

### DIFF
--- a/composer/callbacks/health_checker.py
+++ b/composer/callbacks/health_checker.py
@@ -4,6 +4,7 @@
 """Check GPU Health during training."""
 import logging
 import os
+import warnings
 from collections import deque
 from datetime import datetime
 from typing import List, Optional, Tuple
@@ -52,6 +53,7 @@ class HealthChecker(Callback):
         slack_webhook_url: Optional[str] = None,
         test_mode: bool = False,
     ) -> None:
+        warnings.warn(f'HealthChecker is deprecated and will be removed in v0.16.')
         self.sample_freq = sample_freq
         self.window_size = window_size
         self.wait = wait

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -10,9 +10,8 @@ import composer.callbacks
 import composer.loggers
 import composer.profiler
 from composer import Callback
-from composer.callbacks import EarlyStopper, ImageVisualizer, MemoryMonitor, SpeedMonitor, ThresholdStopper
-from composer.callbacks.export_for_inference import ExportForInferenceCallback
-from composer.callbacks.mlperf import MLPerfCallback
+from composer.callbacks import (EarlyStopper, ExportForInferenceCallback, HealthChecker, ImageVisualizer, MemoryMonitor,
+                                MLPerfCallback, SpeedMonitor, ThresholdStopper)
 from composer.loggers import (CometMLLogger, ConsoleLogger, LoggerDestination, MLFlowLogger, ProgressBarLogger,
                               RemoteUploaderDownloader, TensorboardLogger, WandBLogger)
 from tests.common import get_module_subclasses
@@ -125,6 +124,7 @@ _callback_marks: Dict[Type[Callback], List[pytest.MarkDecorator],] = {
     TensorboardLogger: [pytest.mark.skipif(not _TENSORBOARD_INSTALLED, reason='Tensorboard is optional'),],
     ImageVisualizer: [pytest.mark.skipif(not _WANDB_INSTALLED, reason='Wandb is optional')],
     MLFlowLogger: [pytest.mark.skipif(not _MLFLOW_INSTALLED, reason='mlflow is optional'),],
+    HealthChecker: [pytest.mark.filterwarnings('ignore:.*HealthChecker is deprecated.*')],
 }
 
 

--- a/tests/callbacks/test_health_checker.py
+++ b/tests/callbacks/test_health_checker.py
@@ -24,6 +24,7 @@ class MockUtil:
 
 @pytest.mark.gpu
 @world_size(1, 2)
+@pytest.mark.filterwarnings('ignore:.*HealthChecker is deprecated.*')
 def test_gpu_utilization(world_size):
     assert HealthChecker._is_available()
 
@@ -52,6 +53,7 @@ def test_gpu_utilization(world_size):
 
 @pytest.mark.gpu
 @world_size(1, 2)
+@pytest.mark.filterwarnings('ignore:.*HealthChecker is deprecated.*')
 def test_health_checker(world_size):
 
     state = MagicMock()
@@ -86,6 +88,7 @@ def test_health_checker(world_size):
         assert health_checker.metrics[0].alerted == should_alert
 
 
+@pytest.mark.filterwarnings('ignore:.*HealthChecker is deprecated.*')
 def test_health_checker_sampling():
     timestamp = Timestamp(total_wct=datetime.timedelta(seconds=0))
 


### PR DESCRIPTION
# What does this PR do?

Deprecate healthchecker, which has been superseded by nodedoctor.

# What issue(s) does this change relate to?

[CO-2103](https://mosaicml.atlassian.net/browse/CO-2103)

[CO-2103]: https://mosaicml.atlassian.net/browse/CO-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ