### PR TITLE
Fix FSDP arg default to match torch

### DIFF
--- a/composer/trainer/dist_strategy.py
+++ b/composer/trainer/dist_strategy.py
@@ -138,7 +138,7 @@ def set_fsdp_default(fsdp_config: Dict[str, Any]):
     fsdp_config.setdefault('forward_prefetch', False)
     fsdp_config.setdefault('ignored_modules', None)
     fsdp_config.setdefault('keep_low_precision_grads', False)
-    fsdp_config.setdefault('limit_all_gathers', False)
+    fsdp_config.setdefault('limit_all_gathers', True)
     fsdp_config.setdefault('load_monolith_rank0_only', False)
     fsdp_config.setdefault('mixed_precision', 'DEFAULT')
     fsdp_config.setdefault('sharded_ckpt_prefix_dir', 'ep{epoch}-ba{batch}')


### PR DESCRIPTION
# What does this PR do?

Fix FSDP arg default to match torch for limit all gathers

<img width="460" alt="image" src="https://github.com/mosaicml/composer/assets/17102158/9f6f5b6a-002b-4cfa-b047-d5a5aedea544">
