### PR TITLE
Spin dataloader arg

### DIFF
--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -95,9 +95,9 @@ def get_gpu_flops_available(state: State):
 
     # torch.cuda.get_device_name() ex output: 'NVIDIA A100-SXM4-40GB'
     device_name = torch.cuda.get_device_name().lower()
-    if 'h100-sxm' in device_name:
+    if 'h100' in device_name and 'hbm3' in device_name:
         device_name = 'h100-sxm'
-    elif 'h100-pcie' in device_name:
+    elif 'h100' in device_name and ('pcie' in device_name or 'hbm2e' in device_name):
         device_name = 'h100-pcie'
     elif 'a100' in device_name:
         device_name = 'a100'

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1524,6 +1524,7 @@ class Trainer:
         train_dataloader: Optional[Union[Iterable, DataSpec, Dict[str, Any]]] = None,
         train_dataloader_label: str = 'train',
         train_subset_num_batches: Optional[int] = None,
+        spin_dataloaders: Optional[bool] = None,
 
         # Timing
         duration: Optional[Union[int, str, Time[int]]] = None,
@@ -1618,6 +1619,7 @@ class Trainer:
             train_dataloader (Iterable | DataSpec | Dict[str, Any], optional): See :class:`.Trainer`.
             train_dataloader_label (str, optional): See :class:`.Trainer`.
             train_subset_num_batches (int, optional): See :class:`.Trainer`.
+            spin_dataloaders (bool, optional): See :class:`.Trainer`.
             reset_time (bool): Whether to reset the :attr:`.State.timestamp` to zero values. Defaults to False.
 
                 If ``True``, the timestamp will be zeroed out, causing :class:`.ComposerScheduler` and
@@ -1663,6 +1665,8 @@ class Trainer:
             _raise_missing_argument_exception('train_dataloader')
         if train_subset_num_batches is not None:
             self.state.dataloader_len = train_subset_num_batches
+        if spin_dataloaders is not None:
+            self.spin_dataloaders = spin_dataloaders
 
         # Reset Time
         if reset_time:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -420,14 +420,15 @@ class Trainer:
 
             This parameter is ignored if ``train_dataloader`` is not specified.
         spin_dataloaders (bool, optional): If ``True``, dataloaders will be spun up to the current timestamp
-            by skipping samples which have already been trained on if a dataloader does not have a way to
-            resume from the current batch. This ensures dataloaders continue from the same batch when resuming
-            training. (default: ``True``)
+            by skipping samples which have already been trained on. If a dataloader has a way to resume from
+            the current batch without spinning, this will be a no-op. This ensures dataloaders continue from
+            the same batch when resuming training. (default: ``True``)
 
             .. note:: Spinning dataloaders can be potentially very slow but is required to skip samples which
                 have already been trained on. If it is acceptable to repeat samples when resuming training,
                 it is possible to resume faster by setting ``spin_dataloaders=False``. This may have severe
-                performance implications and is generally not recommended unless you confidently understand the implications.
+                performance implications and is generally not recommended unless you confidently understand the
+                implications.
         max_duration (Time | str | int, optional): The maximum duration to train. Can be an integer, which will be
             interpreted to be epochs, a str (e.g. ``1ep``, or ``10ba``), or a :class:`.Time` object.
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -427,7 +427,7 @@ class Trainer:
             .. note:: Spinning dataloaders can be potentially very slow but is required to skip samples which
                 have already been trained on. If it is acceptable to repeat samples when resuming training,
                 it is possible to resume faster by setting ``spin_dataloaders=False``. This may have severe
-                performance implications and is generally not recommended.
+                performance implications and is generally not recommended unless you confidently understand the implications.
         max_duration (Time | str | int, optional): The maximum duration to train. Can be an integer, which will be
             interpreted to be epochs, a str (e.g. ``1ep``, or ``10ba``), or a :class:`.Time` object.
 

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -103,6 +103,7 @@ def test_extract_hparams_trainer():
         'train_dataloader': 'DataLoader',
         'train_dataloader_label': 'train',
         'train_subset_num_batches': -1,
+        'spin_dataloaders': True,
 
         # Stopping Condition
         'max_duration': None,


### PR DESCRIPTION
# What does this PR do?

Add `spin_dataloader` argument to Trainer. This lets users disable spinning for faster resumption, which users have occasionally requested when they don't want deterministic resumption.

It's a little annoying that we have a var `spin_datalaoders` but a fn `_spin_dataloaders`.... It's probably fine but open to other ideas? We could also just flatten `_spin_dataloaders` since its only used once.

# What issue(s) does this change relate to?

[CO-2154
](https://mosaicml.atlassian.net/browse/CO-2154)