### PR TITLE
Fix torch profiler error on close

### DIFF
--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -342,7 +342,7 @@ class TorchProfiler(Callback):  # noqa: D101
 
     def close(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
-        if self.profiler is not None:
+        if self.profiler is not None and self.profiler.profiler is not None:
             log.info(self.profiler.key_averages().table(sort_by='cpu_time_total', row_limit=20))
             if self.profile_memory:
                 log.info(self.profiler.key_averages().table(sort_by='self_cpu_memory_usage', row_limit=20))


### PR DESCRIPTION
# What does this PR do?

Fix torch profiler error on close. Avoids:
```
2024-01-04 20:48:13,231: rank7[1408][MainThread]: ERROR: composer.core.engine: Error running TorchProfiler.close(). Skipping TorchProfiler.post_close().
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/composer/core/engine.py", line 527, in _close
    callback.close(state, logger)
  File "/usr/lib/python3/dist-packages/composer/profiler/torch_profiler.py", line 346, in close
    log.info(self.profiler.key_averages().table(sort_by='cpu_time_total', row_limit=20))
  File "/usr/lib/python3/dist-packages/torch/profiler/profiler.py", line 209, in key_averages
    assert self.profiler
AssertionError
Stack (most recent call last):
  File "/usr/lib/python3/dist-packages/composer/core/engine.py", line 529, in _close
    log.error(
```
when an error happens before profiler runs