### PR TITLE
[fix] Use Enum value when logging hyper-parameters

### DIFF
--- a/composer/utils/auto_log_hparams.py
+++ b/composer/utils/auto_log_hparams.py
@@ -3,6 +3,7 @@
 
 """Contains helper functions for auto-logging hparams."""
 
+from enum import Enum
 from typing import Any, Dict, List, Tuple
 
 __all__ = ['extract_hparams', 'convert_nested_dict_to_flat_dict', 'convert_flat_dict_to_nested_dict']
@@ -49,11 +50,13 @@ def _get_obj_repr(obj: Any):
         obj (Any): the object.
 
     Returns:
-        obj if obj is None or it is a int, float, str, bool type. Otherwise
-        returns obj.__class__.__name__.
+        obj if obj is None or it is a int, float, str, bool type.
+        obj.value if obj is an Enum. Otherwise returns obj.__class__.__name__.
     """
     if any([isinstance(obj, type_) for type_ in [int, float, str, bool]]) or obj is None:
         return obj
+    elif isinstance(obj, Enum):
+        return obj.value
     else:
         return obj.__class__.__name__
 

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -8,8 +8,13 @@ from composer.algorithms import EMA
 from composer.callbacks import SpeedMonitor
 from composer.loggers import InMemoryLogger
 from composer.trainer import Trainer
-from composer.utils import (convert_flat_dict_to_nested_dict, convert_nested_dict_to_flat_dict, extract_hparams,
-                            StringEnum, using_torch_2)
+from composer.utils import (
+    StringEnum,
+    convert_flat_dict_to_nested_dict,
+    convert_nested_dict_to_flat_dict,
+    extract_hparams,
+    using_torch_2,
+)
 from tests.common.datasets import RandomClassificationDataset
 from tests.common.models import SimpleModel
 

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -6,6 +6,7 @@ from torch.utils.data import DataLoader
 
 from composer.algorithms import EMA
 from composer.callbacks import SpeedMonitor
+from composer.core import Precision
 from composer.loggers import InMemoryLogger
 from composer.trainer import Trainer
 from composer.utils import (
@@ -95,6 +96,7 @@ def test_extract_hparams_trainer():
         model=model,
         train_dataloader=train_dl,
         device_train_microbatch_size=16,
+        precision=Precision.FP32,
         optimizers=optimizer,
         auto_log_hparams=True,
         progress_bar=False,
@@ -179,7 +181,7 @@ def test_extract_hparams_trainer():
 
         # System/Numerics
         'device': 'DeviceCPU',
-        'precision': 'Precision',
+        'precision': 'fp32',
         'precision_config': None,
         'device_train_microbatch_size': 16,
 

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -9,7 +9,7 @@ from composer.callbacks import SpeedMonitor
 from composer.loggers import InMemoryLogger
 from composer.trainer import Trainer
 from composer.utils import (convert_flat_dict_to_nested_dict, convert_nested_dict_to_flat_dict, extract_hparams,
-                            using_torch_2)
+                            StringEnum, using_torch_2)
 from tests.common.datasets import RandomClassificationDataset
 from tests.common.models import SimpleModel
 
@@ -42,6 +42,9 @@ def test_extract_hparams():
         def __init__(self):
             self.local_hparams = {'m': 11}
 
+    class Baz(StringEnum):
+        A = "abc"
+
     locals_dict = {
         'a': 1.5,
         'b': {
@@ -53,7 +56,8 @@ def test_extract_hparams():
         'p': Bar(),
         '_g': 7,
         'h': None,
-        'i': True
+        'i': True,
+        'j': Baz.A,
     }
 
     expected_parsed_dict = {
@@ -71,6 +75,7 @@ def test_extract_hparams():
         },
         'h': None,
         'i': True,
+        'j': 'abc',
     }
 
     parsed_dict = extract_hparams(locals_dict)

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -9,13 +9,8 @@ from composer.callbacks import SpeedMonitor
 from composer.core import Precision
 from composer.loggers import InMemoryLogger
 from composer.trainer import Trainer
-from composer.utils import (
-    StringEnum,
-    convert_flat_dict_to_nested_dict,
-    convert_nested_dict_to_flat_dict,
-    extract_hparams,
-    using_torch_2,
-)
+from composer.utils import (StringEnum, convert_flat_dict_to_nested_dict, convert_nested_dict_to_flat_dict,
+                            extract_hparams, using_torch_2)
 from tests.common.datasets import RandomClassificationDataset
 from tests.common.models import SimpleModel
 

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -49,7 +49,7 @@ def test_extract_hparams():
             self.local_hparams = {'m': 11}
 
     class Baz(StringEnum):
-        A = "abc"
+        A = 'abc'
 
     locals_dict = {
         'a': 1.5,


### PR DESCRIPTION
# What does this PR do?

When logging hyper-parameters only built-in types were supported. Otherwise the class name was used. This cause a loss of information when using enum. For example when logging precision `precision: Precision`.

This contribution takes the value field if the object is an Enum. Resulting in `precision: amp_fp16`