### PR TITLE
Add ignore_metrics field to the MLflow logger

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -54,6 +54,7 @@ class MLFlowLogger(LoggerDestination):
             synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously. (default: ``False``)
         log_system_metrics (bool, optional): Whether to log system metrics. If ``True``, Mlflow will
             log system metrics (CPU/GPU/memory/network usage) during training. (default: ``True``)
+        ignore_metrics (List[str], optional): A list of metrics to ignore when logging metrics. (default: ``[]``)
     """
 
     def __init__(
@@ -68,6 +69,7 @@ class MLFlowLogger(LoggerDestination):
         model_registry_uri: Optional[str] = None,
         synchronous: bool = False,
         log_system_metrics: bool = True,
+        ignore_metrics: Optional[List[str]] = [],
     ) -> None:
         try:
             import mlflow
@@ -85,6 +87,7 @@ class MLFlowLogger(LoggerDestination):
         self.model_registry_uri = model_registry_uri
         self.synchronous = synchronous
         self.log_system_metrics = log_system_metrics
+        self.ignore_metrics = ignore_metrics
         if self.model_registry_uri == 'databricks-uc':
             if len(self.model_registry_prefix.split('.')) != 2:
                 raise ValueError(f'When registering to Unity Catalog, model_registry_prefix must be in the format ' +
@@ -198,7 +201,7 @@ class MLFlowLogger(LoggerDestination):
         from mlflow import log_metrics
         if self._enabled:
             # Convert all metrics to floats to placate mlflow.
-            metrics = {k: float(v) for k, v in metrics.items()}
+            metrics = {k: float(v) for k, v in metrics.items() if k not in self.ignore_metrics}
             log_metrics(
                 metrics=metrics,
                 step=step,

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -69,7 +69,7 @@ class MLFlowLogger(LoggerDestination):
         model_registry_uri: Optional[str] = None,
         synchronous: bool = False,
         log_system_metrics: bool = True,
-        ignore_metrics: Optional[List[str]] = [],
+        ignore_metrics: Optional[List[str]] = None,
     ) -> None:
         try:
             import mlflow
@@ -87,7 +87,7 @@ class MLFlowLogger(LoggerDestination):
         self.model_registry_uri = model_registry_uri
         self.synchronous = synchronous
         self.log_system_metrics = log_system_metrics
-        self.ignore_metrics = ignore_metrics
+        self.ignore_metrics = [] if ignore_metrics is None else ignore_metrics
         if self.model_registry_uri == 'databricks-uc':
             if len(self.model_registry_prefix.split('.')) != 2:
                 raise ValueError(f'When registering to Unity Catalog, model_registry_prefix must be in the format ' +

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -54,7 +54,7 @@ class MLFlowLogger(LoggerDestination):
             synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously. (default: ``False``)
         log_system_metrics (bool, optional): Whether to log system metrics. If ``True``, Mlflow will
             log system metrics (CPU/GPU/memory/network usage) during training. (default: ``True``)
-        ignore_metrics (List[str], optional): A list of metrics to ignore when logging metrics. (default: ``[]``)
+        ignore_metrics (List[str], optional): A list of metrics to ignore when logging. (default: ``[]``)
     """
 
     def __init__(

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -5,9 +5,9 @@
 
 from __future__ import annotations
 
+import fnmatch
 import os
 import pathlib
-import re
 import textwrap
 import time
 import warnings
@@ -55,7 +55,7 @@ class MLFlowLogger(LoggerDestination):
             synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously. (default: ``False``)
         log_system_metrics (bool, optional): Whether to log system metrics. If ``True``, Mlflow will
             log system metrics (CPU/GPU/memory/network usage) during training. (default: ``True``)
-        ignore_metrics (List[str], optional): A list of regexes for metrics to ignore when logging. (default: ``None``)
+        ignore_metrics (List[str], optional): A list of glob patterns for metrics to ignore when logging. (default: ``None``)
     """
 
     def __init__(
@@ -205,10 +205,8 @@ class MLFlowLogger(LoggerDestination):
             metrics = {
                 k: float(v)
                 for k, v in metrics.items()
-                if not any(re.match(pattern, k) for pattern in self.ignore_metrics)
+                if not any(fnmatch.fnmatch(k, pattern) for pattern in self.ignore_metrics)
             }
-            print(f"ignored metrics: {self.ignore_metrics}")
-            print(f"logged metrics: {metrics}")
             log_metrics(
                 metrics=metrics,
                 step=step,

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -54,7 +54,7 @@ class MLFlowLogger(LoggerDestination):
             synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously. (default: ``False``)
         log_system_metrics (bool, optional): Whether to log system metrics. If ``True``, Mlflow will
             log system metrics (CPU/GPU/memory/network usage) during training. (default: ``True``)
-        ignore_metrics (List[str], optional): A list of metrics to ignore when logging. (default: ``[]``)
+        ignore_metrics (List[str], optional): A list of metrics to ignore when logging. (default: ``None``)
     """
 
     def __init__(

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import re
 import textwrap
 import time
 import warnings
@@ -54,7 +55,7 @@ class MLFlowLogger(LoggerDestination):
             synchronously to the MLflow backend. If ``False``, Mlflow will log asynchronously. (default: ``False``)
         log_system_metrics (bool, optional): Whether to log system metrics. If ``True``, Mlflow will
             log system metrics (CPU/GPU/memory/network usage) during training. (default: ``True``)
-        ignore_metrics (List[str], optional): A list of metrics to ignore when logging. (default: ``None``)
+        ignore_metrics (List[str], optional): A list of regexes for metrics to ignore when logging. (default: ``None``)
     """
 
     def __init__(
@@ -201,7 +202,13 @@ class MLFlowLogger(LoggerDestination):
         from mlflow import log_metrics
         if self._enabled:
             # Convert all metrics to floats to placate mlflow.
-            metrics = {k: float(v) for k, v in metrics.items() if k not in self.ignore_metrics}
+            metrics = {
+                k: float(v)
+                for k, v in metrics.items()
+                if not any(re.match(pattern, k) for pattern in self.ignore_metrics)
+            }
+            print(f"ignored metrics: {self.ignore_metrics}")
+            print(f"logged metrics: {metrics}")
             log_metrics(
                 metrics=metrics,
                 step=step,

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -588,7 +588,7 @@ def test_mlflow_ignore_metrics(tmp_path, device):
         tracking_uri=mlflow_uri,
         experiment_name=experiment_name,
         log_system_metrics=False,
-        ignore_metrics=[r'^metrics/eval/.*$'],
+        ignore_metrics=['metrics/eval/*'],
     )
     # Reduce the system metrics sampling interval to speed up the test.
     mlflow.set_system_metrics_sampling_interval(1)

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -588,7 +588,7 @@ def test_mlflow_ignore_metrics(tmp_path, device):
         tracking_uri=mlflow_uri,
         experiment_name=experiment_name,
         log_system_metrics=False,
-        ignore_metrics=['metrics/train/MulticlassAccuracy', 'loss/train/total'],
+        ignore_metrics=[r'^metrics/eval/.*$'],
     )
     # Reduce the system metrics sampling interval to speed up the test.
     mlflow.set_system_metrics_sampling_interval(1)
@@ -621,8 +621,8 @@ def test_mlflow_ignore_metrics(tmp_path, device):
 
     # Test metrics logged.
     for metric_name in [
-            'metrics/eval/MulticlassAccuracy',
-            'metrics/eval/CrossEntropy',
+            'metrics/train/MulticlassAccuracy',
+            'loss/train/total',
     ]:
         metric_file = run_file_path / Path('metrics') / Path(metric_name)
         with open(metric_file) as f:
@@ -632,7 +632,7 @@ def test_mlflow_ignore_metrics(tmp_path, device):
         assert len(lines) == num_batches
 
     # Test metrics are not logged.
-    for metric_name in ['metrics/train/MulticlassAccuracy', 'loss/train/total']:
+    for metric_name in ['metrics/eval/MulticlassAccuracy', 'metrics/eval/CrossEntropy']:
         metric_file = run_file_path / Path('metrics') / Path(metric_name)
         assert not os.path.exists(metric_file)
 

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -588,7 +588,7 @@ def test_mlflow_ignore_metrics(tmp_path, device):
         tracking_uri=mlflow_uri,
         experiment_name=experiment_name,
         log_system_metrics=False,
-        ignore_metrics=['metrics/eval/*'],
+        ignore_metrics=['metrics/eval/*', 'nothing/should/match', 'metrics/train/CrossEntropy'],
     )
     # Reduce the system metrics sampling interval to speed up the test.
     mlflow.set_system_metrics_sampling_interval(1)
@@ -632,7 +632,7 @@ def test_mlflow_ignore_metrics(tmp_path, device):
         assert len(lines) == num_batches
 
     # Test metrics are not logged.
-    for metric_name in ['metrics/eval/MulticlassAccuracy', 'metrics/eval/CrossEntropy']:
+    for metric_name in ['metrics/eval/MulticlassAccuracy', 'metrics/eval/CrossEntropy', 'metrics/train/CrossEntropy']:
         metric_file = run_file_path / Path('metrics') / Path(metric_name)
         assert not os.path.exists(metric_file)
 

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -576,3 +576,69 @@ def test_mlflow_log_image_works(tmp_path, device):
     run_file_path = mlflow_uri / Path(experiment_id) / Path(run_id)
     im_dir = run_file_path / Path('artifacts')
     assert len(os.listdir(im_dir)) == expected_num_ims
+
+
+@device('cpu')
+def test_mlflow_ignore_metrics(tmp_path, device):
+    mlflow = pytest.importorskip('mlflow')
+
+    mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
+    experiment_name = 'mlflow_logging_test'
+    test_mlflow_logger = MLFlowLogger(
+        tracking_uri=mlflow_uri,
+        experiment_name=experiment_name,
+        log_system_metrics=False,
+        ignore_metrics=['metrics/train/MulticlassAccuracy', 'loss/train/total'],
+    )
+    # Reduce the system metrics sampling interval to speed up the test.
+    mlflow.set_system_metrics_sampling_interval(1)
+
+    dataset_size = 64
+    batch_size = 4
+    num_batches = 4
+    eval_interval = '1ba'
+
+    trainer = Trainer(model=SimpleConvModel(),
+                      loggers=test_mlflow_logger,
+                      train_dataloader=DataLoader(RandomImageDataset(size=dataset_size), batch_size),
+                      eval_dataloader=DataLoader(RandomImageDataset(size=dataset_size), batch_size),
+                      max_duration=f'{num_batches}ba',
+                      eval_interval=eval_interval,
+                      device=device)
+    trainer.fit()
+    # Allow async logging to finish.
+    time.sleep(3)
+    test_mlflow_logger.post_close()
+
+    run = _get_latest_mlflow_run(
+        experiment_name=experiment_name,
+        tracking_uri=mlflow_uri,
+    )
+    run_id = run.info.run_id
+    experiment_id = run.info.experiment_id
+
+    run_file_path = mlflow_uri / Path(experiment_id) / Path(run_id)
+
+    # Test metrics logged.
+    for metric_name in [
+            'metrics/eval/MulticlassAccuracy',
+            'metrics/eval/CrossEntropy',
+    ]:
+        metric_file = run_file_path / Path('metrics') / Path(metric_name)
+        with open(metric_file) as f:
+            csv_reader = csv.reader(f, delimiter=' ')
+            lines = list(csv_reader)
+
+        assert len(lines) == num_batches
+
+    # Test metrics are not logged.
+    for metric_name in ['metrics/train/MulticlassAccuracy', 'loss/train/total']:
+        metric_file = run_file_path / Path('metrics') / Path(metric_name)
+        assert not os.path.exists(metric_file)
+
+    # Test system metrics are not logged.
+    metric_file = run_file_path / Path('metrics') / Path('system/cpu_utilization_percentage')
+    assert not os.path.exists(metric_file)
+
+    # Undo the setup to avoid affecting other test cases.
+    mlflow.set_system_metrics_sampling_interval(None)


### PR DESCRIPTION
# What does this PR do?

Adds a new field to the MLflow logger to disable certain metrics from being logged. 

# What issue(s) does this change relate to?

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
note: covered by parameter docs https://mosaicml-docsite--2869.com.readthedocs.build/projects/composer/en/2869/api_reference/generated/composer.loggers.MLFlowLogger.html#composer.loggers.MLFlowLogger
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
