### PR TITLE
File lock for sharded checkpoint download

### DIFF
--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -123,7 +123,7 @@ class MosaicMLLogger(LoggerDestination):
         # Log model training finished time for run events
         self._log_metadata({'train_finished_time': time.time()})
         training_progress_data = self._get_training_progress_metrics(state)
-        log.debug(f'\nLogging FINAL training progress data to metadata:\n{dict_to_str(training_progress_data)}')
+        log.debug(f'\nLogging final training progress data to metadata:\n{dict_to_str(training_progress_data)}')
         self._log_metadata(training_progress_data)
         self._flush_metadata(force_flush=True)
 
@@ -161,7 +161,6 @@ class MosaicMLLogger(LoggerDestination):
                 self.buffered_metadata = {}
                 self.time_last_logged = time.time()
                 done, incomplete = wait(self._futures, timeout=0.01)
-                log.info(f'Logged {len(done)} metadata to MosaicML, waiting on {len(incomplete)}')
                 # Raise any exceptions
                 for f in done:
                     if f.exception() is not None:

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -469,7 +469,7 @@ def load_sharded_checkpoint(
 
             # 2. Wait for all ranks to finish.
             log.debug(f'Rank {dist.get_global_rank()} finished downloading all files.')
-            # Use busy wait to avoid timeouts on large downloads for non-sharded checkpoints
+            # Use busy wait to avoid timeouts on large downloads
             signal_file_path = os.path.join(self.destination_path,
                                             f'.node_{dist.get_node_rank()}_local_rank0_completed')
             if dist.get_local_rank() == 0:


### PR DESCRIPTION
# What does this PR do?

Adds file lock to download for sharded checkpoints to minimize potential time spent at barrier to avoid requiring large timeouts.

Along for ride, removes some annoying frequent logs.