### PR TITLE
Fix daily tests for peft on 1.13

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -23,7 +23,8 @@ from torchmetrics import Metric
 
 from composer.metrics import InContextLearningMetric, InContextLearningQAAccuracy
 from composer.models.base import ComposerModel
-from composer.utils import MissingConditionalImportError, dist, get_file, import_object, is_model_fsdp, safe_torch_load, using_torch_2
+from composer.utils import (MissingConditionalImportError, dist, get_file, import_object, is_model_fsdp,
+                            safe_torch_load, using_torch_2)
 
 try:
     from peft import PeftModel, get_peft_model

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -23,7 +23,7 @@ from torchmetrics import Metric
 
 from composer.metrics import InContextLearningMetric, InContextLearningQAAccuracy
 from composer.models.base import ComposerModel
-from composer.utils import MissingConditionalImportError, dist, get_file, import_object, is_model_fsdp, safe_torch_load
+from composer.utils import MissingConditionalImportError, dist, get_file, import_object, is_model_fsdp, safe_torch_load, using_torch_2
 
 try:
     from peft import PeftModel, get_peft_model
@@ -140,6 +140,9 @@ class HuggingFaceModel(ComposerModel):
             self.model = _maybe_get_peft_model(peft_config, self.model)
 
         self.using_peft = isinstance(self.model, PeftModel) if peft_installed else False
+
+        if self.using_peft and not using_torch_2():
+            raise RuntimeError('PEFT models are only supported in Torch 2.0+')
 
     def _check_tokenizer_and_maybe_resize_embeddings(self, allow_embedding_resizing: bool) -> None:
         if self.tokenizer is None:

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -1221,18 +1221,23 @@ def test_peft_init(peft_type: str, task_type: str, tiny_gpt2_model, gpt2_peft_co
     pytest.importorskip('peft')
     from peft import PeftModelForCausalLM
 
+    expectation = pytest.raises(RuntimeError) if not using_torch_2() else nullcontext()
+
     peft_config = copy.deepcopy(gpt2_peft_config)
     peft_config.peft_type = peft_type
     peft_config.task_type = task_type
 
     original_model = copy.deepcopy(tiny_gpt2_model)
-    hf_model = HuggingFaceModel(tiny_gpt2_model, peft_config=peft_config)
-    assert isinstance(hf_model.model, PeftModelForCausalLM)
-    assert hf_model.model.peft_config['default'].peft_type == 'LORA'
-    assert hf_model.model.peft_config['default'].task_type == 'CAUSAL_LM'
-    assert hf_model.model.config == original_model.config
+
+    with expectation:
+        hf_model = HuggingFaceModel(tiny_gpt2_model, peft_config=peft_config)
+        assert isinstance(hf_model.model, PeftModelForCausalLM)
+        assert hf_model.model.peft_config['default'].peft_type == 'LORA'
+        assert hf_model.model.peft_config['default'].task_type == 'CAUSAL_LM'
+        assert hf_model.model.config == original_model.config
 
 
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0'), reason='requires PyTorch 2+')
 def test_peft_init_errors(tiny_gpt2_model, gpt2_peft_config):
     pytest.importorskip('peft')
     peft_config = copy.deepcopy(gpt2_peft_config)
@@ -1242,6 +1247,7 @@ def test_peft_init_errors(tiny_gpt2_model, gpt2_peft_config):
         _ = HuggingFaceModel(tiny_gpt2_model, peft_config=peft_config)
 
 
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0'), reason='requires PyTorch 2+')
 def test_peft_init_not_installed(tiny_gpt2_model, gpt2_peft_config):
     pytest.importorskip('peft')
 
@@ -1251,6 +1257,7 @@ def test_peft_init_not_installed(tiny_gpt2_model, gpt2_peft_config):
             _ = HuggingFaceModel(tiny_gpt2_model, peft_config=gpt2_peft_config)
 
 
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0'), reason='requires PyTorch 2+')
 @pytest.mark.parametrize('should_save_peft_only', [True, False])
 def test_peft_trains_and_loads(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_peft_config, tmp_path, should_save_peft_only):
     pytest.importorskip('peft')
@@ -1281,6 +1288,7 @@ def test_peft_trains_and_loads(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_peft_c
         torch.testing.assert_close(p1, p2)
 
 
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0'), reason='requires PyTorch 2+')
 @pytest.mark.parametrize('model,tokenizer,peft_config', [
     (configure_tiny_gpt2_model, configure_tiny_gpt2_tokenizer, _gpt2_peft_config()),
     (configure_tiny_mistral_model, configure_tiny_mistral_tokenizer, _mistral_peft_config()),
@@ -1300,6 +1308,7 @@ def test_peft_generate(model, tokenizer, peft_config):
     hf_model.generate(**input_dict, max_new_tokens=5, pad_token_id=tokenizer.pad_token_id)
 
 
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0'), reason='requires PyTorch 2+')
 def test_peft_metadata(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_peft_config):
     pytest.importorskip('peft')
 
@@ -1312,6 +1321,7 @@ def test_peft_metadata(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_peft_config):
     assert loaded_peft_config == gpt2_peft_config
 
 
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0'), reason='requires PyTorch 2+')
 @pytest.mark.parametrize('should_save_peft_only', [True, False])
 def test_peft_write_hf_from_composer(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_peft_config, tmp_path,
                                      should_save_peft_only):
@@ -1351,13 +1361,10 @@ def test_peft_write_hf_from_composer(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_
 @pytest.mark.gpu
 @world_size(2)
 @pytest.mark.parametrize('should_save_peft_only', [True, False])
-@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.13.0'),
-                    reason='requires PyTorch 1.13 or higher')
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0'), reason='requires PyTorch 2+')
 def test_peft_fsdp_trains(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_peft_config, tmp_path, world_size,
                           should_save_peft_only):
     pytest.importorskip('peft')
-
-    expectation = pytest.raises(RuntimeError) if not using_torch_2() else nullcontext()
 
     fsdp_config = {
         'sharding_strategy': 'FULL_SHARD',
@@ -1371,61 +1378,61 @@ def test_peft_fsdp_trains(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_peft_config
 
     stashed_model = copy.deepcopy(tiny_gpt2_model)
 
-    with expectation:
-        trainer = get_lm_trainer(
-            tiny_gpt2_model,
-            tiny_gpt2_tokenizer,
-            str(tmp_path / 'trainer1'),
-            peft_config=gpt2_peft_config,
-            device_train_microbatch_size=1,
-            mlm=False,
-            fsdp_config=fsdp_config,
-            should_save_peft_only=should_save_peft_only,
-        )
+    trainer = get_lm_trainer(
+        tiny_gpt2_model,
+        tiny_gpt2_tokenizer,
+        str(tmp_path / 'trainer1'),
+        peft_config=gpt2_peft_config,
+        device_train_microbatch_size=1,
+        mlm=False,
+        fsdp_config=fsdp_config,
+        should_save_peft_only=should_save_peft_only,
+    )
 
-        for n, p in trainer.state.model.model.named_parameters():
-            if 'lora' in n:
-                assert p.requires_grad
-            else:
-                assert not p.requires_grad
+    for n, p in trainer.state.model.model.named_parameters():
+        if 'lora' in n:
+            assert p.requires_grad
+        else:
+            assert not p.requires_grad
 
-        trainer.fit()
-        trainer.close()
+    trainer.fit()
+    trainer.close()
 
-        load_trainer = get_lm_trainer(
-            stashed_model,
-            tiny_gpt2_tokenizer,
-            str(tmp_path / 'trainer2'),
-            peft_config=gpt2_peft_config,
-            device_train_microbatch_size=1,
-            mlm=False,
-            load_path=str(tmp_path / 'trainer1' / 'hf-checkpoint.pt'),
-            fsdp_config=fsdp_config,
-            should_save_peft_only=should_save_peft_only,
-        )
+    load_trainer = get_lm_trainer(
+        stashed_model,
+        tiny_gpt2_tokenizer,
+        str(tmp_path / 'trainer2'),
+        peft_config=gpt2_peft_config,
+        device_train_microbatch_size=1,
+        mlm=False,
+        load_path=str(tmp_path / 'trainer1' / 'hf-checkpoint.pt'),
+        fsdp_config=fsdp_config,
+        should_save_peft_only=should_save_peft_only,
+    )
 
-        for n, p in load_trainer.state.model.model.named_parameters():
-            if 'lora' in n:
-                assert p.requires_grad
-            else:
-                assert not p.requires_grad
+    for n, p in load_trainer.state.model.model.named_parameters():
+        if 'lora' in n:
+            assert p.requires_grad
+        else:
+            assert not p.requires_grad
 
-        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+    from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-        with FSDP.summon_full_params(trainer.state.model), FSDP.summon_full_params(load_trainer.state.model):
-            for p1, p2 in zip(trainer.state.model.parameters(), load_trainer.state.model.parameters()):
-                torch.testing.assert_close(p1, p2)
+    with FSDP.summon_full_params(trainer.state.model), FSDP.summon_full_params(load_trainer.state.model):
+        for p1, p2 in zip(trainer.state.model.parameters(), load_trainer.state.model.parameters()):
+            torch.testing.assert_close(p1, p2)
 
-        if dist.get_global_rank() == 0:
-            loaded_ckpt_1 = torch.load(str(tmp_path / 'trainer1' / 'hf-checkpoint.pt'))
+    if dist.get_global_rank() == 0:
+        loaded_ckpt_1 = torch.load(str(tmp_path / 'trainer1' / 'hf-checkpoint.pt'))
 
-            # Check that only the LoRA parameters were saved
-            if should_save_peft_only:
-                assert all('lora' in k for k in loaded_ckpt_1['state']['model'].keys())
-            else:
-                assert not all('lora' in k for k in loaded_ckpt_1['state']['model'].keys())
+        # Check that only the LoRA parameters were saved
+        if should_save_peft_only:
+            assert all('lora' in k for k in loaded_ckpt_1['state']['model'].keys())
+        else:
+            assert not all('lora' in k for k in loaded_ckpt_1['state']['model'].keys())
 
 
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.0'), reason='requires PyTorch 2+')
 def test_filtered_state_dict(tiny_gpt2_model, tiny_gpt2_tokenizer, gpt2_peft_config, tmp_path):
     pytest.importorskip('peft')
 


### PR DESCRIPTION
# What does this PR do?
The dailys surfaced an error with peft + fsdp that I haven't seen before
```
    def __setstate__(self, state):
        super().__setstate__(state)
        for group in self.param_groups:
            group.setdefault('amsgrad', False)
            group.setdefault('maximize', False)
            group.setdefault('foreach', None)
            group.setdefault('capturable', False)
        state_values = list(self.state.values())
>       step_is_tensor = (len(state_values) != 0) and torch.is_tensor(state_values[0]['step'])
E       KeyError: 'step'
```

Given that (a) we will not support 1.13 for much longer anyway, as everyone should be using torch 2+, and (b) there is no clean way to _only_ prevent peft usage on 1.13 when used in conjunction with FSDP, I decided to just gate peft usage on torch 2+.

