### PR TITLE
[Bugfix][UC] Add back the full object path

### DIFF
--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -212,7 +212,7 @@ class UCObjectStore(ObjectStore):
             # does not work. Once fixed, we will call the files API endpoint. We currently only use this
             # function in Composer and LLM-foundry to check the UC object's existence.
             self.client.api_client.do(method='HEAD',
-                                      path=f'{self._UC_VOLUME_FILES_API_ENDPOINT}/{self.prefix}/{object_name}',
+                                      path=f'{self._UC_VOLUME_FILES_API_ENDPOINT}/{self._get_object_path(object_name)}',
                                       headers={'Source': 'mosaicml/composer'})
             return 1000000  # Dummy value, as we don't have a way to get the size of the file
         except DatabricksError as e:


### PR DESCRIPTION
# What does this PR do?

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->
In previous change, https://github.com/mosaicml/composer/pull/2982 I dropped using the full object path `self._get_object_path(object_name)`. This PR adds it back.

# Testing
Works when modified the code in long-living pod in prod. 
```
>>> llmfoundry.data.finetuning.dataloader._download_remote_hf_dataset('dbfs:/Volumes/finetuning/ift/train_vol', 'train')
'/usr/lib/python3/dist-packages/llmfoundry/.downloaded_finetuning/train'
```
confirmed file is downloaded in the directory
```
# head data/train-00000-of-00001.jsonl
{"prompt": "<|im_start|>system\nA conversation between a user and an LLM-based AI assistant.
...
```

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
