### PR TITLE
Rename `backwards_create_graph` description

### DIFF
--- a/composer/core/algorithm.py
+++ b/composer/core/algorithm.py
@@ -56,7 +56,7 @@ class Algorithm(Serializable, ABC):
 
     @property
     def backwards_create_graph(self) -> bool:
-        """Whether this Algorithm requires the backwards pass to be differentiable. Defaults to ``False``.
+        """Whether this algorithm requires the backwards pass to be differentiable. Defaults to ``False``.
 
         If it returns ``True``, ``create_graph=True`` will be passed to :meth:`torch.Tensor.backward` which will result in
         the graph of the gradient also being constructed. This allows the computation of second order derivatives.

--- a/composer/core/algorithm.py
+++ b/composer/core/algorithm.py
@@ -56,7 +56,7 @@ class Algorithm(Serializable, ABC):
 
     @property
     def backwards_create_graph(self) -> bool:
-        """Return ``True`` to indicate this algorithm requires a second derivative to be computed. Defaults to ``False``.
+        """Whether this Algorithm requires the backwards pass to be differentiable. Defaults to ``False``.
 
         If it returns ``True``, ``create_graph=True`` will be passed to :meth:`torch.Tensor.backward` which will result in
         the graph of the gradient also being constructed. This allows the computation of second order derivatives.


### PR DESCRIPTION
# What does this PR do?

Rename `backwards_create_graph` decription

# What issue(s) does this change relate to?

[CO-931](https://mosaicml.atlassian.net/browse/CO-931)

[CO-931]: https://mosaicml.atlassian.net/browse/CO-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ