### PR TITLE
fix get file(overwite=True) to properly handle pre-existing files

### DIFF
--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -581,7 +581,7 @@ def _get_file(
 
     if os.path.exists(destination) and overwrite:
         os.remove(destination)
-        
+
     os.symlink(os.path.abspath(path), destination)
 
 

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -578,6 +578,10 @@ def _get_file(
     # It's a local filepath
     if not os.path.exists(path):
         raise FileNotFoundError(f'Local path {path} does not exist')
+
+    if os.path.exists(destination) and overwrite:
+        os.remove(destination)
+        
     os.symlink(os.path.abspath(path), destination)
 
 

--- a/tests/utils/test_file_helpers.py
+++ b/tests/utils/test_file_helpers.py
@@ -149,6 +149,33 @@ def test_get_file_local_path(tmp_path: pathlib.Path):
         assert f.read() == 'hi!'
 
 
+def test_get_file_local_path_overwrite_false(tmp_path: pathlib.Path):
+    tmpfile_name = os.path.join(tmp_path, 'file.txt')
+    with open(tmpfile_name, 'x') as f:
+        f.write('hi!')
+
+    with open(str(tmp_path / 'example'), 'w') as f:
+        f.write('already exists!')
+
+    with pytest.raises(FileExistsError):
+        get_file(path=tmpfile_name, object_store=None, destination=str(tmp_path / 'example'), overwrite=False)
+        with open(str(tmp_path / 'example'), 'r') as f:
+            assert f.read() == 'hi!'
+
+
+def test_get_file_local_path_overwrite_true(tmp_path: pathlib.Path):
+    tmpfile_name = os.path.join(tmp_path, 'file.txt')
+    with open(tmpfile_name, 'x') as f:
+        f.write('hi!')
+
+    with open(str(tmp_path / 'example'), 'w') as f:
+        f.write('already exists!')
+
+    get_file(path=tmpfile_name, object_store=None, destination=str(tmp_path / 'example'), overwrite=True)
+    with open(str(tmp_path / 'example'), 'r') as f:
+        assert f.read() == 'hi!'
+
+
 def test_get_file_local_path_not_found():
     with pytest.raises(FileNotFoundError):
         get_file(


### PR DESCRIPTION
# What does this PR do?

Fixes a bug in which _get_file(overwrite=True) would fail if the destination path already exists. Ideally, we would instead delete anything at the existing destination path and overwrite it. This created bugs because ICL datasets rely on this utility and was failing if multiple runs in a row tried to write to the same destination. https://github.com/mosaicml/composer/blob/9b2d5ec34b6c26651c6bdae526dc849a652743cc/composer/datasets/in_context_learning_evaluation.py#LL138C8-L140C72

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
