### PR TITLE
New Console Logger Test and Flush before Eval

### DIFF
--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -87,7 +87,7 @@ class MLPerfCallback(Callback):
                 target='0.759',
             )
 
-    During training, the metric found in ``state.eval_metrics[metric_label][metric_name]``
+    During training, the metric found in ``state.eval_metrics[metric_name][metric_label]``
     will be compared against the target criterion.
 
     .. note::

--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -96,10 +96,6 @@ class ConsoleLogger(LoggerDestination):
 
         if unit == TimeUnit.EPOCH and (cur_epoch % int(self.log_interval) == 0 or cur_epoch == 1):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
-        # Always clear logged metrics so they don't get logged in a subsequent eval call. The
-        # metrics will be recomputed and overridden in future batches so they can be safely
-        # discarded.
-        self.logged_metrics = {}
 
     def batch_end(self, state: State, logger: Logger) -> None:
         cur_batch = int(state.timestamp.batch)
@@ -134,6 +130,9 @@ class ConsoleLogger(LoggerDestination):
             self._log_hparams_to_console()
 
     def eval_start(self, state: State, logger: Logger) -> None:
+        self.logged_metrics = {}
+        # Clear logged metrics before eval so they don't get logged
+        # subsequently.
         total_eval_batches = self._get_total_eval_batches(state)
         deciles = np.linspace(0, 1, NUM_EVAL_LOGGING_EVENTS)
         batch_idxs = np.arange(1, total_eval_batches + 1)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1144,10 +1144,15 @@ class Trainer:
         else:
             eval_metrics = deepcopy(self.state.model.get_metrics(is_train=False))
             model_metric_names = [str(k) for k in eval_metrics.keys()]
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                warnings.warn('Mixing Evaluator and DataLoader is not recommended.')
 
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=model_metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in dataloader_tupled
             ]
             # match metric names to model metrics
             self.state.eval_metrics = {

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -469,12 +469,13 @@ class Trainer:
             Setting this to ``True`` will force schedulers to be stepped every batch,
             while ``False`` means schedulers stepped every epoch. ``None`` indicates the default behavior.
             (default: ``None``)
-        eval_dataloader (DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.DataLoader`,
+        eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.Iterable`,
             :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
 
             To evaluate one or more specific metrics across one or more datasets, pass in an
-            :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.DataLoader` is passed in, then all
-            metrics returned by ``model.get_metrics()`` will be used during evaluation.
+            :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.Iterable` is passed in, then all
+            metrics returned by ``model.get_metrics()`` will be used during evaluation. If another class is used
+            with :class:`.Evaluator` in a list, a ValueError will be raised.
             ``None`` results in no evaluation. (default: ``None``)
         eval_interval (int | str | Time | (State, Event) -> bool, optional): Specifies how frequently to run evaluation.
             An integer, which will be interpreted to be epochs, a str (e.g. ``1ep``, or ``10ba``), a :class:`.Time`
@@ -2591,9 +2592,10 @@ class Trainer:
             drop duplicate samples.
 
         Args:
-            eval_dataloader (DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
+            eval_dataloader (Iterable | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
                 for evaluation.  If not provided, defaults to using the
-                ``eval_dataloader`` provided to the trainer init().
+                ``eval_dataloader`` provided to the trainer init(). If a list of Evaluators is provided
+                mixed with other classes, a ValueError will be raised.
             subset_num_batches (int, optional): Evaluate on this many batches. Default to ``-1`` (the entire
                 dataloader. Can also be provided in the trainer.__init__() as ``eval_subset_num_batches``.
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1149,7 +1149,8 @@ class Trainer:
             evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
 
             if any(evaluator_types) and not all(evaluator_types):
-                warnings.warn('Mixing Evaluator and DataLoader is not recommended.')
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
 
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in dataloader_tupled
@@ -1716,9 +1717,15 @@ class Trainer:
             eval_metrics = self._original_model.get_metrics(is_train=False)
             metric_names = [str(k) for k in eval_metrics.keys()]
 
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in dataloader_tupled
             ]
 
             # match metric names to model metrics
@@ -2596,9 +2603,16 @@ class Trainer:
             eval_metrics = deepcopy(self._original_model.get_metrics(is_train=False))
             metric_names = [str(k) for k in eval_metrics.keys()]
 
+            dataloader_tupled = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in dataloader_tupled]
+
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator and DataLoader is allowed, please wrap'
+                                 'DataLoaders in the Evaluator class if you wish to do so.')
+
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in dataloader_tupled
             ]
 
             if self.state.eval_metrics:

--- a/tests/loggers/test_console_logger.py
+++ b/tests/loggers/test_console_logger.py
@@ -9,10 +9,11 @@ import pytest
 from torch.utils.data import DataLoader
 from torchmetrics import MetricCollection
 
-from composer.callbacks import SpeedMonitor
+from composer.callbacks import OptimizerMonitor, SpeedMonitor
 from composer.core import Evaluator
 from composer.loggers import ConsoleLogger
 from composer.loggers.console_logger import NUM_EVAL_LOGGING_EVENTS
+from composer.optim import DecoupledAdamW
 from composer.trainer import Trainer
 from tests.common import RandomClassificationDataset, SimpleModel
 
@@ -287,3 +288,50 @@ def test_console_logger_with_a_callback(console_logger_test_stream, console_logg
     expected_speed_monitor_lines = num_speed_monitor_lines_per_log_event * expected_num_logging_events
 
     assert actual_num_speed_monitor_lines == expected_speed_monitor_lines
+
+
+@pytest.mark.filterwarnings('ignore:Cannot split tensor of length .* into batches of size .*:UserWarning')
+def test_console_logger_overlapping(console_logger_test_stream, console_logger_test_file_path):
+
+    batch_size = 1
+    dataset_size = 96
+
+    grad_monitor = OptimizerMonitor(log_optimizer_metrics=True, batch_log_interval=5)
+
+    model = SimpleModel()
+    trainer = Trainer(
+        model=model,
+        callbacks=grad_monitor,
+        console_stream=console_logger_test_stream,
+        console_log_interval='98ba',
+        log_to_console=True,
+        progress_bar=False,
+        train_dataloader=DataLoader(RandomClassificationDataset(size=dataset_size), batch_size=batch_size),
+        optimizers=DecoupledAdamW(model.parameters()),
+        max_duration='2ep',
+    )
+    trainer.fit()
+    console_logger_test_stream.flush()
+    console_logger_test_stream.close()
+
+    with open(console_logger_test_file_path, 'r') as f:
+        lines = f.readlines()
+
+    # Make a regular expression for matches for any line that contains "Train" followed by
+    # a colon.
+    reg_exp = re.compile('Train *:*')
+    actual_num_log_lines = sum(
+        [1 if bool(reg_exp.search(line)) and ('trainer/' not in line and 'time/' not in line) else 0 for line in lines])
+
+    assert model.train_metrics is not None
+    num_metrics = len(list(model.train_metrics.keys())) if isinstance(model.train_metrics, MetricCollection) else 1
+    num_metrics += len(list(model.parameters())) * 7 + 1  # number from Adam
+    for line in lines:
+        print(line)
+    num_losses = 1
+    num_metrics_and_losses_per_logging_event = num_metrics + num_losses
+
+    expected_num_lines = 2 + num_metrics_and_losses_per_logging_event
+    # metrics for optimizer are only calculated at second log
+
+    assert actual_num_log_lines == expected_num_lines

--- a/tests/loggers/test_console_logger.py
+++ b/tests/loggers/test_console_logger.py
@@ -326,8 +326,7 @@ def test_console_logger_overlapping(console_logger_test_stream, console_logger_t
     assert model.train_metrics is not None
     num_metrics = len(list(model.train_metrics.keys())) if isinstance(model.train_metrics, MetricCollection) else 1
     num_metrics += len(list(model.parameters())) * 7 + 1  # number from Adam
-    for line in lines:
-        print(line)
+
     num_losses = 1
     num_metrics_and_losses_per_logging_event = num_metrics + num_losses
 


### PR DESCRIPTION
# What does this PR do?

Changes the behavior of the console logger to empty before eval instead of after each epoch. Added unit test `test_console_logger_overlapping` to test this logic by monitoring the optimizer.

# What issue(s) does this change relate to?

[CO-2152](https://mosaicml.atlassian.net/browse/CO-2152
)



[CO-2152]: https://mosaicml.atlassian.net/browse/CO-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ