### PR TITLE
Add sorted to logs for checkpoint broadcast

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -301,7 +301,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
             log.debug(f'Rank {dist.get_global_rank()} finished transferring files to all ranks.')
             dist.barrier()
             log.debug(
-                f'Done waiting for all ranks to finish transferring files. Local checkpoint files: {os.listdir(self.destination_path)}'
+                f'Done waiting for all ranks to finish transferring files. Local checkpoint files: {sorted(os.listdir(self.destination_path))}'
             )
 
         # 5. Piggyback off of the FileSystemReader to read all the files now that they are downloaded.


### PR DESCRIPTION
# What does this PR do?

Add sorted to log line for checkpoint broadcast. This ensures it prints consistently with pre-broadcast debug log, making it easier to verify transfer.