### PR TITLE
alerts for daily tests

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -78,6 +78,7 @@ jobs:
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       wandb-api-key: ${{ secrets.WANDB_API_KEY }}
+      slack-notifications-bot-token: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
   coverage:
     uses: ./.github/workflows/coverage.yaml
     name: Coverage Results
@@ -125,3 +126,4 @@ jobs:
       python-version: 3.9
     secrets:
       mcloud-api-key: ${{ secrets.MCLOUD_API_KEY }}
+      slack-notifications-bot-token: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -33,6 +33,8 @@ on:
         required: false
       aws-secret-access-key:
         required: false
+      slack-notifications-bot-token:
+        required: false
 jobs:
   pytest-cpu:
     timeout-minutes: 30
@@ -72,3 +74,12 @@ jobs:
         with:
           name: coverage-${{ github.sha }}-${{ inputs.name }}
           path: .coverage
+      - name: Notify slack fail
+        if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.slack-notifications-bot-token }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: composer-helpdesk
+          status: FAILED
+          color: danger

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -75,7 +75,7 @@ jobs:
           name: coverage-${{ github.sha }}-${{ inputs.name }}
           path: .coverage
       - name: Notify slack fail
-        if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+        if: failure() && !cancelled() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
         env:
           SLACK_BOT_TOKEN: ${{ secrets.slack-notifications-bot-token }}
         uses: voxmedia/github-action-slack-notify-build@v1

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -28,6 +28,8 @@ on:
     secrets:
       mcloud-api-key:
         required: true
+      slack-notifications-bot-token:
+        required: false
 jobs:
   pytest-gpu:
     timeout-minutes: 60 # ${{ inputs.gha-timeout }} for some reason not able to turn this into an input
@@ -76,3 +78,12 @@ jobs:
           fi
 
           python .github/mcli/mcli_pytest.py --image '${{ inputs.container }}' --pip_package_name '${{ inputs.composer_package_name }}' --pytest_markers '${{ inputs.pytest-markers }}' --pytest_command '${{ inputs.pytest-command }}' --timeout ${{ inputs.mcloud-timeout }} ${REF_ARGS}
+      - name: Notify slack fail
+        if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.slack-notifications-bot-token }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: composer-helpdesk
+          status: FAILED
+          color: danger

--- a/.github/workflows/pytest-gpu.yaml
+++ b/.github/workflows/pytest-gpu.yaml
@@ -79,7 +79,7 @@ jobs:
 
           python .github/mcli/mcli_pytest.py --image '${{ inputs.container }}' --pip_package_name '${{ inputs.composer_package_name }}' --pytest_markers '${{ inputs.pytest-markers }}' --pytest_command '${{ inputs.pytest-command }}' --timeout ${{ inputs.mcloud-timeout }} ${REF_ARGS}
       - name: Notify slack fail
-        if: failure() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+        if: failure() && !cancelled() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
         env:
           SLACK_BOT_TOKEN: ${{ secrets.slack-notifications-bot-token }}
         uses: voxmedia/github-action-slack-notify-build@v1


### PR DESCRIPTION
# What does this PR do?

Adds alerts for daily tests if they fail. Tested https://github.com/mvpatel2000/composer/pull/53 and 
<img width="509" alt="image" src="https://github.com/mosaicml/composer/assets/17102158/462461f8-e296-4d9a-98dc-6e166260b787">

This will likely have a hiccup or two the first time around so it may require follow-ons

# What issue(s) does this change relate to?

[CO-1631](https://mosaicml.atlassian.net/browse/CO-1631)

[CO-1631]: https://mosaicml.atlassian.net/browse/CO-1631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ