### PR TITLE
Update license

### DIFF
--- a/.ci/FILE_HEADER
+++ b/.ci/FILE_HEADER
@@ -1,2 +1,2 @@
-Copyright 2022 MosaicML Composer authors
+Copyright 2024 MosaicML Composer authors
 SPDX-License-Identifier: Apache-2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.13
+    rev: v1.5.4
     hooks:
       - id: insert-license
         args:
@@ -83,6 +83,7 @@ repos:
           - .ci/FILE_HEADER
           - --comment-style
           - "#"
+          - --allow-past-years
         types: [python]
         exclude: 'composer\/trainer\/activation_checkpointing.py'
 


### PR DESCRIPTION
Updates the license for 2024. New files will have a copyright year of 2024 inserted in the header. Existing files will not be changed.