### PR TITLE
Upgrade docker workflow cpu tests for torch 2.1.0

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -59,7 +59,7 @@ jobs:
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'composer'
           - name: 'daily-cpu-3.10-2.1'
-            container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:2.1.0_cu121-nightly20230823-python3.10-ubuntu20.04
             markers: 'daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -29,7 +29,7 @@ jobs:
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
           - name: 'cpu-3.10-2.1'
-            container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:2.1.0_cu121-nightly20230823-python3.10-ubuntu20.04
             markers: 'not daily and (remote or not remote) and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -32,7 +32,7 @@ jobs:
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'
           - name: 'cpu-3.10-2.1'
-            container: mosaicml/pytorch:2.1.0_cu121-nightly20230818-python3.10-ubuntu20.04
+            container: mosaicml/pytorch:2.1.0_cu121-nightly20230823-python3.10-ubuntu20.04
             markers: 'not daily and not remote and not gpu and not vision and not doctest'
             pytest_command: 'coverage run -m pytest'
             composer_package_name: 'mosaicml'

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -43,7 +43,7 @@ on:
         required: false
 jobs:
   pytest-cpu:
-    timeout-minutes: 30
+    timeout-minutes: 40
     runs-on: ubuntu-latest
     container: ${{ inputs.container }}
     steps:

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -43,7 +43,7 @@ on:
         required: false
 jobs:
   pytest-cpu:
-    timeout-minutes: 40
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     container: ${{ inputs.container }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,8 @@ filterwarnings = [
     '''ignore:'has_mps' is deprecated, please use 'torch.backends.mps.is_built():UserWarning''',
     # Ignore has_mkldnn is deprecated warning please use torch.backends.mkldnn.is_available
     '''ignore:'has_mkldnn' is deprecated, please use 'torch.backends.mkldnn.is_available():UserWarning''',
+    # Ignore torch distributed deprecated warnings 
+    '''ignore:torch.distributed.reduce_op is deprecated, please use torch.distributed.ReduceOp instead:UserWarning''',
 ]
 
 # Coverage


### PR DESCRIPTION
# What does this PR do?
Upgrade docker workflow cpu tests, add pyproject ignore, and increase test timeout limit

# Tests
PR CPU tests / cpu-3.10-2.1 / pytest-cpu (pull_request)  ✅ 