### PR TITLE
[EASY] Always log 1st batch when resuming training 

### DIFF
--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -109,7 +109,7 @@ class ConsoleLogger(LoggerDestination):
         cur_epoch = int(state.timestamp.epoch)  # epoch gets incremented right before EPOCH_END
         unit = self.log_interval.unit
 
-        if unit == TimeUnit.EPOCH and (cur_epoch % int(self.log_interval) == 0 or cur_epoch == 1):
+        if unit == TimeUnit.EPOCH and (cur_epoch % int(self.log_interval) == 0 or self.last_logged_batch == 0):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
             self.last_logged_batch = int(state.timestamp.batch)
             self.logged_metrics = {}  # Clear logged metrics.
@@ -117,8 +117,7 @@ class ConsoleLogger(LoggerDestination):
     def batch_end(self, state: State, logger: Logger) -> None:
         cur_batch = int(state.timestamp.batch)
         unit = self.log_interval.unit
-        if unit == TimeUnit.BATCH and (cur_batch % int(self.log_interval) == 0 or cur_batch == 1 or
-                                       self.last_logged_batch == 0):
+        if unit == TimeUnit.BATCH and (cur_batch % int(self.log_interval) == 0 or self.last_logged_batch == 0):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
             self.last_logged_batch = cur_batch
             self.logged_metrics = {}  # Clear logged metrics.

--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -117,7 +117,8 @@ class ConsoleLogger(LoggerDestination):
     def batch_end(self, state: State, logger: Logger) -> None:
         cur_batch = int(state.timestamp.batch)
         unit = self.log_interval.unit
-        if unit == TimeUnit.BATCH and (cur_batch % int(self.log_interval) == 0 or cur_batch == 1):
+        if unit == TimeUnit.BATCH and (cur_batch % int(self.log_interval) == 0 or cur_batch == 1 or
+                                       self.last_logged_batch == 0):
             self.log_to_console(self.logged_metrics, prefix='Train ', state=state)
             self.last_logged_batch = cur_batch
             self.logged_metrics = {}  # Clear logged metrics.


### PR DESCRIPTION
# What does this PR do?

composer prints the console logging for 1st batch and every `self.log_interval` batches. but when resuming training, we probably want to print the 1st batch no matter if `cur_batch % self.log_interval == 0`. This PR just forces to print console logging for 1st batch after resumption. 

# test
1. firstly save checkpoint after training 3 batches.
2. load checkpoint and set `console_log_interval=7ba` `composer train/train.py train/yamls/pretrain/mpt-125m.yaml train_loader.dataset.split=train_small  max_duration=10ba eval_interval=0 console_log_interval=7ba load_path=./125m/checkpoints/ep0-ba3-rank0.pt`

## before the change:
first logged batch is 7 
<img width="967" alt="image" src="https://github.com/mosaicml/composer/assets/2545820/91839d69-cf2b-4efc-a39f-d3caa67c1e49">
## after the change
first logged batch is 4, then 7
<img width="482" alt="image" src="https://github.com/mosaicml/composer/assets/2545820/76052595-6299-4fa7-892d-706fcda8af6e">

