### PR TITLE
Add secrets check as part of pre-commit

### DIFF
--- a/.github/secrets/exclude.yaml
+++ b/.github/secrets/exclude.yaml
@@ -1,0 +1,2 @@
+.git/.*
+docs/source/_static/js/posthog.js

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,7 +108,6 @@ repos:
     hooks:
       - id: trufflehog
         name: secret scan
-        language: system
         entry: trufflehog filesystem ./
         args:
           - --only-verified

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,5 +103,16 @@ repos:
         pass_filenames: false
         args: [--warnings]
         additional_dependencies: ["pyright@1.1.256"]
+  - repo: https://github.com/trufflesecurity/trufflehog.git
+    rev: v3.40.0
+    hooks:
+      - id: trufflehog
+        name: secret scan
+        language: system
+        entry: trufflehog filesystem ./
+        args:
+          - --only-verified
+          - --fail
+          - --exclude-paths=./.github/secrets/exclude.yaml
 
 exclude: .ci\/release_tests\/.*


### PR DESCRIPTION
# What does this PR do?
- Add secrets check as part of pre-commit.
- The `pre-commit run` command would fail if there is a verified secret leak. 

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?
CO-2201

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
