### PR TITLE
Delete symlinks when not saving checkpoints locally

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -390,7 +390,7 @@ class CheckpointSaver(Callback):  # noqa: D101
         if not saved_path:  # not all ranks save
             return
 
-        if self.latest_filename is not None:
+        if self.latest_filename is not None and self.num_checkpoints_to_keep != 0:
             symlink = self.latest_filename.format(state, is_deepspeed)
             os.makedirs(os.path.dirname(symlink), exist_ok=True)
             try:

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1020,6 +1020,6 @@ def test_rotate_checkpoints(
     files = glob(os.path.join(save_folder, 'checkpoint_*'))
     symlink_files = glob(os.path.join(save_folder, 'latest-rank*'))
     assert len(files) == expected_num
-    assert len(symlink_files) == (world_size if num_keep != 0 else 0)
+    assert len(symlink_files) == ((1 if not deepspeed_enabled else world_size) if num_keep != 0 else 0)
 
     dist.barrier()  # all ranks finish before cleaning up tmpdir


### PR DESCRIPTION
# What does this PR do?

Add unit tests and functionality so that we delete symlinks when there are no checkpoints that should be saved locally.

# What issue(s) does this change relate to?

[CO-2112](https://mosaicml.atlassian.net/browse/CO-2112)


[CO-2112]: https://mosaicml.atlassian.net/browse/CO-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ