### PR TITLE
Add errors for Mixed Dataloader Eval

### DIFF
--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -115,7 +115,7 @@ class MLPerfCallback(Callback):
         metric_name (str, optional): name of the metric to compare against the target.
             Default: ``MulticlassAccuracy``.
         metric_label (str, optional): The label name. The metric will be accessed via
-            ``state.eval_metrics[metric_label][metric_name]``.
+            ``state.eval_metrics[evaluator_label][metric_name]``.
         submitter (str, optional): Submitting organization. Default: ``"MosaicML"``.
         system_name (str, optional): Name of the system (e.g. 8xA100_composer). If
             not provided, system name will default to ``[world_size]x[device_name]_composer``,

--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -87,7 +87,7 @@ class MLPerfCallback(Callback):
                 target='0.759',
             )
 
-    During training, the metric found in ``state.eval_metrics[metric_name][metric_label]``
+    During training, the metric found in ``state.eval_metrics[evaluator_label][metric_name]``
     will be compared against the target criterion.
 
     .. note::

--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -87,7 +87,7 @@ class MLPerfCallback(Callback):
                 target='0.759',
             )
 
-    During training, the metric found in ``state.eval_metrics[metric_label][metric_name]``
+    During training, the metric found in ``state.eval_metrics[metric_name][metric_label]``
     will be compared against the target criterion.
 
     .. note::

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1144,10 +1144,15 @@ class Trainer:
         else:
             eval_metrics = deepcopy(self.state.model.get_metrics(is_train=False))
             model_metric_names = [str(k) for k in eval_metrics.keys()]
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                warnings.warn('Mixing Evaluator and DataLoader is not recommended.')
 
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=model_metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in dataloader_tupled
             ]
             # match metric names to model metrics
             self.state.eval_metrics = {

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -469,12 +469,13 @@ class Trainer:
             Setting this to ``True`` will force schedulers to be stepped every batch,
             while ``False`` means schedulers stepped every epoch. ``None`` indicates the default behavior.
             (default: ``None``)
-        eval_dataloader (DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.DataLoader`,
+        eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.Iterable`,
             :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
 
             To evaluate one or more specific metrics across one or more datasets, pass in an
-            :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.DataLoader` is passed in, then all
-            metrics returned by ``model.get_metrics()`` will be used during evaluation.
+            :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.Iterable` is passed in, then all
+            metrics returned by ``model.get_metrics()`` will be used during evaluation. If another class is used
+            with :class:`.Evaluator` in a list, a ValueError will be raised.
             ``None`` results in no evaluation. (default: ``None``)
         eval_interval (int | str | Time | (State, Event) -> bool, optional): Specifies how frequently to run evaluation.
             An integer, which will be interpreted to be epochs, a str (e.g. ``1ep``, or ``10ba``), a :class:`.Time`
@@ -2591,9 +2592,10 @@ class Trainer:
             drop duplicate samples.
 
         Args:
-            eval_dataloader (DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
+            eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
                 for evaluation.  If not provided, defaults to using the
-                ``eval_dataloader`` provided to the trainer init().
+                ``eval_dataloader`` provided to the trainer init(). If a list of Evaluators is provided
+                mixed with other classes, a ValueError will be raised.
             subset_num_batches (int, optional): Evaluate on this many batches. Default to ``-1`` (the entire
                 dataloader. Can also be provided in the trainer.__init__() as ``eval_subset_num_batches``.
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1148,7 +1148,6 @@ class Trainer:
             eval_dataloader = ensure_tuple(eval_dataloader)
 
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
-
             if any(evaluator_types) and not all(evaluator_types):
                 raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
                                  'all other classes with the Evaluator class.')
@@ -1720,7 +1719,6 @@ class Trainer:
             eval_dataloader = ensure_tuple(eval_dataloader)
 
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
-
             if any(evaluator_types) and not all(evaluator_types):
                 raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
                                  'all other classes with the Evaluator class.')
@@ -2616,7 +2614,6 @@ class Trainer:
             eval_dataloader = ensure_tuple(eval_dataloader)
 
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
-
             if any(evaluator_types) and not all(evaluator_types):
                 raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
                                  'all other classes with the Evaluator class.')

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -469,13 +469,13 @@ class Trainer:
             Setting this to ``True`` will force schedulers to be stepped every batch,
             while ``False`` means schedulers stepped every epoch. ``None`` indicates the default behavior.
             (default: ``None``)
-        eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.Iterable`,
+        eval_dataloader (Iterable | DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.Iterable`,
             :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
 
             To evaluate one or more specific metrics across one or more datasets, pass in an
             :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.Iterable` is passed in, then all
-            metrics returned by ``model.get_metrics()`` will be used during evaluation. If another class is used
-            with :class:`.Evaluator` in a list, a ValueError will be raised.
+            metrics returned by ``model.get_metrics()`` will be used during evaluation. If a :class:`.Evaluator`
+            is specified in a list, all eval dataloaders must be :class:`.Evaluator` instances.
             ``None`` results in no evaluation. (default: ``None``)
         eval_interval (int | str | Time | (State, Event) -> bool, optional): Specifies how frequently to run evaluation.
             An integer, which will be interpreted to be epochs, a str (e.g. ``1ep``, or ``10ba``), a :class:`.Time`
@@ -1145,16 +1145,16 @@ class Trainer:
         else:
             eval_metrics = deepcopy(self.state.model.get_metrics(is_train=False))
             model_metric_names = [str(k) for k in eval_metrics.keys()]
-            dataloader_tupled = ensure_tuple(eval_dataloader)
+            eval_dataloader = ensure_tuple(eval_dataloader)
 
-            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
 
             if any(evaluator_types) and not all(evaluator_types):
-                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
-                                 'DataLoaders in the Evaluator class if you wish to do so.')
+                raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
+                                 'all other classes with the Evaluator class.')
 
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in dataloader_tupled
+                ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in eval_dataloader
             ]
             # match metric names to model metrics
             self.state.eval_metrics = {
@@ -1717,16 +1717,16 @@ class Trainer:
             # could be DDP / DeepSpeed wrapped.
             eval_metrics = self._original_model.get_metrics(is_train=False)
             metric_names = [str(k) for k in eval_metrics.keys()]
+            eval_dataloader = ensure_tuple(eval_dataloader)
 
-            dataloader_tupled = ensure_tuple(eval_dataloader)
-
-            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
 
             if any(evaluator_types) and not all(evaluator_types):
-                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
-                                 'DataLoaders in the Evaluator class if you wish to do so.')
+                raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
+                                 'all other classes with the Evaluator class.')
+
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in dataloader_tupled
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in eval_dataloader
             ]
 
             # match metric names to model metrics
@@ -2592,10 +2592,9 @@ class Trainer:
             drop duplicate samples.
 
         Args:
-            eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
+            eval_dataloader (Iterable | DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
                 for evaluation.  If not provided, defaults to using the
-                ``eval_dataloader`` provided to the trainer init(). If a list of Evaluators is provided
-                mixed with other classes, a ValueError will be raised.
+                ``eval_dataloader`` provided to the trainer init().
             subset_num_batches (int, optional): Evaluate on this many batches. Default to ``-1`` (the entire
                 dataloader. Can also be provided in the trainer.__init__() as ``eval_subset_num_batches``.
 
@@ -2605,16 +2604,16 @@ class Trainer:
             eval_metrics = deepcopy(self._original_model.get_metrics(is_train=False))
             metric_names = [str(k) for k in eval_metrics.keys()]
 
-            dataloader_tupled = ensure_tuple(eval_dataloader)
+            eval_dataloader = ensure_tuple(eval_dataloader)
 
-            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
 
             if any(evaluator_types) and not all(evaluator_types):
-                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
-                                 'DataLoaders in the Evaluator class if you wish to do so.')
+                raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
+                                 'all other classes with the Evaluator class.')
 
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in dataloader_tupled
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in eval_dataloader
             ]
 
             if self.state.eval_metrics:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1149,7 +1149,8 @@ class Trainer:
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
 
             if any(evaluator_types) and not all(evaluator_types):
-                warnings.warn('Mixing Evaluator and DataLoader is not recommended.')
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
 
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in dataloader_tupled
@@ -1716,9 +1717,15 @@ class Trainer:
             eval_metrics = self._original_model.get_metrics(is_train=False)
             metric_names = [str(k) for k in eval_metrics.keys()]
 
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in dataloader_tupled
             ]
 
             # match metric names to model metrics
@@ -2596,9 +2603,16 @@ class Trainer:
             eval_metrics = deepcopy(self._original_model.get_metrics(is_train=False))
             metric_names = [str(k) for k in eval_metrics.keys()]
 
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
+
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in dataloader_tupled
             ]
 
             if self.state.eval_metrics:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1738,7 +1738,8 @@ class Trainer:
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
             if any(evaluator_types) and not all(evaluator_types):
                 raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
-                                 'all other classes with the Evaluator class.')
+                                 'all other classes with the Evaluator class. These are the classes'
+                                 'that were detected:' + str([type(evaluator) for evaluator in eval_dataloader]))
 
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in eval_dataloader
@@ -2634,7 +2635,8 @@ class Trainer:
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
             if any(evaluator_types) and not all(evaluator_types):
                 raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
-                                 'all other classes with the Evaluator class.')
+                                 'all other classes with the Evaluator class. These are the classes'
+                                 'that were detected:' + str([type(evaluator) for evaluator in eval_dataloader]))
 
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in eval_dataloader

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -480,10 +480,10 @@ class Trainer:
             while ``False`` means schedulers stepped every epoch. ``None`` indicates the default behavior.
             (default: ``None``)
         eval_dataloader (Iterable | DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.Iterable`,
-            :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
+            :class:`.DataLoader`, :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
 
             To evaluate one or more specific metrics across one or more datasets, pass in an
-            :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.Iterable` is passed in, then all
+            :class:`.Evaluator`. If a :class:`.DataLoader`, :class:`.DataSpec`, or :class:`.Iterable` is passed in, then all
             metrics returned by ``model.get_metrics()`` will be used during evaluation. If a :class:`.Evaluator`
             is specified in a list, all eval dataloaders must be :class:`.Evaluator` instances.
             ``None`` results in no evaluation. (default: ``None``)
@@ -1161,7 +1161,8 @@ class Trainer:
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
             if any(evaluator_types) and not all(evaluator_types):
                 raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
-                                 'all other classes with the Evaluator class.')
+                                 'all other classes with the Evaluator class. These are the classes'
+                                 'that were detected:' + str([type(evaluator) for evaluator in eval_dataloader]))
 
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in eval_dataloader

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ extra_deps['dev'] = [
     # Should manually update dependency versions occassionally.
     'custom_inherit==2.4.1',
     'junitparser==3.1.0',
-    'coverage[toml]==7.2.5',
+    'coverage[toml]==7.2.6',
     'fasteners==0.18',  # object store tests require fasteners
     'pytest==7.3.1',
     'toml==0.10.2',

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -641,3 +641,16 @@ def test_evaluator_metric_names_string_errors(metric_names):
         ValueError, match='should be a list of strings')
     with context:
         _ = Evaluator(label='evaluator', dataloader=eval_dataloader, metric_names=metric_names)
+
+
+# Test that trainer throws a value error if the eval is passed a mixed list of evaluators/dataloaders
+def test_evaluator_dataloader_value_error():
+    eval_dataset = RandomClassificationDataset(size=8)
+    eval_data1 = DataLoader(eval_dataset, batch_size=4, sampler=dist.get_sampler(eval_dataset))
+    eval_data2 = Evaluator(label='eval', dataloader=eval_data1, metric_names=['MulticlassAccuracy'])
+
+    eval_dataloader = (eval_data1, eval_data2)
+    with pytest.raises(ValueError,
+                       match='Mixing Evaluator with other classes is not allowed, please wrap'
+                       'all other classes with the Evaluator class.') as _:
+        _ = Trainer(model=SimpleModel(), train_dataloader=None, eval_dataloader=eval_dataloader, max_duration='1ep')


### PR DESCRIPTION
# What does this PR do?

Now, if a user passes in a list of some DataLoaders/DataSpecs and Evaluators to the Trainer class, it no longer tries to apply all metrics to the DataLoaders/DataSpecs, causing a crash. Instead, it raises a ValueError and instructs the user to wrap the DataLoaders in an Evaluator beforehand to prevent unexpected behavior.

# What issue(s) does this change relate to?

[CO-1763](https://mosaicml.atlassian.net/browse/CO-1763
)
# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))



[CO-1763]: https://mosaicml.atlassian.net/browse/CO-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ