### PR TITLE
Bump version to 0.20.1

### DIFF
--- a/composer/_version.py
+++ b/composer/_version.py
@@ -3,4 +3,4 @@
 
 """The Composer Version."""
 
-__version__ = '0.20.0'
+__version__ = '0.20.1'

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,8 +15,8 @@ all dependencies for both NLP and Vision models. They are built on top of the
 <!-- BEGIN_COMPOSER_BUILD_MATRIX -->
 | Composer Version   | CUDA Support   | Docker Tag                                                     |
 |--------------------|----------------|----------------------------------------------------------------|
-| 0.20.0             | Yes            | `mosaicml/composer:latest`, `mosaicml/composer:0.20.0`         |
-| 0.20.0             | No             | `mosaicml/composer:latest_cpu`, `mosaicml/composer:0.20.0_cpu` |
+| 0.20.1             | Yes            | `mosaicml/composer:latest`, `mosaicml/composer:0.20.1`         |
+| 0.20.1             | No             | `mosaicml/composer:latest_cpu`, `mosaicml/composer:0.20.1_cpu` |
 <!-- END_COMPOSER_BUILD_MATRIX -->
 
 **Note**: For a lightweight installation, we recommended using a [MosaicML PyTorch Image](#pytorch-images) and manually

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -246,9 +246,9 @@
   TORCHVISION_VERSION: 0.18.0
 - AWS_OFI_NCCL_VERSION: ''
   BASE_IMAGE: nvidia/cuda:12.1.0-cudnn8-devel-ubuntu20.04
-  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.20.0
+  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.20.1
   CUDA_VERSION: 12.1.0
-  IMAGE_NAME: composer-0-20-0
+  IMAGE_NAME: composer-0-20-1
   MOFED_VERSION: 5.5-1.0.3.2
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
@@ -269,15 +269,15 @@
   PYTORCH_NIGHTLY_VERSION: ''
   PYTORCH_VERSION: 2.1.2
   TAGS:
-  - mosaicml/composer:0.20.0
+  - mosaicml/composer:0.20.1
   - mosaicml/composer:latest
   TARGET: composer_stage
   TORCHVISION_VERSION: 0.16.2
 - AWS_OFI_NCCL_VERSION: ''
   BASE_IMAGE: ubuntu:20.04
-  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.20.0
+  COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.20.1
   CUDA_VERSION: ''
-  IMAGE_NAME: composer-0-20-0-cpu
+  IMAGE_NAME: composer-0-20-1-cpu
   MOFED_VERSION: 5.5-1.0.3.2
   NVIDIA_REQUIRE_CUDA_OVERRIDE: ''
   PYTHON_VERSION: '3.10'
@@ -285,7 +285,7 @@
   PYTORCH_NIGHTLY_VERSION: ''
   PYTORCH_VERSION: 2.1.2
   TAGS:
-  - mosaicml/composer:0.20.0_cpu
+  - mosaicml/composer:0.20.1_cpu
   - mosaicml/composer:latest_cpu
   TARGET: composer_stage
   TORCHVISION_VERSION: 0.16.2

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -261,7 +261,7 @@ def _main():
     composer_entries = []
 
     # The `GIT_COMMIT` is a placeholder and Jenkins will substitute it with the actual git commit for the `composer_staging` images
-    composer_versions = ['0.20.0']  # Only build images for the latest composer version
+    composer_versions = ['0.20.1']  # Only build images for the latest composer version
     composer_python_versions = [PRODUCTION_PYTHON_VERSION]  # just build composer against the latest
 
     for product in itertools.product(composer_python_versions, composer_versions, cuda_options):


### PR DESCRIPTION
# What does this PR do?

Bump version to 0.20.1 ahead of patch release for torch 2.2.1 