### PR TITLE
Runtime estimator eval fix

### DIFF
--- a/composer/callbacks/runtime_estimator.py
+++ b/composer/callbacks/runtime_estimator.py
@@ -4,12 +4,15 @@
 """Estimate total time of training."""
 from __future__ import annotations
 
+import logging
 import time
 import warnings
 from typing import Dict, List, Optional
 
 from composer.core import Callback, State, TimeUnit
 from composer.loggers import Logger
+
+log = logging.getLogger(__name__)
 
 __all__ = ['RuntimeEstimator']
 
@@ -125,6 +128,9 @@ class RuntimeEstimator(Callback):
             elapsed_time -= self.total_eval_wct  # Subtract time spent evaluating
             rate = elapsed_time / (elapsed_dur - self.start_dur)
             remaining_time = rate * (1 - elapsed_dur)
+            log.info(
+                f'{elapsed_dur=}, Elapsed Time: {time.time() - self.start_time}, {elapsed_time=}, {rate=}, {remaining_time=}'
+            )
 
             # Add remaining time from each evaluator using known frequencies. We explicitly compute
             # frequency instead of using time interpolation to avoid saw tooth pattern in estimates
@@ -140,6 +146,9 @@ class RuntimeEstimator(Callback):
                 num_total_evals = 1 / eval_rate * (1 - self.start_dur)
                 remaining_calls = num_total_evals - num_evals_finished
                 remaining_time += eval_wct_avg * remaining_calls
+                log.info(
+                    f'{dataloader_label=}, {eval_wct_avg=}, {eval_rate=}, {self.start_dur=}, {num_total_evals=}, {remaining_calls=}, {remaining_time=}'
+                )
 
             logger.log_metrics({'time/remaining_estimate': remaining_time / self.divider})
 

--- a/composer/callbacks/runtime_estimator.py
+++ b/composer/callbacks/runtime_estimator.py
@@ -132,9 +132,6 @@ class RuntimeEstimator(Callback):
             elapsed_time -= self.total_eval_wct  # Subtract time spent evaluating
             rate = elapsed_time / (elapsed_dur - self.start_dur)
             remaining_time = rate * (1 - elapsed_dur)
-            print(
-                f'\n{elapsed_dur=}, Elapsed Time: {time.time() - self.start_time}, {elapsed_time=}, {rate=}, {remaining_time=}'
-            )
 
             # Add remaining time from each evaluator using known frequencies. We explicitly compute
             # frequency instead of using time interpolation to avoid saw tooth pattern in estimates
@@ -150,9 +147,6 @@ class RuntimeEstimator(Callback):
                 num_total_evals = 1 / eval_rate * (1 - self.start_dur)
                 remaining_calls = num_total_evals - num_evals_finished
                 remaining_time += eval_wct_avg * remaining_calls
-                print(
-                    f'{dataloader_label=}, {eval_wct_avg=}, {eval_rate=}, {self.start_dur=}, {num_total_evals=}, {remaining_calls=}, {remaining_time=}'
-                )
 
             logger.log_metrics({'time/remaining_estimate': remaining_time / self.divider})
 
@@ -172,7 +166,4 @@ class RuntimeEstimator(Callback):
         assert self.start_dur is not None, 'start_dur is set on batch_start if enabled'
         elapsed_fraction = elapsed_dur - self.start_dur
         num_evals_finished = len(self.eval_wct_per_label[state.dataloader_label])
-        print(
-            f'{self.total_eval_wct=}, eval_timestamp={state.eval_timestamp.total_wct.total_seconds()}, {elapsed_dur=}, {elapsed_fraction=}, {num_evals_finished=}'
-        )
         self.eval_frequency_per_label[state.dataloader_label] = elapsed_fraction / num_evals_finished

--- a/composer/callbacks/runtime_estimator.py
+++ b/composer/callbacks/runtime_estimator.py
@@ -128,8 +128,8 @@ class RuntimeEstimator(Callback):
             elapsed_time -= self.total_eval_wct  # Subtract time spent evaluating
             rate = elapsed_time / (elapsed_dur - self.start_dur)
             remaining_time = rate * (1 - elapsed_dur)
-            log.info(
-                f'{elapsed_dur=}, Elapsed Time: {time.time() - self.start_time}, {elapsed_time=}, {rate=}, {remaining_time=}'
+            print(
+                f'\n{elapsed_dur=}, Elapsed Time: {time.time() - self.start_time}, {elapsed_time=}, {rate=}, {remaining_time=}'
             )
 
             # Add remaining time from each evaluator using known frequencies. We explicitly compute
@@ -146,7 +146,7 @@ class RuntimeEstimator(Callback):
                 num_total_evals = 1 / eval_rate * (1 - self.start_dur)
                 remaining_calls = num_total_evals - num_evals_finished
                 remaining_time += eval_wct_avg * remaining_calls
-                log.info(
+                print(
                     f'{dataloader_label=}, {eval_wct_avg=}, {eval_rate=}, {self.start_dur=}, {num_total_evals=}, {remaining_calls=}, {remaining_time=}'
                 )
 

--- a/composer/callbacks/runtime_estimator.py
+++ b/composer/callbacks/runtime_estimator.py
@@ -168,4 +168,7 @@ class RuntimeEstimator(Callback):
         assert self.start_dur is not None, 'start_dur is set on batch_start if enabled'
         elapsed_fraction = elapsed_dur - self.start_dur
         num_evals_finished = len(self.eval_wct_per_label[state.dataloader_label])
+        print(
+            f'{self.total_eval_wct=}, eval_timestamp={state.eval_timestamp.total_wct.total_seconds()}, {elapsed_dur=}, {elapsed_fraction=}, {num_evals_finished=}'
+        )
         self.eval_frequency_per_label[state.dataloader_label] = elapsed_fraction / num_evals_finished

--- a/tests/callbacks/test_runtime_estimator.py
+++ b/tests/callbacks/test_runtime_estimator.py
@@ -8,8 +8,8 @@ import pytest
 from torch.utils.data import DataLoader
 
 from composer.callbacks import RuntimeEstimator
-from composer.core import Time
-from composer.loggers import InMemoryLogger
+from composer.core import Callback, State, Time
+from composer.loggers import InMemoryLogger, Logger
 from composer.trainer import Trainer
 from tests.common import RandomClassificationDataset, SimpleModel
 
@@ -75,3 +75,45 @@ def test_runtime_estimator(time_unit: str):
     elif time_unit == 'days':
         assert ba_2_estimate < 1 / 60 / 60 / 24
         assert ba_2_estimate > 0.1 / 60 / 60 / 24
+
+
+class CheckEvalFrequency(Callback):
+
+    def __init__(self, runtime_estimator) -> None:
+        self.runtime_estimator = runtime_estimator
+
+    def batch_end(self, state: State, logger: Logger) -> None:
+        eval_frequency = self.runtime_estimator.eval_frequency_per_label
+        if eval_frequency is not None:
+            for rate in eval_frequency.values():
+                assert rate >= 0
+                assert rate <= 1
+
+
+def test_eval_rates():
+    # Construct the callbacks
+    runtime_estimator = RuntimeEstimator()
+    in_memory_logger = InMemoryLogger()  # track the logged metrics in the in_memory_logger
+
+    simple_model = SimpleModel()
+    original_fwd = simple_model.forward
+
+    def new_fwd(x):
+        time.sleep(0.02)
+        return original_fwd(x)
+
+    simple_model.forward = new_fwd  # type: ignore
+
+    # Construct the trainer and train
+    trainer = Trainer(
+        model=simple_model,
+        callbacks=[runtime_estimator, CheckEvalFrequency(runtime_estimator)],
+        loggers=in_memory_logger,
+        train_dataloader=DataLoader(RandomClassificationDataset()),
+        eval_dataloader=DataLoader(RandomClassificationDataset()),
+        max_duration='1ep',
+        eval_interval='5ba',
+        train_subset_num_batches=7,
+        eval_subset_num_batches=2,
+    )
+    trainer.fit()


### PR DESCRIPTION
# What does this PR do?

Previously, the runtime estimator used `state.dataloader.dataloader_len` when computing how often eval was run. This becomes inaccurate when an eval dataloader is swapped in, which caused incorrect computation for eval frequencies. This PR corrects the computation and adds a unit test which previously failed before this PR

# What issue(s) does this change relate to?

[CO-2170](https://mosaicml.atlassian.net/browse/CO-2170)

[CO-2170]: https://mosaicml.atlassian.net/browse/CO-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ