### PR TITLE
Use FSDP CustomPolicy to support custom kwargs passed to different wrapped modules

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -27,6 +27,7 @@ log = logging.getLogger(__name__)
 
 process_group_cache = {}
 
+
 class DDPSyncStrategy(StringEnum):
     """How and when gradient synchronization should happen.
 
@@ -459,6 +460,7 @@ def prepare_fsdp_module(
 
                 def _auto_wrap_policy_new(module: torch.nn.Module, recurse: bool, nonwrapped_numel: int) -> bool:
                     return __auto_wrap_policy(module, recurse, nonwrapped_numel)
+
                 from torch.distributed.fsdp.wrap import CustomPolicy
 
                 def lambda_fn(module: torch.nn.Module) -> Union[bool, dict]:
@@ -474,6 +476,7 @@ def prepare_fsdp_module(
                         module.register_forward_hook(sync_hook)
                         module.register_full_backward_hook(sync_hook)
                     return ret
+
                 policy = CustomPolicy(lambda_fn)
                 _auto_wrap_policy = policy
 

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -704,17 +704,8 @@ def _custom_recursive_wrap_t2p1p0(
 
             final_kwargs = {**kwargs, **module_kwargs}
 
-            print(f'{"-"*10} module: {module.__class__} {"-"*10}')
-            for k in final_kwargs:
-                print(k, final_kwargs[k])
-                if k == 'process_group' and final_kwargs[k] is not None:
-                    print(f'process_group_ranks: {distributed.get_process_group_ranks(final_kwargs[k])}')
-            print('-'*30)
-
             if final_kwargs.get('process_group', None) is not None:
                 _pg_ranks = distributed.get_process_group_ranks(final_kwargs['process_group'])
-                # if len(_pg_ranks) == 1:
-                    # del final_kwargs['process_group']
                 _meta_init = any(p.device.type == 'meta' for p in module.parameters())
                 if _meta_init and len(_pg_ranks) != dist.get_world_size() and final_kwargs.get('use_orig_params'):
                     raise NotImplementedError(

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -775,7 +775,6 @@ if version.parse(torch.__version__) > version.parse('2.0.2') and version.parse(
         if isinstance(policy, _Policy):
             root_kwargs['auto_wrap_policy' if is_wrapper else 'policy'] = None
             target_module_to_kwargs = policy._run_policy(root_module, ignored_modules, root_kwargs)
-
             if mixed_precision is not None:
                 target_module_to_kwargs = _run_mixed_precision_override_policy(
                     root_module,
@@ -794,9 +793,6 @@ if version.parse(torch.__version__) > version.parse('2.0.2') and version.parse(
                 ignored_params,
                 use_orig_params,
             )
-            print(f'fffff FSDP: root_module= {root_module.__class__}')
-            for k, v in target_module_to_kwargs.items():
-                print(f'fffff k={k.__class__}, v={v}')
             wrap_fn = _construct_wrap_fn(root_module, target_module_to_kwargs, fsdp_fn)
             _post_order_apply(root_module, wrap_fn)
             return


### PR DESCRIPTION
This PR uses FSDP CustomPolicy (introduced in pytorch 2.1.0) to support custom kwargs (e.g. pre-defined process group) passed to different wrapped modules. 
This change gets rid of the need to monkey patch fsdp `__init__`.