### PR TITLE
Add distributed barrier test fixture to ensure pytest cleans up resources properly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 import pytest
 import torch
-from composer.utils import reproducibility
+from composer.utils import dist, reproducibility
 
 # Allowed options for pytest.mark.world_size()
 # Important: when updating this list, make sure to also up ./.ci/test.sh
@@ -63,12 +63,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         Rank zero seed to use. `reproducibility.seed_all(seed + dist.get_global_rank())` will be invoked
         before each test.""")
     _add_option(parser, 's3_bucket', help='S3 Bucket for integration tests')
-
-@pytest.fixture(scope='session', autouse=True)
-def session_setup_teardown():
-    # setup code goes here if needed
-    yield
-    torch.distributed.barrier() 
 
 def _get_world_size(item: pytest.Item):
     """Returns the world_size of a test, defaults to 1."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,8 @@ import os
 from typing import List, Optional
 
 import pytest
-import torch
 
-from composer.utils import dist, reproducibility
+from composer.utils import reproducibility
 
 # Allowed options for pytest.mark.world_size()
 # Important: when updating this list, make sure to also up ./.ci/test.sh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import os
 from typing import List, Optional
 
 import pytest
-
+import torch
 from composer.utils import reproducibility
 
 # Allowed options for pytest.mark.world_size()
@@ -64,6 +64,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         before each test.""")
     _add_option(parser, 's3_bucket', help='S3 Bucket for integration tests')
 
+@pytest.fixture(scope='session', autouse=True)
+def session_setup_teardown():
+    # setup code goes here if needed
+    yield
+    torch.distributed.barrier() 
 
 def _get_world_size(item: pytest.Item):
     """Returns the world_size of a test, defaults to 1."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 import pytest
 import torch
+
 from composer.utils import dist, reproducibility
 
 # Allowed options for pytest.mark.world_size()
@@ -63,6 +64,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         Rank zero seed to use. `reproducibility.seed_all(seed + dist.get_global_rank())` will be invoked
         before each test.""")
     _add_option(parser, 's3_bucket', help='S3 Bucket for integration tests')
+
 
 def _get_world_size(item: pytest.Item):
     """Returns the world_size of a test, defaults to 1."""

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -71,10 +71,10 @@ def configure_dist(request: pytest.FixtureRequest):
     # (e.g. rank 1 starts the next test while rank 0 is finishing up the previous test).
     dist.barrier()
     yield
-    # Ensure that all tests have finished before tearing down the pytest environment and file system.
-    # Helps avoid race conditions where a test is still writing to a file on one rank while the 
-    # file system is being torn down on another rank
-    dist.barrier()
+    # # Ensure that all tests have finished before tearing down the pytest environment and file system.
+    # # Helps avoid race conditions where a test is still writing to a file on one rank while the 
+    # # file system is being torn down on another rank
+    # dist.barrier()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -71,10 +71,10 @@ def configure_dist(request: pytest.FixtureRequest):
     # (e.g. rank 1 starts the next test while rank 0 is finishing up the previous test).
     dist.barrier()
     yield
-    # # Ensure that all tests have finished before tearing down the pytest environment and file system.
-    # # Helps avoid race conditions where a test is still writing to a file on one rank while the 
-    # # file system is being torn down on another rank
-    # dist.barrier()
+    # Ensure that all tests have finished before tearing down the pytest environment and file system.
+    # Helps avoid race conditions where a test is still writing to a file on one rank while the
+    # file system is being torn down on another rank
+    dist.barrier()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -47,15 +47,12 @@ def disable_wandb(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureReques
             monkeypatch.setenv('WANDB_PROJECT', 'pytest')
 
 
-@pytest.fixture(autouse=True, scope='session')
+@pytest.fixture(scope='session')
 def cleanup_dist():
     """ Ensure all dist tests have been cleaning up properly"""
     if dist.get_world_size() == 1:
         return
-    try:
-        yield
-    except Exception:
-        pass
+    yield
     # Ensure that all tests have finished before tearing down the pytest environment and file system.
     # Helps avoid race conditions where a test is still writing to a file on one rank while the
     # file system is being torn down on another rank.

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -49,13 +49,10 @@ def disable_wandb(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureReques
 
 @pytest.fixture(scope='session')
 def cleanup_dist():
-    """ Ensure all dist tests have been cleaning up properly"""
-    if dist.get_world_size() == 1:
-        return
+    """Ensure all dist tests clean up resources properly."""
     yield
-    # Ensure that all tests have finished before tearing down the pytest environment and file system.
-    # Helps avoid race conditions where a test is still writing to a file on one rank while the
-    # file system is being torn down on another rank.
+    # Avoid race condition where a test is still writing to a file on one rank
+    # while the file system is being torn down on another rank.
     dist.barrier()
 
 

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -52,7 +52,10 @@ def cleanup_dist():
     """ Ensure all dist tests have been cleaning up properly"""
     if dist.get_world_size() == 1:
         return
-    yield
+    try:
+        yield
+    except Exception:
+        pass
     # Ensure that all tests have finished before tearing down the pytest environment and file system.
     # Helps avoid race conditions where a test is still writing to a file on one rank while the
     # file system is being torn down on another rank.
@@ -82,7 +85,6 @@ def configure_dist(request: pytest.FixtureRequest):
     # any test before other ranks are ready to start it, which could be a cause of random timeouts
     # (e.g. rank 1 starts the next test while rank 0 is finishing up the previous test).
     dist.barrier()
-    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -48,6 +48,12 @@ def disable_wandb(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureReques
 
 
 @pytest.fixture(autouse=True, scope='session')
+def cleanup_dist():
+    yield
+    dist.barrier()
+
+
+@pytest.fixture(autouse=True, scope='session')
 def configure_dist(request: pytest.FixtureRequest):
     # Configure dist globally when the world size is greater than 1,
     # so individual tests that do not use the trainer
@@ -71,10 +77,6 @@ def configure_dist(request: pytest.FixtureRequest):
     # (e.g. rank 1 starts the next test while rank 0 is finishing up the previous test).
     dist.barrier()
     yield
-    # Ensure that all tests have finished before tearing down the pytest environment and file system.
-    # Helps avoid race conditions where a test is still writing to a file on one rank while the
-    # file system is being torn down on another rank
-    dist.barrier()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -70,6 +70,11 @@ def configure_dist(request: pytest.FixtureRequest):
     # any test before other ranks are ready to start it, which could be a cause of random timeouts
     # (e.g. rank 1 starts the next test while rank 0 is finishing up the previous test).
     dist.barrier()
+    yield
+    # Ensure that all tests have finished before tearing down the pytest environment and file system.
+    # Helps avoid race conditions where a test is still writing to a file on one rank while the 
+    # file system is being torn down on another rank
+    dist.barrier()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/autouse_fixtures.py
+++ b/tests/fixtures/autouse_fixtures.py
@@ -49,7 +49,13 @@ def disable_wandb(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureReques
 
 @pytest.fixture(autouse=True, scope='session')
 def cleanup_dist():
+    """ Ensure all dist tests have been cleaning up properly"""
+    if dist.get_world_size() == 1:
+        return
     yield
+    # Ensure that all tests have finished before tearing down the pytest environment and file system.
+    # Helps avoid race conditions where a test is still writing to a file on one rank while the
+    # file system is being torn down on another rank.
     dist.barrier()
 
 


### PR DESCRIPTION
# What does this PR do?
Fix broken local eval test by adding distributed barrier to pytest sessions to ensure teardown cleans up resources properly. 

# What issue(s) does this change relate to?
Fix spurious [test](https://github.com/mosaicml/composer/actions/runs/6791886988/job/18464220412?pr=2565#step:5:4077)

# Tests 
12/12 CPU tests passing stably
- Passing 3/3 https://github.com/mosaicml/composer/actions/runs/6803305965
- Passing 3/3 https://github.com/mosaicml/composer/actions/runs/6804399138/job/18501846426?pr=2694 
- Passing 3/3 tests again https://github.com/mosaicml/composer/actions/runs/6804399138 
- Passing CPU test https://github.com/mosaicml/composer/actions/runs/6804407850
