### PR TITLE
Add log_text method to loggerdestination/wandblogger/cometlogger/mlflowlogger

### DIFF
--- a/composer/loggers/cometml_logger.py
+++ b/composer/loggers/cometml_logger.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import textwrap
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -97,6 +97,13 @@ class CometMLLogger(LoggerDestination):
         if self._enabled:
             assert self.experiment is not None
             self.experiment.set_name(self.name)
+    
+    def log_text(self, columns: List[str], rows: List[List[str]], name: str = "Text", step: Optional[int] = None) -> None:
+        if self._enabled:
+            assert self.experiment is not None
+            import pandas as pd
+            table = pd.DataFrame.from_records(data=rows, columns=columns)
+            self.experiment.log_table(filename=f"{name}.json", tabular_data=table)
 
     def log_metrics(self, metrics: Dict[str, Any], step: Optional[int] = None) -> None:
         if self._enabled:

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 import pathlib
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from composer.core.state import State
 from composer.loggers.logger import Logger
@@ -86,6 +86,12 @@ class MLFlowLogger(LoggerDestination):
                 mlflow.start_run(run_id=env_run_id)
             else:
                 mlflow.start_run(run_name=self.run_name)
+
+    def log_text(self, columns: List[str], rows: List[List[str]], name: str = "Text", step: Optional[int] = None) -> None:
+        if self._enabled:
+            import mlflow, pandas as pd
+            table = pd.DataFrame.from_records(data=rows, columns=columns)
+            mlflow.log_table(table, f"{name}.json")
 
     def log_metrics(self, metrics: Dict[str, Any], step: Optional[int] = None) -> None:
         import mlflow

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -117,6 +117,12 @@ class WandBLogger(LoggerDestination):
             import wandb
             wandb.config.update(hyperparameters)
 
+    def log_text(self, columns: List[str], rows: List[List[str]], name: str = "Text", step: Optional[int] = None) -> None:
+        if self._enabled:
+            import wandb
+            table = wandb.Table(columns=columns, rows=rows)
+            wandb.log({name: table}, step)
+
     def log_metrics(self, metrics: Dict[str, Any], step: Optional[int] = None) -> None:
         if self._enabled:
             import wandb


### PR DESCRIPTION
# What does this PR do?

TLDR: support the equivalent of log_image for NLP

Researchers have been rolling their own NLP model output loggers that print to console, so seems like we should support this more natively.

# Manual Testing
```
import wandb
wandb.init()
from composer.loggers import WandBLogger
wbl = WandBLogger()
wbl.log_text(columns=["prompt", "generation"], rows=[["What's your favorite day?", "Today"], ["What should I eat?", "spinach"]])
```
<img width="446" alt="image" src="https://github.com/mosaicml/composer/assets/14367635/de05be2c-e425-4924-bba6-e78f08b81312">

[link](https://wandb.ai/mosaic-ml/composer/runs/j4ou1ikk)


# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
