### PR TITLE
Fix wandb errror with autoresume issue

### DIFF
--- a/.github/secrets/exclude.yaml
+++ b/.github/secrets/exclude.yaml
@@ -1,2 +1,3 @@
 .git/.*
 docs/source/_static/js/posthog.js
+docs/_build/html/_static/js/posthog.js

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -288,9 +288,7 @@ class WandBLogger(LoggerDestination):
         try:
             wandb_artifact = api.artifact('/'.join([self.entity, self.project, new_remote_file_name]))
         except wandb.errors.CommError as e:
-            if 'does not contain artifact' in str(e):
-                raise FileNotFoundError(f'WandB Artifact {new_remote_file_name} not found') from e
-            raise e
+            raise FileNotFoundError(f'WandB Artifact {new_remote_file_name} not found') from e
         with tempfile.TemporaryDirectory() as tmpdir:
             wandb_artifact_folder = os.path.join(tmpdir, 'wandb_artifact_folder/')
             wandb_artifact.download(root=wandb_artifact_folder)


### PR DESCRIPTION
# What does this PR do?
The new wandb release (0.15.5) changes it's error messages for artifact downloading failures. Our `WandBLogger` is designed to be EAFP instead of LBYL, so it relies on catching an exact error to prevent autoresume from trying to download checkpoints from wandb that aren't actually there.
This PR makes it so the check is not so specific (i.e. it catches all wandb CommErrors instead of just ones with specific messages). As a result, the EAFP code will then work with the new wandb install.