### PR TITLE
Remove compute_on_step from MAP

### DIFF
--- a/composer/metrics/map.py
+++ b/composer/metrics/map.py
@@ -139,7 +139,6 @@ class MAP(Metric):
 
     Args:
         class_metrics (bool, optional): Option to enable per-class metrics for mAP and mAR_100. Has a performance impact. Default: ``False``.
-        compute_on_step (bool, optional): Forward only calls ``update()`` and return ``None`` if this is set to ``False``. Default: ``False``.
         dist_sync_on_step (bool, optional): Synchronize metric state across processes at each ``forward()`` before returning the value at the step. Default: ``False``.
         process_group (any, optional): Specify the process group on which synchronization is called. Default: ``None`` (which selects the entire world).
         dist_sync_fn (callable, optional): Callback that performs the allgather operation on the metric state. When ``None``, DDP will be used to perform the all_gather. Default: ``None``.
@@ -154,13 +153,11 @@ class MAP(Metric):
     def __init__(
             self,
             class_metrics: bool = False,
-            compute_on_step: bool = True,
             dist_sync_on_step: bool = False,
             process_group: Optional[Any] = None,
             dist_sync_fn: Callable = None,  # type: ignore
     ) -> None:  # type: ignore
         super().__init__(
-            compute_on_step=compute_on_step,
             dist_sync_on_step=dist_sync_on_step,
             process_group=process_group,
             dist_sync_fn=dist_sync_fn,

--- a/tests/metrics/test_map.py
+++ b/tests/metrics/test_map.py
@@ -1,76 +1,73 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 import torch
-import torch.nn.functional as F
 
 from composer.metrics import MAP
-
 
 
 def test_map_perfect():
     map = MAP()
 
     targets = [
-            {
-                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
-                "labels": torch.tensor([4]),
-            },  # coco image id 42
-            {
-                "boxes": torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
-                "labels": torch.tensor([3, 2]),
-            },  # coco image id 73
+        {
+            'boxes': torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+            'labels': torch.tensor([4]),
+        },  # coco image id 42
+        {
+            'boxes': torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
+            'labels': torch.tensor([3, 2]),
+        },  # coco image id 73
     ]
 
     # Perfect result
     predictions = [
-            {
-                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
-                "scores": torch.tensor([0.236]),
-                "labels": torch.tensor([4]),
-            },  # coco image id 42
-            {
-                "boxes": torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
-                "scores": torch.tensor([0.318, 0.726]),
-                "labels": torch.tensor([3, 2]),
-            },  # coco image id 73
+        {
+            'boxes': torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+            'scores': torch.tensor([0.236]),
+            'labels': torch.tensor([4]),
+        },  # coco image id 42
+        {
+            'boxes': torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
+            'scores': torch.tensor([0.318, 0.726]),
+            'labels': torch.tensor([3, 2]),
+        },  # coco image id 73
     ]
-    
+
     map.update(predictions, targets)
     map_result = map.compute()
-    
+
     assert map_result['map'] == 1.
     assert map_result['map_50'] == 1.
     assert map_result['map_75'] == 1.
 
-    
+
 # Completly wrong predictions
 def test_map_wront():
     map = MAP()
 
     targets = [
-            {
-                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
-                "labels": torch.tensor([4]),
-            },  # coco image id 42
-            {
-                "boxes": torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
-                "labels": torch.tensor([3, 2]),
-            },  # coco image id 73
+        {
+            'boxes': torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+            'labels': torch.tensor([4]),
+        },  # coco image id 42
+        {
+            'boxes': torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
+            'labels': torch.tensor([3, 2]),
+        },  # coco image id 73
     ]
 
     predictions = [
-            {
-                "boxes": torch.tensor([[0.0, 3.0, 4.0, 10.0]]),
-                "scores": torch.tensor([0.9]),
-                "labels": torch.tensor([2]),
-            },  # coco image id 42
-            {
-                "boxes": torch.tensor([[10.0, 15.0, 25.0, 50.0]]),
-                "scores": torch.tensor([0.8]),
-                "labels": torch.tensor([1]),
-            },  # coco image id 73
+        {
+            'boxes': torch.tensor([[0.0, 3.0, 4.0, 10.0]]),
+            'scores': torch.tensor([0.9]),
+            'labels': torch.tensor([2]),
+        },  # coco image id 42
+        {
+            'boxes': torch.tensor([[10.0, 15.0, 25.0, 50.0]]),
+            'scores': torch.tensor([0.8]),
+            'labels': torch.tensor([1]),
+        },  # coco image id 73
     ]
 
     map.update(predictions, targets)
@@ -85,28 +82,28 @@ def test_map_imperfect():
     map = MAP()
 
     targets = [
-            {
-                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
-                "labels": torch.tensor([4]),
-            },  # coco image id 42
-            {
-                "boxes": torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
-                "labels": torch.tensor([3, 2]),
-            },  # coco image id 73
+        {
+            'boxes': torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+            'labels': torch.tensor([4]),
+        },  # coco image id 42
+        {
+            'boxes': torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
+            'labels': torch.tensor([3, 2]),
+        },  # coco image id 73
     ]
 
     # Perfect result
     predictions = [
-            {
-                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
-                "scores": torch.tensor([0.236]),
-                "labels": torch.tensor([4]),
-            },  # coco image id 42
-            {
-                "boxes": torch.tensor([[50.0, 22.0, 565.00, 615.0], [12.66, 3.32, 281.26, 275.23]]),
-                "scores": torch.tensor([0.318, 0.726]),
-                "labels": torch.tensor([3, 1]),
-            },  # coco image id 73
+        {
+            'boxes': torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+            'scores': torch.tensor([0.236]),
+            'labels': torch.tensor([4]),
+        },  # coco image id 42
+        {
+            'boxes': torch.tensor([[50.0, 22.0, 565.00, 615.0], [12.66, 3.32, 281.26, 275.23]]),
+            'scores': torch.tensor([0.318, 0.726]),
+            'labels': torch.tensor([3, 1]),
+        },  # coco image id 73
     ]
 
     map.update(predictions, targets)
@@ -125,4 +122,3 @@ def test_map_imperfect():
     torch.testing.assert_close(map_result['mar_large'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
     torch.testing.assert_close(map_result['map_per_class'], torch.tensor(-1.))
     torch.testing.assert_close(map_result['mar_100_per_class'], torch.tensor(-1.))
-

--- a/tests/metrics/test_map.py
+++ b/tests/metrics/test_map.py
@@ -1,0 +1,128 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from composer.metrics import MAP
+
+
+
+def test_map_perfect():
+    map = MAP()
+
+    targets = [
+            {
+                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+                "labels": torch.tensor([4]),
+            },  # coco image id 42
+            {
+                "boxes": torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
+                "labels": torch.tensor([3, 2]),
+            },  # coco image id 73
+    ]
+
+    # Perfect result
+    predictions = [
+            {
+                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+                "scores": torch.tensor([0.236]),
+                "labels": torch.tensor([4]),
+            },  # coco image id 42
+            {
+                "boxes": torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
+                "scores": torch.tensor([0.318, 0.726]),
+                "labels": torch.tensor([3, 2]),
+            },  # coco image id 73
+    ]
+    
+    map.update(predictions, targets)
+    map_result = map.compute()
+    
+    assert map_result['map'] == 1.
+    assert map_result['map_50'] == 1.
+    assert map_result['map_75'] == 1.
+
+    
+# Completly wrong predictions
+def test_map_wront():
+    map = MAP()
+
+    targets = [
+            {
+                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+                "labels": torch.tensor([4]),
+            },  # coco image id 42
+            {
+                "boxes": torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
+                "labels": torch.tensor([3, 2]),
+            },  # coco image id 73
+    ]
+
+    predictions = [
+            {
+                "boxes": torch.tensor([[0.0, 3.0, 4.0, 10.0]]),
+                "scores": torch.tensor([0.9]),
+                "labels": torch.tensor([2]),
+            },  # coco image id 42
+            {
+                "boxes": torch.tensor([[10.0, 15.0, 25.0, 50.0]]),
+                "scores": torch.tensor([0.8]),
+                "labels": torch.tensor([1]),
+            },  # coco image id 73
+    ]
+
+    map.update(predictions, targets)
+    map_result = map.compute()
+    assert map_result['map'] == 0.
+    assert map_result['map_50'] == 0.
+    assert map_result['map_75'] == 0.
+
+
+# Imperfect predictions
+def test_map_imperfect():
+    map = MAP()
+
+    targets = [
+            {
+                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+                "labels": torch.tensor([4]),
+            },  # coco image id 42
+            {
+                "boxes": torch.tensor([[61.00, 22.75, 565.00, 632.42], [12.66, 3.32, 281.26, 275.23]]),
+                "labels": torch.tensor([3, 2]),
+            },  # coco image id 73
+    ]
+
+    # Perfect result
+    predictions = [
+            {
+                "boxes": torch.tensor([[258.15, 41.29, 606.41, 285.07]]),
+                "scores": torch.tensor([0.236]),
+                "labels": torch.tensor([4]),
+            },  # coco image id 42
+            {
+                "boxes": torch.tensor([[50.0, 22.0, 565.00, 615.0], [12.66, 3.32, 281.26, 275.23]]),
+                "scores": torch.tensor([0.318, 0.726]),
+                "labels": torch.tensor([3, 1]),
+            },  # coco image id 73
+    ]
+
+    map.update(predictions, targets)
+    map_result = map.compute()
+    torch.testing.assert_close(map_result['map'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(map_result['map_50'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(map_result['map_75'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(map_result['map_small'], torch.tensor(-1.))
+    torch.testing.assert_close(map_result['map_medium'], torch.tensor(-1.))
+    torch.testing.assert_close(map_result['map_large'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(map_result['mar_1'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(map_result['mar_10'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(map_result['mar_100'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(map_result['mar_small'], torch.tensor(-1.))
+    torch.testing.assert_close(map_result['mar_medium'], torch.tensor(-1.))
+    torch.testing.assert_close(map_result['mar_large'], torch.tensor(0.6667), atol=1e-4, rtol=1e-5)
+    torch.testing.assert_close(map_result['map_per_class'], torch.tensor(-1.))
+    torch.testing.assert_close(map_result['mar_100_per_class'], torch.tensor(-1.))
+


### PR DESCRIPTION
# What does this PR do?

`compute_on_step` has been deprecated from `torchmetrics`. In this PR I remove it and add basic tests to the MAP metric to detect other changes.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

