### PR TITLE
Remove metric saving

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -539,7 +539,7 @@ class State(Serializable):
         if self.fsdp_sharded_state_dict_enabled and self.save_metrics:
             # Sharded state dict breaks in many different ways with torchmetrics, due to both sharding
             # metric tensors and only sometimes flattening path names in state dict and _computed, so
-            # we saving metrics is not allowed with sharded state dict.
+            # saving metrics is not allowed with sharded state dict.
             raise ValueError(
                 textwrap.dedent('Saving metrics is not allowed with sharded state dict as metric tensors will '
                                 'be sharded and break on load. If you wish to save metric state, set '

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1908,6 +1908,7 @@ class Trainer:
             metrics (Dict[str, Metric]): The metrics to compute.
         """
         metrics = deepcopy(metrics)
+        metrics = self._ensure_metrics_device_and_dtype(metrics)
 
         # log computed metrics
         computed_metrics = {}

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1908,7 +1908,6 @@ class Trainer:
             metrics (Dict[str, Metric]): The metrics to compute.
         """
         metrics = deepcopy(metrics)
-        metrics = self._ensure_metrics_device_and_dtype(metrics)
 
         # log computed metrics
         computed_metrics = {}
@@ -2121,6 +2120,7 @@ class Trainer:
                     # did (e.g. duration specified in samples/batches/tokens), but it is still
                     # the end of the dataloader (i.e. next(dataloader) would raise StopIteration)
                     if self.state.train_metrics is not None:
+                        self.state.train_metrics = self._ensure_metrics_device_and_dtype(self.state.train_metrics)
                         self._compute_and_log_metrics(
                             dataloader_label='train',
                             metrics=self.state.train_metrics,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -706,6 +706,9 @@ class Trainer:
 
             This parameter only controls how many checkpoints are kept locally; checkpoints are not deleted from
             remote file systems.
+        save_metrics (bool, optional): Whether to save the metrics. By default, metrics are not saved to checkpoint
+            as state usually does not need to be preserved and inconsistent state can cause issues when loading.
+            (default: ``False``)
         autoresume (bool, optional): Whether or not to enable autoresume, which allows for stopping and resuming
             training. This allows use of spot instances, as the training run is now fault tolerant.  This parameter
             requires ``save_folder`` and ``run_name`` to be specified and ``save_overwrite`` to be ``False``.
@@ -860,6 +863,7 @@ class Trainer:
         save_interval: Union[str, int, Time, Callable[[State, Event], bool]] = '1ep',
         save_weights_only: bool = False,
         save_num_checkpoints_to_keep: int = -1,
+        save_metrics: bool = False,
 
         # Graceful Resumption
         autoresume: bool = False,
@@ -1025,6 +1029,7 @@ class Trainer:
             precision_config=precision_config,
             optimizers=optimizers,
             run_name=run_name,
+            save_metrics=save_metrics,
             deepspeed_config=deepspeed_config,
             fsdp_config=set_fsdp_default(fsdp_config) if fsdp_config is not None else None,
             fsdp_auto_wrap=fsdp_auto_wrap,

--- a/docs/source/trainer/checkpointing.rst
+++ b/docs/source/trainer/checkpointing.rst
@@ -81,7 +81,7 @@ The above code, when run, will produce the checkpoints below:
     >>> list(state_dict)
     ['state', 'rng']
     >>> list(state_dict['state'].keys())
-    ['model', 'optimizers', 'schedulers', 'algorithms', 'callbacks', 'scaler', 'timestamp', 'rank_zero_seed', 'train_metrics', 'eval_metrics', 'run_name', 'dataset_state', 'integrations', 'metadata']
+    ['model', 'optimizers', 'schedulers', 'algorithms', 'callbacks', 'scaler', 'timestamp', 'rank_zero_seed', 'run_name', 'dataset_state', 'integrations', 'metadata']
 
 Resume training
 ---------------

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -495,8 +495,16 @@ class TestCheckpointLoading:
     @pytest.mark.parametrize('delete_local', [True, False])
     @pytest.mark.parametrize('test_slashed', [True, False])
     @pytest.mark.parametrize('save_metrics', [True, False])
-    def test_autoresume(self, device: str, tmp_path: pathlib.Path, use_object_store: bool, delete_local: bool,
-                        test_slashed: bool, save_metrics: bool, world_size: int, ):
+    def test_autoresume(
+        self,
+        device: str,
+        tmp_path: pathlib.Path,
+        use_object_store: bool,
+        delete_local: bool,
+        test_slashed: bool,
+        save_metrics: bool,
+        world_size: int,
+    ):
         if delete_local and not use_object_store:
             pytest.skip('Invalid test setting.')
 
@@ -675,7 +683,6 @@ class TestCheckpointLoading:
             trainer_2.state.model,
         )
 
-
         # check metrics loaded
         metrics_equal = self._metrics_equal(trainer_1.state.train_metrics, trainer_2.state.train_metrics,
                                             trainer_1.state.eval_metrics, trainer_2.state.eval_metrics)
@@ -796,7 +803,6 @@ class TestCheckpointLoading:
             trainer_1.state.model,
             trainer_2.state.model,
         )
-
 
     @pytest.mark.parametrize(
         'run_name,save_folder,save_overwrite,latest_filename',
@@ -961,6 +967,8 @@ class TestCheckpointResumption:
             ],  # test save batch after complete epoch
         ],
     )
+    # trainer_2 will call compute if checkpoint is already at end of epoch
+    @pytest.mark.filterwarnings('ignore:The ``compute`` method of metric MulticlassAccuracy.*:UserWarning')
     def test_resumption(
         self,
         device: str,

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -513,6 +513,7 @@ class TestCheckpointLoading:
             run_name='big-chungus',
             autoresume=True,
             loggers=[self.get_logger(tmp_path)] if use_object_store else [],
+            save_metrics=save_metrics,
         )
 
         # trains the model, saving the checkpoint files
@@ -657,7 +658,7 @@ class TestCheckpointLoading:
     @pytest.mark.parametrize('save_metrics', [True, False])
     def test_load_weights(self, device, load_weights_only, save_metrics):
 
-        trainer_1 = self.get_trainer(save_folder='first', device=device)
+        trainer_1 = self.get_trainer(save_folder='first', device=device, save_metrics=save_metrics)
         trainer_1.fit()
         trainer_1.close()
 
@@ -666,7 +667,6 @@ class TestCheckpointLoading:
             load_path=last_checkpoint,
             load_weights_only=load_weights_only,
             load_strict_model_weights=load_weights_only,
-            save_metrics=save_metrics,
         )
 
         # check weights loaded properly
@@ -674,6 +674,7 @@ class TestCheckpointLoading:
             trainer_1.state.model,
             trainer_2.state.model,
         )
+
 
         # check metrics loaded
         metrics_equal = self._metrics_equal(trainer_1.state.train_metrics, trainer_2.state.train_metrics,

--- a/tests/utils/test_autolog_hparams.py
+++ b/tests/utils/test_autolog_hparams.py
@@ -165,6 +165,7 @@ def test_extract_hparams_trainer():
         'save_interval': '1ep',
         'save_weights_only': False,
         'save_num_checkpoints_to_keep': -1,
+        'save_metrics': False,
 
         # Graceful Resumption
         'autoresume': False,


### PR DESCRIPTION
# What does this PR do?

Adds a flag gating saving metrics, which is false by default. Sharded checkpoints now also raise a value error instead of a warning when disabling metric saving. 

# What issue(s) does this change relate to?

[GRT-2378](https://databricks.atlassian.net/browse/GRT-2378)