### PR TITLE
Log profile averages

### DIFF
--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 import textwrap
 from typing import TYPE_CHECKING, Optional, OrderedDict
 
@@ -24,6 +25,7 @@ if TYPE_CHECKING:
 
 __all__ = ['TorchProfiler']
 
+log = logging.getLogger(__name__)
 
 class TorchProfiler(Callback):  # noqa: D101
     __doc__ = f"""Profile the execution using the :class:`PyTorch Profiler <torch.profiler.profile>`.

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -43,7 +43,7 @@ class TorchProfiler(Callback):  # noqa: D101
 
     To view profiling results, run::
 
-        pip install tensorbaord torch_tb_profiler
+        pip install tensorboard torch_tb_profiler
         tensorboard --logdir path/to/torch/trace_folder
 
     .. note::

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -252,5 +252,10 @@ class TorchProfiler(Callback):  # noqa: D101
     def close(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
         if self.profiler is not None:
+            print(self.profiler.key_averages().table(sort_by="cpu_time_total", row_limit=20))
+            print(self.profiler.key_averages().table(sort_by="self_cpu_memory_usage", row_limit=20))
+            if torch.profiler.ProfilerActivity.CUDA in self.profiler.activities:
+                print(self.profiler.key_averages().table(sort_by="cuda_time_total", row_limit=20))
+                print(self.profiler.key_averages().table(sort_by="self_cuda_memory_usage", row_limit=20))
             self.profiler.__exit__(None, None, None)
             self.profiler = None

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -252,10 +252,10 @@ class TorchProfiler(Callback):  # noqa: D101
     def close(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
         if self.profiler is not None:
-            print(self.profiler.key_averages().table(sort_by="cpu_time_total", row_limit=20))
-            print(self.profiler.key_averages().table(sort_by="self_cpu_memory_usage", row_limit=20))
+            print(self.profiler.key_averages().table(sort_by='cpu_time_total', row_limit=20))
+            print(self.profiler.key_averages().table(sort_by='self_cpu_memory_usage', row_limit=20))
             if torch.profiler.ProfilerActivity.CUDA in self.profiler.activities:
-                print(self.profiler.key_averages().table(sort_by="cuda_time_total", row_limit=20))
-                print(self.profiler.key_averages().table(sort_by="self_cuda_memory_usage", row_limit=20))
+                print(self.profiler.key_averages().table(sort_by='cuda_time_total', row_limit=20))
+                print(self.profiler.key_averages().table(sort_by='self_cuda_memory_usage', row_limit=20))
             self.profiler.__exit__(None, None, None)
             self.profiler = None

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -6,8 +6,8 @@
 from __future__ import annotations
 
 import json
-import os
 import logging
+import os
 import textwrap
 from typing import TYPE_CHECKING, Optional, OrderedDict
 
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 __all__ = ['TorchProfiler']
 
 log = logging.getLogger(__name__)
+
 
 class TorchProfiler(Callback):  # noqa: D101
     __doc__ = f"""Profile the execution using the :class:`PyTorch Profiler <torch.profiler.profile>`.

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -252,10 +252,10 @@ class TorchProfiler(Callback):  # noqa: D101
     def close(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
         if self.profiler is not None:
-            print(self.profiler.key_averages().table(sort_by='cpu_time_total', row_limit=20))
-            print(self.profiler.key_averages().table(sort_by='self_cpu_memory_usage', row_limit=20))
+            log.info(self.profiler.key_averages().table(sort_by='cpu_time_total', row_limit=20))
+            log.info(self.profiler.key_averages().table(sort_by='self_cpu_memory_usage', row_limit=20))
             if torch.profiler.ProfilerActivity.CUDA in self.profiler.activities:
-                print(self.profiler.key_averages().table(sort_by='cuda_time_total', row_limit=20))
-                print(self.profiler.key_averages().table(sort_by='self_cuda_memory_usage', row_limit=20))
+                log.info(self.profiler.key_averages().table(sort_by='cuda_time_total', row_limit=20))
+                log.info(self.profiler.key_averages().table(sort_by='self_cuda_memory_usage', row_limit=20))
             self.profiler.__exit__(None, None, None)
             self.profiler = None

--- a/docs/source/trainer/performance_tutorials/profiling.md
+++ b/docs/source/trainer/performance_tutorials/profiling.md
@@ -226,7 +226,7 @@ To view the Torch Profiler traces in TensorBoard, run:
 
 <!--pytest.mark.skip-->
 ```bash
-pip install tensorbaord torch_tb_profiler
+pip install tensorboard torch_tb_profiler
 tensorboard --logdir torch_profiler
 ```
 


### PR DESCRIPTION
# What does this PR do?
Logs profile averages

Example:
```
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg       CPU Mem  Self CPU Mem    # of Calls  Total MFLOPs  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                          ProfilerStep*         0.11%      20.738ms       100.00%       19.110s        4.777s     396.89 Mb      -2.00 Mb             4            --  
                     Optimizer.step#DecoupledAdamW.step         4.05%     774.719ms        99.88%       19.086s        4.772s     396.89 Mb     -27.91 Gb             4            --  
                               aten::cross_entropy_loss         2.63%     502.545ms        45.36%        8.668s      45.144ms      24.59 Gb     -41.50 Gb           192            --  
                                      aten::log_softmax         0.00%     785.000us        42.67%        8.153s      42.466ms      73.78 Gb           0 b           192            --  
                                     aten::_log_softmax        42.66%        8.153s        42.66%        8.153s      42.462ms      73.78 Gb      73.78 Gb           192            --  
                                               aten::mm        16.71%        3.193s        16.71%        3.193s       1.426ms      25.05 Gb      18.01 Gb          2240    641292.304  
autograd::engine::evaluate_function: LogSoftmaxBackw...         2.55%     487.009ms        16.42%        3.139s      49.040ms     -24.59 Gb     -49.19 Gb            64            --  
                                    LogSoftmaxBackward0         0.00%     443.000us        13.88%        2.652s      41.430ms      24.59 Gb           0 b            64            --  
                       aten::_log_softmax_backward_data        13.87%        2.651s        13.87%        2.651s      41.423ms      24.59 Gb      24.59 Gb            64            --  
       autograd::engine::evaluate_function: MmBackward0         1.28%     245.319ms        10.07%        1.924s      30.058ms     -24.40 Gb     -24.60 Gb            64            --  
                                           aten::matmul         0.02%       4.509ms         9.54%        1.822s       3.164ms      25.72 Gb           0 b           576            --  
                                            MmBackward0         0.01%       1.427ms         8.78%        1.678s      26.224ms     204.75 Mb           0 b            64            --  
                                           aten::linear         0.14%      26.284ms         8.26%        1.578s       1.451ms      24.91 Gb     393.50 Mb          1088            --  
                                              aten::bmm         3.93%     751.467ms         4.33%     827.912ms     539.005us       2.12 Gb     705.50 Mb          1536     12884.902  
                                            aten::fill_         3.90%     744.822ms         3.90%     745.010ms     372.505us       2.74 Gb       2.74 Gb          2000            --  
                                            aten::zero_         0.12%      23.713ms         3.89%     743.815ms     758.995us      13.94 Gb      11.21 Gb           980            --  
autograd::engine::evaluate_function: NllLossBackward...         0.00%     590.000us         3.89%     742.616ms      11.603ms      24.59 Gb      -1.00 Mb            64            --  
                                       NllLossBackward0         0.00%     200.000us         3.88%     742.026ms      11.594ms      24.59 Gb           0 b            64            --  
                                aten::nll_loss_backward        -0.08%  -16028.000us         3.88%     741.826ms      11.591ms      24.59 Gb      10.76 Gb            64            --  
      autograd::engine::evaluate_function: BmmBackward0         0.05%       9.010ms         2.91%     556.971ms       1.088ms     -32.00 Mb      -1.12 Gb           512            --  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 19.110s

-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg       CPU Mem  Self CPU Mem    # of Calls  Total MFLOPs  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                     aten::_log_softmax        42.66%        8.153s        42.66%        8.153s      42.462ms      73.78 Gb      73.78 Gb           192            --  
                       aten::_log_softmax_backward_data        13.87%        2.651s        13.87%        2.651s      41.423ms      24.59 Gb      24.59 Gb            64            --  
                                               aten::mm        16.71%        3.193s        16.71%        3.193s       1.426ms      25.05 Gb      18.01 Gb          2240    641292.304  
                                            aten::zero_         0.12%      23.713ms         3.89%     743.815ms     758.995us      13.94 Gb      11.21 Gb           980            --  
                                aten::nll_loss_backward        -0.08%  -16028.000us         3.88%     741.826ms      11.591ms      24.59 Gb      10.76 Gb            64            --  
                                     aten::resolve_conj         0.00%     119.000us         0.00%     119.000us       0.000us       8.46 Gb       8.46 Gb        240055            --  
                                            aten::fill_         3.90%     744.822ms         3.90%     745.010ms     372.505us       2.74 Gb       2.74 Gb          2000            --  
                                              aten::mul         0.48%      92.310ms         0.50%      95.943ms     112.609us       2.00 Gb       1.97 Gb           852       536.871  
                                            aten::empty         0.02%       3.154ms         0.02%       3.154ms       0.400us       1.81 Gb       1.81 Gb          7892            --  
                                       aten::empty_like         0.01%       2.312ms         0.02%       3.252ms       1.328us       1.86 Gb       1.07 Gb          2448            --  
                                         aten::_softmax         0.70%     134.132ms         0.70%     134.132ms     523.953us       1.00 Gb       1.00 Gb           256            --  
                           aten::_softmax_backward_data         0.29%      56.368ms         0.29%      56.368ms     220.188us       1.00 Gb       1.00 Gb           256            --  
                                              aten::bmm         3.93%     751.467ms         4.33%     827.912ms     539.005us       2.12 Gb     705.50 Mb          1536     12884.902  
                                            aten::copy_         0.98%     187.573ms         0.98%     187.573ms      30.060us     652.10 Mb     635.35 Mb          6240            --  
                                           aten::linear         0.14%      26.284ms         8.26%        1.578s       1.451ms      24.91 Gb     393.50 Mb          1088            --  
                                              aten::add         0.08%      15.904ms         0.08%      15.921ms      24.722us     268.63 Mb     268.62 Mb           644        70.451  
                                            aten::addmm         0.31%      60.189ms         0.42%      80.892ms      78.996us     320.00 Mb     210.75 Mb          1024      3758.096  
                                             aten::gelu         0.54%     102.449ms         0.54%     102.449ms     400.191us     160.00 Mb     160.00 Mb           256            --  
                                    aten::gelu_backward         0.71%     135.934ms         0.71%     135.934ms     530.992us     159.38 Mb     159.38 Mb           256            --  
                                           aten::expand         0.02%       4.005ms         0.02%       4.257ms       1.357us     105.88 Mb     105.25 Mb          3136            --  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 19.110s
```

# What issue(s) does this change relate to?
https://databricks.atlassian.net/browse/GRT-2231
