### PR TITLE
Fix daily tests by patching cupy version

### DIFF
--- a/examples/ffcv_dataloaders.ipynb
+++ b/examples/ffcv_dataloaders.ipynb
@@ -66,7 +66,7 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "cuda_ver = torch.version.cuda.replace(\".\", \"\")\n",
+    "cuda_ver = torch.version.cuda.split(\".\")[0] + 'x'\n",
     "%pip install cupy-cuda{cuda_ver}"
    ]
   },


### PR DESCRIPTION
# What does this PR do?

We changed dockerfile cupy version, but forgot to update notebook, so it installs the wrong version in tests. Fixes daily