### PR TITLE
Fix mapi mocking

### DIFF
--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -6,6 +6,7 @@ import logging
 import os
 import pathlib
 
+import mcli
 import pytest
 import torch
 import tqdm.std
@@ -103,3 +104,9 @@ def seed_all(rank_zero_seed: int, monkeypatch: pytest.MonkeyPatch):
     each test to the rank local seed."""
     monkeypatch.setattr(reproducibility, 'get_random_seed', lambda: rank_zero_seed)
     reproducibility.seed_all(rank_zero_seed + dist.get_global_rank())
+
+
+@pytest.fixture(autouse=True)
+def mapi_fixture(monkeypatch):
+    mock_update = lambda x: None
+    monkeypatch.setattr(mcli, 'update_run_metadata', mock_update)

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -108,5 +108,6 @@ def seed_all(rank_zero_seed: int, monkeypatch: pytest.MonkeyPatch):
 
 @pytest.fixture(autouse=True)
 def mapi_fixture(monkeypatch):
+    # Composer auto-adds mosaicml logger when running on platform. Disable logging for tests.
     mock_update = lambda *args, **kwargs: None
     monkeypatch.setattr(mcli, 'update_run_metadata', mock_update)

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -108,5 +108,5 @@ def seed_all(rank_zero_seed: int, monkeypatch: pytest.MonkeyPatch):
 
 @pytest.fixture(autouse=True)
 def mapi_fixture(monkeypatch):
-    mock_update = lambda x: None
+    mock_update = lambda *args, **kwargs: None
     monkeypatch.setattr(mcli, 'update_run_metadata', mock_update)


### PR DESCRIPTION
# What does this PR do?

We currently slam MAPI when we auto add mosaicml logger. This disables for autouse fixture