### PR TITLE
Fix daily tests for peft + fsdp

### DIFF
--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -477,8 +477,6 @@ def get_lm_trainer(hf_model,
                    should_save_peft_only: bool = False):
     transformers = pytest.importorskip('transformers')
 
-    torch_less_than_2 = version.parse(torch.__version__) < version.parse('2.1.0')
-
     metrics: List[Metric] = [LanguageCrossEntropy(ignore_index=-100)]
     if not is_conditional_generation:
         metrics.append(MaskedAccuracy(ignore_index=-100))
@@ -492,7 +490,7 @@ def get_lm_trainer(hf_model,
         should_save_peft_only=should_save_peft_only,
     )
 
-    if torch_less_than_2 and peft_config is not None:
+    if version.parse(torch.__version__) < version.parse('2.1.0') and peft_config is not None:
         for name, module in model.named_modules():
             if 'lora' in name.lower() and 'default' in name.lower():
                 has_parameters = any(True for _ in module.parameters())

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -498,7 +498,7 @@ def get_lm_trainer(hf_model,
                 has_parameters = any(True for _ in module.parameters())
                 has_buffers = any(True for _ in module.buffers())
                 if has_parameters or has_buffers:
-                    module._fsdp_wrap = True
+                    module._fsdp_wrap = True  # type: ignore
 
     vocab_size = hf_model.config.vocab_size
     sequence_length = 4

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -490,6 +490,8 @@ def get_lm_trainer(hf_model,
         should_save_peft_only=should_save_peft_only,
     )
 
+    # On torch 2.0, fsdp wrapped modules can not have both frozen and unfrozen params.
+    # On 2.1+, if you have use_orig_params=True, they can. So we need a special case for the tests here.
     if version.parse(torch.__version__) < version.parse('2.1.0') and peft_config is not None:
         for name, module in model.named_modules():
             if 'lora' in name.lower() and 'default' in name.lower():


### PR DESCRIPTION
On torch 2.0, fsdp wrapped modules can not have both frozen and unfrozen params. On 2.1+, if you have `use_orig_params=True`, they can. So we need a special case for the tests here.