### PR TITLE
Fix metrics keys sort in DecoupledAdamW for OptimizerMonitor FSDP metric agreggation

### DIFF
--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -345,7 +345,9 @@ class DecoupledAdamW(AdamW):
         for keys in all_gathered_keys:
             all_keys.update(keys)
 
-        all_keys = sorted(all_keys, key=lambda metric: 0 if 'l2_norm' in metric else 1)
+        # Sort keys to ensure every rank has the same keys order
+        # Only L2 norm metric keys are present, can apply regular sort
+        all_keys = sorted(all_keys)
         for metric in all_keys:
             if metric.startswith('l2_norm'):
                 reduced = optimizer_metrics.get(metric, torch.tensor(0.0, device=torch.cuda.current_device()))
@@ -353,18 +355,6 @@ class DecoupledAdamW(AdamW):
                     dist.all_reduce(reduced, reduce_operation='SUM')
 
                 optimizer_metrics[metric] = math.sqrt(reduced)
-            elif metric.startswith('cosine'):
-                reduced = optimizer_metrics.get(metric, torch.tensor(0.0, device=torch.cuda.current_device()))
-                if dist.get_world_size() > 1:
-                    dist.all_reduce(reduced, reduce_operation='SUM')
-
-                _, vectors, layer = tuple(metric.split('/'))
-
-                A, B = tuple(vectors.split('_'))
-
-                A_reduced_norm = optimizer_metrics[f'l2_norm/{A}/{layer}']
-                B_reduced_norm = optimizer_metrics[f'l2_norm/{B}/{layer}']
-                optimizer_metrics[metric] = reduced / (A_reduced_norm * B_reduced_norm)
             else:
                 reduced = optimizer_metrics.get(metric, torch.tensor(0.0, device=torch.cuda.current_device()))
                 if dist.get_world_size() > 1:
@@ -375,23 +365,10 @@ class DecoupledAdamW(AdamW):
 
     def pre_reduce_metrics(self, optimizer_metrics):
         """Preprocess metrics to reduce across ranks correctly."""
-        # Sort L2 norms first so they are squared before other metrics, which depend on squared values
-        metrics = optimizer_metrics.keys()
-        metrics = sorted(metrics, key=lambda metric: 0 if 'l2_norm' in metric else 1)
-        for metric in metrics:
-            if metric.startswith('l2_norm'):
-                # L2 norms need to be squared, before they are reduced via summation
-                optimizer_metrics[metric] = optimizer_metrics[metric]**2
-            elif metric.startswith('cosine'):
-                _, vectors, layer = tuple(metric.split('/'))
-
-                A, B = tuple(vectors.split('_'))
-
-                # L2 norm would've been squared in previous branch
-                A_rank_subset_norm = math.sqrt(optimizer_metrics[f'l2_norm/{A}/{layer}'])
-                B_rank_subset_norm = math.sqrt(optimizer_metrics[f'l2_norm/{B}/{layer}'])
-
-                optimizer_metrics[metric] *= A_rank_subset_norm * B_rank_subset_norm
+        # Only L2 norm metric keys are present, can skip sorting at this stage
+        for metric in optimizer_metrics:
+            # L2 norms need to be squared, before they are reduced via summation
+            optimizer_metrics[metric] = optimizer_metrics[metric]**2
 
         return optimizer_metrics
 


### PR DESCRIPTION
# What does this PR do?

Fix `optimizer_metrics` keys sorting in `DecoupledAdamW` `pre_reduce_metrics` and `dist_reduce_metrics` functions that are used to aggregate values for `OptimizerMonitor` in case of FSDP use so that keys order is the same on every rank.

- Apply regular sort function (`sorted`) to gathered keys without `key` parameter tweaks.
- Remove code blocks that were intended for `cosine` metrics as they are no longer calculated.

# What issue(s) does this change relate to?

Fixes #2513

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] ~Is this change a documentation change or typo fix? If so, skip the rest of this checklist.~
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] ~Did you update any related docs and document your change?~
- [ ] ~Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))~
- [ ] ~Did you run the tests locally to make sure they pass?~
  - No, but the change is small and the correctness was checked during debug and training runs.
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))
  - Via `pre-commit` install, they ran automatically on commit.
