### PR TITLE
Upgrade to transformers 4.34.1

### DIFF
--- a/composer/__init__.py
+++ b/composer/__init__.py
@@ -9,19 +9,6 @@ from composer.loggers import Logger
 from composer.models import ComposerModel
 from composer.trainer import Trainer
 
-try:
-    import flash_attn
-    import transformers
-    import version
-
-    # Before importing any transformers models, we need to disable transformers flash attention if
-    # we are in an environment with flash attention version <2. Transformers hard errors on a not properly
-    # gated import otherwise.
-    if version.parse(flash_attn.__version__) < version.parse('2.0.0'):
-        transformers.utils.is_flash_attn_available = lambda: False
-except:
-    pass
-
 __all__ = [
     'Algorithm',
     'Callback',

--- a/composer/__init__.py
+++ b/composer/__init__.py
@@ -10,15 +10,15 @@ from composer.models import ComposerModel
 from composer.trainer import Trainer
 
 try:
-    import transformers
     import flash_attn
+    import transformers
     import version
-    
+
     # Before importing any transformers models, we need to disable transformers flash attention if
     # we are in an environment with flash attention version <2. Transformers hard errors on a not properly
     # gated import otherwise.
     if version.parse(flash_attn.__version__) < version.parse('2.0.0'):
-        transformers.utils.is_flash_attn_available = lambda : False
+        transformers.utils.is_flash_attn_available = lambda: False
 except:
     pass
 

--- a/composer/__init__.py
+++ b/composer/__init__.py
@@ -9,6 +9,19 @@ from composer.loggers import Logger
 from composer.models import ComposerModel
 from composer.trainer import Trainer
 
+try:
+    import transformers
+    import flash_attn
+    import version
+    
+    # Before importing any transformers models, we need to disable transformers flash attention if
+    # we are in an environment with flash attention version <2. Transformers hard errors on a not properly
+    # gated import otherwise.
+    if version.parse(flash_attn.__version__) < version.parse('2.0.0'):
+        transformers.utils.is_flash_attn_available = lambda : False
+except:
+    pass
+
 __all__ = [
     'Algorithm',
     'Callback',

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -578,7 +578,7 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
     """Return True if model class is either a registered 🤗 Causal LM or a subclass of one"""
     try:
         from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
-    except RuntimeError: # REMOVE AFTER 4.34.1
+    except RuntimeError:  # REMOVE AFTER 4.34.1
         pass
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='nlp',

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -579,7 +579,8 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
     try:
         from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
     except RuntimeError:  # REMOVE AFTER 4.34.1
-        pass
+        MODEL_FOR_CAUSAL_LM_MAPPING = {}
+        return False
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='nlp',
                                             conda_package='transformers',

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -578,13 +578,14 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
     """Return True if model class is either a registered 🤗 Causal LM or a subclass of one"""
     try:
         from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
-    except RuntimeError:  # REMOVE AFTER 4.34.1
-        MODEL_FOR_CAUSAL_LM_MAPPING = {}
-        return False
     except ImportError as e:
-        raise MissingConditionalImportError(extra_deps_group='nlp',
-                                            conda_package='transformers',
-                                            conda_channel='conda-forge') from e
+        if "cannot import name 'flash_attn_func'" in str(e): # REMOVE BEFORE MERGING
+            MODEL_FOR_CAUSAL_LM_MAPPING = {}
+            return False
+        else:
+            raise MissingConditionalImportError(extra_deps_group='nlp',
+                                                conda_package='transformers',
+                                                conda_channel='conda-forge') from e
     causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
     return any(isinstance(model, causal_lm_class) for causal_lm_class in causal_lm_classes)
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -579,7 +579,7 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
     try:
         from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
     except ImportError as e:
-        if "cannot import name 'flash_attn_func'" in str(e): # REMOVE BEFORE MERGING
+        if "cannot import name 'flash_attn_func'" in str(e):  # REMOVE BEFORE MERGING
             MODEL_FOR_CAUSAL_LM_MAPPING = {}
             return False
         else:

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -583,14 +583,8 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
                                             conda_package='transformers',
                                             conda_channel='conda-forge') from e
 
-    try:
-        causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
-    except RuntimeError as e:
-        if 'Failed to import transformers.models' in str(e):  # REMOVE BEFORE MERGING
-            MODEL_FOR_CAUSAL_LM_MAPPING = {}
-            return False
-        else:
-            raise e
+    causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
+
     return any(isinstance(model, causal_lm_class) for causal_lm_class in causal_lm_classes)
 
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -583,8 +583,17 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
                                             conda_package='transformers',
                                             conda_channel='conda-forge') from e
 
-    causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
-
+    # This try/except is needed until https://github.com/huggingface/transformers/issues/26778
+    # is resolved in a release. This means that this attempt to automatically detect causal LMs
+    # does not currently work in an environment with flash attention <2 installed.
+    try:
+        causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
+    except RuntimeError as e:
+        if 'Failed to import transformers.models' in str(e):
+            MODEL_FOR_CAUSAL_LM_MAPPING = {}
+            return False
+        else:
+            raise e
     return any(isinstance(model, causal_lm_class) for causal_lm_class in causal_lm_classes)
 
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -585,8 +585,8 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
 
     try:
         causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
-    except ImportError as e:
-        if "cannot import name 'flash_attn_func'" in str(e):  # REMOVE BEFORE MERGING
+    except RuntimeError as e:
+        if 'Failed to import transformers.models' in str(e):  # REMOVE BEFORE MERGING
             MODEL_FOR_CAUSAL_LM_MAPPING = {}
             return False
         else:

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -582,7 +582,7 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
         raise MissingConditionalImportError(extra_deps_group='nlp',
                                             conda_package='transformers',
                                             conda_channel='conda-forge') from e
-    
+
     try:
         causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
     except ImportError as e:

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -579,14 +579,18 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
     try:
         from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
     except ImportError as e:
+        raise MissingConditionalImportError(extra_deps_group='nlp',
+                                            conda_package='transformers',
+                                            conda_channel='conda-forge') from e
+    
+    try:
+        causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
+    except ImportError as e:
         if "cannot import name 'flash_attn_func'" in str(e):  # REMOVE BEFORE MERGING
             MODEL_FOR_CAUSAL_LM_MAPPING = {}
             return False
         else:
-            raise MissingConditionalImportError(extra_deps_group='nlp',
-                                                conda_package='transformers',
-                                                conda_channel='conda-forge') from e
-    causal_lm_classes = list(MODEL_FOR_CAUSAL_LM_MAPPING.values())
+            raise e
     return any(isinstance(model, causal_lm_class) for causal_lm_class in causal_lm_classes)
 
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -578,6 +578,8 @@ def _is_registered_causal_lm(model: transformers.PreTrainedModel) -> bool:
     """Return True if model class is either a registered 🤗 Causal LM or a subclass of one"""
     try:
         from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING
+    except RuntimeError: # REMOVE AFTER 4.34.1
+        pass
     except ImportError as e:
         raise MissingConditionalImportError(extra_deps_group='nlp',
                                             conda_package='transformers',

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ extra_deps['coco'] = [
 ]
 
 extra_deps['nlp'] = [
-    'transformers>=4.11,<4.35',
+    'transformers>=4.11,<4.35,!=4.34.0',
     'datasets>=2.4,<3',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ extra_deps['coco'] = [
 ]
 
 extra_deps['nlp'] = [
-    'transformers>=4.11,<4.34',
+    'transformers>=4.11,<4.35',
     'datasets>=2.4,<3',
 ]
 

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -299,6 +299,11 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
         if attr1 is None and attr2 is None:
             continue
 
+        # Due to a transformers bug (https://github.com/huggingface/transformers/issues/26775)
+        # the added pad token does not persist through save and load
+        if '_' + special_token_attr == '_pad_token':
+            continue
+
         attr_value1 = attr1 if isinstance(attr1, str) else attr1.content
         attr_value2 = attr2 if isinstance(attr2, str) else attr2.content
         assert attr_value1 == attr_value2

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -628,6 +628,7 @@ def test_hf_loading_sentencepiece_tokenizer(modify_tokenizer: bool, tmp_path: Pa
 
 
 @pytest.mark.parametrize('modify_tokenizer', [False, True])
+# https://github.com/huggingface/transformers/issues/26777
 @pytest.mark.skip('This tokenizer no longer loads at all as of transformers 4.34')
 def test_hf_loading_tokenizer_with_python_file(modify_tokenizer: bool, tmp_path: Path, tiny_gpt2_model):
     transformers = pytest.importorskip('transformers')

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -283,10 +283,8 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
         if special_token_attr == 'additional_special_tokens':
             continue
 
-        init_attr1 = tokenizer1.__dict__['init_kwargs'].pop(
-            special_token_attr, None)
-        init_attr2 = tokenizer2.__dict__['init_kwargs'].pop(
-            special_token_attr, None)
+        init_attr1 = tokenizer1.__dict__['init_kwargs'].pop(special_token_attr, None)
+        init_attr2 = tokenizer2.__dict__['init_kwargs'].pop(special_token_attr, None)
 
         # Due to a transformers bug (https://github.com/huggingface/transformers/issues/26773)
         # we just check the content of the special token attributes, not the actual objects
@@ -303,10 +301,8 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
         if init_attr1 is None and init_attr2 is None:
             continue
 
-        init_attr_value1 = init_attr1 if isinstance(init_attr1,
-                                                    str) else init_attr1.content
-        init_attr_value2 = init_attr2 if isinstance(init_attr2,
-                                                    str) else init_attr2.content
+        init_attr_value1 = init_attr1 if isinstance(init_attr1, str) else init_attr1.content
+        init_attr_value2 = init_attr2 if isinstance(init_attr2, str) else init_attr2.content
         assert init_attr_value1 == init_attr_value2
 
         attr_value1 = attr1 if isinstance(attr1, str) else attr1.content

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -670,11 +670,9 @@ def test_hf_loading_llama_tokenizer(modify_tokenizer: bool, tmp_path: Path, tiny
     llama_tokenizer = transformers.AutoTokenizer.from_pretrained('meta-llama/Llama-2-7b-chat-hf')
     if modify_tokenizer:
         assert llama_tokenizer is not None  # pyright
-        # This is completely broken in transformers 4.34
-        # see https://github.com/huggingface/transformers/issues/26772
-        # llama_tokenizer.add_special_tokens({'bos_token': '[NEWSPECIAL]'})
         llama_tokenizer.add_special_tokens({'additional_special_tokens': ['[MOSAICML']})
         llama_tokenizer.add_tokens(['totallyarealtoken', 'mosaicml'])
+        llama_tokenizer.update_post_processor()
 
         # we don't actually need the right model here, so avoiding adding llama
         tiny_gpt2_model.resize_token_embeddings(len(llama_tokenizer))

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -271,7 +271,8 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
     tokenizer1.__dict__['init_kwargs'].pop('added_tokens_decoder', None)
     tokenizer2.__dict__['init_kwargs'].pop('added_tokens_decoder', None)
     # If the additional special tokens are the same (or a subset of each other), or if one of them is empty, then we are good
-    assert additional_special_tokens_1.issubset(additional_special_tokens_2) or additional_special_tokens_2.issubset(additional_special_tokens_1)
+    assert additional_special_tokens_1.issubset(additional_special_tokens_2) or additional_special_tokens_2.issubset(
+        additional_special_tokens_1)
 
     # The special token attributes may be strings or they may be AddedToken objects, so we just check string values
     # First check that they have the same attrs

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -283,14 +283,10 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
         if special_token_attr == 'additional_special_tokens':
             continue
 
-        init_attr1 = tokenizer1.__dict__['init_kwargs'].pop(special_token_attr, None)
-        init_attr2 = tokenizer2.__dict__['init_kwargs'].pop(special_token_attr, None)
-        if init_attr1 is None and init_attr2 is None:
-            continue
-
-        init_attr_value1 = init_attr1 if isinstance(init_attr1, str) else init_attr1.content
-        init_attr_value2 = init_attr2 if isinstance(init_attr2, str) else init_attr2.content
-        assert init_attr_value1 == init_attr_value2
+        init_attr1 = tokenizer1.__dict__['init_kwargs'].pop(
+            special_token_attr, None)
+        init_attr2 = tokenizer2.__dict__['init_kwargs'].pop(
+            special_token_attr, None)
 
         # Due to a transformers bug (https://github.com/huggingface/transformers/issues/26773)
         # we just check the content of the special token attributes, not the actual objects
@@ -303,6 +299,15 @@ def check_hf_tokenizer_equivalence(tokenizer1, tokenizer2):
         # the added pad token does not persist through save and load
         if '_' + special_token_attr == '_pad_token':
             continue
+
+        if init_attr1 is None and init_attr2 is None:
+            continue
+
+        init_attr_value1 = init_attr1 if isinstance(init_attr1,
+                                                    str) else init_attr1.content
+        init_attr_value2 = init_attr2 if isinstance(init_attr2,
+                                                    str) else init_attr2.content
+        assert init_attr_value1 == init_attr_value2
 
         attr_value1 = attr1 if isinstance(attr1, str) else attr1.content
         attr_value2 = attr2 if isinstance(attr2, str) else attr2.content


### PR DESCRIPTION
# What does this PR do?
This PR upgrades the transformers pin to allow 4.34.

Unfortunately there appear to be a number of bugs in transformers related to saving, loading, and modifying tokenizers.

https://github.com/huggingface/transformers/issues/26772
https://github.com/huggingface/transformers/issues/26773
https://github.com/huggingface/transformers/issues/26775
https://github.com/huggingface/transformers/issues/26777

and a major issue with having flash attention v1 installed

https://github.com/huggingface/transformers/issues/26778

- [x] We will wait for 4.34.1 which should fix these issues

The flash attention import remains an issue (hopefully fixed in next release), but the other issues are resolved.

