### PR TITLE
use flash attn fuse cross entropy loss to reduce metric memory usage

### DIFF
--- a/composer/metrics/nlp.py
+++ b/composer/metrics/nlp.py
@@ -97,7 +97,11 @@ class LanguageCrossEntropy(Metric):
         super().__init__(dist_sync_on_step=dist_sync_on_step)
 
         self.ignore_index = ignore_index
-        self.loss_fn = torch.nn.CrossEntropyLoss(ignore_index=ignore_index, reduction='sum')
+        try:
+            from flash_attn.losses.cross_entropy import CrossEntropyLoss as FusedCrossEntropyLoss
+            self.loss_fn = FusedCrossEntropyLoss(ignore_index=ignore_index, reduction='sum')
+        except ImportError:
+            self.loss_fn = torch.nn.CrossEntropyLoss(ignore_index=ignore_index, reduction='sum')
         self.add_state('sum_loss', default=torch.tensor(0.), dist_reduce_fx='sum')
         self.add_state('total_items', default=torch.tensor(0), dist_reduce_fx='sum')
 


### PR DESCRIPTION
This PR uses fused cross entropy loss from flash attention in the metric LanguageCrossEntropy (also LanguagePerplexity). 
The current torch.nn.CrossEntropyLoss call needs `6 * seq_len * vocab_size` GPU memory, and can be the bottleneck memory usage when sequence length is long (where act ckpt is probably used). Using  cross entropy loss from flash attn resolves this problem.

Example test model with long sequence and full act ckpt:
with torch loss fn:
![image](https://github.com/mosaicml/composer/assets/17418037/80e7a99d-62ee-4cef-8a08-796b1b2302e9)

with flash_attn loss fn
![image](https://github.com/mosaicml/composer/assets/17418037/06c1d658-1284-4930-ad93-51a1c6ac8897)
