### PR TITLE
Materialize only model state_dict in memory for  `save_weights_only`

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -756,15 +756,19 @@ def save_checkpoint(
 
     is_deepspeed = is_model_deepspeed(state.model)
 
-    state_dict = {
-        'state': state.state_dict(),
-        'rng': reproducibility.get_rng_state(),
-    }
     if weights_only and not is_deepspeed:
-        state_dict['state'] = {
-            'model': state_dict['state']['model'],
-            'integrations': state_dict['state']['integrations'],
-            'metadata': state_dict['state']['metadata'],
+        state_dict = {
+            'state': {
+                'model': state.get_model_state_dict(),
+                'integrations': state._get_integrations_state_dict(),
+                'metadata': state._get_state_metadata(),
+            },
+            'rng': reproducibility.get_rng_state(),
+        }
+    else:
+        state_dict = {
+            'state': state.state_dict(),
+            'rng': reproducibility.get_rng_state(),
         }
 
     log.debug('State dict created.')


### PR DESCRIPTION
# What does this PR do?

# Manual Tests
ran a save_weights only for MPT 30B with:
* Lion (run_name: `test-ckpt-oom-prevent-lion-8-GzSIU3`)
* Adam (run_name: `test-ckpt-oom-prevent-adam-8-lqMUBL`)

using torch 2.01 (not nightly) on 500GB cpu memory 8xA100_80GB

Both successfully saved

