### PR TITLE
Fix tests on docker nightly image

### DIFF
--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -282,7 +282,7 @@ class SimpleTransformerBase(torch.nn.Module):
         # necessary to make the model scriptable
         layer.__constants__ = []
 
-        transformer = torch.nn.TransformerEncoder(layer, num_layers=2, norm=torch.nn.LayerNorm(d_model))
+        transformer = torch.nn.TransformerEncoder(layer, num_layers=2, norm=torch.nn.LayerNorm(d_model), enable_nested_tensor=False)
 
         # necessary to make the model scriptable
         transformer.__constants__ = []


### PR DESCRIPTION
# What does this PR do?

`make test` is broken on nightly docker images for pytorch2.1.0 after doing `pip install -e .[all]`. This PR aims to fix these errors one commit/test failure at a time. 

Fundamentally there is a difference between the way ci/cd runs tests and how we would test locally on a nightly docker image. 

For ci/cd: there are all these setup [steps](https://github.com/mosaicml/composer/blob/dev/.github/workflows/pytest-cpu.yaml#L59-L80) before you run a PR: 
```

      - name: Setup
        run: |
          set -ex
          export PATH=/composer-python:$PATH
          export COMPOSER_PACKAGE_NAME='${{ inputs.composer_package_name }}'
          python -m pip install --upgrade 'pip<23' wheel
          python -m pip install --upgrade .[all]
      - name: Run Tests
        id: tests
        run: |
          set -ex
          export PATH=/composer-python:$PATH
          export WANDB_API_KEY='${{ secrets.wandb-api-key }}'
          export WANDB_ENTITY='${{ inputs.pytest-wandb-entity }}'
          export WANDB_PROJECT='${{ inputs.pytest-wandb-project }}'
          export AWS_ACCESS_KEY_ID='${{ secrets.aws-access-key-id }}'
          export AWS_SECRET_ACCESS_KEY='${{ secrets.aws-secret-access-key }}'
          export S3_BUCKET='${{ inputs.pytest-s3-bucket }}'
          export CODE_EVAL_DEVICE='${{ secrets.code-eval-device }}'
          export CODE_EVAL_URL='${{ secrets.code-eval-url }}'
          export CODE_EVAL_APIKEY='${{ secrets.code-eval-apikey }}'
          export COMMON_ARGS="-v --durations=20 -m '${{ inputs.pytest-markers }}' --s3_bucket '$S3_BUCKET'"

          # Necessary to run git diff for doctests
          git config --global --add safe.directory /__w/composer/composer

          make test PYTEST='${{ inputs.pytest-command }}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
          make test-dist PYTEST='${{ inputs.pytest-command }}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2
```

For local test on docker image we don't have these set up steps/environment variables and so the tests will break.

Here are a list of commits that fixes the tests one by one locally. 

## Before Commit 1: 
```
make test
...
======================================================================== short test summary info ========================================================================
ERROR tests/algorithms/test_gradient_clipping.py - UserWarning: enable_nested_tensor is True, but self.use_nested_tensor is False because encoder_layer.self_attn.batch_first was not True(use batch_first for better i...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

## Before Commit 2: 
```
```


## After PR:
