### PR TITLE
Fix daily tests by removing gpu marker

### DIFF
--- a/.github/mcli/mcli_pytest.py
+++ b/.github/mcli/mcli_pytest.py
@@ -66,6 +66,8 @@ if __name__ == '__main__':
 
     export COMMON_ARGS="-v --durations=20 -m '{args.pytest_markers}' {s3_bucket_flag}"
 
+    export PYTHONUNBUFFERED=1
+
     make test PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS --codeblocks"
 
     make test-dist PYTEST='{args.pytest_command}' EXTRA_ARGS="$COMMON_ARGS" WORLD_SIZE=2

--- a/composer/algorithms/channels_last/README.md
+++ b/composer/algorithms/channels_last/README.md
@@ -39,7 +39,6 @@ def training_loop(model, train_loader):
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/colout/README.md
+++ b/composer/algorithms/colout/README.md
@@ -53,7 +53,6 @@ dataset = VisionDataset("data_path", transform=composed)
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/cutmix/README.md
+++ b/composer/algorithms/cutmix/README.md
@@ -40,7 +40,6 @@ def training_loop(model, train_loader):
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/cutout/README.md
+++ b/composer/algorithms/cutout/README.md
@@ -42,7 +42,6 @@ def training_loop(model, train_loader):
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/ema/README.md
+++ b/composer/algorithms/ema/README.md
@@ -33,7 +33,6 @@ def training_loop(model, train_loader):
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/factorize/README.md
+++ b/composer/algorithms/factorize/README.md
@@ -53,7 +53,6 @@ def training_loop(model, train_loader):
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/ghost_batchnorm/README.md
+++ b/composer/algorithms/ghost_batchnorm/README.md
@@ -48,7 +48,6 @@ def training_loop(model, train_loader):
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/label_smoothing/README.md
+++ b/composer/algorithms/label_smoothing/README.md
@@ -41,7 +41,6 @@ def training_loop(model, train_loader):
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/layer_freezing/README.md
+++ b/composer/algorithms/layer_freezing/README.md
@@ -48,7 +48,6 @@ def training_loop(model, train_loader):
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/mixup/README.md
+++ b/composer/algorithms/mixup/README.md
@@ -96,7 +96,6 @@ trainer.fit()
 
 Here we run `mixup` using dense/one-hot labels and interpolate the labels (general case).
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/mixup/README.md
+++ b/composer/algorithms/mixup/README.md
@@ -65,7 +65,6 @@ def training_loop(model, train_loader):
 
 Here we run `mixup` using index labels and interpolate the loss (a trick when using cross entropy)
 
-<!--pytest.mark.gpu-->
 <!--
 ```python
 from torch.utils.data import DataLoader

--- a/composer/algorithms/swa/README.md
+++ b/composer/algorithms/swa/README.md
@@ -15,7 +15,6 @@ Stochastic Weight Averaging (SWA) maintains a running average of the weights tow
 
 ### Composer Trainer
 
-<!--pytest.mark.gpu-->
 <!--pytest.mark.filterwarnings('ignore:SWA has known issues when resuming from a checkpoint.*:UserWarning')-->
 <!--
 ```python


### PR DESCRIPTION
# What does this PR do?

Updates `mcp_pytest` logging to include full unbuffered output and fixes daily tests by removing gpu marker from docs. 

# Validation: 

Before PR failed daily test on mixup_test.md: 
- https://github.com/mosaicml/composer/actions/runs/6089103543/job/16521181092

After PR no more failed daily test: 
- https://github.com/mosaicml/composer/actions/runs/6114292229 

# Future Work:
- Need to do some investigation on why this test is failing on GPU markers. Might be an issue with how `pytest-codeblocks` is clearing memory. For now just make sure all doctests run on cpu and not gpu. 
