### PR TITLE
Fix OCI reraising errors.

### DIFF
--- a/composer/core/types.py
+++ b/composer/core/types.py
@@ -6,8 +6,6 @@
 Attributes:
     Batch (Any): Alias to type Any.
         A batch of data can be represented in several formats, depending on the application.
-    PyTorchScheduler (torch.optim.lr_scheduler._LRScheduler): Alias for base class of learning rate schedulers such
-        as :class:`torch.optim.lr_scheduler.ConstantLR`.
     JSON (str | float | int | None | List['JSON'] | Dict[str, 'JSON']): JSON Data.
     Dataset (torch.utils.data.Dataset[Batch]): Alias for :class:`torch.utils.data.Dataset`.
 """

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -26,13 +26,8 @@ def _reraise_oci_errors(uri: str, e: Exception):
                                             conda_channel='conda-forge') from e
 
     # If it's an oci service error with code: ObjectNotFound or status 404
-    if isinstance(e, oci.exceptions.ServiceError):
-        if e.status == 404:  # type: ignore
-            if e.code == 'ObjectNotFound':  # type: ignore
-                raise FileNotFoundError(f'Object {uri} not found. {e.message}') from e  # type: ignore
-            if e.code == 'BucketNotFound':  # type: ignore
-                raise ValueError(f'Bucket specified in {uri} not found. {e.message}') from e  # type: ignore
-            raise e
+    if isinstance(e, oci.exceptions.ServiceError) and e.status == 404:
+        raise FileNotFoundError(f'Object {uri} not found. {e.message}') from e  # type: ignore
 
     # Client errors
     if isinstance(e, oci.exceptions.ClientError):

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -26,7 +26,7 @@ def _reraise_oci_errors(uri: str, e: Exception):
                                             conda_channel='conda-forge') from e
 
     # If it's an oci service error with code: ObjectNotFound or status 404
-    if isinstance(e, oci.exceptions.ServiceError) and e.status == 404:
+    if isinstance(e, oci.exceptions.ServiceError) and e.status == 404:  # type: ignore
         raise FileNotFoundError(f'Object {uri} not found. {e.message}') from e  # type: ignore
 
     # Client errors

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -27,7 +27,7 @@ def _reraise_oci_errors(uri: str, e: Exception):
 
     # If it's an oci service error with code: ObjectNotFound or status 404
     if isinstance(e, oci.exceptions.ServiceError) and e.status == 404:  # type: ignore
-        raise FileNotFoundError(f'Object {uri} not found. {e.message}') from e  # type: ignore
+        raise FileNotFoundError(f'Object or bucket for object {uri} not found. {e.message}') from e  # type: ignore
 
     # Client errors
     if isinstance(e, oci.exceptions.ClientError):

--- a/tests/utils/object_store/test_oci_object_store.py
+++ b/tests/utils/object_store/test_oci_object_store.py
@@ -131,7 +131,7 @@ def test_download_object(test_oci_obj_store, monkeypatch, tmp_path, mock_bucket_
         mock_get_object_fn_with_exception = Mock(side_effect=oci.exceptions.ServiceError(
             status=404, code=None, headers={'opc-request-id': 'foo'}, message=bucket_not_found_msg))
         with monkeypatch.context() as m:
-            m.setattr(oci_os.client.head_object, 'get_object', bucket_not_found_msg)
+            m.setattr(oci_os.client, 'get_object', bucket_not_found_msg)
             with pytest.raises(
                     FileNotFoundError,
                     match=

--- a/tests/utils/object_store/test_oci_object_store.py
+++ b/tests/utils/object_store/test_oci_object_store.py
@@ -126,12 +126,12 @@ def test_download_object(test_oci_obj_store, monkeypatch, tmp_path, mock_bucket_
             ):
                 oci_os.download_object(mock_object_name, filename=file_to_download_to)
     elif result == 'no_code':
-        file_to_download_to = str(tmp_path / Path('my_obj_not_found_file.bin'))
-        obj_not_found_msg = f"The object '{mock_object_name}' was not found in the bucket f'{mock_bucket_name}'"
-        mock_head_object = Mock(side_effect=oci.exceptions.ServiceError(
-            status=404, code=None, headers={'opc-request-id': 'foo'}, message=obj_not_found_msg))
+        file_to_download_to = str(tmp_path / Path('my_bucket_not_found_file.bin'))
+        bucket_not_found_msg = f'Either the bucket named f{mock_bucket_name} does not exist in the namespace*'
+        mock_get_object_fn_with_exception = Mock(side_effect=oci.exceptions.ServiceError(
+            status=404, code=None, headers={'opc-request-id': 'foo'}, message=bucket_not_found_msg))
         with monkeypatch.context() as m:
-            m.setattr(oci_os.client.head_object, 'get_object', mock_head_object)
+            m.setattr(oci_os.client.head_object, 'get_object', bucket_not_found_msg)
             with pytest.raises(
                     FileNotFoundError,
                     match=

--- a/tests/utils/object_store/test_oci_object_store.py
+++ b/tests/utils/object_store/test_oci_object_store.py
@@ -131,7 +131,7 @@ def test_download_object(test_oci_obj_store, monkeypatch, tmp_path, mock_bucket_
         mock_get_object_fn_with_exception = Mock(side_effect=oci.exceptions.ServiceError(
             status=404, code=None, headers={'opc-request-id': 'foo'}, message=bucket_not_found_msg))
         with monkeypatch.context() as m:
-            m.setattr(oci_os.client, 'get_object', bucket_not_found_msg)
+            m.setattr(oci_os.client, 'get_object', mock_get_object_fn_with_exception)
             with pytest.raises(
                     FileNotFoundError,
                     match=

--- a/tests/utils/object_store/test_oci_object_store.py
+++ b/tests/utils/object_store/test_oci_object_store.py
@@ -131,7 +131,7 @@ def test_download_object(test_oci_obj_store, monkeypatch, tmp_path, mock_bucket_
         mock_head_object = Mock(side_effect=oci.exceptions.ServiceError(
             status=404, code=None, headers={'opc-request-id': 'foo'}, message=obj_not_found_msg))
         with monkeypatch.context() as m:
-            m.setattr(oci_os.head_object, 'get_object', mock_head_object)
+            m.setattr(oci_os.client.head_object, 'get_object', mock_head_object)
             with pytest.raises(
                     FileNotFoundError,
                     match=

--- a/tests/utils/object_store/test_oci_object_store.py
+++ b/tests/utils/object_store/test_oci_object_store.py
@@ -54,7 +54,7 @@ def test_upload_object(test_oci_obj_store, monkeypatch, tmp_path, mock_bucket_na
                                                      bucket_name=mock_bucket_name,
                                                      object_name=mock_object_name,
                                                      file_path=file_to_upload)
-    elif result == "bucket_not_found":
+    elif result == 'bucket_not_found':
         bucket_not_found_msg = f'Either the bucket named f{mock_bucket_name} does not exist in the namespace*'
         mock_upload_file_with_exception = Mock(side_effect=oci.exceptions.ServiceError(
             status=404, code='BucketNotFound', headers={'opc-request-id': 'foo'}, message=bucket_not_found_msg))


### PR DESCRIPTION
# What does this PR do?

OCI got rid of `e.code`, breaking our autoresume logic. Let's just always raise.

https://github.com/oracle/oci-cli/blob/b03b3b1f2b05f00bcbfeed84b7fcf6e0d091478e/services/dts/src/oci_cli_dts/base_client.py#L88

Along for ride, fixes docs with types PR