### PR TITLE
Add error messages for Eval Dataloaders

### DIFF
--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -87,7 +87,7 @@ class MLPerfCallback(Callback):
                 target='0.759',
             )
 
-    During training, the metric found in ``state.eval_metrics[metric_label][metric_name]``
+    During training, the metric found in ``state.eval_metrics[metric_name][metric_label]``
     will be compared against the target criterion.
 
     .. note::

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1144,10 +1144,15 @@ class Trainer:
         else:
             eval_metrics = deepcopy(self.state.model.get_metrics(is_train=False))
             model_metric_names = [str(k) for k in eval_metrics.keys()]
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                warnings.warn('Mixing Evaluator and DataLoader is not recommended.')
 
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=model_metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in dataloader_tupled
             ]
             # match metric names to model metrics
             self.state.eval_metrics = {

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -469,12 +469,13 @@ class Trainer:
             Setting this to ``True`` will force schedulers to be stepped every batch,
             while ``False`` means schedulers stepped every epoch. ``None`` indicates the default behavior.
             (default: ``None``)
-        eval_dataloader (DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.DataLoader`,
+        eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.Iterable`,
             :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
 
             To evaluate one or more specific metrics across one or more datasets, pass in an
-            :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.DataLoader` is passed in, then all
-            metrics returned by ``model.get_metrics()`` will be used during evaluation.
+            :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.Iterable` is passed in, then all
+            metrics returned by ``model.get_metrics()`` will be used during evaluation. If another class is used
+            with :class:`.Evaluator` in a list, a ValueError will be raised.
             ``None`` results in no evaluation. (default: ``None``)
         eval_interval (int | str | Time | (State, Event) -> bool, optional): Specifies how frequently to run evaluation.
             An integer, which will be interpreted to be epochs, a str (e.g. ``1ep``, or ``10ba``), a :class:`.Time`
@@ -2591,9 +2592,10 @@ class Trainer:
             drop duplicate samples.
 
         Args:
-            eval_dataloader (DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
+            eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
                 for evaluation.  If not provided, defaults to using the
-                ``eval_dataloader`` provided to the trainer init().
+                ``eval_dataloader`` provided to the trainer init(). If a list of Evaluators is provided
+                mixed with other classes, a ValueError will be raised.
             subset_num_batches (int, optional): Evaluate on this many batches. Default to ``-1`` (the entire
                 dataloader. Can also be provided in the trainer.__init__() as ``eval_subset_num_batches``.
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1149,7 +1149,8 @@ class Trainer:
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
 
             if any(evaluator_types) and not all(evaluator_types):
-                warnings.warn('Mixing Evaluator and DataLoader is not recommended.')
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
 
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in dataloader_tupled
@@ -1716,9 +1717,15 @@ class Trainer:
             eval_metrics = self._original_model.get_metrics(is_train=False)
             metric_names = [str(k) for k in eval_metrics.keys()]
 
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in dataloader_tupled
             ]
 
             # match metric names to model metrics
@@ -2596,9 +2603,16 @@ class Trainer:
             eval_metrics = deepcopy(self._original_model.get_metrics(is_train=False))
             metric_names = [str(k) for k in eval_metrics.keys()]
 
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
+
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in dataloader_tupled
             ]
 
             if self.state.eval_metrics:


### PR DESCRIPTION
# What does this PR do?

Now, if a user passes in a list of some DataLoaders/DataSpecs and Evaluators to the Trainer class, it no longer tries to apply all metrics to the DataLoaders/DataSpecs, causing a crash. Instead, it raises a ValueError and instructs the user to wrap the DataLoaders in an Evaluator beforehand to prevent unexpected behavior.

# What issue(s) does this change relate to?

[CO-1763](https://mosaicml.atlassian.net/browse/CO-1763
)
# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-1763]: https://mosaicml.atlassian.net/browse/CO-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ