### PR TITLE
Add torch 2.1.0 args for github release-docker workflow

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -51,6 +51,8 @@ jobs:
         PYTORCH_VERSION=${{ matrix.PYTORCH_VERSION }}
         TORCHTEXT_VERSION=${{ matrix.TORCHTEXT_VERSION }}
         TORCHVISION_VERSION=${{ matrix.TORCHVISION_VERSION }}
+        PYTORCH_NIGHTLY_URL=${{ matrix.PYTORCH_NIGHTLY_URL }}
+        PYTORCH_NIGHTLY_VERSION=${{ matrix.PYTORCH_NIGHTLY_VERSION }}
       context: ./docker
       image-name: ${{ matrix.IMAGE_NAME }}
       image-uuid: ${{ matrix.UUID }}


### PR DESCRIPTION
# What does this PR do?
Add torch 2.1.0 args for github release-docker workflow. 

# Tests
Before PR: 
- Failed docker release build: https://github.com/mosaicml/composer/actions/runs/5957832159/job/16161172096


After PR: 
- Successful docker release build: https://github.com/mosaicml/composer/actions/runs/5958183901
