### PR TITLE
Chuck/bump transfer config

### DIFF
--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -107,7 +107,7 @@ class S3ObjectStore(ObjectStore):
         )
         if transfer_config is None:
             transfer_config = {
-                "num_download_attempts" : 10,  # default of 5, increase for resiliency
+                'num_download_attempts': 10,  # default of 5, increase for resiliency
             }
         self.transfer_config = TransferConfig(**transfer_config)
 

--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -106,7 +106,9 @@ class S3ObjectStore(ObjectStore):
             aws_session_token=aws_session_token,
         )
         if transfer_config is None:
-            transfer_config = {}
+            transfer_config = {
+                "num_download_attempts" : 10,  # default of 5, increase for resiliency
+            }
         self.transfer_config = TransferConfig(**transfer_config)
 
     def get_uri(self, object_name: str) -> str:


### PR DESCRIPTION
# What does this PR do?
Large file transfer fail when training large models. This bumps up the `num_download_attempts` flag in an attempt to make our code more resilient to these failures

# What issue(s) does this change relate to?
https://databricks.atlassian.net/browse/RGENAI-49

# TODO: 
Test at scale