### PR TITLE
Read Composer run name env var

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -526,8 +526,8 @@ class Trainer:
 
             .. seealso:: :mod:`composer.loggers` for the different loggers built into Composer.
         run_name (str, optional): A name for this training run. If not specified, the env var
-            `COMPOSER_RUN_NAME` will be used if set. Otherwise, the timestamp will be combined with
-            a :doc:`coolname <coolname:index>`, e.g. ``1654298855-electric-zebra``.
+            `COMPOSER_RUN_NAME` or `RUN_NAME` will be used if set. Otherwise, the timestamp will be
+            combined with a :doc:`coolname <coolname:index>`, e.g. ``1654298855-electric-zebra``.
         progress_bar (bool): Whether to show a progress bar. (default: ``True``)
         log_to_console (bool): Whether to print logging statements to the console. (default: ``False``)
         console_stream (TextIO | str, optional): The stream to write to. If a string, it can either be
@@ -999,6 +999,7 @@ class Trainer:
 
         # Run Name
         run_name = os.getenv('COMPOSER_RUN_NAME', None) if run_name is None else run_name
+        run_name = os.getenv('RUN_NAME', None) if run_name is None else run_name
         if run_name is None:
             if autoresume:
                 raise ValueError('When autoresume=True, the `run_name` must be specified.')

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -525,8 +525,9 @@ class Trainer:
         loggers (LoggerDestination | Sequence[LoggerDestination], optional): The destinations to log training information to.
 
             .. seealso:: :mod:`composer.loggers` for the different loggers built into Composer.
-        run_name (str, optional): A name for this training run. If not specified, the timestamp will be combined with a
-            :doc:`coolname <coolname:index>`, e.g. ``1654298855-electric-zebra``.
+        run_name (str, optional): A name for this training run. If not specified, the env var
+            `COMPOSER_RUN_NAME` will be used if set. Otherwise, the timestamp will be combined with
+            a :doc:`coolname <coolname:index>`, e.g. ``1654298855-electric-zebra``.
         progress_bar (bool): Whether to show a progress bar. (default: ``True``)
         log_to_console (bool): Whether to print logging statements to the console. (default: ``False``)
         console_stream (TextIO | str, optional): The stream to write to. If a string, it can either be

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -997,6 +997,7 @@ class Trainer:
             optimizers = map_collection(optimizers, device.optimizer_to_device)
 
         # Run Name
+        run_name = os.getenv('COMPOSER_RUN_NAME', None) if run_name is None else run_name
         if run_name is None:
             if autoresume:
                 raise ValueError('When autoresume=True, the `run_name` must be specified.')

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,6 @@ extra_deps['dev'] = [
     'cryptography==38.0.4',
     'pytest-httpserver>=1.0.4,<1.1',
     'setuptools<=59.5.0',
-    'pydantic>=1.0,<2',
 ]
 
 extra_deps['health_checker'] = {
@@ -148,6 +147,7 @@ extra_deps['slack'] = {
 
 extra_deps['deepspeed'] = [
     'deepspeed==0.8.3',
+    'pydantic>=1.0,<2',
 ]
 
 extra_deps['wandb'] = [


### PR DESCRIPTION
# What does this PR do?

Add support for reading run_name from env var
