### PR TITLE
raise min mcli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ install_requires = [
     'py-cpuinfo>=8.0.0,<10',
     'packaging>=21.3.0,<23',
     'importlib-metadata>=5.0.0,<7',
-    'mosaicml-cli>=0.4.0,<0.5',
+    'mosaicml-cli>=0.4.12,<0.5',
 ]
 extra_deps = {}
 


### PR DESCRIPTION
# What does this PR do?

MosaicML logger auto-adding requires version 0.4.12 in order to autoread key and avoid running mcli init for adding API key. 

# What issue(s) does this change relate to?

[CO-2228](https://mosaicml.atlassian.net/browse/CO-2228)