### PR TITLE
Confirming the output variable has two dimensions before confirming the shape of the second element.

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -372,7 +372,7 @@ class HuggingFaceModel(ComposerModel):
                 output = output[1] if len(output[0].shape) == 0 else output[0]
 
             # if we are in the single class case, then remove the classes dimension
-            if output.shape[1] == 1:
+            if output.ndim == 2 and output.shape[1] == 1:
                 output = output.squeeze(dim=1)
         else:
             output = outputs if outputs else self.forward(batch)

--- a/tests/common/datasets.py
+++ b/tests/common/datasets.py
@@ -225,20 +225,13 @@ class RandomTextRegressionDataset(Dataset):
     Args:
         vocab_size (int): vocab size to use (default: 10)
         size (int): number of samples (default: 100)
-        num_classes (int): number of classes (default: 1)
         sequence_length (int): sequence length to use, all sequences will be of this length with no padding (default: 8)
         use_keys: (bool): whether to return the item in a dictionary with keys for input and output
     """
 
-    def __init__(self,
-                 size: int = 100,
-                 vocab_size: int = 10,
-                 sequence_length: int = 8,
-                 num_classes: int = 1,
-                 use_keys: bool = False):
+    def __init__(self, size: int = 100, vocab_size: int = 10, sequence_length: int = 8, use_keys: bool = False):
         self.vocab_size = vocab_size
         self.sequence_length = sequence_length
-        self.num_classes = num_classes
         self.use_keys = use_keys
 
         self.input_key = 'input_ids'
@@ -259,11 +252,10 @@ class RandomTextRegressionDataset(Dataset):
         if self.x is None:
             self.x = torch.randint(low=0, high=self.vocab_size, size=(self.size, self.sequence_length))
         if self.y is None:
-            self.y = torch.randint(low=0, high=self.num_classes, size=(self.size,))
+            self.y = torch.rand(size=(self.size,))
 
         x = self.x[index]
-        y = self.y[index].float()
-
+        y = self.y[index]
         if self.use_keys:
             return {'input_ids': x, 'labels': y}
         else:

--- a/tests/common/datasets.py
+++ b/tests/common/datasets.py
@@ -220,6 +220,56 @@ class RandomTextClassificationDataset(Dataset):
             return x, y
 
 
+class RandomTextRegressionDataset(Dataset):
+    """ Text Regression dataset with values (just input token ids) drawn uniformly
+    Args:
+        vocab_size (int): vocab size to use (default: 10)
+        size (int): number of samples (default: 100)
+        num_classes (int): number of classes (default: 1)
+        sequence_length (int): sequence length to use, all sequences will be of this length with no padding (default: 8)
+        use_keys: (bool): whether to return the item in a dictionary with keys for input and output
+    """
+
+    def __init__(self,
+                 size: int = 100,
+                 vocab_size: int = 10,
+                 sequence_length: int = 8,
+                 num_classes: int = 1,
+                 use_keys: bool = False):
+        self.vocab_size = vocab_size
+        self.sequence_length = sequence_length
+        self.num_classes = num_classes
+        self.use_keys = use_keys
+
+        self.input_key = 'input_ids'
+        self.label_key = 'labels'
+
+        self.size = size
+        self.x = None
+        self.y = None
+
+        super().__init__()
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, index: int):
+        # Note: lazily generate data so it runs after Composer seeds everything, giving the same
+        # dataset across multiple calls when using the same seed.
+        if self.x is None:
+            self.x = torch.randint(low=0, high=self.vocab_size, size=(self.size, self.sequence_length))
+        if self.y is None:
+            self.y = torch.randint(low=0, high=self.num_classes, size=(self.size,))
+
+        x = self.x[index]
+        y = self.y[index].float()
+
+        if self.use_keys:
+            return {'input_ids': x, 'labels': y}
+        else:
+            return x, y
+
+
 class RandomTextLMDataset(Dataset):
     """ Text LM dataset with values (just input token ids) drawn uniformly
     Args:

--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -452,6 +452,31 @@ def configure_tiny_bert_hf_model(use_logits=True):
     return HuggingFaceModel(configure_tiny_bert_model(), configure_tiny_bert_tokenizer(), use_logits)
 
 
+def configure_tiny_deberta_model():
+    try:
+        return copy.deepcopy(pytest.tiny_deberta_model)
+    except AttributeError:
+        pytest.skip('Composer installed without NLP support')
+
+
+def configure_tiny_deberta_tokenizer():
+    try:
+        return copy.deepcopy(pytest.tiny_deberta_tokenizer)
+    except AttributeError:
+        pytest.skip('Composer installed without NLP support')
+
+
+def configure_tiny_deberta_config():
+    try:
+        return copy.deepcopy(pytest.tiny_deberta_config)
+    except AttributeError:
+        pytest.skip('Composer installed without NLP support')
+
+
+def configure_tiny_deberta_hf_model(use_logits=True):
+    return HuggingFaceModel(configure_tiny_deberta_model(), configure_tiny_deberta_tokenizer(), use_logits)
+
+
 def configure_tiny_gpt2_model():
     try:
         return copy.deepcopy(pytest.tiny_gpt2_model)

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -176,7 +176,7 @@ def tiny_deberta_model_helper(config):
 
 
 @pytest.fixture(scope='session')
-def _session_tiny_berta_model(_session_tiny_deberta_config):  # type: ignore
+def _session_tiny_deberta_model(_session_tiny_deberta_config):  # type: ignore
     return tiny_deberta_model_helper(_session_tiny_deberta_config)
 
 

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -169,6 +169,45 @@ def _session_tiny_bert_config():  # type: ignore
     return tiny_bert_config_helper()
 
 
+def tiny_deberta_model_helper(config):
+    transformers = pytest.importorskip('transformers')
+
+    return transformers.AutoModelForMaskedLM.from_config(config)  # type: ignore (thirdparty)
+
+
+@pytest.fixture(scope='session')
+def _session_tiny_berta_model(_session_tiny_deberta_config):  # type: ignore
+    return tiny_deberta_model_helper(_session_tiny_deberta_config)
+
+
+def tiny_deberta_tokenizer_helper():
+    transformers = pytest.importorskip('transformers')
+
+    return transformers.AutoTokenizer.from_pretrained('microsoft/deberta-base')
+
+
+@pytest.fixture(scope='session')
+def _session_tiny_deberta_tokenizer():  # type: ignore
+    return tiny_deberta_tokenizer_helper()
+
+
+def tiny_deberta_config_helper():
+    transformers = pytest.importorskip('transformers')
+    tiny_overrides = {
+        'hidden_size': 128,
+        'pooler_hidden_size': 128,
+        'num_attention_heads': 2,
+        'num_hidden_layers': 2,
+        'intermediate_size': 512,
+    }
+    return transformers.AutoConfig.from_pretrained('microsoft/deberta-base', **tiny_overrides)
+
+
+@pytest.fixture(scope='session')
+def _session_tiny_deberta_config():  # type: ignore
+    return tiny_deberta_config_helper()
+
+
 def tiny_gpt2_model_helper(config):
     transformers = pytest.importorskip('transformers')
 
@@ -258,6 +297,21 @@ def tiny_bert_tokenizer(_session_tiny_bert_tokenizer):
 @pytest.fixture
 def tiny_bert_config(_session_tiny_bert_config):
     return copy.deepcopy(_session_tiny_bert_config)
+
+
+@pytest.fixture
+def tiny_deberta_model(_session_tiny_deberta_model):
+    return copy.deepcopy(_session_tiny_deberta_model)
+
+
+@pytest.fixture
+def tiny_deberta_tokenizer(_session_tiny_deberta_tokenizer):
+    return copy.deepcopy(_session_tiny_deberta_tokenizer)
+
+
+@pytest.fixture
+def tiny_deberta_config(_session_tiny_deberta_config):
+    return copy.deepcopy(_session_tiny_deberta_config)
 
 
 @pytest.fixture

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -89,37 +89,32 @@ def test_hf_train_eval_predict(num_classes: int, tiny_bert_config):
     assert predictions[0]['logits'].shape == (batch_size, num_classes)
 
 
-@pytest.mark.parametrize('num_classes', [1, 1])
-def test_hf_train_eval_predict_regression(num_classes: int, tiny_deberta_config):
+def test_hf_train_eval_predict_regression(tiny_deberta_config):
     transformers = pytest.importorskip('transformers')
 
-    tiny_deberta_config.num_labels = num_classes
+    tiny_deberta_config.num_labels = 1
     hf_model = transformers.AutoModelForSequenceClassification.from_config(
         tiny_deberta_config)  # type: ignore (thirdparty)
 
     metrics = PearsonCorrCoef(num_outputs=1)
     model = HuggingFaceModel(hf_model, metrics=[metrics], use_logits=True)
 
-    vocab_size = 30522  # Match bert vocab size
+    vocab_size = 50265  # Match deberta vocab size
     sequence_length = 4
-    num_classes = num_classes
     size = 16
     batch_size = 8
 
     train_dataset = RandomTextRegressionDataset(size=size,
                                                 vocab_size=vocab_size,
                                                 sequence_length=sequence_length,
-                                                num_classes=num_classes,
                                                 use_keys=True)
     eval_dataset = RandomTextRegressionDataset(size=size,
                                                vocab_size=vocab_size,
                                                sequence_length=sequence_length,
-                                               num_classes=num_classes,
                                                use_keys=True)
     predict_dataset = RandomTextRegressionDataset(size=size,
                                                   vocab_size=vocab_size,
                                                   sequence_length=sequence_length,
-                                                  num_classes=num_classes,
                                                   use_keys=True)
 
     train_dataloader = DataLoader(train_dataset, batch_size=batch_size, sampler=dist.get_sampler(train_dataset))


### PR DESCRIPTION
# What does this PR do?

This pull request first checks if the output variable has two dimensions before then checking if the shape of the second element of the output variable is 1, then after using squeeze(dim=1) to squeeze the second element. 

The previous code was failing sometimes, when the output variable had only 1 dimension, and the code was checking for the shape of the second element. I was getting an error: 
```
IndexError: tuple index out of range
```

# What issue(s) does this change relate to?

Was discussed on the Slack channel together with @dakinggg when I was facing an issue with a regression example using the HuggingFace Model.

Tagging Daniel to help with creating tests and configuring this PR in the best way possible for it to be merged

# Before submitting
- [ -] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [- ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so. (Slack)
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
