### PR TITLE
default to no torch profiler memory timeline

### DIFF
--- a/composer/profiler/profiler.py
+++ b/composer/profiler/profiler.py
@@ -102,7 +102,7 @@ class Profiler:
         torch_prof_folder: str = '{run_name}/torch_traces',
         torch_prof_filename: str = 'rank{rank}.{batch}.pt.trace.json',
         torch_prof_remote_file_name: Optional[str] = '{run_name}/torch_traces/rank{rank}.{batch}.pt.trace.json',
-        torch_prof_memory_filename: Optional[str] = 'rank{rank}.{batch}.pt.memory_trace.html',
+        torch_prof_memory_filename: Optional[str] = None,
         torch_prof_memory_remote_file_name: Optional[
             str] = '{run_name}/torch_memory_traces/rank{rank}.{batch}.pt.memory_trace.html',
         torch_prof_overwrite: bool = False,
@@ -154,7 +154,7 @@ class Profiler:
                 f'Memory profiling is enabled and uses {torch_prof_memory_filename} as the filename to generate the memory timeline graph. To disable the memory timeline graph generation, explicitly set torch_prof_memory_filename to None.'
             )
         else:
-            log.info(f'torch_prof_memory_filename is explicitly set to None. Memory timeline will not be be generated.')
+            log.info(f'torch_prof_memory_filename is set to None. Memory timeline will not be be generated.')
 
         if torch_prof_record_shapes or torch_prof_profile_memory or torch_prof_with_stack or torch_prof_with_flops:
             self._callbacks.append(

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -111,7 +111,7 @@ class TorchProfiler(Callback):  # noqa: D101
 
             To disable uploading trace files, set this parameter to ``None``.
         memory_filename (str, optional): A format string describing how to name Torch Profiler memory trace files.
-            Defaults to ``'rank{{rank}}.{{batch}}.pt.trace.memory.html'``.
+            Defaults to None. An example memory_filename is ``'rank{{rank}}.{{batch}}.pt.trace.memory.html'``.
 
             At the end of each batch where :meth:`~composer.profiler.Profiler.get_action` returns
             :attr:`~composer.profiler._profiler_action.ProfilerAction.ACTIVE_AND_SAVE`, trace files are saved
@@ -185,7 +185,7 @@ class TorchProfiler(Callback):  # noqa: D101
         folder: str = '{run_name}/torch_traces',
         filename: str = 'rank{rank}.{batch}.pt.trace.json',
         remote_file_name: Optional[str] = '{run_name}/torch_traces/rank{rank}.{batch}.pt.trace.json',
-        memory_filename: Optional[str] = 'rank{rank}.{batch}.pt.trace.memory.html',
+        memory_filename: Optional[str] = None,
         memory_remote_file_name: Optional[
             str] = '{run_name}/torch_memory_traces/rank{rank}.{batch}.pt.trace.memory.html',
         overwrite: bool = False,


### PR DESCRIPTION
This PR changes the default behavior from enabling memorytimeline with a default name to not enabling  memory timeline generation if users do not specify torch_profiler_memory_filename. Thus users don't get a ValueError the first time they run the profiler without the three required flags on (torch_prof_with_stack, torch_prof_record_shapes, and torch_prof_profile_memory).