### PR TITLE
Move pydantic pin to deepspeed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,6 @@ extra_deps['dev'] = [
     'cryptography==38.0.4',
     'pytest-httpserver>=1.0.4,<1.1',
     'setuptools<=59.5.0',
-    'pydantic>=1.0,<2',
 ]
 
 extra_deps['health_checker'] = {
@@ -148,6 +147,7 @@ extra_deps['slack'] = {
 
 extra_deps['deepspeed'] = [
     'deepspeed==0.8.3',
+    'pydantic>=1.0,<2',
 ]
 
 extra_deps['wandb'] = [


### PR DESCRIPTION
# What does this PR do?

Only deepspeed has errors with pydantic 2. Moving the pin down to there as we don't actually use in composer normally