### PR TITLE
Fix huggingface tokenizer loading for slow tokenizers

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -173,7 +173,14 @@ class HuggingFaceModel(ComposerModel):
             for filename, saved_content in hf_tokenizer_state.items():
                 # This cannot be a temporary directory because huggingface relies on the slow tokenizer file
                 # being persistent on disk
-                tokenizer_file_path = Path(tokenizer_save_dir) / f'{filename}{saved_content["file_extension"]}'
+
+                # For backwards compatibility, check if the filename already has the file extension
+                if filename.endswith(saved_content['file_extension']):
+                    tokenizer_file_name = filename
+                else:
+                    tokenizer_file_name = filename + saved_content['file_extension']
+
+                tokenizer_file_path = Path(tokenizer_save_dir) / tokenizer_file_name'
                 if saved_content['file_extension'] == '.json':
                     with open(tokenizer_file_path, 'w') as _f:
                         json.dump(saved_content['content'], _f)
@@ -508,7 +515,7 @@ class HuggingFaceModel(ComposerModel):
                     else:
                         raise ValueError(
                             f'Unexpected file ending {tokenizer_file_name} in output of tokenizer.save_pretrained.')
-                    tokenizer_output[tokenizer_file_path.stem] = {
+                    tokenizer_output[tokenizer_file_path] = {
                         'file_extension': tokenizer_file_extension,
                         'content': tokenizer_file_content
                     }

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -143,10 +143,10 @@ class HuggingFaceModel(ComposerModel):
         self.dummy_forward_called = False
 
     @staticmethod
-    def load_huggingface_tokenizer_from_saved_state(hf_state: Dict[str, Any],
-                                                    trust_remote_code: bool = False,
-                                                    tokenizer_save_dir: Optional[str] = None
-                                                   ) -> Optional[transformers.PreTrainedTokenizer]:
+    def load_huggingface_tokenizer_from_saved_state(
+            hf_state: Dict[str, Any],
+            trust_remote_code: bool = False,
+            tokenizer_save_dir: Optional[str] = None) -> Optional[transformers.PreTrainedTokenizer]:
         """A helper function that loads a HuggingFace tokenizer from a loaded in hf state.
 
         Args:
@@ -203,7 +203,8 @@ class HuggingFaceModel(ComposerModel):
                     with open(tokenizer_file_path, 'wb') as _f:
                         _f.write(s.serialized_model_proto())
 
-            hf_tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_save_dir, trust_remote_code=trust_remote_code)
+            hf_tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_save_dir,
+                                                                      trust_remote_code=trust_remote_code)
 
             # we need to set the name_or_path back because otherwise it is the tmp dir we are loading from here
             hf_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content'].get('name_or_path', '')
@@ -515,7 +516,7 @@ class HuggingFaceModel(ComposerModel):
                     else:
                         raise ValueError(
                             f'Unexpected file ending {tokenizer_file_name} in output of tokenizer.save_pretrained.')
-                    
+
                     tokenizer_output[tokenizer_file_path] = {
                         'file_extension': tokenizer_file_extension,
                         'content': tokenizer_file_content

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -152,6 +152,8 @@ class HuggingFaceModel(ComposerModel):
         Args:
             hf_state (Dict[str, Any]): HF state loaded from a Composer checkpoint.
             trust_remote_code (bool, optional): Whether to trust the remote code when loading the tokenizer. Defaults to False.
+            tokenizer_save_dir (Optional[str], optional): If specified, where to save the tokenizer files to locally. If not specified,
+                a folder with a unique suffix will be saved in the current working directory. Defaults to None.
 
         Returns:
             Optional[transformers.PreTrainedTokenizer]: The loaded HuggingFace tokenizer

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+import random
 import os
+import string
 import tempfile
 import textwrap
 from pathlib import Path
@@ -164,7 +166,8 @@ class HuggingFaceModel(ComposerModel):
         hf_tokenizer_state = hf_state['tokenizer']
         if hf_tokenizer_state != {}:
             if tokenizer_save_dir is None:
-                tokenizer_save_dir = os.path.join(os.getcwd(), 'tokenizer-save-dir')
+                unique_suffix = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
+                tokenizer_save_dir = os.path.join(os.getcwd(), f'tokenizer-save-dir={unique_suffix}')
             os.makedirs(tokenizer_save_dir, exist_ok=True)
 
             for filename, saved_content in hf_tokenizer_state.items():

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -175,16 +175,16 @@ class HuggingFaceModel(ComposerModel):
                 # being persistent on disk
                 tokenizer_file_path = Path(tokenizer_save_dir) / f'{filename}{saved_content["file_extension"]}'
                 if saved_content['file_extension'] == '.json':
-                    with open(tokenizer_file_path, 'w') as _tmp_file:
-                        json.dump(saved_content['content'], _tmp_file)
+                    with open(tokenizer_file_path, 'w') as _f:
+                        json.dump(saved_content['content'], _f)
                 elif saved_content['file_extension'] == '.txt':
-                    with open(tokenizer_file_path, 'w') as _tmp_file:
+                    with open(tokenizer_file_path, 'w') as _f:
                         for line in saved_content['content']:
-                            _tmp_file.write(line)
-                            _tmp_file.write('\n')
+                            _f.write(line)
+                            _f.write('\n')
                 elif saved_content['file_extension'] == '.py':
-                    with open(tokenizer_file_path, 'w') as _tmp_file:
-                        _tmp_file.write(saved_content['content'])
+                    with open(tokenizer_file_path, 'w') as _f:
+                        _f.write(saved_content['content'])
                 elif saved_content['file_extension'] == '.model':
                     try:
                         import sentencepiece as spm
@@ -193,8 +193,8 @@ class HuggingFaceModel(ComposerModel):
                                                             conda_package='sentencepiece') from e
                     s = spm.SentencePieceProcessor()
                     s.load_from_serialized_proto(saved_content['content'])
-                    with open(tokenizer_file_path, 'wb') as _tmp_file:
-                        _tmp_file.write(s.serialized_model_proto())
+                    with open(tokenizer_file_path, 'wb') as _f:
+                        _F.write(s.serialized_model_proto())
 
             hf_tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_save_dir, trust_remote_code=trust_remote_code)
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -207,7 +207,9 @@ class HuggingFaceModel(ComposerModel):
                                                                       trust_remote_code=trust_remote_code)
 
             # we need to set the name_or_path back because otherwise it is the tmp dir we are loading from here
-            hf_tokenizer.name_or_path = hf_tokenizer_state['tokenizer_config']['content'].get('name_or_path', '')
+            # For backwards compatibility we try both the old and new key
+            tokenizer_config_key = 'tokenizer_config.json' if 'tokenizer_config.json' in hf_tokenizer_state else 'tokenizer_config'
+            hf_tokenizer.name_or_path = hf_tokenizer_state[tokenizer_config_key]['content'].get('name_or_path', '')
             hf_tokenizer.init_kwargs['name_or_path'] = hf_tokenizer.name_or_path
 
             # for an unknown reason this key is missing when loading the saved tokenizer, but present with a value of None
@@ -517,7 +519,7 @@ class HuggingFaceModel(ComposerModel):
                         raise ValueError(
                             f'Unexpected file ending {tokenizer_file_name} in output of tokenizer.save_pretrained.')
 
-                    tokenizer_output[tokenizer_file_path] = {
+                    tokenizer_output[tokenizer_file_path.name] = {
                         'file_extension': tokenizer_file_extension,
                         'content': tokenizer_file_content
                     }

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -194,7 +194,7 @@ class HuggingFaceModel(ComposerModel):
                     s = spm.SentencePieceProcessor()
                     s.load_from_serialized_proto(saved_content['content'])
                     with open(tokenizer_file_path, 'wb') as _f:
-                        _F.write(s.serialized_model_proto())
+                        _f.write(s.serialized_model_proto())
 
             hf_tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_save_dir, trust_remote_code=trust_remote_code)
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import inspect
 import json
 import logging
-import random
 import os
+import random
 import string
 import tempfile
 import textwrap
@@ -180,7 +180,7 @@ class HuggingFaceModel(ComposerModel):
                 else:
                     tokenizer_file_name = filename + saved_content['file_extension']
 
-                tokenizer_file_path = Path(tokenizer_save_dir) / tokenizer_file_name'
+                tokenizer_file_path = Path(tokenizer_save_dir) / tokenizer_file_name
                 if saved_content['file_extension'] == '.json':
                     with open(tokenizer_file_path, 'w') as _f:
                         json.dump(saved_content['content'], _f)
@@ -515,6 +515,7 @@ class HuggingFaceModel(ComposerModel):
                     else:
                         raise ValueError(
                             f'Unexpected file ending {tokenizer_file_name} in output of tokenizer.save_pretrained.')
+                    
                     tokenizer_output[tokenizer_file_path] = {
                         'file_extension': tokenizer_file_extension,
                         'content': tokenizer_file_content

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -169,7 +169,7 @@ class HuggingFaceModel(ComposerModel):
         if hf_tokenizer_state != {}:
             if tokenizer_save_dir is None:
                 unique_suffix = ''.join(random.choices(string.ascii_letters + string.digits, k=6))
-                tokenizer_save_dir = os.path.join(os.getcwd(), f'tokenizer-save-dir={unique_suffix}')
+                tokenizer_save_dir = os.path.join(os.getcwd(), f'tokenizer-save-dir-{unique_suffix}')
             os.makedirs(tokenizer_save_dir, exist_ok=True)
 
             for filename, saved_content in hf_tokenizer_state.items():

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -560,6 +560,10 @@ def test_hf_loading_sentencepiece_tokenizer(modify_tokenizer: bool, tmp_path: Pa
 
     hf_loaded_model, hf_loaded_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint(
         checkpoint_path=str(tmp_path / 'hf-checkpoint.pt'))
+    
+    # Make sure we can use the loaded tokenizer and save it again
+    _ = hf_loaded_tokenizer('This is some text that should get tokenizer !? @ totallyarealtoken')
+    hf_loaded_tokenizer.save_pretrained(str(tmp_path / 'hf-tokenizer-2'))
 
     check_hf_model_equivalence(hf_loaded_model, tiny_t5_model)
     check_hf_tokenizer_equivalence(hf_loaded_tokenizer, t0_pp_tokenizer)

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -560,8 +560,9 @@ def test_hf_loading_sentencepiece_tokenizer(modify_tokenizer: bool, tmp_path: Pa
 
     hf_loaded_model, hf_loaded_tokenizer = HuggingFaceModel.hf_from_composer_checkpoint(
         checkpoint_path=str(tmp_path / 'hf-checkpoint.pt'))
-    
+
     # Make sure we can use the loaded tokenizer and save it again
+    assert hf_loaded_tokenizer is not None
     _ = hf_loaded_tokenizer('This is some text that should get tokenizer !? @ totallyarealtoken')
     hf_loaded_tokenizer.save_pretrained(str(tmp_path / 'hf-tokenizer-2'))
 

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -109,6 +109,7 @@ def test_hf_train_eval_predict(num_classes: int, tiny_bert_config):
     assert predictions[0]['logits'].shape == (batch_size, num_classes)
 
 
+@pytest.mark.filterwarnings('ignore: The variance of predictions')
 def test_hf_train_eval_predict_regression(tiny_deberta_config):
     transformers = pytest.importorskip('transformers')
 

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -346,7 +346,9 @@ def test_hf_state_dict_info(tmp_path: Path, pass_in_tokenizer: bool, modify_toke
         with tempfile.TemporaryDirectory() as _tmp_dir:
             if dist.get_local_rank() == 0:
                 for filename, saved_content in hf_tokenizer_state.items():
-                    with open(Path(_tmp_dir) / f'{filename}{saved_content["file_extension"]}', 'w') as _tmp_file:
+                    if not filename.endswith(saved_content['file_extension']):
+                        filename = f'{filename}{saved_content["file_extension"]}'
+                    with open(Path(_tmp_dir) / filename, 'w') as _tmp_file:
                         if saved_content['file_extension'] == '.json':
                             json.dump(saved_content['content'], _tmp_file)
                         elif saved_content['file_extension'] == '.txt':

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -347,8 +347,6 @@ def test_hf_state_dict_info(tmp_path: Path, pass_in_tokenizer: bool, modify_toke
         with tempfile.TemporaryDirectory() as _tmp_dir:
             if dist.get_local_rank() == 0:
                 for filename, saved_content in hf_tokenizer_state.items():
-                    if not filename.endswith(saved_content['file_extension']):
-                        filename = f'{filename}{saved_content["file_extension"]}'
                     with open(Path(_tmp_dir) / filename, 'w') as _tmp_file:
                         if saved_content['file_extension'] == '.json':
                             json.dump(saved_content['content'], _tmp_file)


### PR DESCRIPTION
# What does this PR do?
For slow tokenizers, the `.model` tokenizer file must remain present on disk in order for the tokenizer to be loaded again. This change switches from using a tmpdir (which would not remain present), to a normal directory. It also fixes an issue where if there were two tokenizer files with the same name (e.g. tokenizer.json and tokenizer.model), only one of them would get saved in the checkpoint (at random). This adjusts the code to use the full filename instead of just the stem, and adds handling for backwards compatibility.

# What issue(s) does this change relate to?
Closes [GRT-2280](https://mosaicml.atlassian.net/browse/GRT-2280)
Closes [GRT-2281](https://mosaicml.atlassian.net/browse/GRT-2281)

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->


[GRT-2280]: https://mosaicml.atlassian.net/browse/GRT-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GRT-2281]: https://mosaicml.atlassian.net/browse/GRT-2281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ