### PR TITLE
[fix] Remove wandb from the `ImageVisualizer`

### DIFF
--- a/composer/callbacks/image_visualizer.py
+++ b/composer/callbacks/image_visualizer.py
@@ -9,7 +9,6 @@ import torch
 from composer.core import Callback, State, Time, TimeUnit
 from composer.loggers import Logger
 from composer.loss.utils import infer_target_type
-from composer.utils import MissingConditionalImportError
 
 __all__ = ['ImageVisualizer']
 

--- a/composer/callbacks/image_visualizer.py
+++ b/composer/callbacks/image_visualizer.py
@@ -82,15 +82,6 @@ class ImageVisualizer(Callback):
         self.input_key = input_key
         self.target_key = target_key
 
-        # TODO(Evan): Generalize as part of the logger refactor
-        try:
-            import wandb
-        except ImportError as e:
-            raise MissingConditionalImportError(extra_deps_group='wandb',
-                                                conda_package='wandb',
-                                                conda_channel='conda-forge') from e
-        del wandb  # unused
-
         # Check that the output mode is valid
         if self.mode.lower() not in ['input', 'segmentation']:
             raise ValueError(f'Invalid mode: {mode}')


### PR DESCRIPTION
# What does this PR do?

The `ImageVisualizer` doesn't need `wanbd`. This is the responsibility of the logger.

We are trying to use a different logger and the  `ImageVisualizer` crashes because `wanbd` is not installed. 


# Before submitting
- [X] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?

