### PR TITLE
Fixed how save_checkpoint_to_save_folder called CheckpointSaver object to save state and logger

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2990,7 +2990,7 @@ class Trainer:
             raise ValueError(
                 'In order to use save_checkpoint_to_save_folder you must pass a save_folder to the Trainer.')
         else:
-            self._checkpoint_saver._save_checkpoint
+            self._checkpoint_saver._save_checkpoint(self.state, self.logger)
 
     def export_for_inference(
         self,

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -698,8 +698,7 @@ class TestTrainerInitOrFit:
                            max_duration=max_duration,
                            train_dataloader=train_dataloader,
                            save_folder=checkpoint_path)
-        trainer1.fit(duration='2ba')
-        name = 'ep0-ba2-rank0.pt'
+        name = 'ep0-ba0-rank0.pt'
         if checkpoint_path is not None:
             trainer1.save_checkpoint_to_save_folder()
             trainer2 = Trainer(model=copied_model,


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug where saving a checkpoint in training was called incorrectly and not saving the state and logger

# What issue(s) does this change relate to?

This change fixes CO-2178

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
