### PR TITLE
Change strip_dataset to True in InContextLearningCodeEvalDataset

### DIFF
--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -1324,7 +1324,7 @@ class InContextLearningCodeEvalDataset(InContextLearningDataset):
         super().__init__(
             context_key='prompt',
             answer_key='canonical_solution',
-            strip_dataset=False,
+            strip_dataset=True,
             static_keys=static_keys,
             list_keys=list_keys,
             tensor_keys=tensor_keys,

--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -36,7 +36,7 @@ __all__ = [
 
 def strip_data(example: Dict) -> Dict:
     """
-    Remove white space from the begging and end of string values in a dictionary
+    Remove white space from the beginning and end of string values in a dictionary
 
     Args:
         example: Dictionary to be stripped
@@ -44,7 +44,7 @@ def strip_data(example: Dict) -> Dict:
     Returns:
         dict: The same dictionary with .strip() applied to any value in the dict that is a string
     """
-    return {k: v.strip() if isinstance(v, str) else v for k, v in example.items()}
+    return {k: v.strip(' ') if isinstance(v, str) else v for k, v in example.items()}
 
 
 def _tokenizer_needs_prefix_space(tokenizer: transformers.PreTrainedTokenizerBase,) -> bool:
@@ -528,7 +528,7 @@ class InContextLearningDataset(Dataset):
         preamble = self._fix_eos_on_preamble(preamble)
         if self.strip_data:
             # rstrip context because a prompt ending in a space results in degenerate output
-            ctxt = ctxt.rstrip()
+            ctxt = ctxt.rstrip(' ')
         # Never add special tokens to context
         tokenized_context = self.tokenizer(ctxt, add_special_tokens=False)['input_ids']
         assert isinstance(preamble, list)
@@ -951,7 +951,7 @@ class InContextLearningMultipleChoiceTaskDataset(InContextLearningDataset):
         preamble = self._fix_eos_on_preamble(preamble)
         if self.strip_data:
             # rstrip context because a prompt ending in a space results in degenerate output
-            ctxt = ctxt.rstrip()
+            ctxt = ctxt.rstrip(' ')
         # Never add special tokens to context
         tokenized_context = self.tokenizer(ctxt, add_special_tokens=False)['input_ids']
         assert isinstance(tokenized_context, list)
@@ -1148,7 +1148,7 @@ class InContextLearningSchemaTaskDataset(InContextLearningMultipleChoiceTaskData
         context_options = example[self.choices_key]
         if len(preceding_text) > 0:
             if self.strip_data:
-                cont_del = self.continuation_delimiter.rstrip()
+                cont_del = self.continuation_delimiter.rstrip(' ')
             else:
                 cont_del = self.continuation_delimiter
             context_options = [f'{self.example_delimiter}{c}{cont_del}' for c in context_options]


### PR DESCRIPTION
# What does this PR do?

Adds `strip_dataset=True` to `InContextLearningCodeEvalDataset` to correct poor results. 

# What issue(s) does this change relate to?

Poor `HumanEval` scores.

New, more correct score seen in this run: `eval-humaneval-mpt-7b-strip-data-EcQZQh`

