### PR TITLE
CE loss vs CE metric equivalence

### DIFF
--- a/tests/common/datasets.py
+++ b/tests/common/datasets.py
@@ -1,6 +1,6 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-from typing import Sequence
+from typing import Optional, Sequence
 
 import pytest
 import torch
@@ -219,13 +219,15 @@ class RandomTextLMDataset(Dataset):
                  use_keys: bool = False,
                  use_token_type_ids: bool = True,
                  conditional_generation: bool = False,
-                 causal_lm: bool = False):
+                 causal_lm: bool = False,
+                 pad_token_id: Optional[int] = None):
         self.vocab_size = vocab_size
         self.sequence_length = sequence_length
         self.use_keys = use_keys
         self.use_token_type_ids = use_token_type_ids
         self.conditional_generation = conditional_generation
         self.causal_lm = causal_lm
+        self.pad_token_id = pad_token_id
 
         self.input_key = 'input_ids'
 
@@ -243,6 +245,9 @@ class RandomTextLMDataset(Dataset):
         # dataset across multiple calls when using the same seed.
         if self.x is None:
             self.x = torch.randint(low=0, high=self.vocab_size, size=(self.size, self.sequence_length))
+            if self.pad_token_id is not None:
+                mask = torch.randint(low=0, high=2, size=(self.size, self.sequence_length // 2)).bool()
+                self.x[:, :self.sequence_length // 2][mask] = self.pad_token_id
             if self.conditional_generation:
                 self.y = torch.randint(low=0, high=self.vocab_size, size=(self.size, 2 * self.sequence_length))
             if self.causal_lm:


### PR DESCRIPTION
# What does this PR do?
This adds two tests. One checks that in a case with no padding, CE loss and CE metric are equivalent. The other xfails that when you use microbatching and padding, CE loss and CE metric are not equivalent. This is because the microbatching engine does not take into account the number of loss generating tokens in each sample, and just weights samples equally.