### PR TITLE
New Console Logger Test + Discard before Eval

### DIFF
--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -95,9 +95,9 @@ def get_gpu_flops_available(state: State):
 
     # torch.cuda.get_device_name() ex output: 'NVIDIA A100-SXM4-40GB'
     device_name = torch.cuda.get_device_name().lower()
-    if 'h100-sxm' in device_name:
+    if 'h100' in device_name and 'hbm3' in device_name:
         device_name = 'h100-sxm'
-    elif 'h100-pcie' in device_name:
+    elif 'h100' in device_name and ('pcie' in device_name or 'hbm2e' in device_name):
         device_name = 'h100-pcie'
     elif 'a100' in device_name:
         device_name = 'a100'

--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -99,8 +99,7 @@ class ConsoleLogger(LoggerDestination):
         if unit == TimeUnit.EPOCH and (cur_epoch % int(self.log_interval) == 0 or cur_epoch == 1):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
             self.last_logged_batch = int(state.timestamp.batch)
-            # Clear logged metrics
-            self.logged_metrics = {}
+            self.logged_metrics = {}  # Clear logged metrics.
 
     def batch_end(self, state: State, logger: Logger) -> None:
         cur_batch = int(state.timestamp.batch)
@@ -108,8 +107,7 @@ class ConsoleLogger(LoggerDestination):
         if unit == TimeUnit.BATCH and (cur_batch % int(self.log_interval) == 0 or cur_batch == 1):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
             self.last_logged_batch = cur_batch
-            # Clear logged metrics.
-            self.logged_metrics = {}
+            self.logged_metrics = {}  # Clear logged metrics.
 
     def fit_end(self, state: State, logger: Logger) -> None:
         # Always clear logged metrics so they don't get logged in a subsequent eval call.

--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -96,10 +96,6 @@ class ConsoleLogger(LoggerDestination):
 
         if unit == TimeUnit.EPOCH and (cur_epoch % int(self.log_interval) == 0 or cur_epoch == 1):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
-        # Always clear logged metrics so they don't get logged in a subsequent eval call. The
-        # metrics will be recomputed and overridden in future batches so they can be safely
-        # discarded.
-        self.logged_metrics = {}
 
     def batch_end(self, state: State, logger: Logger) -> None:
         cur_batch = int(state.timestamp.batch)
@@ -134,6 +130,9 @@ class ConsoleLogger(LoggerDestination):
             self._log_hparams_to_console()
 
     def eval_start(self, state: State, logger: Logger) -> None:
+        self.logged_metrics = {}
+        # Clear logged metrics before eval so they don't get logged
+        # subsequently.
         total_eval_batches = self._get_total_eval_batches(state)
         deciles = np.linspace(0, 1, NUM_EVAL_LOGGING_EVENTS)
         batch_idxs = np.arange(1, total_eval_batches + 1)

--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -130,9 +130,7 @@ class ConsoleLogger(LoggerDestination):
             self._log_hparams_to_console()
 
     def eval_start(self, state: State, logger: Logger) -> None:
-        self.logged_metrics = {}
-        # Clear logged metrics before eval so they don't get logged
-        # subsequently.
+        self.logged_metrics = {}  # Clear logged metrics before eval so they don't get logged subsequently.
         total_eval_batches = self._get_total_eval_batches(state)
         deciles = np.linspace(0, 1, NUM_EVAL_LOGGING_EVENTS)
         batch_idxs = np.arange(1, total_eval_batches + 1)

--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -48,7 +48,7 @@ class ConsoleLogger(LoggerDestination):
         if isinstance(log_interval, str):
             log_interval = Time.from_timestring(log_interval)
 
-        self.last_log = 0
+        self.last_logged_batch = 0
 
         if log_interval.unit not in (TimeUnit.EPOCH, TimeUnit.BATCH):
             raise ValueError('The `console_log_interval` argument must have units of EPOCH or BATCH.')
@@ -98,7 +98,7 @@ class ConsoleLogger(LoggerDestination):
 
         if unit == TimeUnit.EPOCH and (cur_epoch % int(self.log_interval) == 0 or cur_epoch == 1):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
-            self.last_log = int(state.timestamp.batch)
+            self.last_logged_batch = int(state.timestamp.batch)
             # Clear logged metrics
             self.logged_metrics = {}
 
@@ -107,14 +107,14 @@ class ConsoleLogger(LoggerDestination):
         unit = self.log_interval.unit
         if unit == TimeUnit.BATCH and (cur_batch % int(self.log_interval) == 0 or cur_batch == 1):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
-            self.last_log = cur_batch
+            self.last_logged_batch = cur_batch
             # Clear logged metrics.
             self.logged_metrics = {}
 
     def fit_end(self, state: State, logger: Logger) -> None:
         # Always clear logged metrics so they don't get logged in a subsequent eval call.
         cur_batch = int(state.timestamp.batch)
-        if self.last_log != cur_batch:
+        if self.last_logged_batch != cur_batch:
             self.log_to_console(self.logged_metrics, prefix='Train ',
                                 state=state)  # log at the end of training if you didn't just log
 

--- a/tests/loggers/test_console_logger.py
+++ b/tests/loggers/test_console_logger.py
@@ -57,8 +57,6 @@ def test_console_logger_interval(console_logger_test_stream, console_logger_test
     with open(console_logger_test_file_path, 'r') as f:
         lines = f.readlines()
 
-    for line in lines:
-        print(line)
     # Make a regular expression for matches for any line that contains "Train" followed by
     # a colon.
     reg_exp = re.compile('Train *:*')

--- a/tests/loggers/test_console_logger.py
+++ b/tests/loggers/test_console_logger.py
@@ -9,10 +9,11 @@ import pytest
 from torch.utils.data import DataLoader
 from torchmetrics import MetricCollection
 
-from composer.callbacks import SpeedMonitor
+from composer.callbacks import OptimizerMonitor, SpeedMonitor
 from composer.core import Evaluator
 from composer.loggers import ConsoleLogger
 from composer.loggers.console_logger import NUM_EVAL_LOGGING_EVENTS
+from composer.optim import DecoupledAdamW
 from composer.trainer import Trainer
 from tests.common import RandomClassificationDataset, SimpleModel
 
@@ -287,3 +288,49 @@ def test_console_logger_with_a_callback(console_logger_test_stream, console_logg
     expected_speed_monitor_lines = num_speed_monitor_lines_per_log_event * expected_num_logging_events
 
     assert actual_num_speed_monitor_lines == expected_speed_monitor_lines
+
+
+@pytest.mark.filterwarnings('ignore:Cannot split tensor of length .* into batches of size .*:UserWarning')
+def test_console_logger_overlapping(console_logger_test_stream, console_logger_test_file_path):
+
+    batch_size = 1
+    dataset_size = 96
+
+    grad_monitor = OptimizerMonitor(log_optimizer_metrics=True, batch_log_interval=5)
+
+    model = SimpleModel()
+    trainer = Trainer(
+        model=model,
+        callbacks=grad_monitor,
+        console_stream=console_logger_test_stream,
+        console_log_interval='98ba',
+        log_to_console=True,
+        progress_bar=False,
+        train_dataloader=DataLoader(RandomClassificationDataset(size=dataset_size), batch_size=batch_size),
+        optimizers=DecoupledAdamW(model.parameters()),
+        max_duration='2ep',
+    )
+    trainer.fit()
+    console_logger_test_stream.flush()
+    console_logger_test_stream.close()
+
+    with open(console_logger_test_file_path, 'r') as f:
+        lines = f.readlines()
+
+    # Make a regular expression for matches for any line that contains "Train" followed by
+    # a colon.
+    reg_exp = re.compile('Train *:*')
+    actual_num_log_lines = sum(
+        [1 if bool(reg_exp.search(line)) and ('trainer/' not in line and 'time/' not in line) else 0 for line in lines])
+
+    assert model.train_metrics is not None
+    num_metrics = len(list(model.train_metrics.keys())) if isinstance(model.train_metrics, MetricCollection) else 1
+    num_metrics += len(list(model.parameters())) * 7 + 1  # number from Adam
+
+    num_losses = 1
+    num_metrics_and_losses_per_logging_event = num_metrics + num_losses
+
+    expected_num_lines = 2 + num_metrics_and_losses_per_logging_event
+    # metrics for optimizer are only calculated at second log
+
+    assert actual_num_log_lines == expected_num_lines

--- a/tests/loggers/test_console_logger.py
+++ b/tests/loggers/test_console_logger.py
@@ -347,12 +347,13 @@ def test_console_logger_overlapping(console_logger_test_stream, console_logger_t
 
     assert model.train_metrics is not None
     num_metrics = len(list(model.train_metrics.keys())) if isinstance(model.train_metrics, MetricCollection) else 1
-    num_metrics += len(list(model.parameters())) * 7 + 1  # number from Adam
+    num_metrics += len(list(model.parameters())) * 7 + 1  # number from Adam, 7 metrics per layer
 
     num_losses = 1
-    num_metrics_and_losses_per_logging_event = num_metrics + num_losses
+    num_metrics_and_losses_per_logging_event = num_metrics + num_losses  # prints loss and all metrics at each log
 
     expected_num_lines = 2 + 2 * num_metrics_and_losses_per_logging_event
     # metrics for optimizer are only calculated at second log and at FIT_END
+    # prints only loss/accuracy at the first batch
 
     assert actual_num_log_lines == expected_num_lines


### PR DESCRIPTION
# What does this PR do?

New PR for the console logger test, which is now smaller and has documentation, for the discard before eval and not at the end of epoch functionality.

# What issue(s) does this change relate to?

[CO-2152](https://mosaicml.atlassian.net/browse/CO-2152)
[CO-2030](https://mosaicml.atlassian.net/browse/CO-2030
)

[CO-2152]: https://mosaicml.atlassian.net/browse/CO-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CO-2030]: https://mosaicml.atlassian.net/browse/CO-2030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ