### PR TITLE
Add a `EVAL_STANDALONE_START` and `EVAL_STANDALONE_END` events and change RUD to not `wait_for_workers` every eval

### DIFF
--- a/composer/core/callback.py
+++ b/composer/core/callback.py
@@ -449,6 +449,24 @@ class Callback(Serializable, abc.ABC):
         del state, logger  # unused
         pass
 
+    def standalone_eval_start(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.STANDALONE_EVAL_START` event.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+        """
+        pass
+
+    def standalone_eval_end(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.STANDALONE_EVAL_END` event.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+        """
+        pass
+
     def fit_end(self, state: State, logger: Logger) -> None:
         """Called on the :attr:`.Event.FIT_END` event.
 

--- a/composer/core/callback.py
+++ b/composer/core/callback.py
@@ -449,8 +449,8 @@ class Callback(Serializable, abc.ABC):
         del state, logger  # unused
         pass
 
-    def standalone_eval_start(self, state: State, logger: Logger) -> None:
-        """Called on the :attr:`.Event.STANDALONE_EVAL_START` event.
+    def eval_standalone_start(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.EVAL_STANDALONE_START` event.
 
         Args:
             state (State): The training state.
@@ -458,8 +458,8 @@ class Callback(Serializable, abc.ABC):
         """
         pass
 
-    def standalone_eval_end(self, state: State, logger: Logger) -> None:
-        """Called on the :attr:`.Event.STANDALONE_EVAL_END` event.
+    def eval_standalone_end(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.EVAL_STANDALONE_END` event.
 
         Args:
             state (State): The training state.

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -352,7 +352,8 @@ class Engine():
     def _assert_dataloader_and_duration_set(state: State, event: Event):
         # correctness checks that dataloader and max duration need to be set for certain events
 
-        if event != Event.INIT and event != Event.AFTER_LOAD:  # dataloader should be set on all events expect INIT/AFTER_LOAD
+        # dataloader should be set on all events expect INIT/AFTER_LOAD/EVAL_STANDALONE_START/EVAL_STANDALONE_END
+        if event not in {Event.INIT, Event.AFTER_LOAD, Event.EVAL_STANDALONE_START, Event.EVAL_STANDALONE_END}:
             assert state.dataloader is not None, f'The trainer should have set state.dataloader for event {event}.'
 
         if event != Event.INIT and event != Event.AFTER_LOAD and not event.is_predict and not event.is_eval:

--- a/composer/core/event.py
+++ b/composer/core/event.py
@@ -136,6 +136,9 @@ class Event(StringEnum):
         EVAL_BATCH_END: After the call to ``model.eval_forward(batch)``
         EVAL_END: End of evaluation through the validation dataset.
         EVAL_AFTER_ALL: After all evaluators process validation dataset.
+
+        STANDALONE_EVAL_START: Start of evaluation through a direct call to `trainer.eval`.
+        STANDALONE_EVAL_END: End of evaluation through a direct call to `trainer.eval`.
     """
 
     INIT = 'init'
@@ -178,6 +181,9 @@ class Event(StringEnum):
     EVAL_BATCH_END = 'eval_batch_end'
     EVAL_END = 'eval_end'
     EVAL_AFTER_ALL = 'eval_after_all'
+
+    STANDALONE_EVAL_START = 'standalone_eval_start'
+    STANDALONE_EVAL_END = 'standalone_eval_end'
 
     PREDICT_START = 'predict_start'
     PREDICT_BATCH_START = 'predict_batch_start'
@@ -240,8 +246,9 @@ class Event(StringEnum):
 _BEFORE_EVENTS = (Event.FIT_START, Event.EPOCH_START, Event.BEFORE_DATALOADER, Event.BATCH_START,
                   Event.BEFORE_TRAIN_BATCH, Event.BEFORE_FORWARD, Event.BEFORE_LOSS, Event.BEFORE_BACKWARD,
                   Event.EVAL_BEFORE_ALL, Event.EVAL_START, Event.EVAL_BATCH_START, Event.EVAL_BEFORE_FORWARD,
-                  Event.PREDICT_START, Event.PREDICT_BATCH_START, Event.PREDICT_BEFORE_FORWARD)
+                  Event.PREDICT_START, Event.PREDICT_BATCH_START, Event.PREDICT_BEFORE_FORWARD,
+                  Event.STANDALONE_EVAL_START)
 _AFTER_EVENTS = (Event.EPOCH_END, Event.BATCH_END, Event.AFTER_DATALOADER, Event.AFTER_TRAIN_BATCH, Event.AFTER_FORWARD,
                  Event.AFTER_LOSS, Event.AFTER_BACKWARD, Event.EVAL_AFTER_ALL, Event.EVAL_END, Event.EVAL_BATCH_END,
                  Event.EVAL_AFTER_FORWARD, Event.FIT_END, Event.PREDICT_END, Event.PREDICT_BATCH_END,
-                 Event.PREDICT_AFTER_FORWARD)
+                 Event.PREDICT_AFTER_FORWARD, Event.STANDALONE_EVAL_END)

--- a/composer/core/event.py
+++ b/composer/core/event.py
@@ -137,8 +137,8 @@ class Event(StringEnum):
         EVAL_END: End of evaluation through the validation dataset.
         EVAL_AFTER_ALL: After all evaluators process validation dataset.
 
-        STANDALONE_EVAL_START: Start of evaluation through a direct call to `trainer.eval`.
-        STANDALONE_EVAL_END: End of evaluation through a direct call to `trainer.eval`.
+        EVAL_STANDALONE_START: Start of evaluation through a direct call to `trainer.eval`.
+        EVAL_STANDALONE_END: End of evaluation through a direct call to `trainer.eval`.
     """
 
     INIT = 'init'
@@ -182,8 +182,8 @@ class Event(StringEnum):
     EVAL_END = 'eval_end'
     EVAL_AFTER_ALL = 'eval_after_all'
 
-    STANDALONE_EVAL_START = 'standalone_eval_start'
-    STANDALONE_EVAL_END = 'standalone_eval_end'
+    EVAL_STANDALONE_START = 'eval_standalone_start'
+    EVAL_STANDALONE_END = 'eval_standalone_end'
 
     PREDICT_START = 'predict_start'
     PREDICT_BATCH_START = 'predict_batch_start'
@@ -247,8 +247,8 @@ _BEFORE_EVENTS = (Event.FIT_START, Event.EPOCH_START, Event.BEFORE_DATALOADER, E
                   Event.BEFORE_TRAIN_BATCH, Event.BEFORE_FORWARD, Event.BEFORE_LOSS, Event.BEFORE_BACKWARD,
                   Event.EVAL_BEFORE_ALL, Event.EVAL_START, Event.EVAL_BATCH_START, Event.EVAL_BEFORE_FORWARD,
                   Event.PREDICT_START, Event.PREDICT_BATCH_START, Event.PREDICT_BEFORE_FORWARD,
-                  Event.STANDALONE_EVAL_START)
+                  Event.EVAL_STANDALONE_START)
 _AFTER_EVENTS = (Event.EPOCH_END, Event.BATCH_END, Event.AFTER_DATALOADER, Event.AFTER_TRAIN_BATCH, Event.AFTER_FORWARD,
                  Event.AFTER_LOSS, Event.AFTER_BACKWARD, Event.EVAL_AFTER_ALL, Event.EVAL_END, Event.EVAL_BATCH_END,
                  Event.EVAL_AFTER_FORWARD, Event.FIT_END, Event.PREDICT_END, Event.PREDICT_BATCH_END,
-                 Event.PREDICT_AFTER_FORWARD, Event.STANDALONE_EVAL_END)
+                 Event.PREDICT_AFTER_FORWARD, Event.EVAL_STANDALONE_END)

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -447,7 +447,7 @@ class RemoteUploaderDownloader(LoggerDestination):
     def fit_end(self, state: State, logger: Logger):
         self.wait_for_workers(state.device)
 
-    def standalone_eval_end(self, state: State, logger: Logger):
+    def eval_standlone_end(self, state: State, logger: Logger):
         self.wait_for_workers(state.device)
 
     def predict_end(self, state: State, logger: Logger):

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -447,7 +447,7 @@ class RemoteUploaderDownloader(LoggerDestination):
     def fit_end(self, state: State, logger: Logger):
         self.wait_for_workers(state.device)
 
-    def eval_end(self, state: State, logger: Logger):
+    def standalone_eval_end(self, state: State, logger: Logger):
         self.wait_for_workers(state.device)
 
     def predict_end(self, state: State, logger: Logger):

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -447,7 +447,7 @@ class RemoteUploaderDownloader(LoggerDestination):
     def fit_end(self, state: State, logger: Logger):
         self.wait_for_workers(state.device)
 
-    def eval_standlone_end(self, state: State, logger: Logger):
+    def eval_standalone_end(self, state: State, logger: Logger):
         self.wait_for_workers(state.device)
 
     def predict_end(self, state: State, logger: Logger):

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2707,7 +2707,7 @@ class Trainer:
                 dataloader. Can also be provided in the trainer.__init__() as ``eval_subset_num_batches``.
 
         """
-        self.engine.run_event(Event.STANDALONE_EVAL_START)
+        self.engine.run_event(Event.EVAL_STANDALONE_START)
 
         if eval_dataloader is not None:
             eval_passed_in = True
@@ -2765,7 +2765,7 @@ class Trainer:
             if eval_passed_in:
                 self.state.evaluators.remove(evaluator)  # Remove them from state once eval is finished.
 
-        self.engine.run_event(Event.STANDALONE_EVAL_END)
+        self.engine.run_event(Event.EVAL_STANDALONE_END)
 
     def _eval_loop(
         self,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2707,6 +2707,8 @@ class Trainer:
                 dataloader. Can also be provided in the trainer.__init__() as ``eval_subset_num_batches``.
 
         """
+        self.engine.run_event(Event.STANDALONE_EVAL_START)
+
         if eval_dataloader is not None:
             eval_passed_in = True
             eval_metrics = deepcopy(self._original_model.get_metrics(is_train=False))
@@ -2762,6 +2764,8 @@ class Trainer:
             )
             if eval_passed_in:
                 self.state.evaluators.remove(evaluator)  # Remove them from state once eval is finished.
+
+        self.engine.run_event(Event.STANDALONE_EVAL_END)
 
     def _eval_loop(
         self,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -171,6 +171,8 @@ class TestEventCalls:
             Event.EVAL_BATCH_END: total_eval_steps,
             Event.EVAL_END: total_evals_start,
             Event.EVAL_AFTER_ALL: total_evals,
+            Event.STANDALONE_EVAL_START: 0,
+            Event.STANDALONE_EVAL_END: 0,
         }
 
         counter_callback = (cb for cb in trainer.state.callbacks if isinstance(cb, EventCounterCallback))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -171,8 +171,6 @@ class TestEventCalls:
             Event.EVAL_BATCH_END: total_eval_steps,
             Event.EVAL_END: total_evals_start,
             Event.EVAL_AFTER_ALL: total_evals,
-            Event.STANDALONE_EVAL_START: 0,
-            Event.STANDALONE_EVAL_END: 0,
         }
 
         counter_callback = (cb for cb in trainer.state.callbacks if isinstance(cb, EventCounterCallback))


### PR DESCRIPTION
# What does this PR do?
Previously, `RemoteUploaderDownloader.wait_for_workers` was called on the `eval_end` event. This meant that `wait_for_workers` would happen after _every_ individual evaluator loop. This results in unnecessary hangs waiting for checkpoint upload in the middle of a run. This PR adds new events to signify that the standalone `trainer.eval` is being called, as opposed to eval from within the training loop, and changes the `RemoteUploaderDownloader` to use that event instead of the `eval_end` event. It also spawns a new issue [CO-2268](https://mosaicml.atlassian.net/browse/CO-2268).

# What issue(s) does this change relate to?
Closes [CO-2267](https://mosaicml.atlassian.net/browse/CO-2267)

# Manual test
Manual test is by running
```
composer train.py yamls/finetune/mpt-7b_dolly_sft.yaml max_duration=5ba global_train_batch_size=4 device_train_microbatch_size=1 save_folder=oci://mosaicml-internal-checkpoints/daniel/checkpoints/{run_name} eval_subset_num_batches=2 eval_first=False optimizer.name=decoupled_lionw model.pretrained=False dist_timeout=20 loggers.wandb={} model.config_overrides.d_model=256 model.config_overrides.n_layers=12 run_name=test-run eval_interval=2ba autoresume=False save_overwrite=True save_interval=1ba
```
Before this PR it would hang after each eval, after this pr it just waits at the end of the run for the uploads to complete.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[CO-2268]: https://mosaicml.atlassian.net/browse/CO-2268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CO-2267]: https://mosaicml.atlassian.net/browse/CO-2267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ