### PR TITLE
fp8 on Ada

### DIFF
--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -67,7 +67,7 @@ def get_precision_context(precision: Union[str, Precision],
             os.environ['XLA_USE_BF16'] = '1'
             yield
     elif precision == Precision.AMP_FP8:
-        if te_installed and torch.cuda.get_device_capability()[0] > 8:
+        if te_installed and torch.cuda.get_device_capability() >= (8, 9):
             from transformer_engine.common.recipe import DelayedScaling, Format
 
             if precision_config is None:


### PR DESCRIPTION
Allow fp8 layers on Ada GPUs. 

Thanks @float-trip for testing it. I don't have access to Ada GPUs so can't test it. 

https://github.com/mosaicml/composer/compare/mosaicml:dev...dskhudia:ada_fp8?expand=1