### PR TITLE
[UCVolumes] Rely on databricks-sdk auth for the right requirements

### DIFF
--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -55,9 +55,13 @@ class UCObjectStore(ObjectStore):
         except ImportError as e:
             raise MissingConditionalImportError('databricks', conda_package='databricks-sdk>=0.8.0,<1.0') from e
 
-        if not 'DATABRICKS_HOST' in os.environ or not 'DATABRICKS_TOKEN' in os.environ:
-            raise ValueError('Environment variables `DATABRICKS_HOST` and `DATABRICKS_TOKEN` '
-                             'must be set to use Databricks Unity Catalog Volumes')
+        try:
+            self.client = WorkspaceClient()
+        except Exception as e:
+            raise ValueError(
+                f'Databricks SDK credentials not correctly setup. '
+                'Visit https://databricks-sdk-py.readthedocs.io/en/latest/authentication.html#databricks-native-authentication '
+                'to identify different ways to setup credentials.') from e
         self.prefix = self.validate_path(path)
         self.client = WorkspaceClient()
 

--- a/setup.py
+++ b/setup.py
@@ -228,7 +228,7 @@ extra_deps['mlflow'] = [
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']
 
-extra_deps['databricks'] = ['databricks-sdk>=0.8.0,<1.0']
+extra_deps['databricks'] = ['databricks-sdk>=0.15.0,<1.0']
 
 extra_deps['all'] = {dep for deps in extra_deps.values() for dep in deps}
 


### PR DESCRIPTION
# What does this PR do?
- The databricks deployed MAPI uses a config file to provide the credentials instead of the environment variables. Use the underlying `databricks-sdk` to determine if the right configs are set to authenticate instead of forcing users to set the environment variables.
- Also update the sdk to the latest version on pypi to allow for better automatic authentication

# Testing
- Existing unit tests pass
- Run integration test locally to verify that it passes
```
pytest -m "remote" tests/utils/object_store/test_uc_object_store.py::test_uc_object_store_integration
================================================================== test session starts ===================================================================
platform darwin -- Python 3.11.5, pytest-7.4.2, pluggy-1.3.0
rootdir: /Users/harsh.panchal/mosaic/composer
configfile: pyproject.toml
plugins: pytest_codeblocks-0.16.1, anyio-4.0.0, httpserver-1.0.8
collected 1 item

tests/utils/object_store/test_uc_object_store.py .                                                                                                 [100%]

==================================================================== warnings summary ====================================================================
venv/lib/python3.11/site-packages/torchmetrics/utilities/imports.py:18
  /Users/harsh.panchal/mosaic/composer/venv/lib/python3.11/site-packages/torchmetrics/utilities/imports.py:18: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.version import LooseVersion

venv/lib/python3.11/site-packages/pkg_resources/_vendor/pyparsing.py:87
  /Users/harsh.panchal/mosaic/composer/venv/lib/python3.11/site-packages/pkg_resources/_vendor/pyparsing.py:87: DeprecationWarning: module 'sre_constants' is deprecated
    import sre_constants

venv/lib/python3.11/site-packages/jupyter_client/connect.py:20
  /Users/harsh.panchal/mosaic/composer/venv/lib/python3.11/site-packages/jupyter_client/connect.py:20: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir, jupyter_runtime_dir, secure_write

venv/lib/python3.11/site-packages/comet_ml/monkey_patching.py:19
  /Users/harsh.panchal/mosaic/composer/venv/lib/python3.11/site-packages/comet_ml/monkey_patching.py:19: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

tests/utils/object_store/test_uc_object_store.py::test_uc_object_store_integration
  /Users/harsh.panchal/mosaic/composer/venv/lib/python3.11/site-packages/deepspeed/ops/op_builder/builder.py:15: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
    import distutils.sysconfig

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================= 1 passed, 5 warnings in 10.59s =============================================================
```
- Manual testing without explicitly setting `DATABRICKS_HOST` and `DATABRICKS_TOKEN`
```
source venv/bin/activate
python3
>>> from composer.utils.object_store import UCObjectStore
>>> uc = UCObjectStore(path='Volumes/ml/harsh/mosaicml/')
uc.list_objects('Volumes/ml/harsh/mosaicml/.')
['/Volumes/ml/harsh/mosaicml/.credentials_validated_successfully']
>>>
```

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
