### PR TITLE
Fix tests for wandb and mlflow loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
     <a href="https://docs.mosaicml.com/projects/composer/en/stable/">
         <img alt="Documentation" src="https://readthedocs.org/projects/composer/badge/?version=stable">
     </a>
-    <a href="https://mosaicml-community.slack.com/join/shared_invite/zt-1btms90mc-GipE2ufuPkKY0QBrmF3LSA#/shared-invite/email">
+    <a href="https://mosaicml.me/slack">
         <img alt="Chat @ Slack" src="https://img.shields.io/badge/slack-chat-2eb67d.svg?logo=slack">
     </a>
     <a href="https://github.com/mosaicml/composer/blob/dev/LICENSE">

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -390,7 +390,7 @@ class CheckpointSaver(Callback):  # noqa: D101
         if not saved_path:  # not all ranks save
             return
 
-        if self.latest_filename is not None:
+        if self.latest_filename is not None and self.num_checkpoints_to_keep != 0:
             symlink = self.latest_filename.format(state, is_deepspeed)
             os.makedirs(os.path.dirname(symlink), exist_ok=True)
             try:

--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -87,7 +87,7 @@ class MLPerfCallback(Callback):
                 target='0.759',
             )
 
-    During training, the metric found in ``state.eval_metrics[metric_label][metric_name]``
+    During training, the metric found in ``state.eval_metrics[evaluator_label][metric_name]``
     will be compared against the target criterion.
 
     .. note::
@@ -115,7 +115,7 @@ class MLPerfCallback(Callback):
         metric_name (str, optional): name of the metric to compare against the target.
             Default: ``MulticlassAccuracy``.
         metric_label (str, optional): The label name. The metric will be accessed via
-            ``state.eval_metrics[metric_label][metric_name]``.
+            ``state.eval_metrics[evaluator_label][metric_name]``.
         submitter (str, optional): Submitting organization. Default: ``"MosaicML"``.
         system_name (str, optional): Name of the system (e.g. 8xA100_composer). If
             not provided, system name will default to ``[world_size]x[device_name]_composer``,

--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -243,7 +243,8 @@ class InContextLearningQATaskDataset(Dataset):
             'labels': answers,
             'generation_length': self.max_answer_length,
             'generation_kwargs': {
-                'pad_token_id': self.pad_tok_id
+                'pad_token_id': self.pad_tok_id,
+                'use_cache': True
             }
         }
 

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -24,12 +24,7 @@ __all__ = ['ProgressBarLogger']
 
 _IS_TRAIN_TO_KEYS_TO_LOG = {
     True: ['loss/train'],
-    False: [
-        'metrics/eval/Accuracy',
-        'metrics/eval/BinaryAccuracy',
-        'metrics/eval/MulticlassAccuracy',
-        'metrics/eval/MultilabelAccuracy',
-    ],
+    False: ['eval'],
 }
 
 

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -292,7 +292,7 @@ class WandBLogger(LoggerDestination):
                 raise FileNotFoundError(f'WandB Artifact {new_remote_file_name} not found') from e
             raise e
         with tempfile.TemporaryDirectory() as tmpdir:
-            wandb_artifact_folder = os.path.join(tmpdir, 'wandb_artifact_folder')
+            wandb_artifact_folder = os.path.join(tmpdir, 'wandb_artifact_folder/')
             wandb_artifact.download(root=wandb_artifact_folder)
             wandb_artifact_names = os.listdir(wandb_artifact_folder)
             # We only log one file per artifact

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -140,6 +140,122 @@ class HuggingFaceModel(ComposerModel):
         self.dummy_forward_called = False
 
     @staticmethod
+    def load_huggingface_tokenizer_from_saved_state(
+            hf_state: Dict[str, Any]) -> Optional[transformers.PreTrainedTokenizer]:
+        """A helper function that loads a HuggingFace tokenizer from a loaded in hf state.
+
+        Args:
+            hf_state (Dict[str, Any]): HF state loaded from a Composer checkpoint.
+
+        Returns:
+            Optional[transformers.PreTrainedTokenizer]: The loaded HuggingFace tokenizer
+        """
+        try:
+            import transformers
+        except ImportError as e:
+            raise MissingConditionalImportError(extra_deps_group='nlp',
+                                                conda_package='transformers',
+                                                conda_channel='conda-forge') from e
+        hf_tokenizer = None
+        hf_tokenizer_state = hf_state['tokenizer']
+        if hf_tokenizer_state != {}:
+            with tempfile.TemporaryDirectory() as _tmp_dir:
+                for filename, saved_content in hf_tokenizer_state.items():
+                    tokenizer_file_path = Path(_tmp_dir) / f'{filename}{saved_content["file_extension"]}'
+                    if saved_content['file_extension'] == '.json':
+                        with open(tokenizer_file_path, 'w') as _tmp_file:
+                            json.dump(saved_content['content'], _tmp_file)
+                    elif saved_content['file_extension'] == '.txt':
+                        with open(tokenizer_file_path, 'w') as _tmp_file:
+                            for line in saved_content['content']:
+                                _tmp_file.write(line)
+                                _tmp_file.write('\n')
+                    elif saved_content['file_extension'] == '.model':
+                        try:
+                            import sentencepiece as spm
+                        except ImportError as e:
+                            raise MissingConditionalImportError(extra_deps_group='sentencepiece',
+                                                                conda_package='sentencepiece') from e
+                        s = spm.SentencePieceProcessor()
+                        s.load_from_serialized_proto(saved_content['content'])
+                        with open(tokenizer_file_path, 'wb') as _tmp_file:
+                            _tmp_file.write(s.serialized_model_proto())
+                hf_tokenizer = transformers.AutoTokenizer.from_pretrained(_tmp_dir, trust_remote_code=True)
+
+                # we need to set the name_or_path back because otherwise it is the tmp dir we are loading from here
+                hf_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content'].get('name_or_path', '')
+                hf_tokenizer.init_kwargs['name_or_path'] = hf_tokenizer.name_or_path
+
+                # for an unknown reason this key is missing when loading the saved tokenizer, but present with a value of None
+                # for the original tokenizer, so we default it to None
+                hf_tokenizer.init_kwargs['tokenizer_file'] = hf_tokenizer.init_kwargs.get('tokenizer_file', None)
+        return hf_tokenizer
+
+    @staticmethod
+    def load_huggingface_model_from_saved_state(
+            hf_state: Dict[str, Any], loaded_state_dict: Dict[str, Dict[str, Dict[str, Dict[str, Any]]]],
+            model_instantiation_class: type | str | None,
+            model_config_kwargs: Dict[str, Any] | None) -> transformers.PreTrainedModel:
+        """A helper function that loads a HuggingFace model class from a loaded in hf state.
+
+        Args:
+            hf_state (Dict[str, Any]): HF state loaded from a Composer checkpoint.
+            model_instantiation_class (Union[Type[:class:`transformers.PreTrainedModel`], Type[:class:`transformers.AutoModel`], str]), optional):
+                Class to use to create the HuggingFace model. Defaults to the model class used in the original checkpoint. If this argument is
+                a HuggingFace auto class (e.g. :class:`transformers.AutoModel` or :class:`transformers.AutoModelForSequenceClassification`), the ``from_config`` method will be used,
+                while if it is of type :class:`transformers.PreTrainedModel`, the constructor will be called. This argument can also be a string,
+                which will attempt to be imported as the class to use.
+            model_config_kwargs: Dict[str, Any]: Extra arguments to pass in for the model config creation (e.g. ``num_labels`` for creating a sequence classification model)
+        Returns:
+            transformers.PreTrainedModel: The loaded HuggingFace model
+        """
+        try:
+            import transformers
+        except ImportError as e:
+            raise MissingConditionalImportError(extra_deps_group='nlp',
+                                                conda_package='transformers',
+                                                conda_channel='conda-forge') from e
+        loaded_config = get_hf_config_from_composer_state_dict(loaded_state_dict, config_overrides=model_config_kwargs)
+
+        hf_model_state = hf_state['model']
+        if model_instantiation_class is not None:
+            # If the instantiation class is explicitly provided, use it
+            # If a string is provided, attempt to import the class it refers to
+            if isinstance(model_instantiation_class, str):
+                try:
+                    model_instantiation_class = import_object(':'.join(model_instantiation_class.rsplit('.',
+                                                                                                        maxsplit=1)))
+                except (ModuleNotFoundError, AttributeError):
+                    raise ValueError(
+                        textwrap.dedent(
+                            f'The provided model_instantiation_class string {model_instantiation_class} could not be imported. '
+                            f'Please make sure {model_instantiation_class} is discoverable on the python path, or pass the class '
+                            'in directly.'))
+
+            assert model_instantiation_class is not None  # pyright
+            # The AutoModel* classes have `from_config`, while the PreTrainedModel classes do not
+            # pyright can't tell this isn't a string at this point
+            if issubclass(
+                    model_instantiation_class,  # type: ignore
+                    transformers.models.auto.auto_factory._BaseAutoModelClass):
+                hf_model = model_instantiation_class.from_config(loaded_config)  # type: ignore
+            else:
+                hf_model = model_instantiation_class(loaded_config)  # type: ignore
+        else:
+            # If the instantiation class is not explicitly provided, attempt to import the saved class and use it
+            try:
+                saved_class = import_object(':'.join(hf_model_state['config']['class'].rsplit('.', maxsplit=1)))
+            except (ModuleNotFoundError, AttributeError):
+                raise ValueError(
+                    textwrap.dedent(
+                        f'The saved class {hf_model_state["config"]["class"]} could not be imported. '
+                        'Please either pass in the class to use explicitly via the model_instantiation_class '
+                        f'parameter, or make sure that {hf_model_state["config"]["class"]} is discoverable '
+                        'on the python path.'))
+            hf_model = saved_class(loaded_config)
+        return hf_model
+
+    @staticmethod
     def hf_from_composer_checkpoint(
         checkpoint_path: str,
         model_instantiation_class: Optional[Union[Type[transformers.PreTrainedModel], Type['_BaseAutoModelClass'],
@@ -211,12 +327,6 @@ class HuggingFaceModel(ComposerModel):
         Returns:
             Tuple[transformers.PreTrainedModel, Optional[transformers.PreTrainedTokenizer]]: The loaded HuggingFace model and (if present) tokenizer
         """
-        try:
-            import transformers
-        except ImportError as e:
-            raise MissingConditionalImportError(extra_deps_group='nlp',
-                                                conda_package='transformers',
-                                                conda_channel='conda-forge') from e
 
         # default local path to a tempfile if path is not provided
         if local_checkpoint_save_location is None:
@@ -233,82 +343,10 @@ class HuggingFaceModel(ComposerModel):
         loaded_state_dict = safe_torch_load(local_checkpoint_save_location)
 
         hf_state = loaded_state_dict['state']['integrations']['huggingface']
-        hf_model_state = hf_state['model']
-        hf_tokenizer_state = hf_state['tokenizer']
-
-        loaded_config = get_hf_config_from_composer_state_dict(loaded_state_dict, config_overrides=model_config_kwargs)
-
-        if model_instantiation_class is not None:
-            # If the instantiation class is explicitly provided, use it
-            # If a string is provided, attempt to import the class it refers to
-            if isinstance(model_instantiation_class, str):
-                try:
-                    model_instantiation_class = import_object(':'.join(model_instantiation_class.rsplit('.',
-                                                                                                        maxsplit=1)))
-                except (ModuleNotFoundError, AttributeError):
-                    raise ValueError(
-                        textwrap.dedent(
-                            f'The provided model_instantiation_class string {model_instantiation_class} could not be imported. '
-                            f'Please make sure {model_instantiation_class} is discoverable on the python path, or pass the class '
-                            'in directly.'))
-
-            assert model_instantiation_class is not None  # pyright
-            # The AutoModel* classes have `from_config`, while the PreTrainedModel classes do not
-            # pyright can't tell this isn't a string at this point
-            if issubclass(
-                    model_instantiation_class,  # type: ignore
-                    transformers.models.auto.auto_factory._BaseAutoModelClass):
-                hf_model = model_instantiation_class.from_config(loaded_config)  # type: ignore
-            else:
-                hf_model = model_instantiation_class(loaded_config)  # type: ignore
-        else:
-            # If the instantiation class is not explicitly provided, attempt to import the saved class and use it
-            try:
-                saved_class = import_object(':'.join(hf_model_state['config']['class'].rsplit('.', maxsplit=1)))
-            except (ModuleNotFoundError, AttributeError):
-                raise ValueError(
-                    textwrap.dedent(
-                        f'The saved class {hf_model_state["config"]["class"]} could not be imported. '
-                        'Please either pass in the class to use explicitly via the model_instantiation_class '
-                        f'parameter, or make sure that {hf_model_state["config"]["class"]} is discoverable '
-                        'on the python path.'))
-            hf_model = saved_class(loaded_config)
-
-        hf_tokenizer = None
-        if hf_tokenizer_state != {}:
-            with tempfile.TemporaryDirectory() as _tmp_dir:
-                for filename, saved_content in hf_tokenizer_state.items():
-                    tokenizer_file_path = Path(_tmp_dir) / f'{filename}{saved_content["file_extension"]}'
-                    if saved_content['file_extension'] == '.json':
-                        with open(tokenizer_file_path, 'w') as _tmp_file:
-                            json.dump(saved_content['content'], _tmp_file)
-                    elif saved_content['file_extension'] == '.txt':
-                        with open(tokenizer_file_path, 'w') as _tmp_file:
-                            for line in saved_content['content']:
-                                _tmp_file.write(line)
-                                _tmp_file.write('\n')
-                    elif saved_content['file_extension'] == '.py':
-                        with open(tokenizer_file_path, 'w') as _tmp_file:
-                            _tmp_file.write(saved_content['content'])
-                    elif saved_content['file_extension'] == '.model':
-                        try:
-                            import sentencepiece as spm
-                        except ImportError as e:
-                            raise MissingConditionalImportError(extra_deps_group='sentencepiece',
-                                                                conda_package='sentencepiece') from e
-                        s = spm.SentencePieceProcessor()
-                        s.load_from_serialized_proto(saved_content['content'])
-                        with open(tokenizer_file_path, 'wb') as _tmp_file:
-                            _tmp_file.write(s.serialized_model_proto())
-                hf_tokenizer = transformers.AutoTokenizer.from_pretrained(_tmp_dir, trust_remote_code=trust_remote_code)
-
-                # we need to set the name_or_path back because otherwise it is the tmp dir we are loading from here
-                hf_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content'].get('name_or_path', '')
-                hf_tokenizer.init_kwargs['name_or_path'] = hf_tokenizer.name_or_path
-
-                # for an unknown reason this key is missing when loading the saved tokenizer, but present with a value of None
-                # for the original tokenizer, so we default it to None
-                hf_tokenizer.init_kwargs['tokenizer_file'] = hf_tokenizer.init_kwargs.get('tokenizer_file', None)
+        hf_tokenizer = HuggingFaceModel.load_huggingface_tokenizer_from_saved_state(hf_state)
+        hf_model = HuggingFaceModel.load_huggingface_model_from_saved_state(hf_state, loaded_state_dict,
+                                                                            model_instantiation_class,
+                                                                            model_config_kwargs)
 
         return hf_model, hf_tokenizer
 
@@ -612,6 +650,12 @@ def write_huggingface_pretrained_from_composer_checkpoint(
     get_file(str(checkpoint_path), str(local_checkpoint_save_location))
 
     composer_state_dict = safe_torch_load(local_checkpoint_save_location)
+
+    # load tokenizer
+    hf_state = composer_state_dict['state']['integrations']['huggingface']
+    hf_tokenizer = HuggingFaceModel.load_huggingface_tokenizer_from_saved_state(hf_state)
+    assert hf_tokenizer is not None
+    hf_tokenizer.save_pretrained(output_folder)
 
     config = get_hf_config_from_composer_state_dict(composer_state_dict)
     config.save_pretrained(output_folder)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -479,12 +479,13 @@ class Trainer:
             Setting this to ``True`` will force schedulers to be stepped every batch,
             while ``False`` means schedulers stepped every epoch. ``None`` indicates the default behavior.
             (default: ``None``)
-        eval_dataloader (DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.DataLoader`,
-            :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
+        eval_dataloader (Iterable | DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): The :class:`.Iterable`,
+            :class:`.DataLoader`, :class:`.DataSpec`, :class:`.Evaluator`, or sequence of evaluators for the evaluation data.
 
             To evaluate one or more specific metrics across one or more datasets, pass in an
-            :class:`.Evaluator`. If a :class:`.DataSpec` or :class:`.DataLoader` is passed in, then all
-            metrics returned by ``model.get_metrics()`` will be used during evaluation.
+            :class:`.Evaluator`. If a :class:`.DataLoader`, :class:`.DataSpec`, or :class:`.Iterable` is passed in, then all
+            metrics returned by ``model.get_metrics()`` will be used during evaluation. If a :class:`.Evaluator`
+            is specified in a list, all eval dataloaders must be :class:`.Evaluator` instances.
             ``None`` results in no evaluation. (default: ``None``)
         eval_interval (int | str | Time | (State, Event) -> bool, optional): Specifies how frequently to run evaluation.
             An integer, which will be interpreted to be epochs, a str (e.g. ``1ep``, or ``10ba``), a :class:`.Time`
@@ -1155,10 +1156,16 @@ class Trainer:
         else:
             eval_metrics = deepcopy(self.state.model.get_metrics(is_train=False))
             model_metric_names = [str(k) for k in eval_metrics.keys()]
+            eval_dataloader = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
+                                 'all other classes with the Evaluator class. These are the classes'
+                                 'that were detected:' + str([type(evaluator) for evaluator in eval_dataloader]))
 
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=model_metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in eval_dataloader
             ]
             # match metric names to model metrics
             self.state.eval_metrics = {
@@ -1489,6 +1496,7 @@ class Trainer:
             signal_file_path = os.path.join(os.path.dirname(latest_checkpoint_path),
                                             '.local_rank0_completed_autoresume')
             if dist.get_local_rank() == 0:
+                os.makedirs(os.path.dirname(signal_file_path), exist_ok=True)
                 with open(signal_file_path, 'wb') as f:
                     f.write(b'local_rank0_completed_autoresume')
 
@@ -1726,10 +1734,16 @@ class Trainer:
             # could be DDP / DeepSpeed wrapped.
             eval_metrics = self._original_model.get_metrics(is_train=False)
             metric_names = [str(k) for k in eval_metrics.keys()]
+            eval_dataloader = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
+                                 'all other classes with the Evaluator class. These are the classes'
+                                 'that were detected:' + str([type(evaluator) for evaluator in eval_dataloader]))
 
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in eval_dataloader
             ]
 
             # match metric names to model metrics
@@ -2605,7 +2619,7 @@ class Trainer:
             drop duplicate samples.
 
         Args:
-            eval_dataloader (DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
+            eval_dataloader (Iterable | DataLoader | DataSpec | Evaluator | Sequence[Evaluator], optional): Dataloaders
                 for evaluation.  If not provided, defaults to using the
                 ``eval_dataloader`` provided to the trainer init().
             subset_num_batches (int, optional): Evaluate on this many batches. Default to ``-1`` (the entire
@@ -2617,9 +2631,16 @@ class Trainer:
             eval_metrics = deepcopy(self._original_model.get_metrics(is_train=False))
             metric_names = [str(k) for k in eval_metrics.keys()]
 
+            eval_dataloader = ensure_tuple(eval_dataloader)
+
+            evaluator_types = [isinstance(evaluator, Evaluator) for evaluator in eval_dataloader]
+            if any(evaluator_types) and not all(evaluator_types):
+                raise ValueError('Mixing Evaluator with other classes is not allowed, please wrap'
+                                 'all other classes with the Evaluator class. These are the classes'
+                                 'that were detected:' + str([type(evaluator) for evaluator in eval_dataloader]))
+
             evaluators = [
-                ensure_evaluator(evaluator, default_metric_names=metric_names)
-                for evaluator in ensure_tuple(eval_dataloader)
+                ensure_evaluator(evaluator, default_metric_names=metric_names) for evaluator in eval_dataloader
             ]
 
             if self.state.eval_metrics:
@@ -2955,6 +2976,21 @@ class Trainer:
             filename=name,
             weights_only=weights_only,
         )
+
+    def save_checkpoint_to_save_folder(self):
+        """Checkpoints the training :class:`~.State` using a CheckpointSaver if it exists.
+
+        Raises:
+            ValueError: If ``_checkpoint_saver`` does not exist.
+
+        Returns:
+            None
+        """
+        if self._checkpoint_saver is None:
+            raise ValueError(
+                'In order to use save_checkpoint_to_save_folder you must pass a save_folder to the Trainer.')
+        else:
+            self._checkpoint_saver._save_checkpoint(self.state, self.logger)
 
     def export_for_inference(
         self,

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -415,13 +415,11 @@ def maybe_create_remote_uploader_downloader_from_uri(
                                   's3 or one of the supported RemoteUploaderDownloader object stores')
 
 
-def get_file(
-    path: str,
-    destination: str,
-    object_store: Optional[Union[ObjectStore, LoggerDestination]] = None,
-    overwrite: bool = False,
-    progress_bar: bool = True,
-):
+def get_file(path: str,
+             destination: str,
+             object_store: Optional[Union[ObjectStore, LoggerDestination]] = None,
+             overwrite: bool = False,
+             progress_bar: bool = True):
     """Get a file from a local folder, URL, or object store.
 
     Args:
@@ -481,13 +479,11 @@ def get_file(
                 log.debug(f'Read path {real_path} from symlink file.')
 
         # Recurse
-        return get_file(
-            path=real_path,
-            destination=destination,
-            object_store=object_store,
-            overwrite=overwrite,
-            progress_bar=progress_bar,
-        )
+        return get_file(path=real_path,
+                        destination=destination,
+                        object_store=object_store,
+                        overwrite=overwrite,
+                        progress_bar=progress_bar)
 
     try:
         _get_file(
@@ -501,13 +497,11 @@ def get_file(
         new_path = path + '.symlink'
         try:
             # Follow the symlink
-            return get_file(
-                path=new_path,
-                destination=destination,
-                object_store=object_store,
-                overwrite=overwrite,
-                progress_bar=progress_bar,
-            )
+            return get_file(path=new_path,
+                            destination=destination,
+                            object_store=object_store,
+                            overwrite=overwrite,
+                            progress_bar=progress_bar)
         except FileNotFoundError as ee:
             # Raise the original not found error first, which contains the path to the user-specified file
             raise e from ee

--- a/composer/utils/object_store/libcloud_object_store.py
+++ b/composer/utils/object_store/libcloud_object_store.py
@@ -170,6 +170,9 @@ class LibcloudObjectStore(ObjectStore):
             # If the file already exits, short-circuit and skip the download
             raise FileExistsError(f'filename {filename} exists and overwrite was set to False.')
 
+        dirname = os.path.dirname(filename)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
         obj = self._get_object(object_name)
         # Download first to a tempfile, and then rename, in case if the file gets corrupted in transit
         tmp_filepath = str(filename) + f'.{uuid.uuid4()}.tmp'

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -126,6 +126,10 @@ class OCIObjectStore(ObjectStore):
         del callback
         if os.path.exists(filename) and not overwrite:
             raise FileExistsError(f'The file at {filename} already exists and overwrite is set to False')
+
+        dirname = os.path.dirname(filename)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
         tmp_path = str(filename) + f'.{uuid.uuid4()}.tmp'
 
         try:

--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -145,7 +145,12 @@ class S3ObjectStore(ObjectStore):
     ):
         if os.path.exists(filename) and not overwrite:
             raise FileExistsError(f'The file at {filename} already exists and overwrite is set to False.')
+
+        dirname = os.path.dirname(filename)
+        if dirname:
+            os.makedirs(dirname, exist_ok=True)
         tmp_path = str(filename) + f'.{uuid.uuid4()}.tmp'
+
         if callback is None:
             cb_wrapper = None
         else:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -174,4 +174,4 @@ Composer is part of the broader Machine Learning community, and we welcome any c
 
 .. _Twitter: https://twitter.com/mosaicml
 .. _Email: mailto:community@mosaicml.com
-.. _Slack: https://join.slack.com/t/mosaicml-community/shared_invite/zt-w0tiddn9-WGTlRpfjcO9J5jyrMub1dg
+.. _Slack: https://mosaicml.me/slack

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ extra_deps['dev'] = [
     'docutils==0.17.1',
     'sphinx_markdown_tables==0.0.17',
     'sphinx-argparse==0.4.0',
-    'sphinxcontrib.katex==0.9.4',
+    'sphinxcontrib.katex==0.9.5',
     'sphinxext.opengraph==0.8.2',
     'sphinxemoji==0.2.0',
     'furo==2022.9.29',
@@ -162,7 +162,7 @@ extra_deps['tensorboard'] = [
 ]
 
 extra_deps['unet'] = [
-    'monai>=0.9.1,<1.2',
+    'monai>=0.9.1,<1.3',
     'scikit-learn>=1.0.1,<2',
 ]
 
@@ -179,7 +179,7 @@ extra_deps['coco'] = [
 ]
 
 extra_deps['nlp'] = [
-    'transformers>=4.11,<4.30',
+    'transformers>=4.11,<4.31',
     'datasets>=2.4,<3',
 ]
 

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -12,6 +12,7 @@ from torch.utils.data import DataLoader
 from composer.loggers import MLFlowLogger
 from composer.trainer import Trainer
 from tests.common.datasets import RandomImageDataset
+from tests.common.markers import device
 from tests.common.models import SimpleConvModel
 
 
@@ -64,7 +65,8 @@ def test_mlflow_experiment_set_up_correctly(tmp_path):
     test_mlflow_logger.post_close()
 
 
-def test_mlflow_logging_works(tmp_path):
+@device('cpu')
+def test_mlflow_logging_works(tmp_path, device):
     mlflow = pytest.importorskip('mlflow')
     mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
     test_mlflow_logger = MLFlowLogger(tracking_uri=mlflow_uri)
@@ -79,7 +81,8 @@ def test_mlflow_logging_works(tmp_path):
                       train_dataloader=DataLoader(RandomImageDataset(size=dataset_size), batch_size),
                       eval_dataloader=DataLoader(RandomImageDataset(size=dataset_size), batch_size),
                       max_duration=f'{num_batches}ba',
-                      eval_interval=eval_interval)
+                      eval_interval=eval_interval,
+                      device=device)
     trainer.fit()
 
     run_info = mlflow.active_run().info

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -30,6 +30,26 @@ from tests.common.models import (configure_tiny_bert_model, configure_tiny_bert_
 from tests.loggers.test_remote_uploader_downloader import DummyObjectStore
 
 
+def test_hf_tokenizer_save(tmp_path: Path, tiny_bert_model, tiny_bert_tokenizer):
+    transformers = pytest.importorskip('transformers')
+
+    trainer = get_lm_trainer(tiny_bert_model, tiny_bert_tokenizer, str(tmp_path), is_conditional_generation=False)
+    trainer.save_checkpoint(str(tmp_path / 'composer-checkpoint.pt'))
+
+    _, composer_loaded_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint(
+        checkpoint_path=str(tmp_path / 'composer-checkpoint.pt'))
+
+    from composer.models import write_huggingface_pretrained_from_composer_checkpoint
+    write_huggingface_pretrained_from_composer_checkpoint(str(tmp_path / 'composer-checkpoint.pt'), str(tmp_path))
+
+    hf_loaded_tokenizer = transformers.AutoTokenizer.from_pretrained(str(tmp_path))
+
+    composer_tiny_bert = copy.deepcopy(tiny_bert_tokenizer)
+    hf_tiny_bert = copy.deepcopy(tiny_bert_tokenizer)
+    check_hf_tokenizer_equivalence(composer_tiny_bert, composer_loaded_tokenizer)
+    check_hf_tokenizer_equivalence(hf_tiny_bert, hf_loaded_tokenizer)
+
+
 @pytest.mark.parametrize('num_classes', [2, 3])
 def test_hf_train_eval_predict(num_classes: int, tiny_bert_config):
     transformers = pytest.importorskip('transformers')
@@ -145,7 +165,11 @@ def test_hf_train_eval_predict_regression(tiny_deberta_config):
 
 
 def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
-    """This is a best effort attempt to compare two tokenizers for equivalence
+    """
+    WARNING: Parameters are updated within the check so don't call check_hf_tokenizer_equivalence on the same
+    params more than once
+
+    This is a best effort attempt to compare two tokenizers for equivalence
 
     This is not a perfect test, but it should catch most issues. We first check that the vocab is identical
     and that a string is tokenized the same one. Then we compare the __dict__ of the tokenizers, but we remove

--- a/tests/trainer/test_trainer_eval.py
+++ b/tests/trainer/test_trainer_eval.py
@@ -641,3 +641,16 @@ def test_evaluator_metric_names_string_errors(metric_names):
         ValueError, match='should be a list of strings')
     with context:
         _ = Evaluator(label='evaluator', dataloader=eval_dataloader, metric_names=metric_names)
+
+
+# Test that trainer throws a value error if the eval is passed a mixed list of evaluators/dataloaders
+def test_evaluator_dataloader_value_error():
+    eval_dataset = RandomClassificationDataset(size=8)
+    eval_data1 = DataLoader(eval_dataset, batch_size=4, sampler=dist.get_sampler(eval_dataset))
+    eval_data2 = Evaluator(label='eval', dataloader=eval_data1, metric_names=['MulticlassAccuracy'])
+
+    eval_dataloader = (eval_data1, eval_data2)
+    with pytest.raises(ValueError,
+                       match='Mixing Evaluator with other classes is not allowed, please wrap'
+                       'all other classes with the Evaluator class.') as _:
+        _ = Trainer(model=SimpleModel(), train_dataloader=None, eval_dataloader=eval_dataloader, max_duration='1ep')


### PR DESCRIPTION
# What does this PR do?

This PR fixes several logger tests. test_mlflow_logging_works will use cpu when both cpu and gpu are available. test_wandb_artifacts is reenabled for offline mode and mocks the wandb artifact.

# What issue(s) does this change relate to?

[CO-1021](https://mosaicml.atlassian.net/browse/CO-1021)


[CO-1021]: https://mosaicml.atlassian.net/browse/CO-1021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ