### PR TITLE
Set offload_to_cpu True for state_dict_type=sharded

### DIFF
--- a/composer/callbacks/image_visualizer.py
+++ b/composer/callbacks/image_visualizer.py
@@ -9,7 +9,6 @@ import torch
 from composer.core import Callback, State, Time, TimeUnit
 from composer.loggers import Logger
 from composer.loss.utils import infer_target_type
-from composer.utils import MissingConditionalImportError
 
 __all__ = ['ImageVisualizer']
 
@@ -81,15 +80,6 @@ class ImageVisualizer(Callback):
         self.channels_last = channels_last
         self.input_key = input_key
         self.target_key = target_key
-
-        # TODO(Evan): Generalize as part of the logger refactor
-        try:
-            import wandb
-        except ImportError as e:
-            raise MissingConditionalImportError(extra_deps_group='wandb',
-                                                conda_package='wandb',
-                                                conda_channel='conda-forge') from e
-        del wandb  # unused
 
         # Check that the output mode is valid
         if self.mode.lower() not in ['input', 'segmentation']:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -90,6 +90,7 @@ def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str =
         fsdp_state_dict_type = StateDictType.SHARDED_STATE_DICT
         state_dict_config = ShardedStateDictConfig()
         if using_torch_2():
+            state_dict_config = ShardedStateDictConfig(offload_to_cpu=True)
             from torch.distributed.fsdp.fully_sharded_data_parallel import ShardedOptimStateDictConfig
             optim_state_dict_config = ShardedOptimStateDictConfig()
 
@@ -99,6 +100,7 @@ def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str =
         fsdp_state_dict_type = StateDictType.LOCAL_STATE_DICT
         state_dict_config = LocalStateDictConfig()
         if using_torch_2():
+            state_dict_config = LocalStateDictConfig(offload_to_cpu=True)
             from torch.distributed.fsdp.fully_sharded_data_parallel import LocalOptimStateDictConfig
             optim_state_dict_config = LocalOptimStateDictConfig()
     else:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -100,7 +100,6 @@ def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str =
         fsdp_state_dict_type = StateDictType.LOCAL_STATE_DICT
         state_dict_config = LocalStateDictConfig()
         if using_torch_2():
-            state_dict_config = LocalStateDictConfig(offload_to_cpu=True)
             from torch.distributed.fsdp.fully_sharded_data_parallel import LocalOptimStateDictConfig
             optim_state_dict_config = LocalOptimStateDictConfig()
     else:

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -526,8 +526,9 @@ class State(Serializable):
             self.sharded_ckpt_prefix_dir = self.fsdp_config['sharded_ckpt_prefix_dir']
 
         if using_torch_2() and self.fsdp_state_dict_type == 'local':
-            raise DeprecationWarning(textwrap.dedent("FSDP state_dict_type='local' is deprecated in torch>=2.0.0"
-                                                     "Please set fsdp_config['state_dict_type']='sharded' instead."))
+            raise DeprecationWarning(
+                textwrap.dedent("FSDP state_dict_type='local' is deprecated in torch>=2.0.0"
+                                "Please set fsdp_config['state_dict_type']='sharded' instead."))
 
         # Set defaults for transient variables (to make pyright happy)
         self.batch: Any = None

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -521,6 +521,10 @@ class State(Serializable):
         if self.fsdp_config is not None:
             self.sharded_ckpt_prefix_dir = self.fsdp_config['sharded_ckpt_prefix_dir']
 
+        if using_torch_2() and self.fsdp_state_dict_type == 'local':
+            raise DeprecationWarning(textwrap.dedent("FSDP state_dict_type='local' is deprecated in torch>=2.0.0"
+                                                     "Please set fsdp_config['state_dict_type']='sharded' instead."))
+
         # Set defaults for transient variables (to make pyright happy)
         self.batch: Any = None
         self.loss: Union[torch.Tensor, Sequence[torch.Tensor]] = torch.Tensor()

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -527,8 +527,9 @@ class State(Serializable):
 
         if using_torch_2() and self.fsdp_state_dict_type == 'local':
             raise DeprecationWarning(
-                textwrap.dedent("FSDP state_dict_type='local' is deprecated in torch>=2.0.0. "
-                                "Please set fsdp_config['state_dict_type']='sharded' instead and will be removed in v0.17"))
+                textwrap.dedent(
+                    "FSDP state_dict_type='local' is deprecated in torch>=2.0.0. "
+                    "Please set fsdp_config['state_dict_type']='sharded' instead and will be removed in v0.17"))
 
         # Set defaults for transient variables (to make pyright happy)
         self.batch: Any = None

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -527,8 +527,8 @@ class State(Serializable):
 
         if using_torch_2() and self.fsdp_state_dict_type == 'local':
             raise DeprecationWarning(
-                textwrap.dedent("FSDP state_dict_type='local' is deprecated in torch>=2.0.0"
-                                "Please set fsdp_config['state_dict_type']='sharded' instead."))
+                textwrap.dedent("FSDP state_dict_type='local' is deprecated in torch>=2.0.0. "
+                                "Please set fsdp_config['state_dict_type']='sharded' instead and will be removed in v0.17"))
 
         # Set defaults for transient variables (to make pyright happy)
         self.batch: Any = None

--- a/docs/source/notes/distributed_training.rst
+++ b/docs/source/notes/distributed_training.rst
@@ -391,7 +391,7 @@ model state to the other ranks.
 The least communication-heavy option because the state dict for saving and loading is exactly what is used in FSDP.
 For save: each rank saves out the flattened model state shard they are
 responsibile for to a distinct checkpoint file. No gather needed. For load, each rank loads in the checkpoint file
-corresponding to their shard. No scatter needed.
+corresponding to their shard. No scatter needed. **Note: state_dict_type='local' is deprecated in Composer for torch versions 2.0.0 or higher.**
 
 3. :code:`state_dict_type='sharded'`
 Each rank saves out an unflattened shard. Useful when using the checkpoint shard files for a non-FSDP use-case.
@@ -406,7 +406,7 @@ To help keep your checkpoint shard files organized, Composer will save each set 
 by using `'sharded_ckpt_prefix_dir'` (default value `sharded_ckpt_prefix_dir='ep{epoch}-ba{batch}'`). Checkpoint shards will be saved to
 `{save_folder} / {sharded_ckpt_prefix_dir}`
 
-For example, to save local, sharded checkpoints (`state_dict_type='local'`) with FSDP, you can do:
+For example, to save local, sharded checkpoints (`state_dict_type='sharded'`) with FSDP, you can do:
 
 .. code:: python
 
@@ -454,7 +454,7 @@ For example, to save local, sharded checkpoints (`state_dict_type='local'`) with
 
     fsdp_config = {
         'sharding_strategy': 'FULL_SHARD',
-        'state_dict_type': 'local',
+        'state_dict_type': 'sharded',
         'sharded_ckpt_prefix_dir': 'ba{batch}-shards' # will save each set of shards checkpoint to a unique folder based on batch
 
     }
@@ -483,7 +483,7 @@ To load these checkpoint files, you would need to do something like this:
 
     fsdp_config = {
         'sharding_strategy': 'FULL_SHARD',
-        'state_dict_type': 'local',
+        'state_dict_type': 'sharded',
     }
 
 
@@ -500,7 +500,7 @@ Three things to note in this load example:
 1. Instead of setting ``load_path`` to the path to a specific file, we keep the ``{rank}`` placeholder to denote that
 the file to load is different for each rank.
 
-2. We must set ``'state_dict_type': 'local'``, like we did during the save.
+2. We must set ``'state_dict_type': 'sharded'``, like we did during the save.
 
 3. Composer does not support elastic checkpointing (more ranks than checkpoint files or more files than ranks), so you
 must make sure the number of ranks you run on during load is the same as the number you used during save (the same as the number of files).


### PR DESCRIPTION
# What does this PR do?

sets the default for sharded and local state dicts to offload_to_cpu=True. This helps avoid OOMs for large models when saving sharded checkpoints

## Testing
Ran manual test of saving 30B checkpoints

# What issue(s) does this change relate to?
https://github.com/mosaicml/llm-foundry/issues/367
