### PR TITLE
Add min size to OCI download

### DIFF
--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -159,7 +159,7 @@ class OCIObjectStore(ObjectStore):
         # Calculate the part sizes
         num_parts_from_size = object_size // min_part_size
         num_parts = min(num_parts, num_parts_from_size)
-        print(f'Downloading {object_name} with {num_parts=}, {num_parts_from_size=}, {object_size=}, {min_part_size=}')
+        log.info(f'Downloading {object_name} with {num_parts=}, {num_parts_from_size=}, {object_size=}, {min_part_size=}')
         base_part_size, remainder = divmod(object_size, num_parts)
         part_sizes = [base_part_size] * num_parts
         for i in range(remainder):

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -159,7 +159,6 @@ class OCIObjectStore(ObjectStore):
         # Calculate the part sizes
         num_parts_from_size = max(object_size // min_part_size, 1)
         num_parts = min(num_parts, num_parts_from_size)
-        print(f'!! Downloading {object_name} with {num_parts=}, {num_parts_from_size=}, {object_size=}, {min_part_size=}')
         base_part_size, remainder = divmod(object_size, num_parts)
         part_sizes = [base_part_size] * num_parts
         for i in range(remainder):

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -157,9 +157,9 @@ class OCIObjectStore(ObjectStore):
             _reraise_oci_errors(self.get_uri(object_name), e)
 
         # Calculate the part sizes
-        num_parts_from_size = object_size // min_part_size
+        num_parts_from_size = max(object_size // min_part_size, 1)
         num_parts = min(num_parts, num_parts_from_size)
-        print(f'Downloading {object_name} with {num_parts=}, {num_parts_from_size=}, {object_size=}, {min_part_size=}')
+        print(f'!! Downloading {object_name} with {num_parts=}, {num_parts_from_size=}, {object_size=}, {min_part_size=}')
         base_part_size, remainder = divmod(object_size, num_parts)
         part_sizes = [base_part_size] * num_parts
         for i in range(remainder):

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -159,6 +159,7 @@ class OCIObjectStore(ObjectStore):
         # Calculate the part sizes
         num_parts_from_size = object_size // min_part_size
         num_parts = min(num_parts, num_parts_from_size)
+        print(f'Downloading {object_name} with {num_parts=}, {num_parts_from_size=}, {object_size=}, {min_part_size=}')
         base_part_size, remainder = divmod(object_size, num_parts)
         part_sizes = [base_part_size] * num_parts
         for i in range(remainder):

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -159,7 +159,7 @@ class OCIObjectStore(ObjectStore):
         # Calculate the part sizes
         num_parts_from_size = object_size // min_part_size
         num_parts = min(num_parts, num_parts_from_size)
-        log.info(f'Downloading {object_name} with {num_parts=}, {num_parts_from_size=}, {object_size=}, {min_part_size=}')
+        print(f'Downloading {object_name} with {num_parts=}, {num_parts_from_size=}, {object_size=}, {min_part_size=}')
         base_part_size, remainder = divmod(object_size, num_parts)
         part_sizes = [base_part_size] * num_parts
         for i in range(remainder):


### PR DESCRIPTION
# What does this PR do?

Adds minimum size to OCI download parts to avoid multi-part downloading small files (eg symlink)

Manual test:
<img width="415" alt="image" src="https://github.com/mosaicml/composer/assets/17102158/ca44f381-70b6-4cc4-8894-0f989d3a3d83">

Also printed number of parts and verified works correctly.