### PR TITLE
Update local rank 0 to be elastic

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -245,7 +245,7 @@ def load_checkpoint(
 
 def _get_local_rank_zero_path(path: Optional[str]) -> str:
     """Broadcasts the ``path`` from the LOCAL rank zero to all LOCAL ranks."""
-    local_rank_zero = dist.get_local_world_size() * dist.get_node_rank()
+    local_rank_zero = dist.get_global_rank() - dist.get_local_rank()
     paths = dist.all_gather_object(path)
     local_rank_zero_path = paths[local_rank_zero]
     assert local_rank_zero_path is not None, 'local rank zero provides the path'


### PR DESCRIPTION
# What does this PR do?

Compute local ranks from global - local instead of using local world size. This lets us do different nodes with variable sizes

We're not going to test full elastic since it's not a priority. Just patching the obvious bugs for now.

# What issue(s) does this change relate to?

[CO-2151](https://mosaicml.atlassian.net/browse/CO-2151)

[CO-2151]: https://mosaicml.atlassian.net/browse/CO-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ