### PR TITLE
Isolate env var in unit tests

### DIFF
--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -118,14 +118,14 @@ def remove_run_name_env_var():
     # Remove environment variables for run names in unit tests
     composer_run_name = os.environ.get('COMPOSER_RUN_NAME')
     run_name = os.environ.get('RUN_NAME')
-    
+
     if 'COMPOSER_RUN_NAME' in os.environ:
         del os.environ['COMPOSER_RUN_NAME']
     if 'RUN_NAME' in os.environ:
         del os.environ['RUN_NAME']
 
     yield
-    
+
     if composer_run_name is not None:
         os.environ['COMPOSER_RUN_NAME'] = composer_run_name
     if run_name is not None:

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -111,3 +111,22 @@ def mapi_fixture(monkeypatch):
     # Composer auto-adds mosaicml logger when running on platform. Disable logging for tests.
     mock_update = lambda *args, **kwargs: None
     monkeypatch.setattr(mcli, 'update_run_metadata', mock_update)
+
+
+@pytest.fixture(autouse=True)
+def remove_run_name_env_var():
+    # Remove environment variables for run names in unit tests
+    composer_run_name = os.environ.get('COMPOSER_RUN_NAME')
+    run_name = os.environ.get('RUN_NAME')
+    
+    if 'COMPOSER_RUN_NAME' in os.environ:
+        del os.environ['COMPOSER_RUN_NAME']
+    if 'RUN_NAME' in os.environ:
+        del os.environ['RUN_NAME']
+
+    yield
+    
+    if composer_run_name is not None:
+        os.environ['COMPOSER_RUN_NAME'] = composer_run_name
+    if run_name is not None:
+        os.environ['RUN_NAME'] = run_name

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -57,6 +57,12 @@ class TestTrainerInit():
     def test_minimal_init(self, model: ComposerModel):
         Trainer(model=model)
 
+    @pytest.mark.parametrize('env_var', ['COMPOSER_RUN_NAME', 'RUN_NAME'])
+    def test_env_run_name(self, monkeypatch, model: ComposerModel, env_var: str):
+        monkeypatch.setenv(env_var, 'env_run_name')
+        trainer = Trainer(model=model)
+        assert trainer.state.run_name == 'env_run_name'
+
     @world_size(1, 2)
     def test_model_ddp_wrapped(self, model: ComposerModel, world_size: int):
         trainer = Trainer(model=model)


### PR DESCRIPTION
# What does this PR do?

Currently, unit tests all read the environment variable and use the same run name. This breaks things. Instead, we should hide the env var.

Along for ride, a unit test