### PR TITLE
Fix FP8 checkpoint resumption with onnx export flag

### DIFF
--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -78,6 +78,9 @@ def get_precision_context(precision: Union[str, Precision],
                 }
             fp8_recipe = DelayedScaling(**precision_config)
             with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
+                # The te.onnx_export flag ensures that we save all fp8 buffers
+                # as tensors instead of bytes. This is necessary for proper
+                # saving and resumption of checkpoints.
                 with te.onnx_export(enabled=True):
                     yield
         else:

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -78,7 +78,8 @@ def get_precision_context(precision: Union[str, Precision],
                 }
             fp8_recipe = DelayedScaling(**precision_config)
             with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
-                yield
+                with te.onnx_export(enabled=True):
+                    yield
         else:
             if te_installed:
                 raise RuntimeError('AMP_FP8 precision is used but current device does not support it.')


### PR DESCRIPTION
# What does this PR do?
Before this PR checkpoint resumption on fp8 MPT's did not work since checkpoints serialized extra fp8 buffers in bytes which is incompatible with torch's `load_sharded_optimizers`

After this PR checkpoint resumption from fp8 serializes out extra fp8 buffers in tensors in onnx mode. 

# Tests

**Torch 2.1**
- Failed run w/out this PR: `mpt-125m-sharded-regression-fp8-ignore-td0frt` 🔴  
- Working run w/this PR: `mpt-125m-sharded-regression-fp8-ignore-6DD62n` ✅

**Torch 2.3**
- Run w/out this PR: `mpt-125m-sharded-regression-fp8-ignore-tAGCla` ✅ 
- Working run w/this PR: `mpt-125m-sharded-regression-fp8-ignore-8bZirC` ✅
