### PR TITLE
Adding logging and force flushing for run events

### DIFF
--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -89,7 +89,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def after_load(self, state: State, logger: Logger) -> None:
         # Log model data downloaded and initialized for run events
-        log.info(f'Logging model initialized time to run {self.run_name} metadata')
+        log.info(f'Logging model initialized time to metadata')
         self._log_metadata({'model_initialized_time': time.time()})
         # Log WandB run URL if it exists. Must run on after_load as WandB is setup on event init
         for callback in state.callbacks:
@@ -105,7 +105,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def batch_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        log.info(f'Logging training progress data to run {self.run_name} metadata: {training_progress_data}')
+        log.info(f'Logging training progress data to metadata: {training_progress_data}')
         self._log_metadata(training_progress_data)
         self._flush_metadata(force_flush=True)
 
@@ -114,7 +114,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def fit_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        log.info(f'Logging FINAL training progress data to run {self.run_name} metadata: {training_progress_data}')
+        log.info(f'Logging FINAL training progress data to metadata: {training_progress_data}')
         self._log_metadata(training_progress_data)
         self._flush_metadata(force_flush=True)
 

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -156,47 +156,48 @@ class MosaicMLLogger(LoggerDestination):
                     self._enabled = False
 
     def _get_training_progress_metrics(self, state: State) -> Dict[str, Any]:
-            """Calculates training progress metrics.
+        """Calculates training progress metrics.
 
-            If user submits max duration:
-            - in tokens -> format: [token=x/xx]
-            - in batches -> format: [batch=x/xx]
-            - in epoch -> format: [epoch=x/xx] [batch=x/xx] (where batch refers to batches completed in current epoch)
-            If batches per epoch cannot be calculated, return [epoch=x/xx]
+        If user submits max duration:
+        - in tokens -> format: [token=x/xx]
+        - in batches -> format: [batch=x/xx]
+        - in epoch -> format: [epoch=x/xx] [batch=x/xx] (where batch refers to batches completed in current epoch)
+        If batches per epoch cannot be calculated, return [epoch=x/xx]
 
-            If no training duration given -> format: ''
-            """
-            if not self._enabled:
-                return {}
+        If no training duration given -> format: ''
+        """
+        if not self._enabled:
+            return {}
 
-            assert state.max_duration is not None
-            if state.max_duration.unit == TimeUnit.TOKEN:
-                return {
-                    'training_progress': f'[token={state.timestamp.token.value}/{state.max_duration.value}]',
-                }
-            if state.max_duration.unit == TimeUnit.BATCH:
-                return {
-                    'training_progress': f'[batch={state.timestamp.batch.value}/{state.max_duration.value}]',
-                }
-            training_progress_metrics = {}
-            if state.max_duration.unit == TimeUnit.EPOCH:
-                cur_batch = state.timestamp.batch_in_epoch.value
-                cur_epoch = state.timestamp.epoch.value
-                if state.timestamp.epoch.value >= 1:
-                    batches_per_epoch = (state.timestamp.batch -
-                                        state.timestamp.batch_in_epoch).value // state.timestamp.epoch.value
-                    curr_progress = f'[batch={cur_batch}/{batches_per_epoch}]'
-                elif self.train_dataloader_len is not None:
-                    curr_progress = f'[batch={cur_batch}/{self.train_dataloader_len}]'
-                else:
-                    curr_progress = f'[batch={cur_batch}]'
-                if cur_epoch < state.max_duration.value:
-                    cur_epoch += 1
-                training_progress_metrics = {
-                    'training_sub_progress': curr_progress,
-                    'training_progress': f'[epoch={cur_epoch}/{state.max_duration.value}]',
-                }
-            return training_progress_metrics
+        assert state.max_duration is not None
+        if state.max_duration.unit == TimeUnit.TOKEN:
+            return {
+                'training_progress': f'[token={state.timestamp.token.value}/{state.max_duration.value}]',
+            }
+        if state.max_duration.unit == TimeUnit.BATCH:
+            return {
+                'training_progress': f'[batch={state.timestamp.batch.value}/{state.max_duration.value}]',
+            }
+        training_progress_metrics = {}
+        if state.max_duration.unit == TimeUnit.EPOCH:
+            cur_batch = state.timestamp.batch_in_epoch.value
+            cur_epoch = state.timestamp.epoch.value
+            if state.timestamp.epoch.value >= 1:
+                batches_per_epoch = (state.timestamp.batch -
+                                     state.timestamp.batch_in_epoch).value // state.timestamp.epoch.value
+                curr_progress = f'[batch={cur_batch}/{batches_per_epoch}]'
+            elif self.train_dataloader_len is not None:
+                curr_progress = f'[batch={cur_batch}/{self.train_dataloader_len}]'
+            else:
+                curr_progress = f'[batch={cur_batch}]'
+            if cur_epoch < state.max_duration.value:
+                cur_epoch += 1
+            training_progress_metrics = {
+                'training_sub_progress': curr_progress,
+                'training_progress': f'[epoch={cur_epoch}/{state.max_duration.value}]',
+            }
+        return training_progress_metrics
+
 
 def format_data_to_json_serializable(data: Any):
     """Recursively formats data to be JSON serializable.

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -231,4 +231,4 @@ def format_data_to_json_serializable(data: Any):
 
 
 def dict_to_str(data: Dict[str, Any]):
-    return '\n'.join([f'{k}: {v}' for k, v in data.items()])
+    return '\n'.join([f'\t{k}: {v}' for k, v in data.items()])

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -105,7 +105,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def batch_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        log.debug(f'Logging training progress data to metadata: {training_progress_data}')
+        log.debug(f'Logging training progress data to metadata: {dict_to_str(training_progress_data)}')
         self._log_metadata(training_progress_data)
         self._flush_metadata()
 
@@ -114,7 +114,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def fit_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        log.debug(f'Logging FINAL training progress data to metadata: {training_progress_data}')
+        log.debug(f'Logging FINAL training progress data to metadata: {dict_to_str(training_progress_data)}')
         self._log_metadata(training_progress_data)
         self._flush_metadata(force_flush=True)
 
@@ -228,3 +228,7 @@ def format_data_to_json_serializable(data: Any):
         warnings.warn('Encountered unexpected error while formatting data to be JSON serializable. '
                       f'Returning empty string instead. Error: {str(e)}')
         return ''
+
+
+def dict_to_str(data: Dict[str, Any]):
+    return '\n'.join([f'{k}: {v}' for k, v in data.items()])

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -89,7 +89,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def after_load(self, state: State, logger: Logger) -> None:
         # Log model data downloaded and initialized for run events
-        log.info(f'Logging model initialized time to metadata')
+        log.debug(f'Logging model initialized time to metadata')
         self._log_metadata({'model_initialized_time': time.time()})
         # Log WandB run URL if it exists. Must run on after_load as WandB is setup on event init
         for callback in state.callbacks:
@@ -105,16 +105,16 @@ class MosaicMLLogger(LoggerDestination):
 
     def batch_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        log.info(f'Logging training progress data to metadata: {training_progress_data}')
+        log.debug(f'Logging training progress data to metadata: {training_progress_data}')
         self._log_metadata(training_progress_data)
-        self._flush_metadata(force_flush=True)
+        self._flush_metadata()
 
     def epoch_end(self, state: State, logger: Logger) -> None:
         self._flush_metadata()
 
     def fit_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        log.info(f'Logging FINAL training progress data to metadata: {training_progress_data}')
+        log.debug(f'Logging FINAL training progress data to metadata: {training_progress_data}')
         self._log_metadata(training_progress_data)
         self._flush_metadata(force_flush=True)
 

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -105,7 +105,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def batch_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        log.debug(f'Logging training progress data to metadata: {dict_to_str(training_progress_data)}')
+        log.debug(f'\nLogging training progress data to metadata:\n{dict_to_str(training_progress_data)}')
         self._log_metadata(training_progress_data)
         self._flush_metadata()
 
@@ -114,7 +114,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def fit_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        log.debug(f'Logging FINAL training progress data to metadata: {dict_to_str(training_progress_data)}')
+        log.debug(f'\nLogging FINAL training progress data to metadata:\n{dict_to_str(training_progress_data)}')
         self._log_metadata(training_progress_data)
         self._flush_metadata(force_flush=True)
 


### PR DESCRIPTION
# Adding logging and force flushing for run events
We are seeing run events inconsistently sent to run metadata for finetuning runs. Adding logs to help debug and force flushing metadata when run event related metadata is being written to the run.

# Testing
<img width="1157" alt="image" src="https://github.com/mosaicml/composer/assets/29712344/7b814097-cf94-4d80-83fe-ced9e2c6851e">

<img width="671" alt="image" src="https://github.com/mosaicml/composer/assets/29712344/f4caff54-0ca9-4a2e-befd-1c73df91f9cc">

