### PR TITLE
Add precision config arg for FP8

### DIFF
--- a/composer/algorithms/selective_backprop/selective_backprop.py
+++ b/composer/algorithms/selective_backprop/selective_backprop.py
@@ -279,7 +279,7 @@ class SelectiveBackprop(Algorithm):
             assert self._loss_fn is not None, 'loss_fn should be set on Event.INIT'
             return self._loss_fn(p, (torch.Tensor(), y), reduction=reduction)
 
-        with get_precision_context(state.precision):
+        with get_precision_context(state.precision, state.precision_config):
             new_input, new_target = select_using_loss(input, target, model, loss, self.keep, self.scale_factor)
         state.batch_set_item(self.input_key, new_input)
         state.batch_set_item(self.target_key, new_target)

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -287,7 +287,7 @@ class SeqLengthWarmup(Algorithm):
             try:
                 # Start by running a forward and backward pass
                 # of the maximum sequence length to allocate cache.
-                with get_precision_context(state.precision):
+                with get_precision_context(state.precision, state.precision_config):
                     outputs = state.model.forward(model_inputs)
                     loss = self._original_model.loss(outputs, model_inputs)
 

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -6,7 +6,7 @@
 import contextlib
 import os
 import textwrap
-from typing import Generator, Union, Dict, Any
+from typing import Any, Dict, Generator, Union
 
 import torch
 

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -44,7 +44,8 @@ def get_precision_context(precision: Union[str, Precision],
 
     Args:
         precision (str | Precision): Precision for the context
-        precision_config (Dict[str, Any]): Config for FP8 scaling strategy. See parameters for `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
+        precision_config (Dict[str, Any]): Config for FP8 scaling strategy. See parameters for
+            `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
     """
     precision = Precision(precision)
     if precision == Precision.FP32:

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -44,7 +44,7 @@ def get_precision_context(precision: Union[str, Precision],
 
     Args:
         precision (str | Precision): Precision for the context
-        precision_config (Dict[str, Any]): Config for FP8 scaling strategy. See parameters for
+        precision_config (Optional[Dict[str, Any]]): Config for FP8 scaling strategy. See parameters for
             `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
     """
     precision = Precision(precision)

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -68,12 +68,10 @@ def get_precision_context(precision: Union[str, Precision],
             yield
     elif precision == Precision.AMP_FP8:
         if te_installed and torch.cuda.get_device_capability()[0] > 8:
-            from transformer_engine.common.recipe import DelayedScaling, Format
+            from transformer_engine.common.recipe import DelayedScaling
 
             if precision_config is None:
                 precision_config = {}
-            if 'fp8_format' in precision_config and isinstance(precision_config['fp8_format'], str):
-                precision_config['fp8_format'] = Format[precision_config['fp8_format']]
             fp8_recipe = DelayedScaling(**precision_config)
             with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
                 yield

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -6,7 +6,7 @@
 import contextlib
 import os
 import textwrap
-from typing import Any, Dict, Generator, Union
+from typing import Any, Dict, Generator, Optional, Union
 
 import torch
 

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -70,7 +70,7 @@ def get_precision_context(precision: Union[str, Precision], precision_config: Op
 
             if precision_config is None:
                 precision_config = {}
-            if isinstance(precision_config['fp8_format'], str):
+            if 'fp8_format' in precision_config and isinstance(precision_config['fp8_format'], str):
                 precision_config['fp8_format'] = Format[precision_config['fp8_format']]
             fp8_recipe = DelayedScaling(**precision_config)
             with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -38,7 +38,7 @@ class Precision(StringEnum):
 
 
 @contextlib.contextmanager
-def get_precision_context(precision: Union[str, Precision], precision_config: Dict[str, Any]) -> Generator[None, None, None]:
+def get_precision_context(precision: Union[str, Precision], precision_config: Optional[Dict[str, Any]] = None) -> Generator[None, None, None]:
     """Returns a context manager to automatically cast to a specific precision.
 
     Args:
@@ -68,6 +68,8 @@ def get_precision_context(precision: Union[str, Precision], precision_config: Di
         if te_installed and torch.cuda.get_device_capability()[0] > 8:
             from transformer_engine.common.recipe import DelayedScaling, Format
 
+            if precision_config is None:
+                precision_config = {}
             if isinstance(precision_config['fp8_format'], str):
                 precision_config['fp8_format'] = Format[precision_config['fp8_format']]
             fp8_recipe = DelayedScaling(**precision_config)

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -38,7 +38,8 @@ class Precision(StringEnum):
 
 
 @contextlib.contextmanager
-def get_precision_context(precision: Union[str, Precision], precision_config: Optional[Dict[str, Any]] = None) -> Generator[None, None, None]:
+def get_precision_context(precision: Union[str, Precision],
+                          precision_config: Optional[Dict[str, Any]] = None) -> Generator[None, None, None]:
     """Returns a context manager to automatically cast to a specific precision.
 
     Args:

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -43,6 +43,7 @@ def get_precision_context(precision: Union[str, Precision], precision_config: Di
 
     Args:
         precision (str | Precision): Precision for the context
+        precision_config (Dict[str, Any]): Config for FP8 scaling strategy. See parameters for `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
     """
     precision = Precision(precision)
     if precision == Precision.FP32:

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -68,10 +68,14 @@ def get_precision_context(precision: Union[str, Precision],
             yield
     elif precision == Precision.AMP_FP8:
         if te_installed and torch.cuda.get_device_capability()[0] > 8:
-            from transformer_engine.common.recipe import DelayedScaling
+            from transformer_engine.common.recipe import DelayedScaling, Format
 
             if precision_config is None:
-                precision_config = {}
+                precision_config = {
+                    'fp8_format': Format.HYBRID,
+                    'amax_history_len': 16,
+                    'amax_compute_algo': 'max',
+                }
             fp8_recipe = DelayedScaling(**precision_config)
             with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
                 yield

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -435,7 +435,7 @@ class State(Serializable):
 
         # precision
         precision: Union[str, Precision] = Precision.FP32,
-        precision_config: Dict[str, Any] = {},
+        precision_config: Optional[Dict[str, Any]] = None,
 
         # optimizers
         optimizers: Optional[Union[Optimizer, Sequence[Optimizer]]] = None,
@@ -475,6 +475,9 @@ class State(Serializable):
         self.eval_timestamp = Timestamp()
         self.predict_timestamp = Timestamp()
         self._precision = Precision(precision)
+
+        if precision_config is None:
+            precision_config = {}
         self._precision_config = precision_config
 
         if optimizers is None:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -1420,7 +1420,8 @@ class State(Serializable):
     def precision_config(self):
         """The config for FP8 scaling strategy.
 
-        See parameters for `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_."""
+        See parameters for `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
+        """
         return self._precision_config
 
     @property

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -433,6 +433,7 @@ class State(Serializable):
 
         # precision
         precision: Union[str, Precision] = Precision.FP32,
+        precision_config: Dict[str, Any] = {},
 
         # optimizers
         optimizers: Optional[Union[Optimizer, Sequence[Optimizer]]] = None,
@@ -472,6 +473,7 @@ class State(Serializable):
         self.eval_timestamp = Timestamp()
         self.predict_timestamp = Timestamp()
         self._precision = Precision(precision)
+        self._precision_config = precision_config
 
         if optimizers is None:
             self._optimizers = []
@@ -1408,6 +1410,10 @@ class State(Serializable):
     @precision.setter
     def precision(self, precision: Union[str, Precision]):
         self._precision = Precision(precision)
+
+    @property
+    def precision_config(self):
+        return self._precision_config
 
     @property
     def is_model_ddp(self):

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -475,9 +475,6 @@ class State(Serializable):
         self.eval_timestamp = Timestamp()
         self.predict_timestamp = Timestamp()
         self._precision = Precision(precision)
-
-        if precision_config is None:
-            precision_config = {}
         self._precision_config = precision_config
 
         if optimizers is None:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -274,7 +274,7 @@ class State(Serializable):
         max_duration (str | Time, optional): The maximum duration to train for. (default: ``None``)
         precision (str | Precision): The numerical precision to use for training. See :class:`~.Precision` for
             the supported precisions.
-        precision_config (Dict[str, Any]): The config for FP8 scaling strategy. See parameters for
+        precision_config (Optional[Dict[str, Any]]): The config for FP8 scaling strategy. See parameters for
             `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
         optimizers (torch.optim.Optimizer | Sequence[torch.optim.Optimizer], optional): The optimizer being used to
             train the model. Multiple optimizers are not currently supported.

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -50,14 +50,14 @@ def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str =
     """Context manager for materializing or loading an fsdp module's state dict.
 
     Args:
-        module (torch.nn.Module): The torch module that you want to call ``state_dict()``
-            or ``load_state_dict()`` on.
+        module (torch.nn.Module): The torch module that you want to call `state_dict()`
+            or `load_state_dict()` on.
         state_dict_type (str, optional): which of the three state dict types you want to use.
-            choices are ``['full', 'sharded', 'local']``. Defaults to ``'full'``.
-            * ``'full'``: the full, unsharded state dict materialized only on rank 0 with cpu_offload if necessary
-            * ``'local'``: the sharded, flattened state_dict, where each rank only gets a single shard.
-            * ``'sharded'``: the sharded, unflattened state_dict, where each rank only gets a single shard.
-            See ``torch.distributed.fsdp.StateDictType`` for more info.
+            choices are ['full', 'sharded', 'local']. Defaults to 'full'.
+            * 'full': the full, unsharded state dict materialized only on rank 0 with cpu_offload if necessary
+            * 'local': the sharded, flattened state_dict, where each rank only gets a single shard.
+            * 'sharded': the sharded, unflattened state_dict, where each rank only gets a single shard.
+            See torch.distributed.fsdp.StateDictType for more info.
 
     Raises:
         RuntimeError: if your torch version is earlier than 1.13.0 because FSDP is not available for those versions.

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -274,6 +274,8 @@ class State(Serializable):
         max_duration (str | Time, optional): The maximum duration to train for. (default: ``None``)
         precision (str | Precision): The numerical precision to use for training. See :class:`~.Precision` for
             the supported precisions.
+        precision_config (Dict[str, Any]): The config for FP8 scaling strategy. See parameters for
+        `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
         optimizers (torch.optim.Optimizer | Sequence[torch.optim.Optimizer], optional): The optimizer being used to
             train the model. Multiple optimizers are not currently supported.
         schedulers (types.PyTorchScheduler | Sequence[types.PyTorchScheduler], optional):
@@ -1413,6 +1415,9 @@ class State(Serializable):
 
     @property
     def precision_config(self):
+        """The config for FP8 scaling strategy.
+
+        See parameters for `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_."""
         return self._precision_config
 
     @property

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -50,14 +50,14 @@ def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str =
     """Context manager for materializing or loading an fsdp module's state dict.
 
     Args:
-        module (torch.nn.Module): The torch module that you want to call `state_dict()`
-            or `load_state_dict()` on.
+        module (torch.nn.Module): The torch module that you want to call ``state_dict()``
+            or ``load_state_dict()`` on.
         state_dict_type (str, optional): which of the three state dict types you want to use.
-            choices are ['full', 'sharded', 'local']. Defaults to 'full'.
-            * 'full': the full, unsharded state dict materialized only on rank 0 with cpu_offload if necessary
-            * 'local': the sharded, flattened state_dict, where each rank only gets a single shard.
-            * 'sharded': the sharded, unflattened state_dict, where each rank only gets a single shard.
-            See torch.distributed.fsdp.StateDictType for more info.
+            choices are ``['full', 'sharded', 'local']``. Defaults to ``'full'``.
+            * ``'full'``: the full, unsharded state dict materialized only on rank 0 with cpu_offload if necessary
+            * ``'local'``: the sharded, flattened state_dict, where each rank only gets a single shard.
+            * ``'sharded'``: the sharded, unflattened state_dict, where each rank only gets a single shard.
+            See ``torch.distributed.fsdp.StateDictType`` for more info.
 
     Raises:
         RuntimeError: if your torch version is earlier than 1.13.0 because FSDP is not available for those versions.
@@ -275,7 +275,7 @@ class State(Serializable):
         precision (str | Precision): The numerical precision to use for training. See :class:`~.Precision` for
             the supported precisions.
         precision_config (Dict[str, Any]): The config for FP8 scaling strategy. See parameters for
-        `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
+            `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
         optimizers (torch.optim.Optimizer | Sequence[torch.optim.Optimizer], optional): The optimizer being used to
             train the model. Multiple optimizers are not currently supported.
         schedulers (types.PyTorchScheduler | Sequence[types.PyTorchScheduler], optional):

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -307,7 +307,7 @@ def _get_ddp_sync_strategy(ddp_sync_strategy: Optional[Union[str, DDPSyncStrateg
     return ddp_sync_strategy
 
 
-def _get_precision_context(precision: Precision, precision_config: Dict[str, Any], deepspeed_enabled: bool):
+def _get_precision_context(precision: Precision, precision_config: Optional[Dict[str, Any]], deepspeed_enabled: bool):
     if deepspeed_enabled:
         return contextlib.nullcontext()
     return get_precision_context(precision, precision_config)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -918,8 +918,6 @@ class Trainer:
         elif isinstance(precision, str):
             precision = Precision(precision)
         _validate_precision(precision, device)
-        if precision_config is None:
-            precision_config = {}
 
         # check if provided model is compiled or not
         is_torch_2_0 = using_torch_2()

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -741,6 +741,8 @@ class Trainer:
         precision (Precision | str, optional): Numerical precision to use for training. One of ``fp32``, ``amp_bf16``
             or ``amp_fp16`` (recommended). (default: ``Precision.FP32`` if training on CPU; ``Precision.AMP_FP16`` if
             training on GPU)
+        precision_config (Dict[str, Any]): The config for FP8 scaling strategy. See parameters for
+        `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
         device_train_microbatch_size (Union[int, str), optional): The number of samples to process on each device per
             microbatch during training. Gradients are summed over the microbatches per device. If set to ``auto``,
             dynamically decreases device_train_microbatch_size if microbatch is too large for GPU. (default: ``None``)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -741,7 +741,7 @@ class Trainer:
         precision (Precision | str, optional): Numerical precision to use for training. One of ``fp32``, ``amp_bf16``
             or ``amp_fp16`` (recommended). (default: ``Precision.FP32`` if training on CPU; ``Precision.AMP_FP16`` if
             training on GPU)
-        precision_config (Dict[str, Any]): The config for FP8 scaling strategy. See parameters for
+        precision_config (Optional[Dict[str, Any]]): The config for FP8 scaling strategy. See parameters for
             `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
         device_train_microbatch_size (Union[int, str), optional): The number of samples to process on each device per
             microbatch during training. Gradients are summed over the microbatches per device. If set to ``auto``,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -742,7 +742,7 @@ class Trainer:
             or ``amp_fp16`` (recommended). (default: ``Precision.FP32`` if training on CPU; ``Precision.AMP_FP16`` if
             training on GPU)
         precision_config (Dict[str, Any]): The config for FP8 scaling strategy. See parameters for
-        `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
+            `DelayedScaling <https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling>`_.
         device_train_microbatch_size (Union[int, str), optional): The number of samples to process on each device per
             microbatch during training. Gradients are summed over the microbatches per device. If set to ``auto``,
             dynamically decreases device_train_microbatch_size if microbatch is too large for GPU. (default: ``None``)

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -125,4 +125,3 @@ def test_amp_fp8_config():
             fp8_recipe = te.get_fp8_recipe()
             for k, v in precision_config.items():
                 assert getattr(fp8_recipe, k) == v
-

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -122,6 +122,6 @@ def test_amp_fp8_config():
         }
         trainer = get_trainer(Precision.AMP_FP8, precision_config=precision_config)
         with get_precision_context(trainer.state.precision, trainer.state.precision_config):
-            fp8_recipe = te.get_fp8_recipe()
+            fp8_recipe = te.fp8.get_fp8_recipe()
             for k, v in precision_config.items():
                 assert getattr(fp8_recipe, k) == v

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,5 +1,6 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
+from typing import Any, Dict, Optional
 
 import pytest
 import torch
@@ -7,19 +8,18 @@ import torch.distributed
 from torch.utils.data import DataLoader
 
 from composer import Trainer
-from composer.core import Precision
+from composer.core import Precision, get_precision_context
 from composer.models import composer_resnet_cifar
 from tests.common import RandomImageDataset
 
 try:
     import transformer_engine.pytorch as te
-    del te
     te_installed = True
 except ImportError:
     te_installed = False
 
 
-def get_trainer(precision: Precision) -> Trainer:
+def get_trainer(precision: Precision, precision_config: Optional[Dict[str, Any]] = None) -> Trainer:
 
     return Trainer(
         model=composer_resnet_cifar('resnet_9'),
@@ -36,6 +36,7 @@ def get_trainer(precision: Precision) -> Trainer:
             num_workers=0,
         ),
         precision=precision,
+        precision_config=precision_config,
         max_duration='1ep',
         eval_interval='1ep',
         train_subset_num_batches=1,
@@ -108,3 +109,20 @@ def test_amp_fp8_path():
     else:
         with pytest.raises(ImportError, match='AMP_FP8 precision is used but TransformerEngine is not installed'):
             trainer.fit()
+
+
+@pytest.mark.gpu
+def test_amp_fp8_config():
+    if te_installed and torch.cuda.get_device_capability()[0] > 9:
+        from transformer_engine.common.recipe import Format
+        precision_config = {
+            'fp8_format': Format.HYBRID,
+            'amax_history_len': 16,
+            'amax_compute_algo': 'max',
+        }
+        trainer = get_trainer(Precision.AMP_FP8, precision_config=precision_config)
+        with get_precision_context(trainer.state.precision, trainer.state.precision_config):
+            fp8_recipe = te.get_fp8_recipe()
+            for k, v in precision_config.items():
+                assert getattr(fp8_recipe, k) == v
+

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -113,7 +113,7 @@ def test_amp_fp8_path():
 
 @pytest.mark.gpu
 def test_amp_fp8_config():
-    if te_installed and torch.cuda.get_device_capability()[0] > 9:
+    if te_installed and torch.cuda.get_device_capability()[0] >= 9:
         from transformer_engine.common.recipe import Format
         precision_config = {
             'fp8_format': Format.HYBRID,

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -170,6 +170,7 @@ def test_extract_hparams_trainer():
         # System/Numerics
         'device': 'DeviceCPU',
         'precision': 'Precision',
+        'precision_config': None,
         'device_train_microbatch_size': 16,
 
         # Reproducibility


### PR DESCRIPTION
# What does this PR do?

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

This PR introduces a new field to the trainer `State` that configures the FP8 scaling recipe used by Transformer Engine. Previously, these values were [hardcoded](https://github.com/mosaicml/composer/blob/b73c776725c05fbd5b7cf43b63a8ca85ed455af0/composer/core/precision.py#L73-L74), but now we can experiment with different parameters by supplying a `precision_config` dictionary to the `Trainer`. The dictionary should contain init parameters for the [`DelayedScaling`](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html?highlight=delayedscaling#transformer_engine.common.recipe.DelayedScaling) class from Transformer Engine.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

Implements https://mosaicml.atlassian.net/browse/CO-2210
