### PR TITLE
Throttle optimizer monitor

### DIFF
--- a/composer/callbacks/optimizer_monitor.py
+++ b/composer/callbacks/optimizer_monitor.py
@@ -53,37 +53,17 @@ class OptimizerMonitor(Callback):
     | ``l2_norm/moment/LAYER_NAME``                 |  calling optimizer step.                            |
     |                                               |                                                     |
     +-----------------------------------------------+-----------------------------------------------------+
-    |                                               | Layer-wise ratio of the gradient norm to the        |
-    | ``l2_norm_ratio/moment_grad/LAYER_NAME``      | moment norm after calling optimizer step.           |
-    |                                               |                                                     |
-    +-----------------------------------------------+-----------------------------------------------------+
-    |                                               | Layer-wise cosine angle between gradient and moment |
-    | ``cosine/moment_grad/LAYER_NAME``             | after calling optimizer step.                       |
-    |                                               |                                                     |
-    +-----------------------------------------------+-----------------------------------------------------+
     |                                               | Layer-wise L2 norms of parameter weights            |
     | ``l2_norm/param/LAYER_NAME``                  |                                                     |
-    |                                               |                                                     |
-    +-----------------------------------------------+-----------------------------------------------------+
-    |                                               | Layer-wise L2 norms of the square root              |
-    | ``l2_norm/second_moment_sqrt/LAYER_NAME``     |  of the Adam second moment is.                      |
     |                                               |                                                     |
     +-----------------------------------------------+-----------------------------------------------------+
     |                                               | Layer-wise L2 norms of the step                     |
     | ``l2_norm/update/LAYER_NAME``                 |                                                     |
     |                                               |                                                     |
     +-----------------------------------------------+-----------------------------------------------------+
-    |                                               | Layer-wise cosine between the gradient and the step |
-    | ``cosine/update_grad/LAYER_NAME``             |                                                     |
-    |                                               |                                                     |
-    +-----------------------------------------------+-----------------------------------------------------+
-    |                                               | Layer-wise ratio between step size and parameter    |
-    | ``l2_norm_ratio/update_param/LAYER_NAME``     | norm                                                |
-    |                                               |                                                     |
-    +-----------------------------------------------+-----------------------------------------------------+
     """
 
-    def __init__(self, log_optimizer_metrics: bool = True, batch_log_interval: int = 1):
+    def __init__(self, log_optimizer_metrics: bool = True, batch_log_interval: int = 10):
         self.log_optimizer_metrics = log_optimizer_metrics
         self.batch_log_interval = batch_log_interval
 

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -189,14 +189,10 @@ class DecoupledAdamW(AdamW):
     """
 
     metric_functions = {
-        'l2_norm/moment':
-            lambda param, optim_state, step_tensor: torch.linalg.vector_norm(optim_state['exp_avg']),
-        'l2_norm/param':
-            lambda param, optim_state, step_tensor: torch.linalg.vector_norm(param.data),
-        'l2_norm/update':
-            lambda param, optim_state, step_tensor: torch.linalg.vector_norm(step_tensor),
-        'l2_norm/grad':
-            lambda param, optim_state, step_tensor: torch.linalg.vector_norm(param.grad),
+        'l2_norm/moment': lambda param, optim_state, step_tensor: torch.linalg.vector_norm(optim_state['exp_avg']),
+        'l2_norm/param': lambda param, optim_state, step_tensor: torch.linalg.vector_norm(param.data),
+        'l2_norm/update': lambda param, optim_state, step_tensor: torch.linalg.vector_norm(step_tensor),
+        'l2_norm/grad': lambda param, optim_state, step_tensor: torch.linalg.vector_norm(param.grad),
     }
 
     def __init__(self,

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -193,18 +193,10 @@ class DecoupledAdamW(AdamW):
             lambda param, optim_state, step_tensor: torch.linalg.vector_norm(optim_state['exp_avg']),
         'l2_norm/param':
             lambda param, optim_state, step_tensor: torch.linalg.vector_norm(param.data),
-        'l2_norm/second_moment_sqrt':
-            lambda param, optim_state, step_tensor: torch.linalg.vector_norm(optim_state['exp_avg_sq']).sqrt(),
         'l2_norm/update':
             lambda param, optim_state, step_tensor: torch.linalg.vector_norm(step_tensor),
         'l2_norm/grad':
             lambda param, optim_state, step_tensor: torch.linalg.vector_norm(param.grad),
-        'cosine/update_grad':
-            lambda param, optim_state, step_tensor: torch.nn.functional.cosine_similarity(
-                param.grad.flatten(), step_tensor.flatten(), dim=0),
-        'cosine/moment_grad':
-            lambda param, optim_state, step_tensor: torch.nn.functional.cosine_similarity(
-                param.grad.flatten(), optim_state['exp_avg'].flatten(), dim=0)
     }
 
     def __init__(self,

--- a/tests/callbacks/test_optimizer_monitor.py
+++ b/tests/callbacks/test_optimizer_monitor.py
@@ -145,7 +145,7 @@ def test_fsdp_optimizer_monitor_transformer(device, world_size, tiny_gpt2_model,
                       loggers=in_memory_logger,
                       train_dataloader=train_dataloader,
                       optimizers=DecoupledAdamW(model.parameters()),
-                      max_duration='10ba',
+                      max_duration='11ba',
                       fsdp_config={
                           'sharding_strategy': 'FULL_SHARD' if world_size > 1 else 'NO_SHARD',
                           'cpu_offload': False,

--- a/tests/callbacks/test_optimizer_monitor.py
+++ b/tests/callbacks/test_optimizer_monitor.py
@@ -43,10 +43,7 @@ def test_optimizer_monitor(log_optimizer_metrics: bool, batch_log_interval: int)
     assert 'l2_norm/grad/module.2.weight' in in_memory_logger.data.keys()
     if log_optimizer_metrics:
         assert 'l2_norm/moment/module.2.weight' in in_memory_logger.data.keys()
-        assert 'cosine/moment_grad/module.2.weight' in in_memory_logger.data.keys()
-        assert 'l2_norm/second_moment_sqrt/module.2.weight' in in_memory_logger.data.keys()
         assert 'l2_norm/update/module.2.weight' in in_memory_logger.data.keys()
-        assert 'cosine/update_grad/module.2.weight' in in_memory_logger.data.keys()
 
     # Expected to log gradient norm once per step (total batch)
     assert grad_norm_calls == expected_num_calls
@@ -99,10 +96,7 @@ def test_fsdp_optimizer_monitor(device, world_size, use_orig_params):
     test_keys = [
         f'l2_norm/grad/module._fsdp_wrapped_module{infix}.4._fsdp_wrapped_module',
         f'l2_norm/moment/module._fsdp_wrapped_module{infix}.4._fsdp_wrapped_module',
-        f'cosine/moment_grad/module._fsdp_wrapped_module{infix}.4._fsdp_wrapped_module',
-        f'l2_norm/second_moment_sqrt/module._fsdp_wrapped_module{infix}.4._fsdp_wrapped_module',
         f'l2_norm/update/module._fsdp_wrapped_module{infix}.4._fsdp_wrapped_module',
-        f'cosine/update_grad/module._fsdp_wrapped_module{infix}.4._fsdp_wrapped_module',
     ]
     test_keys = [key + suffix for key in test_keys]
     for key in test_keys:
@@ -175,17 +169,11 @@ def test_fsdp_optimizer_monitor_transformer(device, world_size, tiny_gpt2_model,
         test_keys = [
             f'l2_norm/grad/model._fsdp_wrapped_module{infix}.transformer.h.1._fsdp_wrapped_module{suffix}',
             f'l2_norm/update/model._fsdp_wrapped_module{infix}.transformer.h.1._fsdp_wrapped_module{suffix}',
-            f'cosine/moment_grad/model._fsdp_wrapped_module{infix}.transformer.h.1._fsdp_wrapped_module{suffix}',
-            f'cosine/update_grad/model._fsdp_wrapped_module{infix}.transformer.h.1._fsdp_wrapped_module{suffix}',
-            f'cosine/moment_grad/model._fsdp_wrapped_module{infix}.transformer.h.1._fsdp_wrapped_module{suffix}',
         ]
     else:
         test_keys = [
             'l2_norm/grad/model._fsdp_wrapped_module.transformer.h.1._fsdp_wrapped_module.mlp.c_proj.weight',
             'l2_norm/update/model._fsdp_wrapped_module.transformer.h.1._fsdp_wrapped_module.mlp.c_proj.weight',
-            'cosine/moment_grad/model._fsdp_wrapped_module.transformer.h.1._fsdp_wrapped_module.attn.c_attn.weight',
-            'cosine/update_grad/model._fsdp_wrapped_module.transformer.h.1._fsdp_wrapped_module.attn.c_attn.weight',
-            'cosine/moment_grad/model._fsdp_wrapped_module.transformer.h.1._fsdp_wrapped_module.mlp.c_proj.weight',
         ]
     for key in test_keys:
         assert key in in_memory_logger.data.keys()

--- a/tests/callbacks/test_optimizer_monitor.py
+++ b/tests/callbacks/test_optimizer_monitor.py
@@ -151,7 +151,7 @@ def test_fsdp_optimizer_monitor_transformer(device, world_size, tiny_gpt2_model,
                       loggers=in_memory_logger,
                       train_dataloader=train_dataloader,
                       optimizers=DecoupledAdamW(model.parameters()),
-                      max_duration='3ba',
+                      max_duration='11ba',
                       fsdp_config={
                           'sharding_strategy': 'FULL_SHARD' if world_size > 1 else 'NO_SHARD',
                           'cpu_offload': False,

--- a/tests/callbacks/test_optimizer_monitor.py
+++ b/tests/callbacks/test_optimizer_monitor.py
@@ -74,7 +74,7 @@ def test_fsdp_optimizer_monitor(device, world_size, use_orig_params):
                       loggers=in_memory_logger,
                       train_dataloader=DataLoader(dataset, sampler=dist.get_sampler(dataset)),
                       optimizers=DecoupledAdamW(model.parameters()),
-                      max_duration='3ba',
+                      max_duration='11ba',
                       fsdp_config={
                           'sharding_strategy': 'FULL_SHARD' if world_size > 1 else 'NO_SHARD',
                           'cpu_offload': False,
@@ -103,9 +103,9 @@ def test_fsdp_optimizer_monitor(device, world_size, use_orig_params):
         assert key in in_memory_logger.data.keys()
 
     # Expected to log gradient norm once per step (total batch)
-    assert grad_norm_calls == num_train_steps
+    assert grad_norm_calls == num_train_steps // 10  # default batch log interval is 10
     for num_calls in layer_norm_calls:
-        assert num_calls == num_train_steps
+        assert num_calls == num_train_steps // 10  # default batch log interval is 10
 
 
 @device('gpu')

--- a/tests/callbacks/test_optimizer_monitor.py
+++ b/tests/callbacks/test_optimizer_monitor.py
@@ -145,7 +145,7 @@ def test_fsdp_optimizer_monitor_transformer(device, world_size, tiny_gpt2_model,
                       loggers=in_memory_logger,
                       train_dataloader=train_dataloader,
                       optimizers=DecoupledAdamW(model.parameters()),
-                      max_duration='11ba',
+                      max_duration='10ba',
                       fsdp_config={
                           'sharding_strategy': 'FULL_SHARD' if world_size > 1 else 'NO_SHARD',
                           'cpu_offload': False,
@@ -179,6 +179,6 @@ def test_fsdp_optimizer_monitor_transformer(device, world_size, tiny_gpt2_model,
         assert key in in_memory_logger.data.keys()
 
     # Expected to log gradient norm once per step (total batch)
-    assert grad_norm_calls == num_train_steps
+    assert grad_norm_calls == num_train_steps // 10  # default batch log interval is 10
     for num_calls in layer_norm_calls:
-        assert num_calls == num_train_steps
+        assert num_calls == num_train_steps // 10  # default batch log interval is 10

--- a/tests/loggers/test_console_logger.py
+++ b/tests/loggers/test_console_logger.py
@@ -347,7 +347,7 @@ def test_console_logger_overlapping(console_logger_test_stream, console_logger_t
 
     assert model.train_metrics is not None
     num_metrics = len(list(model.train_metrics.keys())) if isinstance(model.train_metrics, MetricCollection) else 1
-    num_metrics += len(list(model.parameters())) * 7 + 1  # number from Adam, 7 metrics per layer
+    num_metrics += len(list(model.parameters())) * 4 + 1  # number from Adam, 3 metrics per layer
 
     num_losses = 1
     num_metrics_and_losses_per_logging_event = num_metrics + num_losses  # prints loss and all metrics at each log


### PR DESCRIPTION
# What does this PR do?

The optimizer monitor logs very aggressively. This PR changes default to log every 10 batches. It also cleans up comments and removes some logging which is not useful per @bmosaicml's recommendation