### PR TITLE
Support no param models by making optimizer optional

### DIFF
--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -10,7 +10,7 @@ from tests.common.datasets import (InfiniteClassificationDataset, ParityDataset,
                                    RandomTextLMDataset, SimpleDataset)
 from tests.common.events import EventCounterCallback
 from tests.common.markers import device, world_size
-from tests.common.models import (ConvModel, EmbeddedWeightTiedModel, SimpleConvModel, SimpleModel,
+from tests.common.models import (ConvModel, EmbeddedWeightTiedModel, EmptyModel, SimpleConvModel, SimpleModel,
                                  SimpleModelWithDropout, SimpleTransformerClassifier, SimpleTransformerMaskedLM,
                                  SimpleWeightTiedModel, ZeroModel)
 from tests.common.state import assert_state_equivalent
@@ -31,6 +31,7 @@ __all__ = [
     'ConvModel',
     'SimpleConvModel',
     'ZeroModel',
+    'EmptyModel',
     'SimpleModel',
     'SimpleTransformerClassifier',
     'SimpleTransformerMaskedLM',

--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -15,6 +15,19 @@ from composer.metrics.nlp import LanguageCrossEntropy, MaskedAccuracy
 from composer.models import ComposerClassifier, HuggingFaceModel
 
 
+class EmptyModel(ComposerClassifier):
+    """Always predict 0 with no parameters."""
+
+    def __init__(self, num_classes: int = 2):
+        super().__init__(module=torch.nn.Sequential(), num_classes=num_classes)
+
+    def forward(self, x):
+        out = torch.rand([x[1].shape[0], 2], dtype=x[0].dtype)
+        out[:, 0] = 0.99
+        out[:, 1] = 0.01
+        return out
+
+
 class ZeroModel(ComposerClassifier):
     """Always predict 0."""
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -30,7 +30,7 @@ from composer.models import ComposerModel
 from composer.optim import ExponentialScheduler
 from composer.trainer.trainer import _generate_run_name
 from composer.utils import dist, is_model_deepspeed, is_model_fsdp, map_collection, reproducibility
-from tests.common import (InfiniteClassificationDataset, RandomClassificationDataset, RandomImageDataset,
+from tests.common import (EmptyModel, InfiniteClassificationDataset, RandomClassificationDataset, RandomImageDataset,
                           RandomTextLMDataset, SimpleConvModel, SimpleModel, SimpleTransformerMaskedLM, device,
                           world_size)
 from tests.common.events import EventCounterCallback
@@ -98,6 +98,25 @@ class TestTrainerInit():
         parameters = trainer.state.optimizers[0].param_groups[0]['params']
         target_device = 'cuda' if device == 'gpu' else 'cpu'
         assert all(param.device.type == target_device for param in parameters)
+
+    @pytest.mark.parametrize('call_fit,call_eval', [[True, False], [False, True]])
+    def test_no_param_model(self, call_fit: bool, call_eval: bool):
+        model = EmptyModel()
+        train_dataset = RandomClassificationDataset()
+        trainer = None
+        with pytest.warns(match='No optimizer was specified, and the model does not have parameters.*'):
+            trainer = Trainer(
+                model=model,
+                max_duration='1ep',
+                train_dataloader=DataLoader(train_dataset, sampler=dist.get_sampler(train_dataset)),
+                eval_dataloader=DataLoader(train_dataset, sampler=dist.get_sampler(train_dataset)),
+            )
+
+        if call_fit:
+            with pytest.raises(ValueError, match='No optimizer was specified when constructing the Trainer.*'):
+                trainer.fit()
+        if call_eval:
+            trainer.eval(subset_num_batches=1)
 
     @pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0.0'),
                         reason='requires PyTorch 2.0 or higher')


### PR DESCRIPTION
# What does this PR do?

Currently, an optimizer is created in Trainer if an optimizer is not specified. If a user wants to evaluate an API model via the gauntlet, they would need to create a ComposerModel with a forward fn that calls the API.  This would currently break as the model does not have any parameters when Trainer attempts to auto-create an optimizer. So, currently, they need to auto-add dummy params (eg a small linear layer) that is unused.

Instead, we should give a warning in this case and defer requiring an optimizer to a fit call.
