### PR TITLE
Avoid overwriting seed==0

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -277,7 +277,7 @@ def _adjust_device_eval_microbatch_size(evaluator: Evaluator):
 
 
 def _distribute_and_get_random_seed(seed: Optional[int], device: Device):
-    if not seed:
+    if seed is None:
         seed = reproducibility.get_random_seed()
 
     # Ensure that each process has a seed = rank_zero_seed + global_rank


### PR DESCRIPTION
Before this change, if I create a Trainer with `seed=0`, the seed is overwritten with a random seed. 


