### PR TITLE
Moves pytest-cpu slack notifications to issues from helpdesk

### DIFF
--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -86,6 +86,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.slack-notifications-bot-token }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: composer-helpdesk
+          channel: composer-issues
           status: FAILED
           color: danger


### PR DESCRIPTION
# What does this PR do?

Moves pytest-cpu slack notifications to issues from helpdesk