### PR TITLE
Patch for tokenizers that have python files in save_pretrained output

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -203,6 +203,7 @@ class HuggingFaceModel(ComposerModel):
             local_checkpoint_save_location (Optional[Union[Path, str]], optional): If specified, where to save the checkpoint file to locally.
                                                                                    If the input ``checkpoint_path`` is already a local path, this will be a symlink.
                                                                                    Defaults to None, which will use a temporary file.
+            trust_remote_code (bool, optional): Whether to trust the remote code when loading the tokenizer. Defaults to False.
 
         Raises:
             ValueError: If the ``model_instantiation_class``, or the model class saved in the checkpoint, is not able to be imported

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -145,7 +145,8 @@ class HuggingFaceModel(ComposerModel):
         model_instantiation_class: Optional[Union[Type[transformers.PreTrainedModel], Type['_BaseAutoModelClass'],
                                                   str]] = None,
         model_config_kwargs: Optional[dict] = None,
-        local_checkpoint_save_location: Optional[Union[Path, str]] = None
+        local_checkpoint_save_location: Optional[Union[Path, str]] = None,
+        trust_remote_code: bool = False,
     ) -> Tuple[transformers.PreTrainedModel, Optional[transformers.PreTrainedTokenizer]]:
         """Loads a HuggingFace model (and tokenizer if present) from a composer checkpoint.
 
@@ -285,6 +286,9 @@ class HuggingFaceModel(ComposerModel):
                             for line in saved_content['content']:
                                 _tmp_file.write(line)
                                 _tmp_file.write('\n')
+                    elif saved_content['file_extension'] == '.py':
+                        with open(tokenizer_file_path, 'w') as _tmp_file:
+                            _tmp_file.write(saved_content['content'])
                     elif saved_content['file_extension'] == '.model':
                         try:
                             import sentencepiece as spm
@@ -295,7 +299,7 @@ class HuggingFaceModel(ComposerModel):
                         s.load_from_serialized_proto(saved_content['content'])
                         with open(tokenizer_file_path, 'wb') as _tmp_file:
                             _tmp_file.write(s.serialized_model_proto())
-                hf_tokenizer = transformers.AutoTokenizer.from_pretrained(_tmp_dir)
+                hf_tokenizer = transformers.AutoTokenizer.from_pretrained(_tmp_dir, trust_remote_code=trust_remote_code)
 
                 # we need to set the name_or_path back because otherwise it is the tmp dir we are loading from here
                 hf_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content'].get('name_or_path', '')
@@ -424,6 +428,9 @@ class HuggingFaceModel(ComposerModel):
                     elif tokenizer_file_extension == '.json':
                         with open(tokenizer_file_path) as _tokenizer_file:
                             tokenizer_file_content = json.load(_tokenizer_file)
+                    elif tokenizer_file_extension == '.py':
+                        with open(tokenizer_file_path) as _tokenizer_file:
+                            tokenizer_file_content = _tokenizer_file.read()
                     elif tokenizer_file_extension == '.model':
                         try:
                             import sentencepiece as spm

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -95,9 +95,11 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     and that a string is tokenized the same one. Then we compare the __dict__ of the tokenizers, but we remove
     some keys that are not important for equivalence. See the inline explanations for each one.
     """
-    #
-    assert tokenizer1.vocab == tokenizer2.vocab
-    assert type(tokenizer1) == type(tokenizer2)
+    if hasattr(tokenizer1, 'vocab') or hasattr(tokenizer2, 'vocab'):
+        assert tokenizer1.vocab == tokenizer2.vocab
+
+    # we only care about the file and class name, not the full import path
+    assert str(type(tokenizer1)).split('.')[-2:] == str(type(tokenizer2)).split('.')[-2:]
 
     expected_tokenizer_output = tokenizer2('This is some text that should get tokenizer !? @ totallyarealtoken')
     actual_tokenizer_output = tokenizer1('This is some text that should get tokenizer !? @ totallyarealtoken')
@@ -105,12 +107,23 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
 
     # we remove the actual _tokenizer object because it is an instantiated object and so does not pass equality
     # the tokenizers are not usable below these pops
-    tokenizer1.__dict__.pop('_tokenizer')
-    tokenizer2.__dict__.pop('_tokenizer')
+    if hasattr(tokenizer1, '_tokenizer') or hasattr(tokenizer2, '_tokenizer'):
+        tokenizer1.__dict__.pop('_tokenizer')
+        tokenizer2.__dict__.pop('_tokenizer')
+
+    # we remove a couple more objects because they are instantiated objects and so do not pass equality
+    if hasattr(tokenizer1, 'sp_model') or hasattr(tokenizer2, 'sp_model'):
+        tokenizer1.__dict__.pop('sp_model')
+        tokenizer2.__dict__.pop('sp_model')
+
+    if hasattr(tokenizer1, 'tokens_trie') or hasattr(tokenizer2, 'tokens_trie'):
+        tokenizer1.__dict__.pop('tokens_trie')
+        tokenizer2.__dict__.pop('tokens_trie')
 
     # extra key that is not important
-    tokenizer1.__dict__.pop('deprecation_warnings')
-    tokenizer2.__dict__.pop('deprecation_warnings')
+    if hasattr(tokenizer1, 'deprecation_warnings') or hasattr(tokenizer2, 'deprecation_warnings'):
+        tokenizer1.__dict__.pop('deprecation_warnings')
+        tokenizer2.__dict__.pop('deprecation_warnings')
 
     # name_or_path will be the path that the tokenizer was loaded from, which will just be a temporary directory for
     # the reloaded tokenizer, so we remove it and don't compare it between the two tokenizers
@@ -460,6 +473,30 @@ def test_hf_loading_sentencepiece_tokenizer(modify_tokenizer: bool, tmp_path: Pa
         checkpoint_path=str(tmp_path / 'hf-checkpoint.pt'))
 
     check_hf_model_equivalence(hf_loaded_model, tiny_t5_model)
+    check_hf_tokenizer_equivalence(hf_loaded_tokenizer, t0_pp_tokenizer)
+
+
+@pytest.mark.parametrize('modify_tokenizer', [False, True])
+def test_hf_loading_tokenizer_with_python_file(modify_tokenizer: bool, tmp_path: Path, tiny_gpt2_model):
+    transformers = pytest.importorskip('transformers')
+
+    t0_pp_tokenizer = transformers.AutoTokenizer.from_pretrained('replit/replit-code-v1-3b', trust_remote_code=True)
+
+    if modify_tokenizer:
+        assert t0_pp_tokenizer is not None  # pyright
+        t0_pp_tokenizer.add_special_tokens({'bos_token': '[NEWSPECIAL]'})
+        t0_pp_tokenizer.add_special_tokens({'additional_special_tokens': ['[MOSAICML']})
+        t0_pp_tokenizer.add_tokens(['totallyarealtoken', 'mosaicml'])
+        tiny_gpt2_model.resize_token_embeddings(len(t0_pp_tokenizer))
+
+    trainer = get_lm_trainer(tiny_gpt2_model, t0_pp_tokenizer, str(tmp_path), is_conditional_generation=True)
+    trainer.save_checkpoint(str(tmp_path / 'hf-checkpoint.pt'))
+
+    hf_loaded_model, hf_loaded_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint(checkpoint_path=str(
+        tmp_path / 'hf-checkpoint.pt'),
+                                                                                        trust_remote_code=True)
+
+    check_hf_model_equivalence(hf_loaded_model, tiny_gpt2_model)
     check_hf_tokenizer_equivalence(hf_loaded_tokenizer, t0_pp_tokenizer)
 
 

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -480,16 +480,16 @@ def test_hf_loading_sentencepiece_tokenizer(modify_tokenizer: bool, tmp_path: Pa
 def test_hf_loading_tokenizer_with_python_file(modify_tokenizer: bool, tmp_path: Path, tiny_gpt2_model):
     transformers = pytest.importorskip('transformers')
 
-    t0_pp_tokenizer = transformers.AutoTokenizer.from_pretrained('replit/replit-code-v1-3b', trust_remote_code=True)
+    replit_tokenizer = transformers.AutoTokenizer.from_pretrained('replit/replit-code-v1-3b', trust_remote_code=True)
 
     if modify_tokenizer:
-        assert t0_pp_tokenizer is not None  # pyright
-        t0_pp_tokenizer.add_special_tokens({'bos_token': '[NEWSPECIAL]'})
-        t0_pp_tokenizer.add_special_tokens({'additional_special_tokens': ['[MOSAICML']})
-        t0_pp_tokenizer.add_tokens(['totallyarealtoken', 'mosaicml'])
-        tiny_gpt2_model.resize_token_embeddings(len(t0_pp_tokenizer))
+        assert replit_tokenizer is not None  # pyright
+        replit_tokenizer.add_special_tokens({'bos_token': '[NEWSPECIAL]'})
+        replit_tokenizer.add_special_tokens({'additional_special_tokens': ['[MOSAICML']})
+        replit_tokenizer.add_tokens(['totallyarealtoken', 'mosaicml'])
+        tiny_gpt2_model.resize_token_embeddings(len(replit_tokenizer))
 
-    trainer = get_lm_trainer(tiny_gpt2_model, t0_pp_tokenizer, str(tmp_path), is_conditional_generation=True)
+    trainer = get_lm_trainer(tiny_gpt2_model, replit_tokenizer, str(tmp_path), is_conditional_generation=True)
     trainer.save_checkpoint(str(tmp_path / 'hf-checkpoint.pt'))
 
     hf_loaded_model, hf_loaded_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint(checkpoint_path=str(
@@ -497,7 +497,7 @@ def test_hf_loading_tokenizer_with_python_file(modify_tokenizer: bool, tmp_path:
                                                                                         trust_remote_code=True)
 
     check_hf_model_equivalence(hf_loaded_model, tiny_gpt2_model)
-    check_hf_tokenizer_equivalence(hf_loaded_tokenizer, t0_pp_tokenizer)
+    check_hf_tokenizer_equivalence(hf_loaded_tokenizer, replit_tokenizer)
 
 
 @pytest.mark.parametrize('modify_tokenizer', [False, True])


### PR DESCRIPTION
# What does this PR do?
Patches our `HuggingFaceModel` integration to allow for `.py` files in the tokenizer output of `save_pretrained`. It appears that as of the latest transformers version, tokenizer `save_pretrained` output does _not_ have python files in it, but i ran the test locally on `transformers==4.28.x` to confirm it passed.

```
(composer-dev-torch2) danielking@MML-1B940F4333E2 composer % pip show transformers
Name: transformers
Version: 4.28.0
Summary: State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow
Home-page: https://github.com/huggingface/transformers
Author: The Hugging Face team (past and future) with the help of all our contributors (https://github.com/huggingface/transformers/graphs/contributors)
Author-email: transformers@huggingface.co
License: Apache 2.0 License
Location: /Users/danielking/miniconda3/envs/composer-dev-torch2/lib/python3.10/site-packages
Requires: filelock, huggingface-hub, numpy, packaging, pyyaml, regex, requests, tokenizers, tqdm
Required-by: mosaicml-streaming
(composer-dev-torch2) danielking@MML-1B940F4333E2 composer % pytest tests/models/test_hf_model.py 
=================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.10.11, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/danielking/github/composer
configfile: pyproject.toml
plugins: pytest_codeblocks-0.16.1, anyio-3.6.2, httpserver-1.0.6
collected 103 items / 33 deselected / 70 selected                                                                                                                                         

tests/models/test_hf_model.py ...s...s...x.............sss..s..s...ss.ss....................s.s.s.s.                                                                                [100%]

==================================================================================== warnings summary =====================================================================================
tests/models/test_hf_model.py::test_hf_train_eval_predict[2]
  /Users/danielking/miniconda3/envs/composer-dev-torch2/lib/python3.10/site-packages/deepspeed/ops/op_builder/builder.py:13: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    import distutils.ccompiler

tests/models/test_hf_model.py::test_hf_train_eval_predict[2]
  /Users/danielking/miniconda3/envs/composer-dev-torch2/lib/python3.10/site-packages/deepspeed/ops/op_builder/builder.py:15: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
    import distutils.sysconfig

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 54 passed, 15 skipped, 33 deselected, 1 xfailed, 2 warnings in 20.26s ==========================================================
(composer-dev-torch2) danielking@MML-1B940F4333E2 composer % 
```