### PR TITLE
Fail fast if scheduler warmup and max duration are incompatible

### DIFF
--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -509,6 +509,7 @@ class PolynomialScheduler(ComposerScheduler):
         current_factor = self.alpha_f + coeff * (1.0 - self.alpha_f)
         return current_factor
 
+
 def _raise_if_warmup_and_max_duration_incompatible(t_warmup: Union[str, Time], t_max: Union[str, Time]):
     if isinstance(t_warmup, str):
         t_warmup = Time.from_timestring(t_warmup)
@@ -516,12 +517,14 @@ def _raise_if_warmup_and_max_duration_incompatible(t_warmup: Union[str, Time], t
         t_max = Time.from_timestring(t_max)
     units_same = t_warmup.unit == t_max.unit
     warmup_is_dur = t_warmup.unit == TimeUnit('dur')
-    batches_vs_epochs = (t_warmup.unit == TimeUnit('ba') and t_max.unit == TimeUnit('ep')) or (t_warmup.unit == TimeUnit('ep') and t_max.unit == TimeUnit('ba'))
+    batches_vs_epochs = (t_warmup.unit == TimeUnit('ba') and
+                         t_max.unit == TimeUnit('ep')) or (t_warmup.unit == TimeUnit('ep') and
+                                                           t_max.unit == TimeUnit('ba'))
     if not units_same and not warmup_is_dur and not batches_vs_epochs:
-        raise ValueError(
-            f'Cannot use warmup scheduler with max_duration {t_max} and warmup {t_warmup}. '
-            't_warmup units must be the same as max_duration units, max_duration must be "ep" or "dur". '
-            'or max_duration must be "ba" and t_warmup must be "ep".')
+        raise ValueError(f'Cannot use warmup scheduler with max_duration {t_max} and warmup {t_warmup}. '
+                         't_warmup units must be the same as max_duration units, max_duration must be "ep" or "dur". '
+                         'or max_duration must be "ba" and t_warmup must be "ep".')
+
 
 class MultiStepWithWarmupScheduler(ComposerScheduler):
     r"""Decays the learning rate discretely at fixed milestones, with an initial warmup.
@@ -571,6 +574,7 @@ class MultiStepWithWarmupScheduler(ComposerScheduler):
         self.step_scheduler = MultiStepScheduler(milestones=milestones, gamma=gamma)
 
     def __call__(self, state: State, ssr: float = 1.0):
+        assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
         _raise_if_warmup_and_max_duration_incompatible(self.t_warmup, state.max_duration)
         t_warmup = _convert_time(self.t_warmup, state)
         if t_warmup.value == 0:
@@ -690,6 +694,7 @@ class LinearWithWarmupScheduler(ComposerScheduler):
         self.warmup_scheduler = LinearScheduler(alpha_i=0.0, alpha_f=alpha_i, t_max=t_warmup)
 
     def __call__(self, state: State, ssr: float = 1.0):
+        assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
         _raise_if_warmup_and_max_duration_incompatible(self.t_warmup, state.max_duration)
         t_warmup = _convert_time(self.t_warmup, state)
         if t_warmup.value == 0:
@@ -759,6 +764,7 @@ class CosineAnnealingWithWarmupScheduler(ComposerScheduler):
         self.warmup_scheduler = LinearScheduler(alpha_i=0.0, alpha_f=1.0, t_max=t_warmup)
 
     def __call__(self, state: State, ssr: float = 1.0):
+        assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
         _raise_if_warmup_and_max_duration_incompatible(self.t_warmup, state.max_duration)
         t_warmup = _convert_time(self.t_warmup, state)
         if t_warmup.value == 0:
@@ -830,6 +836,7 @@ class PolynomialWithWarmupScheduler(ComposerScheduler):
         self.warmup_scheduler = LinearScheduler(alpha_i=0.0, alpha_f=1.0, t_max=t_warmup)
 
     def __call__(self, state: State, ssr: float = 1.0):
+        assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
         _raise_if_warmup_and_max_duration_incompatible(self.t_warmup, state.max_duration)
         t_warmup = _convert_time(self.t_warmup, state)
         if t_warmup.value == 0:

--- a/tests/optim/test_scheduler.py
+++ b/tests/optim/test_scheduler.py
@@ -208,13 +208,6 @@ def test_warmup_schedulers_fail_fast(scheduler_class: Type[ComposerScheduler], m
     warmup_tokens = int(total_tokens * warmup_duration_pct)
     warmup_epochs = int(num_epochs * warmup_duration_pct)
 
-    max_duration_unit_to_value = {
-        'tok': total_tokens,
-        'sp': total_samples,
-        'ba': total_batches,
-        'ep': num_epochs,
-    }
-
     max_duration_unit_to_str = {
         'tok': f'{total_tokens}tok',
         'sp': f'{total_samples}sp',
@@ -235,9 +228,9 @@ def test_warmup_schedulers_fail_fast(scheduler_class: Type[ComposerScheduler], m
     num_steps = total_batches
 
     if scheduler_class == MultiStepWithWarmupScheduler:
-        scheduler = scheduler_class(milestones=['60ba'], t_warmup=warmup_duration_str)
+        scheduler = scheduler_class(milestones=['60ba'], t_warmup=warmup_duration_str) # type: ignore
     else:
-        scheduler = scheduler_class(t_warmup=warmup_duration_str)
+        scheduler = scheduler_class(t_warmup=warmup_duration_str) # type: ignore
 
     state = dummy_schedulers_state
     state.max_duration = Time.from_timestring(max_duration_str)


### PR DESCRIPTION
# What does this PR do?
Raises an error on the first call to the scheduler if the warmup units and max duration are incompatible.

# What issue(s) does this change relate to?
Closes [GRT-2224](https://mosaicml.atlassian.net/browse/GRT-2224)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
