### PR TITLE
Bump aws of nccl version and enable aws platform support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ ARG MOFED_VERSION=5.5-1.0.3.2
 
 # Version of EFA Drivers to install (for AWS Elastic Fabric Adapter support)
 # Leave blank for no EFA Drivers
-ARG AWS_OFI_NCCL_VERSION=v1.7.3-aws
+ARG AWS_OFI_NCCL_VERSION=v1.7.4-aws
 
 # Upgrade certifi to resolve CVE-2022-23491
 ARG CERTIFI_VERSION='>=2022.12.7'
@@ -250,7 +250,8 @@ RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
         ./configure --prefix=/opt/aws-ofi-nccl/install \
             --with-libfabric=/opt/amazon/efa/ \
             --with-cuda=/usr/local/cuda \
-            --disable-tests && \
+            --disable-tests \
+            --enable-platform-aws && \
         make && make install ; \
     fi
 

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -27,7 +27,7 @@
   - mosaicml/pytorch:latest
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.16.1
-- AWS_OFI_NCCL_VERSION: v1.7.3-aws
+- AWS_OFI_NCCL_VERSION: v1.7.4-aws
   BASE_IMAGE: nvidia/cuda:12.1.0-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 12.1.0
   IMAGE_NAME: torch-2-1-1-cu121-aws
@@ -89,7 +89,7 @@
   - mosaicml/pytorch:2.0.1_cu118-python3.10-ubuntu20.04
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.15.2
-- AWS_OFI_NCCL_VERSION: v1.7.3-aws
+- AWS_OFI_NCCL_VERSION: v1.7.4-aws
   BASE_IMAGE: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 11.8.0
   IMAGE_NAME: torch-2-0-1-cu118-aws
@@ -136,7 +136,7 @@
   - mosaicml/pytorch:1.13.1_cu117-python3.10-ubuntu20.04
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.14.1
-- AWS_OFI_NCCL_VERSION: v1.7.3-aws
+- AWS_OFI_NCCL_VERSION: v1.7.4-aws
   BASE_IMAGE: nvidia/cuda:11.7.1-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 11.7.1
   IMAGE_NAME: torch-1-13-1-cu117-aws

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -224,7 +224,7 @@ def _main():
         if interconnect != 'EFA':
             entry['AWS_OFI_NCCL_VERSION'] = ''
         else:
-            entry['AWS_OFI_NCCL_VERSION'] = 'v1.7.3-aws'
+            entry['AWS_OFI_NCCL_VERSION'] = 'v1.7.4-aws'
 
         pytorch_entries.append(entry)
     nightly_entry = {


### PR DESCRIPTION
# What does this PR do?
* Add --enable-platform-aws for proper AWS NCCL Topology discovery 
* Bump on the aws-ofi-nccl plugin



