### PR TITLE
Add callbacks for EVAL_BEFORE_ALL and EVAL_AFTER_ALL

### DIFF
--- a/composer/core/callback.py
+++ b/composer/core/callback.py
@@ -369,6 +369,16 @@ class Callback(Serializable, abc.ABC):
         del state, logger  # unused
         pass
 
+    def eval_before_all(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.EVAL_BEFORE_ALL` event.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+        """
+        del state, logger  # unused
+        pass
+
     def eval_start(self, state: State, logger: Logger) -> None:
         """Called on the :attr:`.Event.EVAL_START` event.
 
@@ -421,6 +431,16 @@ class Callback(Serializable, abc.ABC):
 
     def eval_end(self, state: State, logger: Logger) -> None:
         """Called on the :attr:`.Event.EVAL_END` event.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+        """
+        del state, logger  # unused
+        pass
+
+    def eval_after_all(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.EVAL_AFTER_ALL` event.
 
         Args:
             state (State): The training state.

--- a/composer/core/event.py
+++ b/composer/core/event.py
@@ -54,8 +54,9 @@ class Event(StringEnum):
 
                 # <BATCH_END>
 
-                if should_eval(batch=True):
-                    for eval_dataloader in eval_dataloaders:
+                # <BEFORE_EVAL_ALL>
+                for eval_dataloader in eval_dataloaders:
+                    if should_eval(batch=True):
                         # <EVAL_START>
                         for batch in eval_dataloader:
                             # <EVAL_BATCH_START>
@@ -66,11 +67,14 @@ class Event(StringEnum):
                             # <EVAL_BATCH_END>
                         # <EVAL_END>
 
+                # <AFTER_EVAL_ALL>
+
                 # <BATCH_CHECKPOINT>
             # <EPOCH_END>
 
-            if should_eval(batch=False):
-                for eval_dataloader in eval_dataloaders:
+            # <BEFORE_EVAL_ALL>
+            for eval_dataloader in eval_dataloaders:
+                if should_eval(batch=True):
                     # <EVAL_START>
                     for batch in eval_dataloader:
                         # <EVAL_BATCH_START>
@@ -80,6 +84,8 @@ class Event(StringEnum):
                         metrics.update(outputs, targets)
                         # <EVAL_BATCH_END>
                     # <EVAL_END>
+
+            # <AFTER_EVAL_ALL>
 
             # <EPOCH_CHECKPOINT>
         # <FIT_END>
@@ -122,12 +128,14 @@ class Event(StringEnum):
             and flushing callbacks. Algorithms should not transform the training state on this event, as any changes will not
             be preserved in checkpoints.
 
+        EVAL_BEFORE_ALL: Before any evaluators process validation dataset.
         EVAL_START: Start of evaluation through the validation dataset.
         EVAL_BATCH_START: Before the call to ``model.eval_forward(batch)``
         EVAL_BEFORE_FORWARD: Before the call to ``model.eval_forward(batch)``
         EVAL_AFTER_FORWARD: After the call to ``model.eval_forward(batch)``
         EVAL_BATCH_END: After the call to ``model.eval_forward(batch)``
         EVAL_END: End of evaluation through the validation dataset.
+        EVAL_AFTER_ALL: After all evaluators process validation dataset.
     """
 
     INIT = 'init'
@@ -162,12 +170,14 @@ class Event(StringEnum):
 
     FIT_END = 'fit_end'
 
+    EVAL_BEFORE_ALL = 'eval_before_all'
     EVAL_START = 'eval_start'
     EVAL_BATCH_START = 'eval_batch_start'
     EVAL_BEFORE_FORWARD = 'eval_before_forward'
     EVAL_AFTER_FORWARD = 'eval_after_forward'
     EVAL_BATCH_END = 'eval_batch_end'
     EVAL_END = 'eval_end'
+    EVAL_AFTER_ALL = 'eval_after_all'
 
     PREDICT_START = 'predict_start'
     PREDICT_BATCH_START = 'predict_batch_start'
@@ -229,8 +239,9 @@ class Event(StringEnum):
 
 _BEFORE_EVENTS = (Event.FIT_START, Event.EPOCH_START, Event.BEFORE_DATALOADER, Event.BATCH_START,
                   Event.BEFORE_TRAIN_BATCH, Event.BEFORE_FORWARD, Event.BEFORE_LOSS, Event.BEFORE_BACKWARD,
-                  Event.EVAL_START, Event.EVAL_BATCH_START, Event.EVAL_BEFORE_FORWARD, Event.PREDICT_START,
-                  Event.PREDICT_BATCH_START, Event.PREDICT_BEFORE_FORWARD)
+                  Event.EVAL_BEFORE_ALL, Event.EVAL_START, Event.EVAL_BATCH_START, Event.EVAL_BEFORE_FORWARD,
+                  Event.PREDICT_START, Event.PREDICT_BATCH_START, Event.PREDICT_BEFORE_FORWARD)
 _AFTER_EVENTS = (Event.EPOCH_END, Event.BATCH_END, Event.AFTER_DATALOADER, Event.AFTER_TRAIN_BATCH, Event.AFTER_FORWARD,
-                 Event.AFTER_LOSS, Event.AFTER_BACKWARD, Event.EVAL_END, Event.EVAL_BATCH_END, Event.EVAL_AFTER_FORWARD,
-                 Event.FIT_END, Event.PREDICT_END, Event.PREDICT_BATCH_END, Event.PREDICT_AFTER_FORWARD)
+                 Event.AFTER_LOSS, Event.AFTER_BACKWARD, Event.EVAL_AFTER_ALL, Event.EVAL_END, Event.EVAL_BATCH_END,
+                 Event.EVAL_AFTER_FORWARD, Event.FIT_END, Event.PREDICT_END, Event.PREDICT_BATCH_END,
+                 Event.PREDICT_AFTER_FORWARD)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2064,15 +2064,24 @@ class Trainer:
 
     def _run_evaluators(self, event: Event):
         """Runs evaluators periodically during training."""
+        evaluators_executing = []
         for evaluator in self.state.evaluators:
             assert evaluator.eval_interval is not None, 'eval_interval should have been set on __init__() or fit()'
             assert evaluator.subset_num_batches is not None, 'subset_num_batches should have been set on __init__() or fit()'
-            if evaluator.eval_interval(self.state, event):
+            evaluators_executing.append(evaluator.eval_interval(self.state, event))
+        if not any(evaluators_executing):
+            return
+
+        self.engine.run_event(Event.EVAL_BEFORE_ALL)
+        for index, evaluator in enumerate(self.state.evaluators):
+            if evaluators_executing[index]:
                 self._eval_loop(
                     evaluator=evaluator,
                     subset_num_batches=evaluator.subset_num_batches,
                     metrics=self.state.eval_metrics[evaluator.label],
                 )
+
+        self.engine.run_event(Event.EVAL_AFTER_ALL)
 
     def _train_batch(self, use_grad_scaling: bool) -> Dict[str, torch.Tensor]:
         """Compute loss by training on a full batch of data.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -41,11 +41,15 @@ class TestEventCalls:
                 batch_size=train_batch_size,
                 sampler=dist.get_sampler(train_dataset),
             ),
-            eval_dataloader=DataLoader(
+            eval_dataloader=(DataLoader(
                 dataset=eval_dataset,
                 batch_size=8,
                 sampler=dist.get_sampler(eval_dataset),
-            ),
+            ), DataLoader(
+                dataset=eval_dataset,
+                batch_size=4,
+                sampler=dist.get_sampler(eval_dataset),
+            )),
             device_train_microbatch_size=train_batch_size // 2,
             precision=precision,
             train_subset_num_batches=self.train_subset_num_batches,
@@ -130,9 +134,11 @@ class TestEventCalls:
 
         if trainer.state.evaluators:
             steps_per_eval = self.eval_subset_num_batches
+            total_evals_start = total_evals * len(trainer.state.evaluators)
             total_eval_steps = total_evals * steps_per_eval * len(trainer.state.evaluators)
         else:
             total_eval_steps = 0
+            total_evals_start = 0
 
         expected_num_calls = {
             Event.INIT: 1,
@@ -153,12 +159,14 @@ class TestEventCalls:
             Event.BATCH_CHECKPOINT: total_steps,
             Event.EPOCH_END: num_epochs,
             Event.EPOCH_CHECKPOINT: num_epochs,
-            Event.EVAL_START: total_evals,
+            Event.EVAL_BEFORE_ALL: total_evals,
+            Event.EVAL_START: total_evals_start,
             Event.EVAL_BATCH_START: total_eval_steps,
             Event.EVAL_BEFORE_FORWARD: total_eval_steps,
             Event.EVAL_AFTER_FORWARD: total_eval_steps,
             Event.EVAL_BATCH_END: total_eval_steps,
-            Event.EVAL_END: total_evals,
+            Event.EVAL_END: total_evals_start,
+            Event.EVAL_AFTER_ALL: total_evals,
         }
 
         counter_callback = (cb for cb in trainer.state.callbacks if isinstance(cb, EventCounterCallback))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -34,6 +34,18 @@ class TestEventCalls:
         eval_dataset = RandomClassificationDataset()
         train_batch_size = 4
 
+        evaluator1 = DataLoader(
+            dataset=eval_dataset,
+            batch_size=8,
+            sampler=dist.get_sampler(eval_dataset),
+        )
+
+        evaluator2 = DataLoader(
+            dataset=eval_dataset,
+            batch_size=4,
+            sampler=dist.get_sampler(eval_dataset),
+        )
+
         return Trainer(
             model=model,
             train_dataloader=DataLoader(
@@ -41,15 +53,7 @@ class TestEventCalls:
                 batch_size=train_batch_size,
                 sampler=dist.get_sampler(train_dataset),
             ),
-            eval_dataloader=(DataLoader(
-                dataset=eval_dataset,
-                batch_size=8,
-                sampler=dist.get_sampler(eval_dataset),
-            ), DataLoader(
-                dataset=eval_dataset,
-                batch_size=4,
-                sampler=dist.get_sampler(eval_dataset),
-            )),
+            eval_dataloader=(evaluator1, evaluator2),
             device_train_microbatch_size=train_batch_size // 2,
             precision=precision,
             train_subset_num_batches=self.train_subset_num_batches,


### PR DESCRIPTION
# What does this PR do?

For multiple use cases, such as weight norm calculations, and logging after all evaluators run, we want to add events before and after all evaluators, termed `EVAL_BEFORE_ALL` and `EVAL_AFTER_ALL`. To do this, we modify the documentation and the workflow for the `_run_evaluators` function in order to first cache the results of whether evaluators run and add these events if that occurs.

# What issue(s) does this change relate to?

N/A

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))