### PR TITLE
Only load RNG keys that exist

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -505,7 +505,7 @@ def load_sharded_checkpoint(
                 # For older versions of torch, we load optimizer separately.
                 if version.parse(torch.__version__) < version.parse('2.2.9'):
                     cur_state_dict.pop('optimizers')
-                num_rng_ranks = _get_num_ranks_that_saved_rng
+                num_rng_ranks = _get_num_ranks_that_saved_rng(storage_reader.read_metadata())
                 state_dict: Dict[str, Any] = {
                     'state': cur_state_dict,
                     'rng': reproducibility.get_rng_state()[:num_rng_ranks],

--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -561,11 +561,7 @@ def test_checkpoint_loading_with_validation(world_size, tmp_path, is_valid_check
     # Set the error expectations.
     expectation = does_not_raise()
     if not is_valid_checkpoint:
-        if using_torch_2() and state_dict_type == 'sharded':
-            from torch.distributed.checkpoint import CheckpointException
-            expectation = pytest.raises(CheckpointException)
-        else:
-            expectation = pytest.raises(ValueError)
+        expectation = pytest.raises(ValueError)
 
     def mock_get_checkpoint_validation_function():
         return lambda _: is_valid_checkpoint


### PR DESCRIPTION
# What does this PR do?

Only load RNG keys that exist. This was broken in https://github.com/mosaicml/composer/pull/2897 but was not caught in manual tests for some reason 🤔 