### PR TITLE
Fix TRT-LLM Multigpu Compatibility

### DIFF
--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -724,7 +724,7 @@ class InContextLearningQATaskDataset(InContextLearningDataset):
         tensor_keys = ['input_ids', 'attention_mask']
         list_keys = ['labels']
         super().__init__(
-            padding_side='left',
+            padding_side='right',
             tokenize_labels=False,
             static_keys=static_keys,
             list_keys=list_keys,

--- a/composer/trainer/_scaler.py
+++ b/composer/trainer/_scaler.py
@@ -5,8 +5,14 @@ from collections import defaultdict
 from typing import Optional, Union
 
 import torch
-from torch.cuda.amp.grad_scaler import GradScaler, OptState, _refresh_per_optimizer_state
+from torch.cuda.amp.grad_scaler import GradScaler, OptState
 from torch.optim import Optimizer
+
+from packaging import version
+if version.parse(torch.__version__) >= version.parse('2.2.9'):
+    from torch.amp.grad_scaler import _refresh_per_optimizer_state  # type: ignore
+else:
+    from torch.cuda.amp.grad_scaler import _refresh_per_optimizer_state  # type: ignore
 
 from composer.utils import dist
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -42,7 +42,13 @@ import torch.distributed
 import torch.nn as nn
 import torch.utils.data
 from torch._dynamo import OptimizedModule
-from torch.cuda.amp.grad_scaler import GradScaler, _refresh_per_optimizer_state
+
+from packaging import version
+if version.parse(torch.__version__) >= version.parse('2.2.9'):
+    from torch.amp.grad_scaler import _refresh_per_optimizer_state  # type: ignore
+else:
+    from torch.cuda.amp.grad_scaler import _refresh_per_optimizer_state  # type: ignore
+
 from torch.distributed.fsdp import FullyShardedDataParallel
 from torch.distributed.fsdp._runtime_utils import _post_backward_final_callback
 from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler


### PR DESCRIPTION
# [Wip] What does this PR do?

We need to use Composer to run our evaluation framework on TRT-LLM models. Unfortunately, this breaks in the Multi-GPU case. These fixes allow Composer to run N copies in parallel and feed data in a way that works with multi-gpu TRT-LLM models. Essentially, these changes are (a) not initializing dist and (b) fixing some race conditions related to data loading.

TODO:
- Replace commented out code with parameters we can pass in.