### PR TITLE
Fix UC object store bugfix

### DIFF
--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -209,7 +209,7 @@ class UCObjectStore(ObjectStore):
         try:
             # Note: The UC team is working on changes to fix the files.get_status API, but it currently
             # does not work. Once fixed, we will call the files API endpoint. We currently only use this
-            # function in Composer and LLM-foundry to check the UC object's existance.
+            # function in Composer and LLM-foundry to check the UC object's existence.
             self.client.api_client.do(method='HEAD',
                                       path=f'{self._UC_VOLUME_FILES_API_ENDPOINT}/{self.prefix}/{object_name}',
                                       headers={'Source': 'mosaicml/composer'})

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -25,8 +25,8 @@ _NOT_FOUND_ERROR_CODE = 'NOT_FOUND'
 def _wrap_errors(uri: str, e: Exception):
     from databricks.sdk.errors.mapping import NotFound
     from databricks.sdk.core import DatabricksError
-    if isinstance(e, DatabricksError) or isinstance(e, NotFound):
-        if e.error_code == _NOT_FOUND_ERROR_CODE:  # type: ignore
+    if isinstance(e, DatabricksError):
+        if isinstance(e, NotFound) or e.error_code == _NOT_FOUND_ERROR_CODE:  # type: ignore
             raise FileNotFoundError(f'Object {uri} not found') from e
     raise ObjectStoreTransientError from e
 

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -211,8 +211,9 @@ class UCObjectStore(ObjectStore):
             # does not work. Once fixed, we will call the files API endpoint. We currently only use this
             # function in Composer and LLM-foundry to check the UC object's existance.
             self.client.api_client.do(method='HEAD',
-                                      path=self._UC_VOLUME_FILES_API_ENDPOINT + '/' + object_name,
+                                      path=f'{self._UC_VOLUME_FILES_API_ENDPOINT}/{self.prefix}/{object_name}',
                                       headers={'Source': 'mosaicml/composer'})
+            return 1000000  # Dummy value, as we don't have a way to get the size of the file
         except DatabricksError as e:
             # If the code reaches here, the file was not found
             _wrap_errors(self.get_uri(object_name), e)

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -23,8 +23,8 @@ _NOT_FOUND_ERROR_CODE = 'NOT_FOUND'
 
 
 def _wrap_errors(uri: str, e: Exception):
-    from databricks.sdk.errors.mapping import NotFound
     from databricks.sdk.core import DatabricksError
+    from databricks.sdk.errors.mapping import NotFound
     if isinstance(e, DatabricksError):
         if isinstance(e, NotFound) or e.error_code == _NOT_FOUND_ERROR_CODE:  # type: ignore
             raise FileNotFoundError(f'Object {uri} not found') from e

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -215,8 +215,6 @@ class UCObjectStore(ObjectStore):
                                       path=f'{self._UC_VOLUME_FILES_API_ENDPOINT}/{self.prefix}/{object_name}',
                                       headers={'Source': 'mosaicml/composer'})
             return 1000000  # Dummy value, as we don't have a way to get the size of the file
-        except FileNotFoundError as e:
-            _wrap_errors(self.get_uri(object_name), e)
         except DatabricksError as e:
             # If the code reaches here, the file was not found
             _wrap_errors(self.get_uri(object_name), e)

--- a/tests/utils/object_store/test_uc_object_store.py
+++ b/tests/utils/object_store/test_uc_object_store.py
@@ -78,12 +78,11 @@ def test_uc_object_store_invalid_prefix(monkeypatch):
 @pytest.mark.parametrize('result', ['success', 'not_found'])
 def test_get_object_size(ws_client, uc_object_store, result: str):
     if result == 'success':
-        db_files = pytest.importorskip('databricks.sdk.service.files')
-        ws_client.files.get_status.return_value = db_files.FileInfo(file_size=100)
-        assert uc_object_store.get_object_size('train.txt') == 100
+        ws_client.api_client.do.return_value = {}
+        assert uc_object_store.get_object_size('train.txt') == 1000000
     elif result == 'not_found':
         db_core = pytest.importorskip('databricks.sdk.core', reason='requires databricks')
-        ws_client.files.get_status.side_effect = db_core.DatabricksError('The file being accessed is not found',
+        ws_client.api_client.do.side_effect = db_core.DatabricksError('The file being accessed is not found',
                                                                          error_code='NOT_FOUND')
         with pytest.raises(FileNotFoundError):
             uc_object_store.get_object_size('train.txt')

--- a/tests/utils/object_store/test_uc_object_store.py
+++ b/tests/utils/object_store/test_uc_object_store.py
@@ -83,7 +83,7 @@ def test_get_object_size(ws_client, uc_object_store, result: str):
     elif result == 'not_found':
         db_core = pytest.importorskip('databricks.sdk.core', reason='requires databricks')
         ws_client.api_client.do.side_effect = db_core.DatabricksError('The file being accessed is not found',
-                                                                         error_code='NOT_FOUND')
+                                                                      error_code='NOT_FOUND')
         with pytest.raises(FileNotFoundError):
             uc_object_store.get_object_size('train.txt')
     else:


### PR DESCRIPTION
# What does this PR do?

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->
To unblock Databricks Finetuning PrPr launch, we need to modify the `get_object_size` function, which is currently used to check object existence. The UC team is working on a long-term fix to support `files.get_status` endpoint, but it is not available yet. The workaround we were recommended to use is to call HEAD on the files api endpoint to fetch metadata on the UC resource.

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Testing
Manually tested in r1z2 by pulling my branch and verifying that this works with my Databricks staging UC object.
```
>>> from composer.utils.object_store.uc_object_store import UCObjectStore as US
>>> o = US('Volumes/main/nancyhung/ift')
>>> o.get_object_size('train.jsonl')
1000000
```
-------
Testing by Jerry with a dogfood volume (but functionally should be same):
```
>>> from composer.utils.object_store import UCObjectStore
>>> o = UCObjectStore('Volumes/main/nancyhung/ift')
>>> o.get_object_size('bruh.jsonl')
Traceback (most recent call last):
  File "/composer/composer/utils/object_store/uc_object_store.py", line 214, in get_object_size
    self.client.api_client.do(method='HEAD',
  File "/usr/lib/python3/dist-packages/databricks/sdk/core.py", line 127, in do
    return retryable(self._perform)(method,
  File "/usr/lib/python3/dist-packages/databricks/sdk/retries.py", line 50, in wrapper
    raise err
  File "/usr/lib/python3/dist-packages/databricks/sdk/retries.py", line 29, in wrapper
    return func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/databricks/sdk/core.py", line 230, in _perform
    raise self._make_nicer_error(response=response, message=message) from None
databricks.sdk.errors.mapping.NotFound: Not Found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/composer/composer/utils/object_store/uc_object_store.py", line 220, in get_object_size
    _wrap_errors(self.get_uri(object_name), e)
  File "/composer/composer/utils/object_store/uc_object_store.py", line 30, in _wrap_errors
    raise FileNotFoundError(f'Object {uri} not found') from e
FileNotFoundError: Object dbfs:/Volumes/main/nancyhung/ift/bruh.jsonl not found
>>>
>>> o.get_object_size('train.jsonl')
1000000
```

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
