### PR TITLE
support loading from monolithic checkpoints

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -1181,7 +1181,7 @@ class State(Serializable):
                         except AssertionError as e:
                             if self.fsdp_state_dict_type == 'sharded' and self.fsdp_fallback_to_monolithic:
                                 # If the state dict type of the checkpoint is not sharded
-                                with fsdp_state_dict_type_context(self.model, state_dict_type=None):
+                                with fsdp_state_dict_type_context(self.model, state_dict_type='full'):
                                     missing_keys, unexpected_keys = self.model.load_state_dict(state_dict['model'],
                                                                                                strict=strict)
                             else:


### PR DESCRIPTION
# What does this PR do?

Right now, when we load from a save folder the yaml does not specify in advance whether the state dict will be sharded or monolithic. We would like to move towards using sharded state dicts by default but do not want to fail to load monolithic checkpoints. This PR adds a flag to allow composer to try to load state dicts as sharded by default, falling back to monolithic checkpoints if this fails.

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
