### PR TITLE
Enable system metrics in mosaic mlflow logger

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -53,7 +53,7 @@ class MLFlowLogger(LoggerDestination):
         synchronous (bool, optional): Whether to log synchronously. If ``True``, Mlflow will log
             synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously. (default: ``False``)
         log_system_metrics (bool, optional): Whether to log system metrics. If ``True``, Mlflow will
-            log system metrics (CPU/GPU/memory/network usage) during training.
+            log system metrics (CPU/GPU/memory/network usage) during training. (default: ``True``)
     """
 
     def __init__(

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -47,7 +47,7 @@ class MLFlowLogger(LoggerDestination):
             (default: ``10``).
         model_registry_prefix (str, optional): The prefix to use when registering models.
             If registering to Unity Catalog, must be in the format ``{catalog_name}.{schema_name}``.
-            (default: empty string)
+            (default: `''`)
         model_registry_uri (str, optional): The URI of the model registry to use. To register models
             to Unity Catalog, set to ``databricks-uc``. (default: None)
         synchronous (bool, optional): Whether to log synchronously. If ``True``, Mlflow will log

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -51,7 +51,7 @@ class MLFlowLogger(LoggerDestination):
         model_registry_uri (str, optional): The URI of the model registry to use. To register models
             to Unity Catalog, set to ``databricks-uc``. (default: None)
         synchronous (bool, optional): Whether to log synchronously. If ``True``, Mlflow will log
-            synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously.
+            synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously. (default: ``False``)
         log_system_metrics (bool, optional): Whether to log system metrics. If ``True``, Mlflow will
             log system metrics (CPU/GPU/memory/network usage) during training.
     """

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -50,6 +50,10 @@ class MLFlowLogger(LoggerDestination):
             (default: empty string)
         model_registry_uri (str, optional): The URI of the model registry to use. To register models
             to Unity Catalog, set to ``databricks-uc``. (default: None)
+        synchronous (bool, optional): Whether to log synchronously. If ``True``, Mlflow will log
+            synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously.
+        log_system_metrics (bool, optional): Whether to log system metrics. If ``True``, Mlflow will
+            log system metrics (CPU/GPU/memory/network usage) during training.
     """
 
     def __init__(
@@ -63,6 +67,7 @@ class MLFlowLogger(LoggerDestination):
         model_registry_prefix: str = '',
         model_registry_uri: Optional[str] = None,
         synchronous: bool = False,
+        log_system_metrics: bool = True,
     ) -> None:
         try:
             import mlflow
@@ -79,6 +84,7 @@ class MLFlowLogger(LoggerDestination):
         self.model_registry_prefix = model_registry_prefix
         self.model_registry_uri = model_registry_uri
         self.synchronous = synchronous
+        self.log_system_metrics = log_system_metrics
         if self.model_registry_uri == 'databricks-uc':
             if len(self.model_registry_prefix.split('.')) != 2:
                 raise ValueError(f'When registering to Unity Catalog, model_registry_prefix must be in the format ' +
@@ -132,7 +138,11 @@ class MLFlowLogger(LoggerDestination):
                     run_name=self.run_name,
                 )
                 self._run_id = new_run.info.run_id
-            mlflow.start_run(run_id=self._run_id, tags=self.tags)
+            mlflow.start_run(
+                run_id=self._run_id,
+                tags=self.tags,
+                log_system_metrics=self.log_system_metrics,
+            )
 
     def log_table(self, columns: List[str], rows: List[List[Any]], name: str = 'Table') -> None:
         if self._enabled:

--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ extra_deps['onnx'] = [
 ]
 
 extra_deps['mlflow'] = [
-    'mlflow>=2.8.1,<3.0',
+    'mlflow>=2.9.0,<3.0',
 ]
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -22,6 +22,16 @@ from tests.common.models import SimpleConvModel
 from tests.models.test_hf_model import check_hf_model_equivalence, check_hf_tokenizer_equivalence
 
 
+@pytest.fixture(autouse=True)
+def clear_system_metrics_logging_setup():
+    mlflow = pytest.importorskip('mlflow')
+
+    yield
+    # Unset the environment variables to avoid affecting other test cases.
+    mlflow.set_system_metrics_sampling_interval(None)
+    mlflow.set_system_metrics_samples_before_logging(None)
+
+
 def _get_latest_mlflow_run(experiment_name, tracking_uri=None):
     pytest.importorskip('mlflow')
     from mlflow import MlflowClient
@@ -431,14 +441,17 @@ def test_mlflow_register_uc_error(tmp_path, monkeypatch):
 
 @device('cpu')
 def test_mlflow_logging_works(tmp_path, device):
-    pytest.importorskip('mlflow')
+    mlflow = pytest.importorskip('mlflow')
 
     mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
     experiment_name = 'mlflow_logging_test'
     test_mlflow_logger = MLFlowLogger(
         tracking_uri=mlflow_uri,
         experiment_name=experiment_name,
+        log_system_metrics=True,
     )
+    # Reduce the system metrics sampling interval to speed up the test.
+    mlflow.set_system_metrics_sampling_interval(1)
 
     dataset_size = 64
     batch_size = 4
@@ -468,8 +481,10 @@ def test_mlflow_logging_works(tmp_path, device):
 
     # Test metrics logged.
     for metric_name in [
-            'metrics/train/MulticlassAccuracy', 'metrics/eval/MulticlassAccuracy', 'metrics/eval/CrossEntropy',
-            'loss/train/total'
+            'metrics/train/MulticlassAccuracy',
+            'metrics/eval/MulticlassAccuracy',
+            'metrics/eval/CrossEntropy',
+            'loss/train/total',
     ]:
         metric_file = run_file_path / Path('metrics') / Path(metric_name)
         with open(metric_file) as f:
@@ -486,6 +501,10 @@ def test_mlflow_logging_works(tmp_path, device):
         'num_cpus_per_node', 'node_name', 'num_nodes', 'rank_zero_seed', 'composer_version', 'composer_commit_hash'
     ]
     assert set(expected_params_list) == set(actual_params_list)
+
+    # Test system metrics logged.
+    metric_file = run_file_path / Path('metrics') / Path('system/cpu_utilization_percentage')
+    assert os.path.exists(metric_file)
 
 
 @device('cpu')

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -22,16 +22,6 @@ from tests.common.models import SimpleConvModel
 from tests.models.test_hf_model import check_hf_model_equivalence, check_hf_tokenizer_equivalence
 
 
-@pytest.fixture(autouse=True)
-def clear_system_metrics_logging_setup():
-    mlflow = pytest.importorskip('mlflow')
-
-    yield
-    # Unset the environment variables to avoid affecting other test cases.
-    mlflow.set_system_metrics_sampling_interval(None)
-    mlflow.set_system_metrics_samples_before_logging(None)
-
-
 def _get_latest_mlflow_run(experiment_name, tracking_uri=None):
     pytest.importorskip('mlflow')
     from mlflow import MlflowClient
@@ -505,6 +495,9 @@ def test_mlflow_logging_works(tmp_path, device):
     # Test system metrics logged.
     metric_file = run_file_path / Path('metrics') / Path('system/cpu_utilization_percentage')
     assert os.path.exists(metric_file)
+
+    # Undo the setup to avoid affecting other test cases.
+    mlflow.set_system_metrics_sampling_interval(None)
 
 
 @device('cpu')


### PR DESCRIPTION
# What does this PR do?

Enable system metrics in mosaic mlflow logger. The default mode is on.

Please see the screenshot:
<img width="1515" alt="Screenshot 2023-12-11 at 5 05 58 PM" src="https://github.com/mosaicml/composer/assets/22925031/56b7dc31-ded4-489d-9285-bf7f127915e3">

The order is a bit strange when there are multiple GPUs, we should fix it on the mlflow side. But it does not affect this PR.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
