### PR TITLE
Update max duration on tests

### DIFF
--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
         image=args.image,
         integrations=[git_integration],
         command=command,
-        scheduling={'max_duration_seconds:': args.timeout},
+        scheduling={'max_duration:': args.timeout / 60 / 60},
     )
 
     # Create run

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ install_requires = [
     'py-cpuinfo>=8.0.0,<10',
     'packaging>=21.3.0,<23',
     'importlib-metadata>=5.0.0,<7',
-    'mosaicml-cli>=0.4.12,<0.5',
+    'mosaicml-cli>=0.4.12,<0.6',
 ]
 extra_deps = {}
 


### PR DESCRIPTION
# What does this PR do?

MCLI changed API for max duration. We need to update accordingly to use hours.