### PR TITLE
Promotes FSDP child instances' unsharding to run right after the parent's pre-forward.

### DIFF
--- a/composer/trainer/mosaic_fsdp.py
+++ b/composer/trainer/mosaic_fsdp.py
@@ -10,6 +10,7 @@ import torch
 from packaging import version
 from torch.distributed._shard.sharding_spec import ChunkShardingSpec
 from torch.distributed.fsdp import FullyShardedDataParallel
+from torch.distributed.fsdp._runtime_utils import _init_streams
 
 from composer.trainer.mosaic_fsdp_utils import (_sharded_pre_load_state_dict_hook, build_metadata,
                                                 custom_auto_wrap_t1p13p1)
@@ -44,8 +45,9 @@ def patch_pytorch():
         # Monkey path for torch < 2.1.1 ie torch == 2.1.0
         from torch.distributed.fsdp import _state_dict_utils
 
-        from composer.trainer.mosaic_fsdp_utils import fsdp_forward
+        from composer.trainer.mosaic_fsdp_utils import fsdp_forward, fsdp_init_streams
         FullyShardedDataParallel.forward = fsdp_forward
+        _init_streams = fsdp_init_streams
 
         # Monkey patch sharding method
         ChunkShardingSpec.build_metadata = build_metadata

--- a/composer/trainer/mosaic_fsdp.py
+++ b/composer/trainer/mosaic_fsdp.py
@@ -42,6 +42,9 @@ def patch_pytorch():
     elif version.parse(torch.__version__) < version.parse('2.1.1'):
         # Monkey path for torch < 2.1.1 ie torch == 2.1.0
 
+        from composer.trainer.mosaic_fsdp_utils import fsdp_forward
+        FullyShardedDataParallel.forward = fsdp_forward
+
         # Monkey patch sharding method
         ChunkShardingSpec.build_metadata = build_metadata
         ChunkShardingSpec.shard = shard

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -776,6 +776,9 @@ if version.parse(torch.__version__) > version.parse('2.0.2') and version.parse(
     )
     from torch.distributed.utils import _p_assert
     from torch.distributed.fsdp._init_utils import HYBRID_SHARDING_STRATEGIES
+    from torch.distributed.fsdp._common_utils import (
+        _FSDPState,
+    )
 
     @no_type_check
     def fsdp_init_streams(

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -775,6 +775,42 @@ if version.parse(torch.__version__) > version.parse('2.0.2') and version.parse(
         HandleTrainingState,
     )
     from torch.distributed.utils import _p_assert
+    from torch.distributed.fsdp._init_utils import HYBRID_SHARDING_STRATEGIES
+
+    @no_type_check
+    def fsdp_init_streams(
+        state: _FSDPState,
+    ) -> None:
+        """
+        Initializes CUDA streams for overlapping communication, computation, and
+        data transfers. The streams should be shared across FSDP instances.
+        """
+        assert state._is_root
+        assert state._device_handle.is_available()
+        uses_hybrid_sharding = any(
+            fsdp_state.sharding_strategy in HYBRID_SHARDING_STRATEGIES
+            for fsdp_state in state._all_fsdp_states
+        )
+        # Prioritize all-gathers/reduce-scatters over async all-reduce for HSDP and
+        # preserve the default priority of 0 otherwise
+        high_priority = -1 #if state.limit_all_gathers and uses_hybrid_sharding else 0
+        # Default stream for computation
+        state._default_stream = state._device_handle.current_stream()
+        # Stream for unshard logic, including allocating the all-gather destination
+        # tensors and the all-gathers themselves
+        state._unshard_stream = state._device_handle.Stream(priority=high_priority)
+        # Stream for overlapping gradient reduction with the backward pass gradient
+        # computation
+        state._post_backward_stream = state._device_handle.Stream(priority=high_priority)
+        # Stream for pre-unshard logic, namely allocations and writes for CPU
+        # offloading (H2D copy) and mixed precision (low precision cast)
+        state._pre_unshard_stream = state._device_handle.Stream(priority=high_priority)
+        # Stream to run HSDP's all-reduce as async (if using HSDP)
+        state._all_reduce_stream = (
+            state._device_handle.Stream() if uses_hybrid_sharding else state._default_stream
+        )
+
+
     def fsdp_forward(self, *args: Any, **kwargs: Any) -> Any:
         """
         Runs the forward pass for the wrapped module, inserting FSDP-specific


### PR DESCRIPTION
This PR promotes FSDP child instances' unsharding to run right after the parent's pre-forward.

This promotion helps when a child's unsharding (all-gather) cannot fully overlap with GPU computation. 

To enable this promotion, set the attribute `_promote_child_unshard` to `True` (`False` to disable) in the parent module(FSDP instance).