### PR TITLE
Add debug log before training loop starts

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2086,6 +2086,7 @@ class Trainer:
             # asserted to be not None when Trainer.fit() is called
             raise RuntimeError('max_duration must be specified when initializing the Trainer')
 
+        log.debug('Starting training loop')
         while self.state.timestamp < self.state.max_duration:
             if int(self.state.timestamp.batch_in_epoch) == 0:
                 self.engine.run_event(Event.EPOCH_START)


### PR DESCRIPTION
# What does this PR do?

Streaming often takes a while to start first batch. This changes last seen debug message from user to starting training loop. This avoids confusion with users thinking spinning dataloaders is taking a really long time.