### PR TITLE
Add script to validate remote object store paths

### DIFF
--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -400,6 +400,28 @@ def maybe_create_remote_uploader_downloader_from_uri(
                                   'one of the supported RemoteUploaderDownloader object stores')
 
 
+def list_remote_objects(remote_path: str) -> List[str]:
+    """List objects at the remote path.
+
+    If the path is valid, returns the list of objects at the path.
+    Otherwise, raises an error.
+
+    Args:
+        remote_path (str): Remote object store path.
+
+    Returns:
+        A list of objects at the remote path.
+    """
+    object_store = maybe_create_object_store_from_uri(remote_path)
+    if object_store is None:
+        raise ValueError(f'Failed to create object store. The given path {remote_path} is a local path.')
+    _, _, prefix = parse_uri(remote_path)
+    objects = object_store.list_objects(prefix)
+    if len(objects) == 0:
+        raise ValueError(f'No objects at path {remote_path} found. Please check your path and your access credentials.')
+    return objects
+
+
 def get_file(path: str,
              destination: str,
              object_store: Optional[Union[ObjectStore, LoggerDestination]] = None,

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -403,9 +403,6 @@ def maybe_create_remote_uploader_downloader_from_uri(
 def list_remote_objects(remote_path: str) -> List[str]:
     """List objects at the remote path.
 
-    If the path is valid, returns the list of objects at the path.
-    Otherwise, raises an error.
-
     Args:
         remote_path (str): Remote object store path.
 
@@ -417,9 +414,28 @@ def list_remote_objects(remote_path: str) -> List[str]:
         raise ValueError(f'Failed to create object store. The given path {remote_path} is a local path.')
     _, _, prefix = parse_uri(remote_path)
     objects = object_store.list_objects(prefix)
+    return objects
+
+
+def validate_remote_path():
+    """Entry point to composer_validate_remote_path cli command.
+
+    Validates a remote path.
+    If a the remote path is valid, prints a list of objects at the path.
+    Otherwise, raises an error.
+    """
+    import sys
+    args = sys.argv
+    if len(args) == 1:
+        raise ValueError('Please provide a remote path.')
+    if len(args) > 2:
+        raise ValueError('Extra arguments found. Please provide only one remote path.')
+    remote_path = sys.argv[1]
+    objects = list_remote_objects(remote_path)
     if len(objects) == 0:
         raise ValueError(f'No objects at path {remote_path} found. Please check your path and your access credentials.')
-    return objects
+    objects_str = '\n'.join(objects)
+    print(f'Found {len(objects)} objects at {remote_path} \n{objects_str}')
 
 
 def get_file(path: str,

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -421,7 +421,7 @@ def validate_remote_path():
     """Entry point to composer_validate_remote_path cli command.
 
     Validates a remote path.
-    If a the remote path is valid, prints a list of objects at the path.
+    If the remote path is valid, prints a list of objects at the path.
     Otherwise, raises an error.
     """
     import sys

--- a/setup.py
+++ b/setup.py
@@ -264,8 +264,9 @@ setup(name=package_name,
       install_requires=install_requires,
       entry_points={
           'console_scripts': [
-              'composer = composer.cli.launcher:main', 'composer_collect_env = composer.utils.collect_env:main',
-              'composer_validate_remote_path = composer.utils.file_helpers:validate_remote_path'
+              'composer = composer.cli.launcher:main',
+              'composer_collect_env = composer.utils.collect_env:main',
+              'composer_validate_remote_path = composer.utils.file_helpers:validate_remote_path',
           ],
       },
       extras_require=extra_deps,

--- a/setup.py
+++ b/setup.py
@@ -264,8 +264,8 @@ setup(name=package_name,
       install_requires=install_requires,
       entry_points={
           'console_scripts': [
-              'composer = composer.cli.launcher:main',
-              'composer_collect_env = composer.utils.collect_env:main',
+              'composer = composer.cli.launcher:main', 'composer_collect_env = composer.utils.collect_env:main',
+              'composer_validate_remote_path = composer.utils.file_helpers:validate_remote_path'
           ],
       },
       extras_require=extra_deps,


### PR DESCRIPTION
# What does this PR do?

Adds a script that validates remote object store paths using composer utility functions. 

This is helpful for debugging especially on remote runs. 

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
