### PR TITLE
fixed adding tokenizer to hf

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -145,7 +145,7 @@ class HuggingFaceModel(ComposerModel):
         """A helper function that loads a HuggingFace tokenizer from a loaded in hf state.
 
         Args:
-            hf_state (Dict[str, Any]): A loaded state from a checkpoint save location of a hf model.
+            hf_state (Dict[str, Any]): HF state loaded from a Composer checkpoint.
 
         Returns:
             Optional[transformers.PreTrainedTokenizer]: The loaded HuggingFace tokenizer
@@ -196,11 +196,16 @@ class HuggingFaceModel(ComposerModel):
             hf_state: Dict[str, Any], loaded_state_dict: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]],
             model_instantiation_class: type | str | None,
             model_config_kwargs: Dict[str, Any] | None) -> transformers.PreTrainedModel:
-        """A helper function that loads a HuggingFace model from a loaded in hf state.
+        """A helper function that loads a HuggingFace model class from a loaded in hf state.
 
         Args:
-            hf_state (Dict[str, Any]): A loaded state from a checkpoint save location of a hf model.
-
+            hf_state (Dict[str, Any]): HF state loaded from a Composer checkpoint.
+            model_instantiation_class (Union[Type[:class:`transformers.PreTrainedModel`], Type[:class:`transformers.AutoModel`], str]), optional):
+                Class to use to create the HuggingFace model. Defaults to the model class used in the original checkpoint. If this argument is
+                a HuggingFace auto class (e.g. :class:`transformers.AutoModel` or :class:`transformers.AutoModelForSequenceClassification`), the ``from_config`` method will be used,
+                while if it is of type :class:`transformers.PreTrainedModel`, the constructor will be called. This argument can also be a string,
+                which will attempt to be imported as the class to use.
+            model_config_kwargs: Dict[str, Any]: Extra arguments to pass in for the model config creation (e.g. ``num_labels`` for creating a sequence classification model)
         Returns:
             transformers.PreTrainedModel: The loaded HuggingFace model
         """

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -33,7 +33,7 @@ from tests.loggers.test_remote_uploader_downloader import DummyObjectStore
 def test_hf_tokenizer_save(tmp_path: Path, tiny_bert_model, tiny_bert_tokenizer):
     transformers = pytest.importorskip('transformers')
 
-    trainer = get_lm_trainer(tiny_bert_model, tiny_bert_tokenizer, str(tmp_path), is_conditional_generation=True)
+    trainer = get_lm_trainer(tiny_bert_model, tiny_bert_tokenizer, str(tmp_path), is_conditional_generation=False)
     trainer.save_checkpoint(str(tmp_path / 'composer-checkpoint.pt'))
 
     _, composer_loaded_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint(


### PR DESCRIPTION
# What does this PR do?

Originally the function 'write_huggingface_pretrained_from_composer_checkpoint' would not properly write the tokenizer from the composer checkpoint. This change fixes that by additionally saving the tokenizer from the composer checkpoint to the HuggingFace checkpoint. 

An additional test was implemented for this issue.

# What issue(s) does this change relate to?

- Fixes CO-1976 (https://mosaicml.atlassian.net/browse/CO-1976)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
