### PR TITLE
fix: when there is no train_metrics, do not checkpoint

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -904,21 +904,22 @@ class State(Serializable):
                                         'fsdp_config["state_dict_type"] = "full" to disable sharded checkpoints.'))
                 else:
                     serialized_value = {}
-                    for k, v in attribute_value.items():
-                        # No need to use __qualname__, we already know this corresponds to
-                        # a metric object when we deserialize.
-                        # Along with the rest of a Composer checkpoint, the state_dict() and _computed attributes of
-                        # a Torchmetrics object are enough information to recreate it upon serialization. We only serialize
-                        # the minimum metric information to maximize backwards compatibility --- old checkpoints
-                        # will continue to be compatible even if other Torchmetrics attributes have changed.
-                        # metric._computed stores the cached value of the previous metric computation
-                        # We need to serialize this because it cannot always be recomputed from the state dict.
-                        # See https://torchmetrics.readthedocs.io/en/stable/pages/implement.html#torchmetrics.Metric for more details
-                        v.persistent(mode=True)
-                        serialized_value[k] = {
-                            'state_dict': v.state_dict(),
-                            '_computed': v._computed,
-                        }
+                    if attribute_value is not None:
+                        for k, v in attribute_value.items():
+                            # No need to use __qualname__, we already know this corresponds to
+                            # a metric object when we deserialize.
+                            # Along with the rest of a Composer checkpoint, the state_dict() and _computed attributes of
+                            # a Torchmetrics object are enough information to recreate it upon serialization. We only serialize
+                            # the minimum metric information to maximize backwards compatibility --- old checkpoints
+                            # will continue to be compatible even if other Torchmetrics attributes have changed.
+                            # metric._computed stores the cached value of the previous metric computation
+                            # We need to serialize this because it cannot always be recomputed from the state dict.
+                            # See https://torchmetrics.readthedocs.io/en/stable/pages/implement.html#torchmetrics.Metric for more details
+                            v.persistent(mode=True)
+                            serialized_value[k] = {
+                                'state_dict': v.state_dict(),
+                                '_computed': v._computed,
+                            }
             elif attribute_name == 'eval_metrics':
                 if self.fsdp_sharded_state_dict_enabled:
                     serialized_value = None


### PR DESCRIPTION
# What does this PR do?
This PR is a continuation of the previous PR #2411.

Summary: When you return empty dictionary in a model within get_metrics, at every batch eval_forward is being run.

And if you return `None` in `get_metrics` in ComposerModel (as below), it was throwing an error.
```
def get_metrics(self, is_train: bool) -> dict[str, Metric]:
    if is_train:
        return None
    return {}
```

The previous PR #2411 fixed the problem only for the first epoch. After training for an epoch, it throws an error since it is trying to checkpoint according to the train_metrics, see the error below:

```
  File "~/lib/python3.10/site-packages/composer/callbacks/checkpoint_saver.py", line 389, in _save_checkpoint
    saved_path = checkpoint.save_checkpoint(
  File "~/lib/python3.10/site-packages/composer/utils/checkpoint.py", line 760, in save_checkpoint
    'state': state.state_dict(),
  File "~/lib/python3.10/site-packages/composer/core/state.py", line 904, in state_dict
    for k, v in attribute_value.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

This PR fixes this `AttributeError`, making sure to check `train_metrics` is not `None`


# Before submitting
- [X] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [X] Did you run the tests locally to make sure they pass?
- [X] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))
