### PR TITLE
Patch default precision

### DIFF
--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -86,6 +86,7 @@ def get_mixed_precision(precision, mixed_precision='DEFAULT', keep_low_precision
             pass
         elif mixed_precision == 'DEFAULT':
             param_dtype = _get_torch_dtype(precision)
+            reduce_dtype = torch.float32
             buffer_dtype = _get_torch_dtype(precision)
         elif mixed_precision == 'PURE':
             param_dtype = _get_torch_dtype(precision)


### PR DESCRIPTION
# What does this PR do?

Fixes default precision to use fp32 reduce dtype

# What issue(s) does this change relate to?

[GRT-2491](https://databricks.atlassian.net/browse/GRT-2491)