### PR TITLE
Avoid futures on close for MosaicML logger

### DIFF
--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -135,7 +135,8 @@ class MosaicMLLogger(LoggerDestination):
         self._flush_metadata(force_flush=True)
 
     def close(self, state: State, logger: Logger) -> None:
-        self._flush_metadata(force_flush=True)
+        self._flush_metadata(force_flush=True, future=False)
+        wait(self._futures)  # Ignore raised errors on close
 
     def _log_metadata(self, metadata: Dict[str, Any]) -> None:
         """Buffer metadata and prefix keys with mosaicml."""
@@ -146,14 +147,18 @@ class MosaicMLLogger(LoggerDestination):
                 self.buffered_metadata[f'mosaicml/{key}'] = format_data_to_json_serializable(val)
             self._flush_metadata()
 
-    def _flush_metadata(self, force_flush: bool = False) -> None:
+    def _flush_metadata(self, force_flush: bool = False, future: bool = True) -> None:
         """Flush buffered metadata to MosaicML if enough time has passed since last flush."""
-        if self._enabled and (time.time() - self.time_last_logged > self.log_interval or force_flush):
+        if self._enabled and len(self.buffered_metadata) > 0 and (
+                time.time() - self.time_last_logged > self.log_interval or force_flush):
             try:
-                f = mcli.update_run_metadata(self.run_name, self.buffered_metadata, future=True, protect=True)
+                if future:
+                    f = mcli.update_run_metadata(self.run_name, self.buffered_metadata, future=True, protect=True)
+                    self._futures.append(f)
+                else:
+                    mcli.update_run_metadata(self.run_name, self.buffered_metadata, future=True, protect=True)
                 self.buffered_metadata = {}
                 self.time_last_logged = time.time()
-                self._futures.append(f)
                 done, incomplete = wait(self._futures, timeout=0.01)
                 log.info(f'Logged {len(done)} metadata to MosaicML, waiting on {len(incomplete)}')
                 # Raise any exceptions

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -156,7 +156,7 @@ class MosaicMLLogger(LoggerDestination):
                     f = mcli.update_run_metadata(self.run_name, self.buffered_metadata, future=True, protect=True)
                     self._futures.append(f)
                 else:
-                    mcli.update_run_metadata(self.run_name, self.buffered_metadata, future=True, protect=True)
+                    mcli.update_run_metadata(self.run_name, self.buffered_metadata, future=False, protect=True)
                 self.buffered_metadata = {}
                 self.time_last_logged = time.time()
                 done, incomplete = wait(self._futures, timeout=0.01)

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -123,6 +123,7 @@ def test_logged_data_exception_handling(monkeypatch, world_size: int, ignore_exc
     monkeypatch.setenv('RUN_NAME', run_name)
 
     logger = MosaicMLLogger(ignore_exceptions=ignore_exceptions)
+    logger.buffered_metadata = {'key': 'value'}  # Add dummy data so logging runs
     if dist.get_global_rank() != 0:
         assert logger._enabled is False
         logger._flush_metadata(force_flush=True)

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -195,7 +195,7 @@ def test_metric_full_filtering(monkeypatch):
     )
     trainer.fit()
 
-    assert len(mock_mapi.run_metadata[run_name].keys()) == 0
+    assert run_name not in mock_mapi.run_metadata
 
 
 class SetWandBRunURL(Callback):


### PR DESCRIPTION
# What does this PR do?

Error traces often are masked by a second error raised by mosaicml logger on close where it attempts to schedule a future while python interpreter is shutting down (results in error). This PR makes the last metadata upload on close a non-future. It also adds a wait call for all existing futures

Manually tested on run I was debugging where this kept happening