### PR TITLE
Add metadata logging for wandb

### DIFF
--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -102,6 +102,7 @@ class MosaicMLLogger(LoggerDestination):
                 run_url = callback.run_url
                 if run_url is not None:
                     self._log_metadata({'wandb/run_url': run_url})
+                log.debug(f'Logging WandB run URL to metadata: {run_url}')
         self._flush_metadata(force_flush=True)
 
     def batch_start(self, state: State, logger: Logger) -> None:
@@ -147,7 +148,12 @@ class MosaicMLLogger(LoggerDestination):
         """Flush buffered metadata to MosaicML if enough time has passed since last flush."""
         if self._enabled and (time.time() - self.time_last_logged > self.log_interval or force_flush):
             try:
+<<<<<<< HEAD
                 f = mcli.update_run_metadata(self.run_name, self.buffered_metadata, future=True, protect=True)
+=======
+                log.debug(f'Logging metadata to MosaicML:\n{dict_to_str(self.buffered_metadata)}')
+                mcli.update_run_metadata(self.run_name, self.buffered_metadata)
+>>>>>>> f36dd2db (added logging)
                 self.buffered_metadata = {}
                 self.time_last_logged = time.time()
                 self._futures.append(f)

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -102,7 +102,9 @@ class MosaicMLLogger(LoggerDestination):
                 run_url = callback.run_url
                 if run_url is not None:
                     self._log_metadata({'wandb/run_url': run_url})
-                log.debug(f'Logging WandB run URL to metadata: {run_url}')
+                    log.debug(f'Logging WandB run URL to metadata: {run_url}')
+                else:
+                    log.debug(f'WandB run URL not found, not logging to metadata')
         self._flush_metadata(force_flush=True)
 
     def batch_start(self, state: State, logger: Logger) -> None:
@@ -148,12 +150,7 @@ class MosaicMLLogger(LoggerDestination):
         """Flush buffered metadata to MosaicML if enough time has passed since last flush."""
         if self._enabled and (time.time() - self.time_last_logged > self.log_interval or force_flush):
             try:
-<<<<<<< HEAD
                 f = mcli.update_run_metadata(self.run_name, self.buffered_metadata, future=True, protect=True)
-=======
-                log.debug(f'Logging metadata to MosaicML:\n{dict_to_str(self.buffered_metadata)}')
-                mcli.update_run_metadata(self.run_name, self.buffered_metadata)
->>>>>>> f36dd2db (added logging)
                 self.buffered_metadata = {}
                 self.time_last_logged = time.time()
                 self._futures.append(f)

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -104,7 +104,7 @@ class MosaicMLLogger(LoggerDestination):
                     self._log_metadata({'wandb/run_url': run_url})
                     log.debug(f'Logging WandB run URL to metadata: {run_url}')
                 else:
-                    log.debug(f'WandB run URL not found, not logging to metadata')
+                    log.debug('WandB run URL not found, not logging to metadata')
         self._flush_metadata(force_flush=True)
 
     def batch_start(self, state: State, logger: Logger) -> None:

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -276,7 +276,6 @@ def test_run_events_logged(monkeypatch):
     trainer.fit()
     metadata = mock_mapi.run_metadata[run_name]
     assert isinstance(metadata['mosaicml/model_initialized_time'], float)
-    assert isinstance(metadata['mosaicml/train_finished_time'], float)
     assert 'mosaicml/training_progress' in metadata
     assert metadata['mosaicml/training_progress'] == '[batch=4/4]'
     assert 'mosaicml/training_sub_progress' not in metadata

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -276,6 +276,7 @@ def test_run_events_logged(monkeypatch):
     trainer.fit()
     metadata = mock_mapi.run_metadata[run_name]
     assert isinstance(metadata['mosaicml/model_initialized_time'], float)
+    assert isinstance(metadata['mosaicml/train_finished_time'], float)
     assert 'mosaicml/training_progress' in metadata
     assert metadata['mosaicml/training_progress'] == '[batch=4/4]'
     assert 'mosaicml/training_sub_progress' not in metadata

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -14,7 +14,7 @@ from torch.utils.data import DataLoader
 from composer.core import Callback, Time, TimeUnit
 from composer.loggers import WandBLogger
 from composer.loggers.mosaicml_logger import (MOSAICML_ACCESS_TOKEN_ENV_VAR, MOSAICML_PLATFORM_ENV_VAR, MosaicMLLogger,
-                                              format_data_to_json_serializable,)
+                                              format_data_to_json_serializable)
 from composer.trainer import Trainer
 from composer.utils import dist, get_composer_env_dict
 from tests.callbacks.callback_settings import get_cb_kwargs, get_cb_model_and_datasets, get_cbs_and_marks

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -14,7 +14,7 @@ from torch.utils.data import DataLoader
 from composer.core import Callback, Time, TimeUnit
 from composer.loggers import WandBLogger
 from composer.loggers.mosaicml_logger import (MOSAICML_ACCESS_TOKEN_ENV_VAR, MOSAICML_PLATFORM_ENV_VAR, MosaicMLLogger,
-                                              format_data_to_json_serializable)
+                                              format_data_to_json_serializable,)
 from composer.trainer import Trainer
 from composer.utils import dist, get_composer_env_dict
 from tests.callbacks.callback_settings import get_cb_kwargs, get_cb_model_and_datasets, get_cbs_and_marks


### PR DESCRIPTION
# Add metadata logging for wandb

- We are noticing that wandb url specifically is being dropped from regression test runs inconsistently, adding logs to try to debug this moving forward.

See Jira: https://databricks.atlassian.net/browse/GRT-2588


