### PR TITLE
Remove s3_bucket pytest cli flag

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -76,7 +76,6 @@ jobs:
       pytest-command: ${{ matrix.pytest_command }}
       pytest-markers: ${{ matrix.markers }}
       composer_package_name: ${{ matrix.composer_package_name }}
-      pytest-s3-bucket: "mosaicml-internal-integration-testing"
       pytest-wandb-entity: "mosaicml-public-integration-tests"
       pytest-wandb-project: "integration-tests-${{ github.sha }}"
     secrets:

--- a/.github/workflows/pytest-cpu.yaml
+++ b/.github/workflows/pytest-cpu.yaml
@@ -17,9 +17,6 @@ on:
       pytest-markers:
         required: true
         type: string
-      pytest-s3-bucket:
-        required: false
-        type: string
       pytest-wandb-entity:
         required: false
         type: string
@@ -81,9 +78,7 @@ jobs:
         export GCS_SECRET='${{ secrets.gcs-secret }}'
         export AZURE_ACCOUNT_NAME='${{ secrets.azure-account-name }}'
         export AZURE_ACCOUNT_ACCESS_KEY='${{ secrets.azure-account-access-key }}'
-        export S3_BUCKET='${{ inputs.pytest-s3-bucket }}'
-        export COMMON_ARGS="-v --durations=20 -m '${{ inputs.pytest-markers }}' --s3_bucket '$S3_BUCKET' \
-          -o tmp_path_retention_policy=none"
+        export COMMON_ARGS="-v --durations=20 -m '${{ inputs.pytest-markers }}' -o tmp_path_retention_policy=none"
 
         # Necessary to run git diff for doctests
         git config --global --add safe.directory /__w/composer/composer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,6 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                 help="""\
         Rank zero seed to use. `reproducibility.seed_all(seed + dist.get_global_rank())` will be invoked
         before each test.""")
-    _add_option(parser, 's3_bucket', help='S3 Bucket for integration tests')
 
 
 def _get_world_size(item: pytest.Item):

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -112,7 +112,7 @@ def s3_bucket(request: pytest.FixtureRequest):
     if request.node.get_closest_marker('remote') is None:
         return 'my-bucket'
     else:
-        return _get_option(request.config, 's3_bucket')
+        return 'mosaicml-internal-integration-testing'
 
 
 @pytest.fixture


### PR DESCRIPTION
# What does this PR do?

Removes the s3_bucket flag in pytest and adds it to the fixture. This makes the pytest cicd more generalizable.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
