### PR TITLE
regex clean that parses time

### DIFF
--- a/composer/core/time.py
+++ b/composer/core/time.py
@@ -45,10 +45,10 @@ class TimeUnit(StringEnum):
 
 
 # regex for parsing integers / decimals / scientific notation
-_NUM_REGEX = r'-?[\d.]+(?:e-?\d+)?'
+_NUM_REGEX = r'.+'
 
 # regex for parsing a time string.
-_TIME_STR_REGEX = re.compile(r'^(?:' + r'|'.join(fr'(?:({_NUM_REGEX})({time_unit.value}))' for time_unit in TimeUnit) +
+_TIME_STR_REGEX = re.compile(r'^(' + fr'{_NUM_REGEX}' + ')(' + r'|'.join([fr'{time_unit.value}' for time_unit in TimeUnit]) +
                              r')$',
                              flags=re.IGNORECASE)
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -12,7 +12,10 @@ from composer.core.time import Time, Timestamp, TimeUnit
     ['1ep', 1, TimeUnit.EPOCH],
     ['2ba', 2, TimeUnit.BATCH],
     ['3e10sp', 3 * 10**10, TimeUnit.SAMPLE],
+    ['3_0e10sp', 30 * 10**10, TimeUnit.SAMPLE],
     ['4tok', 4, TimeUnit.TOKEN],
+    ['4_000tok', 4000, TimeUnit.TOKEN],
+    ['4_00_0tok', 4000, TimeUnit.TOKEN],
     ['0.5dur', 0.5, TimeUnit.DURATION],
 ])
 def test_time_parse(time_string: str, expected_value: int, expected_unit: TimeUnit):


### PR DESCRIPTION
# What does this PR do?
Made changes to time.py: Currently, regex used to parse timestring and create Time object (to decide "max_duration" param for training) cannot handle cases such as '3_000_000_000tok'. So, we modified the regex accordingly. Now, it will divide timestring into 2 parts: value and unit of time and then use float() fn of python to convert value to a float. This way python directly handles parsing first part of string.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
