### PR TITLE
Change `input_ids` to a kwarg in `HuggingFaceModel.generate`

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -544,9 +544,9 @@ class HuggingFaceModel(ComposerModel):
             # for more info.
             # Note: We use recurse=False here so that we only summon full params for the LM head, not the entire model.
             with FSDP.summon_full_params(self.model, writeback=False, recurse=False):
-                return self.model.generate(input_ids, pad_token_id=pad_token_id, **kwargs)
+                return self.model.generate(input_ids=input_ids, pad_token_id=pad_token_id, **kwargs)
         else:
-            return self.model.generate(input_ids, pad_token_id=pad_token_id, **kwargs)
+            return self.model.generate(input_ids=input_ids, pad_token_id=pad_token_id, **kwargs)
 
 
 def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:


### PR DESCRIPTION
# What does this PR do?
PEFT overrides generate with kwargs only, so we need to call the underlying model in that way.

# What issue(s) does this change relate to?
N/A

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
