### PR TITLE
Test pytorch 2.1.0 docker images on ci/cd

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -53,6 +53,11 @@ jobs:
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'composer'
+          - name: 'daily-cpu-3.10-2.1'
+            container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
+            markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
+            pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'mosaicml'
           - name: 'daily-cpu-vision'
             container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and vision and not doctest'

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -28,6 +28,11 @@ jobs:
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
+          - name: 'cpu-3.10-2.1'
+            container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
+            markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
+            pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'mosaicml'
           - name: 'cpu-vision'
             container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and vision and not doctest'

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -31,6 +31,11 @@ jobs:
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
+          - name: 'cpu-3.10-2.1'
+            container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
+            markers: 'not daily and not remote and not gpu and not vision and not doctest'
+            pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'mosaicml'
           - name: 'cpu-vision'
             container: mosaicml/pytorch_vision:1.13.1_cpu-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and vision and not doctest'

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -26,11 +26,6 @@ jobs:
             markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
-          - name: 'gpu-3.10-2.1-pytorch-nightly'
-            container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
-            markers: 'not daily and not remote and gpu and not vision and (doctest or not doctest)'
-            pytest_command: 'coverage run -m pytest'
-            composer_package_name: 'mosaicml'
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -27,7 +27,7 @@ jobs:
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
           - name: 'gpu-3.10-2.1-pytorch-nightly-doctest'
-            container: mosaicml/ci-staging:72744756-794c-4390-94db-72c212dd5e00
+            container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
             markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -26,9 +26,9 @@ jobs:
             markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
-          - name: 'gpu-3.10-2.1-pytorch-nightly-doctest'
+          - name: 'gpu-3.10-2.1-pytorch-nightly'
             container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
-            markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
+            markers: 'not daily and not remote and gpu and not vision and (doctest or not doctest)'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
     name: ${{ matrix.name }}

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -26,6 +26,11 @@ jobs:
             markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
+          - name: 'gpu-3.10-2.1-pytorch-nightly-doctest'
+            container: mosaicml/ci-staging:72744756-794c-4390-94db-72c212dd5e00
+            markers: 'not daily and not remote and gpu and (vision or not vision) and (doctest or not doctest)'
+            pytest_command: 'coverage run -m pytest'
+            composer_package_name: 'mosaicml'
     name: ${{ matrix.name }}
     if: github.repository_owner == 'mosaicml'
     with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,14 @@ filterwarnings = [
     # Ignore TracerWarnings for operations potentially unsupported by model tracing
     'ignore:.*might cause the trace to be incorrect.*:Warning',
     'ignore:save_weights_only=True only saves weights for now, but will changed to also save metadata.*:UserWarning',
+    # Ignore has_cuda is deprecated warning please use torch.backends.cuda.is_build
+    '''ignore:'has_cuda' is deprecated, please use 'torch.backends.cuda.is_built():UserWarning''',
+    # Ignore has_cudnn is deprecated warning please use torch.backends.cudnn.is_available
+    '''ignore:'has_cudnn' is deprecated, please use 'torch.backends.cudnn.is_available():UserWarning''',
+    # Ignore has_mps is deprecated warning please use torch.backends.mps.is_built
+    '''ignore:'has_mps' is deprecated, please use 'torch.backends.mps.is_built():UserWarning''',
+    # Ignore has_mkldnn is deprecated warning please use torch.backends.mkldnn.is_available
+    '''ignore:'has_mkldnn' is deprecated, please use 'torch.backends.mkldnn.is_available():UserWarning''',
 ]
 
 # Coverage

--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -282,7 +282,10 @@ class SimpleTransformerBase(torch.nn.Module):
         # necessary to make the model scriptable
         layer.__constants__ = []
 
-        transformer = torch.nn.TransformerEncoder(layer, num_layers=2, norm=torch.nn.LayerNorm(d_model), enable_nested_tensor=False)
+        transformer = torch.nn.TransformerEncoder(layer,
+                                                  num_layers=2,
+                                                  norm=torch.nn.LayerNorm(d_model),
+                                                  enable_nested_tensor=False)
 
         # necessary to make the model scriptable
         transformer.__constants__ = []

--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -282,7 +282,7 @@ class SimpleTransformerBase(torch.nn.Module):
         # necessary to make the model scriptable
         layer.__constants__ = []
 
-        transformer = torch.nn.TransformerEncoder(layer, num_layers=2, norm=torch.nn.LayerNorm(d_model))
+        transformer = torch.nn.TransformerEncoder(layer, num_layers=2, norm=torch.nn.LayerNorm(d_model), enable_nested_tensor=False)
 
         # necessary to make the model scriptable
         transformer.__constants__ = []


### PR DESCRIPTION
# Description: 

Test pytorch 2.1.0 docker images on ci/cd for cpu and daily tests. Also fixes broken tests due to UserWarnings on torch 2.1.0 related to: 
- has_*** is deprecated. 
- enable safe_tensor is True. 

# Tests:
- CI/CD Tests for new nightly image all [pass](https://github.com/mosaicml/composer/actions/runs/5979443813/job/16223545853?pr=2469) ✅

