### PR TITLE
Fix MPS with sequence loss 

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2983,6 +2983,13 @@ class Trainer:
                                                 outputs[k] = v.cpu()
                                             else:
                                                 outputs[k] = v
+                                    elif isinstance(self.state.outputs, Sequence):
+                                        outputs = []
+                                        for v in self.state.outputs:
+                                            if isinstance(v, torch.Tensor):
+                                                outputs.append(v.cpu())
+                                            else:
+                                                outputs.append(v)
                                     else:
                                         outputs = self.state.outputs.cpu()
                                 else:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2990,10 +2990,8 @@ class Trainer:
                                                 outputs.append(v.cpu())
                                             else:
                                                 outputs.append(v)
-                                    elif isinstance(self.state.outputs, torch.Tensor):
-                                        outputs = self.state.outputs.cpu()
                                     else:
-                                        raise ValueError('Unsupported type for state.outputs in trainer eval loop.')
+                                        outputs = self.state.outputs.cpu()
                                 else:
                                     outputs = self.state.outputs
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2990,8 +2990,10 @@ class Trainer:
                                                 outputs.append(v.cpu())
                                             else:
                                                 outputs.append(v)
-                                    else:
+                                    elif isinstance(self.state.outputs, torch.Tensor):
                                         outputs = self.state.outputs.cpu()
+                                    else:
+                                        raise ValueError('Unsupported type for state.outputs in trainer eval loop.')
                                 else:
                                     outputs = self.state.outputs
 


### PR DESCRIPTION
# What does this PR do?

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

**TLDR**
Fixes the trainer eval loop for MPS devices when the model output is a list of tensors rather than a `torch.Tensor` or `Mapping`.

**Related**
Similar issue but with dict: #2632 
PR for above issue: #2706

**Details**
In the trainer evaluation loop, model outputs (`self.state.outputs`) are moved to the CPU if they are on an MPS device (to avoid torchvision numerical errors on MPS devices). Currently this works fine if `self.state.outputs` is a Mapping or a torch.Tensor. However, it fails for Sequence types (e.g. a list of torch.Tensors).

According to the State class, `outputs` is expected to be of type `torch.Tensor | Sequence[torch.Tensor]`. So Sequence types should be supported in this process in the eval loop. Strictly, `outputs` should not be a `Mapping`, despite the eval operation supporting this. I have left the `Mapping` support in place for now but happy to revisit.

As it was a little difficult to debug this issue, I have added an error message which should make it clearer if an invalid output type is used (such that it cannot correctly be mapped from MPS to CPU). 

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
