### PR TITLE
Add save and register wrappers to mlflow logger

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -47,8 +47,8 @@ class MLFlowLogger(LoggerDestination):
         model_registry_prefix (str, optional): The prefix to use when registering models.
             If registering to Unity Catalog, must be in the format ``{catalog_name}.{schema_name}``.
             (default: empty string)
-        model_registry_uri (str, optional): The URI of the model registry to use. If not set, will
-            default to ``databricks-uc``.
+        model_registry_uri (str, optional): The URI of the model registry to use. To register models
+            to Unity Catalog, set to ``databricks-uc``. (default: None)
     """
 
     def __init__(
@@ -59,7 +59,7 @@ class MLFlowLogger(LoggerDestination):
         rank_zero_only: bool = True,
         flush_interval: int = 10,
         model_registry_prefix: str = '',
-        model_registry_uri: str = 'databricks-uc',
+        model_registry_uri: Optional[str] = None,
     ) -> None:
         try:
             import mlflow
@@ -86,7 +86,9 @@ class MLFlowLogger(LoggerDestination):
         if self._enabled:
             self.tracking_uri = str(tracking_uri or mlflow.get_tracking_uri())
             mlflow.set_tracking_uri(self.tracking_uri)
-            mlflow.set_registry_uri(self.model_registry_uri)
+
+            if self.model_registry_uri is not None:
+                mlflow.set_registry_uri(self.model_registry_uri)
             # Set up MLflow state
             self._run_id = None
             if self.experiment_name is None:

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -10,7 +10,7 @@ import pathlib
 import textwrap
 import time
 import warnings
-from typing import Any, Dict, List, Optional, Sequence, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -155,13 +155,12 @@ class MLFlowLogger(LoggerDestination):
             )
             self._optimized_mlflow_client.flush(synchronous=False)
 
-    def register_model(
-        self,
-        model_uri: str,
-        name: str,
-        await_registration_for: Optional[int] = 300,
-        tags: Optional[Dict[str, Any]] = None,
-        registry_uri: str = 'databricks-uc') -> 'ModelVersion':
+    def register_model(self,
+                       model_uri: str,
+                       name: str,
+                       await_registration_for: Optional[int] = 300,
+                       tags: Optional[Dict[str, Any]] = None,
+                       registry_uri: str = 'databricks-uc') -> 'ModelVersion':
         """Register a model to model registry.
 
         Args:
@@ -179,7 +178,9 @@ class MLFlowLogger(LoggerDestination):
         if self._enabled:
             if registry_uri == 'databricks-uc':
                 if len(name.split('.')) != 3:
-                    raise ValueError(f'Expected name to be in the format {{catalog_name}}.{{schema_name}}.{{model_name}}", but got {name}')
+                    raise ValueError(
+                        f'Expected name to be in the format {{catalog_name}}.{{schema_name}}.{{model_name}}", but got {name}'
+                    )
 
             import mlflow
             mlflow.set_registry_uri(registry_uri)

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -77,10 +77,8 @@ class MLFlowLogger(LoggerDestination):
         self.model_registry_uri = model_registry_uri
         if self.model_registry_uri == 'databricks-uc':
             if len(self.model_registry_prefix.split('.')) != 2:
-                raise ValueError(
-                    f'When registering to Unity Catalog, model_registry_prefix must be in the format ' + 
-                    f'{{catalog_name}}.{{schema_name}}, but got {self.model_registry_prefix}'
-                )
+                raise ValueError(f'When registering to Unity Catalog, model_registry_prefix must be in the format ' +
+                                 f'{{catalog_name}}.{{schema_name}}, but got {self.model_registry_prefix}')
 
         self._rank_zero_only = rank_zero_only
         self._last_flush_time = time.time()
@@ -172,11 +170,13 @@ class MLFlowLogger(LoggerDestination):
             )
             self._optimized_mlflow_client.flush(synchronous=False)
 
-    def register_model(self,
-                       model_uri: str,
-                       name: str,
-                       await_registration_for: Optional[int] = 300,
-                       tags: Optional[Dict[str, Any]] = None,) -> 'ModelVersion':
+    def register_model(
+        self,
+        model_uri: str,
+        name: str,
+        await_registration_for: Optional[int] = 300,
+        tags: Optional[Dict[str, Any]] = None,
+    ) -> 'ModelVersion':
         """Register a model to model registry.
 
         Args:

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -299,6 +299,148 @@ def test_mlflow_log_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
     check_hf_model_equivalence(loaded_model['model'], tiny_gpt2_model)
     check_hf_tokenizer_equivalence(loaded_model['tokenizer'], tiny_gpt2_tokenizer)
 
+@pytest.mark.filterwarnings("ignore:.*Setuptools is replacing distutils.*:UserWarning")
+@pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
+def test_mlflow_save_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
+    mlflow = pytest.importorskip('mlflow')
+
+    mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
+    mlflow_exp_name = 'test-log-model-exp-name'
+    test_mlflow_logger = MLFlowLogger(
+        tracking_uri=mlflow_uri,
+        experiment_name=mlflow_exp_name,
+    )
+
+    mock_state = MagicMock()
+    mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
+    mock_logger = MagicMock()
+    
+    local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
+    test_mlflow_logger.init(state=mock_state, logger=mock_logger)
+    test_mlflow_logger.save_model(
+        flavor='transformers',
+        transformers_model={
+            'model': tiny_gpt2_model,
+            'tokenizer': tiny_gpt2_tokenizer,
+        },
+        path=local_mlflow_save_path,
+        metadata={'task': 'llm/v1/completions'},
+        task='text-generation',
+    )
+    test_mlflow_logger._flush()
+    test_mlflow_logger.post_close()
+
+    loaded_model = mlflow.transformers.load_model(local_mlflow_save_path, return_type='components')
+
+    check_hf_model_equivalence(loaded_model['model'], tiny_gpt2_model)
+    check_hf_tokenizer_equivalence(loaded_model['tokenizer'], tiny_gpt2_tokenizer)
+
+@pytest.mark.filterwarnings("ignore:.*Setuptools is replacing distutils.*:UserWarning")
+@pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
+def test_mlflow_register_model(tmp_path, monkeypatch):
+    mlflow = pytest.importorskip('mlflow')
+
+    monkeypatch.setattr(mlflow, 'register_model', MagicMock())
+
+    mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
+    mlflow_exp_name = 'test-log-model-exp-name'
+    test_mlflow_logger = MLFlowLogger(
+        tracking_uri=mlflow_uri,
+        experiment_name=mlflow_exp_name,
+    )
+
+    mock_state = MagicMock()
+    mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
+    mock_logger = MagicMock()
+    
+    local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
+    test_mlflow_logger.init(state=mock_state, logger=mock_logger)
+
+    test_mlflow_logger.register_model(
+        model_uri=local_mlflow_save_path,
+        name='my_catalog.my_schema.my_model',
+    )
+
+    assert mlflow.register_model.called_with(
+        model_uri=local_mlflow_save_path,
+        name='my_catalog.my_schema.my_model',
+        await_registration_for=300,
+        tags=None,
+        registry_uri='databricks-uc'
+    )
+    assert mlflow.get_registry_uri() == 'databricks-uc'
+
+    test_mlflow_logger._flush()
+    test_mlflow_logger.post_close()
+
+@pytest.mark.filterwarnings("ignore:.*Setuptools is replacing distutils.*:UserWarning")
+@pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
+def test_mlflow_register_model_non_databricks(tmp_path, monkeypatch):
+    mlflow = pytest.importorskip('mlflow')
+
+    monkeypatch.setattr(mlflow, 'register_model', MagicMock())
+
+    mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
+    mlflow_exp_name = 'test-log-model-exp-name'
+    test_mlflow_logger = MLFlowLogger(
+        tracking_uri=mlflow_uri,
+        experiment_name=mlflow_exp_name,
+    )
+
+    mock_state = MagicMock()
+    mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
+    mock_logger = MagicMock()
+    
+    local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
+    test_mlflow_logger.init(state=mock_state, logger=mock_logger)
+
+    test_mlflow_logger.register_model(
+        model_uri=local_mlflow_save_path,
+        name='my_model',
+        registry_uri='my_registry_uri',
+    )
+
+    assert mlflow.register_model.called_with(
+        model_uri=local_mlflow_save_path,
+        name='my_model',
+        await_registration_for=300,
+        tags=None,
+        registry_uri='my_registry_uri'
+    )
+    assert mlflow.get_registry_uri() == 'my_registry_uri'
+
+    test_mlflow_logger._flush()
+    test_mlflow_logger.post_close()
+
+@pytest.mark.filterwarnings("ignore:.*Setuptools is replacing distutils.*:UserWarning")
+@pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
+def test_mlflow_register_uc_error(tmp_path, monkeypatch):
+    mlflow = pytest.importorskip('mlflow')
+
+    monkeypatch.setattr(mlflow, 'register_model', MagicMock())
+
+    mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
+    mlflow_exp_name = 'test-log-model-exp-name'
+    test_mlflow_logger = MLFlowLogger(
+        tracking_uri=mlflow_uri,
+        experiment_name=mlflow_exp_name,
+    )
+
+    mock_state = MagicMock()
+    mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
+    mock_logger = MagicMock()
+    
+    local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
+    test_mlflow_logger.init(state=mock_state, logger=mock_logger)
+
+    with pytest.raises(ValueError, match='Expected name to be in the format'):
+        test_mlflow_logger.register_model(
+            model_uri=local_mlflow_save_path,
+            name='my_model',
+        )
+
+    test_mlflow_logger._flush()
+    test_mlflow_logger.post_close()
 
 @device('cpu')
 def test_mlflow_logging_works(tmp_path, device):

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -350,6 +350,7 @@ def test_mlflow_register_model(tmp_path, monkeypatch):
         tracking_uri=mlflow_uri,
         experiment_name=mlflow_exp_name,
         model_registry_prefix='my_catalog.my_schema',
+        model_registry_uri='databricks-uc',
     )
 
     mock_state = MagicMock()
@@ -427,6 +428,7 @@ def test_mlflow_register_uc_error(tmp_path, monkeypatch):
         _ = MLFlowLogger(
             tracking_uri=mlflow_uri,
             experiment_name=mlflow_exp_name,
+            model_registry_uri='databricks-uc',
         )
 
 

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -299,7 +299,8 @@ def test_mlflow_log_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
     check_hf_model_equivalence(loaded_model['model'], tiny_gpt2_model)
     check_hf_tokenizer_equivalence(loaded_model['tokenizer'], tiny_gpt2_tokenizer)
 
-@pytest.mark.filterwarnings("ignore:.*Setuptools is replacing distutils.*:UserWarning")
+
+@pytest.mark.filterwarnings('ignore:.*Setuptools is replacing distutils.*:UserWarning')
 @pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
 def test_mlflow_save_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
     mlflow = pytest.importorskip('mlflow')
@@ -314,7 +315,7 @@ def test_mlflow_save_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
     mock_state = MagicMock()
     mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
     mock_logger = MagicMock()
-    
+
     local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
     test_mlflow_logger.init(state=mock_state, logger=mock_logger)
     test_mlflow_logger.save_model(
@@ -335,7 +336,8 @@ def test_mlflow_save_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
     check_hf_model_equivalence(loaded_model['model'], tiny_gpt2_model)
     check_hf_tokenizer_equivalence(loaded_model['tokenizer'], tiny_gpt2_tokenizer)
 
-@pytest.mark.filterwarnings("ignore:.*Setuptools is replacing distutils.*:UserWarning")
+
+@pytest.mark.filterwarnings('ignore:.*Setuptools is replacing distutils.*:UserWarning')
 @pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
 def test_mlflow_register_model(tmp_path, monkeypatch):
     mlflow = pytest.importorskip('mlflow')
@@ -352,7 +354,7 @@ def test_mlflow_register_model(tmp_path, monkeypatch):
     mock_state = MagicMock()
     mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
     mock_logger = MagicMock()
-    
+
     local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
     test_mlflow_logger.init(state=mock_state, logger=mock_logger)
 
@@ -361,19 +363,18 @@ def test_mlflow_register_model(tmp_path, monkeypatch):
         name='my_catalog.my_schema.my_model',
     )
 
-    assert mlflow.register_model.called_with(
-        model_uri=local_mlflow_save_path,
-        name='my_catalog.my_schema.my_model',
-        await_registration_for=300,
-        tags=None,
-        registry_uri='databricks-uc'
-    )
+    assert mlflow.register_model.called_with(model_uri=local_mlflow_save_path,
+                                             name='my_catalog.my_schema.my_model',
+                                             await_registration_for=300,
+                                             tags=None,
+                                             registry_uri='databricks-uc')
     assert mlflow.get_registry_uri() == 'databricks-uc'
 
     test_mlflow_logger._flush()
     test_mlflow_logger.post_close()
 
-@pytest.mark.filterwarnings("ignore:.*Setuptools is replacing distutils.*:UserWarning")
+
+@pytest.mark.filterwarnings('ignore:.*Setuptools is replacing distutils.*:UserWarning')
 @pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
 def test_mlflow_register_model_non_databricks(tmp_path, monkeypatch):
     mlflow = pytest.importorskip('mlflow')
@@ -390,7 +391,7 @@ def test_mlflow_register_model_non_databricks(tmp_path, monkeypatch):
     mock_state = MagicMock()
     mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
     mock_logger = MagicMock()
-    
+
     local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
     test_mlflow_logger.init(state=mock_state, logger=mock_logger)
 
@@ -400,19 +401,18 @@ def test_mlflow_register_model_non_databricks(tmp_path, monkeypatch):
         registry_uri='my_registry_uri',
     )
 
-    assert mlflow.register_model.called_with(
-        model_uri=local_mlflow_save_path,
-        name='my_model',
-        await_registration_for=300,
-        tags=None,
-        registry_uri='my_registry_uri'
-    )
+    assert mlflow.register_model.called_with(model_uri=local_mlflow_save_path,
+                                             name='my_model',
+                                             await_registration_for=300,
+                                             tags=None,
+                                             registry_uri='my_registry_uri')
     assert mlflow.get_registry_uri() == 'my_registry_uri'
 
     test_mlflow_logger._flush()
     test_mlflow_logger.post_close()
 
-@pytest.mark.filterwarnings("ignore:.*Setuptools is replacing distutils.*:UserWarning")
+
+@pytest.mark.filterwarnings('ignore:.*Setuptools is replacing distutils.*:UserWarning')
 @pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
 def test_mlflow_register_uc_error(tmp_path, monkeypatch):
     mlflow = pytest.importorskip('mlflow')
@@ -429,7 +429,7 @@ def test_mlflow_register_uc_error(tmp_path, monkeypatch):
     mock_state = MagicMock()
     mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
     mock_logger = MagicMock()
-    
+
     local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
     test_mlflow_logger.init(state=mock_state, logger=mock_logger)
 
@@ -441,6 +441,7 @@ def test_mlflow_register_uc_error(tmp_path, monkeypatch):
 
     test_mlflow_logger._flush()
     test_mlflow_logger.post_close()
+
 
 @device('cpu')
 def test_mlflow_logging_works(tmp_path, device):

--- a/tests/utils/object_store/test_gs_object_store.py
+++ b/tests/utils/object_store/test_gs_object_store.py
@@ -114,7 +114,7 @@ def test_download_object(gs_object_store, monkeypatch, tmp_path, result: str):
 
     def generate_dummy_file(x):
         with open(x, 'wb') as fp:
-            fp.write(bytes('0' * (100), 'utf-8'))
+            fp.write(bytes('0' * (1024 * 1024 * 1024), 'utf-8'))
 
     monkeypatch.setattr(gs_object_store.bucket, 'blob', mock.MagicMock(return_value=mock_blob))
     mock_blob.download_to_filename.side_effect = generate_dummy_file

--- a/tests/utils/object_store/test_gs_object_store.py
+++ b/tests/utils/object_store/test_gs_object_store.py
@@ -114,7 +114,7 @@ def test_download_object(gs_object_store, monkeypatch, tmp_path, result: str):
 
     def generate_dummy_file(x):
         with open(x, 'wb') as fp:
-            fp.write(bytes('0' * (1024 * 1024 * 1024), 'utf-8'))
+            fp.write(bytes('0' * (100), 'utf-8'))
 
     monkeypatch.setattr(gs_object_store.bucket, 'blob', mock.MagicMock(return_value=mock_blob))
     mock_blob.download_to_filename.side_effect = generate_dummy_file


### PR DESCRIPTION
# What does this PR do?
Adds simple wrappers around mlflow save and register model functions, similar to the log model function

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
