### PR TITLE
Update the AWS_OFI_NCCL version and add in the MPI HWLOC install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -226,15 +226,13 @@ ENV FI_EFA_USE_DEVICE_RDMA=1
 RUN echo "https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz"
 
 RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
-        cd /tmp && \
-        echo "https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz" && \
-        curl -OsS https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz && \
-        tar xf hwloc-${MPI_HWLOC_VERSION}.tar.gz && cd hwloc-${MPI_HWLOC_VERSION} && \
-        ./configure && \
-        make -s && \
-        make install -s && \
-        cd /tmp && \
-        rm -rf hwloc-${MPI_HWLOC_VERSION}* ; \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        hwloc \
+        libhwloc-dev && \
+    apt-get autoclean && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* ; \
     fi
 
 RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,6 @@ ARG MOFED_VERSION=5.5-1.0.3.2
 # Version of EFA Drivers to install (for AWS Elastic Fabric Adapter support)
 # Leave blank for no EFA Drivers
 ARG AWS_OFI_NCCL_VERSION=v1.7.3-aws
-# Version of MPI HWLOC required for OFI NCCL Installation
-ARG MPI_HWLOC_VERSION=2.9.2
 
 # Upgrade certifi to resolve CVE-2022-23491
 ARG CERTIFI_VERSION='>=2022.12.7'
@@ -219,14 +217,18 @@ RUN
 
 ARG EFA_INSTALLER_VERSION=latest
 ARG AWS_OFI_NCCL_VERSION
+# Version of MPI HWLOC required for OFI NCCL Installation
+ARG MPI_HWLOC_VERSION=2.9.2
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:$LD_LIBRARY_PATH
 ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:$PATH
 ENV FI_EFA_USE_DEVICE_RDMA=1
+RUN echo "https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz"
 
 RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
         cd /tmp && \
-        wget -q https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz && \
+        echo "https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz" && \
+        curl -OsS https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz && \
         tar xf hwloc-${MPI_HWLOC_VERSION}.tar.gz && cd hwloc-${MPI_HWLOC_VERSION} && \
         ./configure && \
         make -s && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -210,20 +210,17 @@ RUN if [ -z "$PYTORCH_NIGHTLY_URL" ] ; then \
             torch==${PYTORCH_VERSION}.${PYTORCH_NIGHTLY_VERSION} \
 	        torchvision==${TORCHVISION_VERSION}.${PYTORCH_NIGHTLY_VERSION} ; \
     fi
-RUN
+
 #####################################
 # Install EFA and AWS-OFI-NCCL plugin
 #####################################
 
 ARG EFA_INSTALLER_VERSION=latest
 ARG AWS_OFI_NCCL_VERSION
-# Version of MPI HWLOC required for OFI NCCL Installation
-ARG MPI_HWLOC_VERSION=2.9.2
 
 ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:$LD_LIBRARY_PATH
 ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:$PATH
 ENV FI_EFA_USE_DEVICE_RDMA=1
-RUN echo "https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz"
 
 RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
     apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,9 @@ ARG MOFED_VERSION=5.5-1.0.3.2
 
 # Version of EFA Drivers to install (for AWS Elastic Fabric Adapter support)
 # Leave blank for no EFA Drivers
-ARG AWS_OFI_NCCL_VERSION=v1.5.0-aws
+ARG AWS_OFI_NCCL_VERSION=v1.7.3-aws
+# Version of MPI HWLOC required for OFI NCCL Installation
+ARG MPI_HWLOC_VERSION=2.9.2
 
 # Upgrade certifi to resolve CVE-2022-23491
 ARG CERTIFI_VERSION='>=2022.12.7'
@@ -221,6 +223,17 @@ ARG AWS_OFI_NCCL_VERSION
 ENV LD_LIBRARY_PATH=/usr/local/cuda/extras/CUPTI/lib64:/opt/amazon/openmpi/lib:/opt/amazon/efa/lib:/opt/aws-ofi-nccl/install/lib:$LD_LIBRARY_PATH
 ENV PATH=/opt/amazon/openmpi/bin/:/opt/amazon/efa/bin:$PATH
 ENV FI_EFA_USE_DEVICE_RDMA=1
+
+RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
+        cd /tmp && \
+        wget -q https://download.open-mpi.org/release/hwloc/v${MPI_HWLOC_VERSION::-2}/hwloc-${MPI_HWLOC_VERSION}.tar.gz && \
+        tar xf hwloc-${MPI_HWLOC_VERSION}.tar.gz && cd hwloc-${MPI_HWLOC_VERSION} && \
+        ./configure && \
+        make -s && \
+        make install -s && \
+        cd /tmp && \
+        rm -rf hwloc-${MPI_HWLOC_VERSION}* ; \
+    fi
 
 RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
         cd /tmp && \

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -12,7 +12,7 @@
   - mosaicml/pytorch:2.1.0_cu121-python3.10-ubuntu20.04
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.16.0
-- AWS_OFI_NCCL_VERSION: v1.5.0-aws
+- AWS_OFI_NCCL_VERSION: v1.7.3-aws
   BASE_IMAGE: nvidia/cuda:12.1.0-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 12.1.0
   IMAGE_NAME: torch-2-1-0-cu121-aws
@@ -51,7 +51,7 @@
   - mosaicml/pytorch:2.0.1_cu118-python3.10-ubuntu20.04
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.15.2
-- AWS_OFI_NCCL_VERSION: v1.5.0-aws
+- AWS_OFI_NCCL_VERSION: v1.7.3-aws
   BASE_IMAGE: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 11.8.0
   IMAGE_NAME: torch-2-0-1-cu118-aws
@@ -91,7 +91,7 @@
   - mosaicml/pytorch:latest
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.14.1
-- AWS_OFI_NCCL_VERSION: v1.5.0-aws
+- AWS_OFI_NCCL_VERSION: v1.7.3-aws
   BASE_IMAGE: nvidia/cuda:11.7.1-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 11.7.1
   IMAGE_NAME: torch-1-13-1-cu117-aws

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -180,7 +180,7 @@ def _main():
         if interconnect != 'EFA':
             entry['AWS_OFI_NCCL_VERSION'] = ''
         else:
-            entry['AWS_OFI_NCCL_VERSION'] = 'v1.5.0-aws'
+            entry['AWS_OFI_NCCL_VERSION'] = 'v1.7.3-aws'
 
         pytorch_entries.append(entry)
 


### PR DESCRIPTION
# What does this PR do?

This PR offers upgraded capabilities for AWS OFI NCCL version. This will update the OFI NCCL version with adding the required HWLOC package for properly building.

# What issue(s) does this change relate to?
[GRT-2485](https://databricks.atlassian.net/browse/GRT-2485)

