### PR TITLE
pin identify version to resolve codequality failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ extra_deps['dev'] = [
     'cryptography==38.0.4',
     'pytest-httpserver>=1.0.4,<1.1',
     'setuptools<=59.5.0',
-    'identity==2.5.25'
+    'identify==2.5.25'
 ]
 
 extra_deps['health_checker'] = {

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ extra_deps['dev'] = [
     'cryptography==38.0.4',
     'pytest-httpserver>=1.0.4,<1.1',
     'setuptools<=59.5.0',
+    'identity==2.5.25'
 ]
 
 extra_deps['health_checker'] = {


### PR DESCRIPTION
# What does this PR do?

identify on pypi has changed to 2.5.26, which cause pretty format json to reformat notebooks which is not compatible nbstripout. As a temporary solution, pinned identify to 2.5.25. 

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x ] Did you run the tests locally to make sure they pass?
- [ x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
