### PR TITLE
Add node rank to signal files

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1515,7 +1515,7 @@ class Trainer:
                                               load_progress_bar)
 
             signal_file_path = os.path.join(os.path.dirname(latest_checkpoint_path),
-                                            '.local_rank0_completed_autoresume')
+                                            f'.node_{dist.get_node_rank()}_local_rank0_completed_autoresume')
             if dist.get_local_rank() == 0:
                 os.makedirs(os.path.dirname(signal_file_path), exist_ok=True)
                 with open(signal_file_path, 'wb') as f:

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -332,7 +332,8 @@ def download_checkpoint(path: str,
     finally:
         # Use busy wait to avoid timeouts on large downloads for non-sharded checkpoints
         if not checkpoint_is_sharded:
-            signal_file_path = os.path.join(node_checkpoint_folder, '.local_rank0_completed')
+            signal_file_path = os.path.join(node_checkpoint_folder,
+                                            f'.node_{dist.get_node_rank()}_local_rank0_completed')
             if dist.get_local_rank() == 0:
                 with open(signal_file_path, 'wb') as f:
                     f.write(b'local_rank0_completed')


### PR DESCRIPTION
# What does this PR do?

Currently, signal files assume each node is actually on a different machine with a different drive. However, this is not the case with NFS. Instead, we need to prefix the signal files with a node rank.

Note that this is not an issue for actual loading because each node creates a temp dir. We could also do tempdirs for signal files... but I think this is fine

# What issue(s) does this change relate to?

[CO-2217](https://mosaicml.atlassian.net/browse/CO-2217)