### PR TITLE
Adding extra condition to avoid running eval_train_metrics

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2462,7 +2462,7 @@ class Trainer:
             self.engine.run_event(Event.AFTER_BACKWARD)
 
             # Use microbatch outputs to update training metrics
-            if self.state.train_metrics is not None:
+            if self.state.train_metrics is not None and len(self.state.train_metrics) != 0:
                 self.state.train_metrics = self._ensure_metrics_device_and_dtype(self.state.train_metrics)
                 self._eval_train_metrics(device_batch)
 


### PR DESCRIPTION
# What does this PR do?

When you return empty dictionary in a model within `get_metrics`, at every batch `eval_forward` is being run.

According to my investigation, this is caused by `_eval_train_metrics` within `Trainer` class. Hence, I have added an extra condition to avoid running `_eval_train_metrics` if the `train_metrics` is returned as an empty dictionary.

Otherwise, you need to return None in `get_metrics` within a `ComposerModel` which causes the checkpointing to break.


# Before submitting
- [X] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [X] Did you run the tests locally to make sure they pass?
- [X] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
