### PR TITLE
Upgrade transformers to 4.35

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ extra_deps['coco'] = [
 ]
 
 extra_deps['nlp'] = [
-    'transformers>=4.11,<4.35,!=4.34.0',
+    'transformers>=4.11,<4.36,!=4.34.0',
     'datasets>=2.4,<3',
 ]
 


### PR DESCRIPTION
The only dangerous thing in this release is that `save_pretrained` now saves safetensors format weights by default