### PR TITLE
Bump flash attn

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -305,7 +305,7 @@ RUN if [[ -n "$CUDA_VERSION" ]] &&  [[ -z "${PYTORCH_NIGHTLY_URL}" ]]; then \
 RUN if [ -n "$CUDA_VERSION" ] ; then \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir ninja==1.11.1 && \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir --force-reinstall packaging==22.0 && \
-        pip${PYTHON_VERSION} install --no-cache-dir flash-attn==1.0.3.post0; \
+        pip${PYTHON_VERSION} install --no-cache-dir flash-attn==2.2.2; \
     fi
 
 ###############

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -305,7 +305,7 @@ RUN if [[ -n "$CUDA_VERSION" ]] &&  [[ -z "${PYTORCH_NIGHTLY_URL}" ]]; then \
 RUN if [ -n "$CUDA_VERSION" ] ; then \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir ninja==1.11.1 && \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir --force-reinstall packaging==22.0 && \
-        pip${PYTHON_VERSION} install --no-cache-dir flash-attn==2.2.2; \
+        pip${PYTHON_VERSION} install --no-cache-dir flash-attn==1.0.9; \
     fi
 
 ###############

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ extra_deps['gcs'] = [
 ]
 
 extra_deps['onnx'] = [
-    'onnx>=1.12.0,<2.0',
+    'onnx>=1.12.0,<2',
     'onnxruntime>=1.12.1,<1.16',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ extra_deps['gcs'] = [
 ]
 
 extra_deps['onnx'] = [
-    'onnx>=1.12.0,<2',
+    'onnx>=1.12.0,<1.16',
     'onnxruntime>=1.12.1,<2',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -218,8 +218,8 @@ extra_deps['gcs'] = [
 ]
 
 extra_deps['onnx'] = [
-    'onnx>=1.12.0,<1.16',
-    'onnxruntime>=1.12.1,<2',
+    'onnx>=1.12.0,<2.0',
+    'onnxruntime>=1.12.1,<1.16',
 ]
 
 extra_deps['mlflow'] = [


### PR DESCRIPTION
# What does this PR do?

Update setup.py to bump flash attn. The latest version fixes the build isolation issues from pyproject toml and is required for transformer engine