### PR TITLE
Properly handle empty metric_names passed to Trainer._filter_metrics

### DIFF
--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -86,11 +86,10 @@ class Evaluator:
         self.label = label
         self.dataloader = ensure_data_spec(dataloader)
 
-        self.metric_names = []
         if metric_names is not None:
             if not isinstance(metric_names, list):
                 raise ValueError(f'``metric_names`` should be a list of strings, not a {type(metric_names)}')
-            self.metric_names = metric_names
+        self.metric_names = metric_names
 
         self.subset_num_batches = subset_num_batches
         self._eval_interval = None
@@ -132,8 +131,8 @@ def ensure_evaluator(evaluator: Union[Evaluator, DataSpec, Iterable, Dict[str, A
     """
     if isinstance(evaluator, Evaluator):
         # If no metric_names are specified, populate with the defaults.
-        if len(evaluator.metric_names) == 0:
-            evaluator.metric_names.extend(default_metric_names)
+        if evaluator.metric_names is None:
+            evaluator.metric_names = default_metric_names
         return evaluator
     else:
         return Evaluator(

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -130,9 +130,6 @@ def ensure_evaluator(evaluator: Union[Evaluator, DataSpec, Iterable, Dict[str, A
         Evaluator: An evaluator.
     """
     if isinstance(evaluator, Evaluator):
-        # If no metric_names are specified, populate with the defaults.
-        if evaluator.metric_names is None:
-            evaluator.metric_names = default_metric_names
         return evaluator
     else:
         return Evaluator(

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -131,6 +131,9 @@ def ensure_evaluator(evaluator: Union[Evaluator, DataSpec, Iterable, Dict[str, A
         Evaluator: An evaluator.
     """
     if isinstance(evaluator, Evaluator):
+        # If no metric_names are specified, populate with the defaults.
+        if len(evaluator.metric_names) == 0:
+            evaluator.metric_names.extend(default_metric_names)
         return evaluator
     else:
         return Evaluator(

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -103,8 +103,10 @@ def _get_default_scheduler_frequency(schedulers: Optional[Union[Scheduler, Seque
         return TimeUnit.BATCH
 
 
-def _filter_metrics(metrics: Dict[str, Metric], metric_names: List[str]) -> Dict[str, Metric]:
+def _filter_metrics(metrics: Dict[str, Metric], metric_names: Optional[List[str]]) -> Dict[str, Metric]:
     """Filter the metrics based on the given metric_names as regex strings (e.g. 'Accuracy', 'f1' for 'BinaryF1Score', 'Top-.' for 'Top-1 Accuracy' and 'Top-2 Accuracy', etc). If no metric_names are provided, all metrics will be returned."""
+    if metric_names is None:
+        raise ValueError('metric_names is None but should be List[str].')
     metrics = deepcopy(metrics)
     filtered_metrics = {}
     for name, metric in metrics.items():

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -103,17 +103,14 @@ def _get_default_scheduler_frequency(schedulers: Optional[Union[Scheduler, Seque
         return TimeUnit.BATCH
 
 
-def _filter_metrics(metrics: Dict[str, Metric], metric_names: Optional[List[str]]) -> Dict[str, Metric]:
+def _filter_metrics(metrics: Dict[str, Metric], metric_names: List[str]) -> Dict[str, Metric]:
     """Filter the metrics based on the given metric_names as regex strings (e.g. 'Accuracy', 'f1' for 'BinaryF1Score', 'Top-.' for 'Top-1 Accuracy' and 'Top-2 Accuracy', etc). If no metric_names are provided, all metrics will be returned."""
     metrics = deepcopy(metrics)
-    if not metric_names:
-        return metrics
-    else:
-        filtered_metrics = {}
-        for name, metric in metrics.items():
-            if any(re.match(f'.*{metric_name}.*', name, re.IGNORECASE) for metric_name in metric_names):
-                filtered_metrics[name] = metric
-        return filtered_metrics
+    filtered_metrics = {}
+    for name, metric in metrics.items():
+        if any(re.match(f'.*{metric_name}.*', name, re.IGNORECASE) for metric_name in metric_names):
+            filtered_metrics[name] = metric
+    return filtered_metrics
 
 
 def _validate_precision(precision: Precision, device: Device):

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -105,9 +105,9 @@ def _get_default_scheduler_frequency(schedulers: Optional[Union[Scheduler, Seque
 
 def _filter_metrics(metrics: Dict[str, Metric], metric_names: Optional[List[str]]) -> Dict[str, Metric]:
     """Filter the metrics based on the given metric_names as regex strings (e.g. 'Accuracy', 'f1' for 'BinaryF1Score', 'Top-.' for 'Top-1 Accuracy' and 'Top-2 Accuracy', etc). If no metric_names are provided, all metrics will be returned."""
-    if metric_names is None:
-        raise ValueError('metric_names is None but should be List[str].')
     metrics = deepcopy(metrics)
+    if metric_names is None:
+        return metrics
     filtered_metrics = {}
     for name, metric in metrics.items():
         if any(re.match(f'.*{metric_name}.*', name, re.IGNORECASE) for metric_name in metric_names):


### PR DESCRIPTION
# What does this PR do?
Addresses error using `use_train_metrics: false`: `KeyError: 'continuation_indices'`
Manual test runs:
no fix: empty-eval-gFgK8Q 
with fix: empty-eval-with-fix-wpQHSK 

Changes
(1) Previously, if `metric_names` is an empty list, we return `metrics` without filtering. This is incorrect as an empty list should signify no metrics. We update this to handle an empty list.
(2) evaluator.metric_names should default to None not an empty list, so we can properly populate it with defaults later

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
