### PR TITLE
Monkeypatch FSDP+TP+Full State Dict errors in Torch

### DIFF
--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -31,9 +31,12 @@ from torch.distributed.fsdp import (BackwardPrefetch, CPUOffload, FullyShardedDa
                                     ShardingStrategy)
 from torch.distributed.fsdp._fsdp_extensions import _ext_pre_load_state_dict_transform
 from torch.distributed.utils import _replace_by_prefix
-
+from torch.distributed.fsdp.api import FullStateDictConfig, StateDictType
 from composer.core import Precision
 from composer.utils import dist
+from torch.distributed.fsdp import _state_dict_utils
+
+
 
 if TYPE_CHECKING:
     if version.parse(torch.__version__) >= version.parse('2.0.1') and version.parse(
@@ -996,6 +999,7 @@ if version.parse(torch.__version__) > version.parse('2.2.9') and version.parse(
 
     from torch.distributed.fsdp._optim_utils import FSDPParamInfo
     from torch.distributed._state_dict_utils import _gather_state_dict
+
     def _shard_orig_param_state(
         fsdp_param_info: FSDPParamInfo,
         fqn: str,
@@ -1033,3 +1037,57 @@ if version.parse(torch.__version__) > version.parse('2.2.9') and version.parse(
             new_optim_state[state_name] = value
         torch.cuda.synchronize()
         return new_optim_state
+
+
+if version.parse(torch.__version__) >= version.parse('2.2.0'):
+
+    # Normally this function will raise an error if it detects the FSDP device mesh has a parent mesh (indicating FSDP + TP)
+    # because Torch claims not to support FULL_STATE_DICT with FSDP + TP. We remove the error because we do use both ;)
+    @no_type_check
+    def _full_pre_state_dict_hook(
+        fsdp_state: _FSDPState,
+        module: nn.Module,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Hook that runs before model.state_dict() is called.
+
+        pre-state_dict hook is not actually supported by ``nn.Module``. As a result,
+        this API is called from ``_full_post_state_dict_hook()`` to simulate the
+        case. Once pre-state_dict is supported in ``nn.Module``, this hook will be
+        registered as a hook in ``nn.Module``.
+        """
+        _state_dict_utils._common_pre_state_dict_hook(module, fsdp_state)
+        _state_dict_utils._common_unshard_pre_state_dict_hook(
+            module,
+            fsdp_state,
+            offload_to_cpu=fsdp_state._state_dict_config.offload_to_cpu,
+            rank0_only=cast(FullStateDictConfig,
+                            fsdp_state._state_dict_config).rank0_only,
+        )
+
+
+    _state_dict_utils._full_pre_state_dict_hook = _full_pre_state_dict_hook
+
+
+    # Normally this function includes a warning forbidding using FULL_STATE_DICT with a device_mesh.
+    # We remove that warning because we do use both ;)
+    @no_type_check
+    def _set_use_dtensor(fsdp_state: _FSDPState) -> None:
+        # If device_mesh is passed in when initalizing FSDP, we automatically turn the
+        # _use_dtensor flag to be true for ShardedStateDictConfig().
+        if getattr(fsdp_state, '_device_mesh', None):
+            state_dict_type = fsdp_state._state_dict_type
+            if state_dict_type == StateDictType.LOCAL_STATE_DICT:
+                raise RuntimeError(
+                    'Found state_dict_type LOCAL_STATE_DICT',
+                    'DeviceMesh is not compatible with LOCAL_STATE_DICT.',
+                    'Please set state_dict_type to SHARDED_STATE_DICT to get DTensor state_dict.',
+                )
+            elif state_dict_type == StateDictType.FULL_STATE_DICT:
+                pass
+            else:
+                fsdp_state._state_dict_config._use_dtensor = True
+
+
+    _state_dict_utils._set_use_dtensor = _set_use_dtensor


### PR DESCRIPTION
Torch throws errors and warnings if it detects you are using a FSDP + TP and want to materialize a StateDictType=FULL state dict. We monkeypatch them to allow this
