### PR TITLE
Gate HSDP by torch 2.1.0

### DIFF
--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -40,7 +40,7 @@ SHARDING_MAP = {
     'FULL_SHARD': ShardingStrategy.FULL_SHARD,
 }
 
-if using_torch_2():
+if version.parse(torch.__version__) >= version.parse('2.1.0'):
     SHARDING_MAP['_HYBRID_SHARD_ZERO2'] = ShardingStrategy._HYBRID_SHARD_ZERO2
     SHARDING_MAP['HYBRID_SHARD'] = ShardingStrategy.HYBRID_SHARD
 

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -15,14 +15,16 @@ import tempfile
 import textwrap
 import warnings
 from pathlib import Path
+from packaging import version
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
-from packaging import version
 
-from composer.utils import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, ObjectStore, dist, format_name_with_dist,
-                            format_name_with_dist_and_time, get_file, is_model_deepspeed, is_tar, reproducibility,
-                            using_torch_2)
+from composer.utils import dist, reproducibility
+from composer.utils.file_helpers import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, format_name_with_dist,
+                                         format_name_with_dist_and_time, get_file, is_tar)
+from composer.utils.misc import is_model_deepspeed, using_torch_2
+from composer.utils.object_store import ObjectStore
 
 if TYPE_CHECKING:
     from composer.core import AlgorithmPass, State

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -15,10 +15,10 @@ import tempfile
 import textwrap
 import warnings
 from pathlib import Path
-from packaging import version
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
+from packaging import version
 
 from composer.utils import dist, reproducibility
 from composer.utils.file_helpers import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, format_name_with_dist,

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -18,16 +18,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
+from packaging import version
 
-from composer.utils import dist, reproducibility
-from composer.utils.file_helpers import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, format_name_with_dist,
-                                         format_name_with_dist_and_time, get_file, is_tar)
-from composer.utils.misc import is_model_deepspeed, using_torch_2, using_torch_2_0_1
-from composer.utils.object_store import ObjectStore
+from composer.utils import (FORMAT_NAME_WITH_DIST_AND_TIME_TABLE, ObjectStore, dist, format_name_with_dist,
+                            format_name_with_dist_and_time, get_file, is_model_deepspeed, is_tar, reproducibility,
+                            using_torch_2)
 
 if TYPE_CHECKING:
-    from composer.core.passes import AlgorithmPass
-    from composer.core.state import State
+    from composer.core import AlgorithmPass, State
     from composer.loggers import Logger, LoggerDestination
 
 log = logging.getLogger(__name__)
@@ -313,7 +311,7 @@ def load_sharded_checkpoint(
             f'Sharded checkpoint loading requires torch version >= 2.0.0. You have torch version {torch.__version__}')
 
     using_multinode = dist.get_world_size() != dist.get_local_world_size()
-    if not using_torch_2_0_1() and using_multinode:
+    if not version.parse(torch.__version__) >= version.parse('2.0.1') and using_multinode:
         raise ValueError(
             f'Sharded checkpoint loading on >1 node requires torch version >= 2.0.1. You have torch version {torch.__version__}'
         )

--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -555,8 +555,8 @@ def test_fsdp_partitioned_state_dict_load(world_size, tmp_path: pathlib.Path, st
 @pytest.mark.parametrize('precision', ['amp_bf16', 'amp_fp16'])
 @pytest.mark.parametrize('autoresume', [False, True])  # True commented out for now
 @pytest.mark.parametrize('num_shards', [2, 4, 7])
-@pytest.mark.parametrize('sharding_strategy', ['FULL_SHARD', 'SHARD_GRAD_OP'])
-@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0.1'), reason='requires PyTorch 2.01 or higher')
+@pytest.mark.parametrize('sharding_strategy', ['FULL_SHARD', 'SHARD_GRAD_OP', 'HYBRID_SHARD', '_HYBRID_SHARD_ZERO2'])
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0.1'), reason='requires PyTorch 2.0.1 or higher')
 @pytest.mark.filterwarnings(r'ignore:TypedStorage is deprecated.:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:MosaicMLLogger is not in the state_dict.:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:.*metrics are not saved with sharded state dict.*:UserWarning')
@@ -566,6 +566,9 @@ def test_elastic_resumption(world_size, tmp_path: pathlib.Path, state_dict_type:
         pytest.xfail(
             'Loading a state_dict_type="local" checkpoint with strict=True errors out. See https://github.com/pytorch/pytorch/issues/102667 for more info'
         )
+    if 'HYBRID' in sharding_strategy and version.parse(torch.__version__) < version.parse('2.1.0'):
+        pytest.skip('Hybrid sharding is only supported in torch 2.1.0 and above')
+
     if autoresume:
         run_name = 'my-autoresume-run'
     else:

--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -556,7 +556,8 @@ def test_fsdp_partitioned_state_dict_load(world_size, tmp_path: pathlib.Path, st
 @pytest.mark.parametrize('autoresume', [False, True])  # True commented out for now
 @pytest.mark.parametrize('num_shards', [2, 4, 7])
 @pytest.mark.parametrize('sharding_strategy', ['FULL_SHARD', 'SHARD_GRAD_OP'])
-@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0.1'), reason='requires PyTorch 2.0.1 or higher')
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0.1'),
+                    reason='requires PyTorch 2.0.1 or higher')
 @pytest.mark.filterwarnings(r'ignore:TypedStorage is deprecated.:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:MosaicMLLogger is not in the state_dict.:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:.*metrics are not saved with sharded state dict.*:UserWarning')

--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -555,7 +555,7 @@ def test_fsdp_partitioned_state_dict_load(world_size, tmp_path: pathlib.Path, st
 @pytest.mark.parametrize('precision', ['amp_bf16', 'amp_fp16'])
 @pytest.mark.parametrize('autoresume', [False, True])  # True commented out for now
 @pytest.mark.parametrize('num_shards', [2, 4, 7])
-@pytest.mark.parametrize('sharding_strategy', ['FULL_SHARD', 'SHARD_GRAD_OP', 'HYBRID_SHARD', '_HYBRID_SHARD_ZERO2'])
+@pytest.mark.parametrize('sharding_strategy', ['FULL_SHARD', 'SHARD_GRAD_OP'])
 @pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0.1'), reason='requires PyTorch 2.0.1 or higher')
 @pytest.mark.filterwarnings(r'ignore:TypedStorage is deprecated.:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:MosaicMLLogger is not in the state_dict.:UserWarning')
@@ -566,9 +566,6 @@ def test_elastic_resumption(world_size, tmp_path: pathlib.Path, state_dict_type:
         pytest.xfail(
             'Loading a state_dict_type="local" checkpoint with strict=True errors out. See https://github.com/pytorch/pytorch/issues/102667 for more info'
         )
-    if 'HYBRID' in sharding_strategy and version.parse(torch.__version__) < version.parse('2.1.0'):
-        pytest.skip('Hybrid sharding is only supported in torch 2.1.0 and above')
-
     if autoresume:
         run_name = 'my-autoresume-run'
     else:


### PR DESCRIPTION
# What does this PR do?

Gate torch import by 2.1.0. We are not confident checkpointing works on earlier versions per @eracah 