### PR TITLE
Add Iteration related Events

### DIFF
--- a/composer/core/callback.py
+++ b/composer/core/callback.py
@@ -135,6 +135,16 @@ class Callback(Serializable, abc.ABC):
         del state, logger  # unused
         pass
 
+    def iteration_start(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.ITERATION_START` event.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+        """
+        del state, logger  # unused
+        pass
+
     def epoch_start(self, state: State, logger: Logger) -> None:
         """Called on the :attr:`.Event.EPOCH_START` event.
 
@@ -299,8 +309,14 @@ class Callback(Serializable, abc.ABC):
 
         .. note::
 
-            :attr:`.State.timestamp` member variable :attr:`.Timestamp.epoch`
-            is incremented immediately before :attr:`.Event.EPOCH_END`.
+           The following :attr:`.State.timestamp` member variables are
+           incremented immediately before the :attr:`.Event.EPOCH_END` event.
+
+           +--------------------------------------+
+           | :attr:`.Timestamp.epoch`             |
+           +--------------------------------------+
+           | :attr:`.Timestamp.epoch_in_iteration`|
+           +--------------------------------------+
 
         Args:
             state (State): The training state.
@@ -311,6 +327,31 @@ class Callback(Serializable, abc.ABC):
 
     def epoch_checkpoint(self, state: State, logger: Logger) -> None:
         """Called on the :attr:`.Event.EPOCH_CHECKPOINT` event.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+        """
+        del state, logger  # unused
+        pass
+
+    def iteration_end(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.ITERATION_END` event.
+
+        .. note::
+
+            :attr:`.State.timestamp` member variable :attr:`.Timestamp.iteration`
+            is incremented immediately before :attr:`.Event.ITERATION_END`.
+
+        Args:
+            state (State): The training state.
+            logger (Logger): The logger.
+        """
+        del state, logger  # unused
+        pass
+
+    def iteration_checkpoint(self, state: State, logger: Logger) -> None:
+        """Called on the :attr:`.Event.ITERATION_CHECKPOINT` event.
 
         Args:
             state (State): The training state.

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -353,7 +353,11 @@ class Engine():
 
         # dataloader should be set on all events except INIT/BEFORE_LOAD/AFTER_LOAD/EVAL_STANDALONE_START/EVAL_STANDALONE_END
         if event not in {
-                Event.INIT, Event.BEFORE_LOAD, Event.AFTER_LOAD, Event.EVAL_STANDALONE_START, Event.EVAL_STANDALONE_END
+                Event.INIT,
+                Event.BEFORE_LOAD,
+                Event.AFTER_LOAD,
+                Event.EVAL_STANDALONE_START,
+                Event.EVAL_STANDALONE_END,
         }:
             assert state.dataloader is not None, f'The trainer should have set state.dataloader for event {event}.'
 
@@ -384,15 +388,17 @@ class Engine():
                 exit_code = algorithm.apply(event, self.state, self.logger)
 
             trace_key = f'{algorithm}/{event}'
-            trace[trace_key] = Trace(name=algorithm.__class__.__name__,
-                                     event=event,
-                                     exit_code=exit_code,
-                                     order=order,
-                                     run=True)
+            trace[trace_key] = Trace(
+                name=algorithm.__class__.__name__,
+                event=event,
+                exit_code=exit_code,
+                order=order,
+                run=True,
+            )
 
         if len(trace) > 0:
             self.logger.log_traces(
-                {f'algorithm_traces/{tr.name}/{tr.event}': 1 if tr.run else 0 for _, tr in trace.items()})
+                ({f'algorithm_traces/{tr.name}/{tr.event}': 1 if tr.run else 0 for _, tr in trace.items()}))
 
         return trace
 

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -29,7 +29,7 @@ from composer.core.data_spec import DataSpec
 from composer.core.event import Event
 from composer.core.precision import Precision
 from composer.core.serializable import Serializable
-from composer.core.time import Time, Timestamp, TimeUnit
+from composer.core.time import Time, Timestamp, TimeUnit, ensure_time
 from composer.devices import Device
 from composer.utils import (batch_get, batch_set, dist, ensure_tuple, get_composer_env_dict, is_model_deepspeed,
                             reproducibility)
@@ -412,6 +412,8 @@ class State(Serializable):
         self.dataset_resumption = dataset_resumption or {}
         self._max_duration = None
         self.max_duration = max_duration
+        self.__iteration_length = None
+        self._iteration_length = self.__iteration_length
         self.save_metrics = save_metrics
 
         self._train_dataloader = train_dataloader
@@ -605,6 +607,22 @@ class State(Serializable):
         if self.max_duration is None:
             return None
         return self.timestamp.get(self.max_duration.unit) / self.max_duration
+
+    @property
+    def _iteration_length(self):
+        """The length of an iteration."""
+        return self.__iteration_length
+
+    @_iteration_length.setter
+    def _iteration_length(self, iteration_length: Optional[Union[str, Time[int]]]):
+        if iteration_length is None:
+            self.__iteration_length = None
+            return
+        if isinstance(iteration_length, str):
+            iteration_length = ensure_time(iteration_length, TimeUnit.EPOCH)
+        if iteration_length.unit != TimeUnit.EPOCH:
+            raise NotImplementedError(f'{iteration_length.unit} is not allowed as a unit for iteration_length.')
+        self.__iteration_length = iteration_length
 
     def stop_training(self):
         """Gracefully stop training.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -152,6 +152,7 @@ class TestEventCalls:
             Event.INIT: 1,
             Event.BEFORE_LOAD: 1,
             Event.AFTER_LOAD: 1,
+            Event.ITERATION_START: 1,
             Event.EPOCH_START: num_epochs,
             Event.BATCH_START: total_steps,
             Event.BEFORE_DATALOADER: total_steps + num_epochs,  # extra call per epoch when dataloader is exhausted
@@ -168,6 +169,8 @@ class TestEventCalls:
             Event.BATCH_CHECKPOINT: total_steps,
             Event.EPOCH_END: num_epochs,
             Event.EPOCH_CHECKPOINT: num_epochs,
+            Event.ITERATION_END: 0,
+            Event.ITERATION_CHECKPOINT: 0,
             Event.EVAL_BEFORE_ALL: total_evals,
             Event.EVAL_START: total_evals_start,
             Event.EVAL_BATCH_START: total_eval_steps,

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1138,6 +1138,25 @@ class TestTrainerInitOrFit:
         assert (torch.equal(next(compiled_model_trainer.state.model.parameters()),
                             next(uncompiled_model_trainer.state.model.parameters())))
 
+    def test_iteration(
+        self,
+        train_dataloader: DataLoader,
+        model: ComposerModel,
+    ):
+        """Tests iteration is properly incremented during training when _iteration_length is set."""
+
+        # Train with max_duration set to 5 epochs with 2 epoch per iteration
+        trainer = Trainer(
+            model=model,
+            max_duration='5ep',
+            train_dataloader=train_dataloader,
+        )
+        trainer.state._iteration_length = '2ep'
+        trainer.fit()
+
+        assert trainer.state.timestamp.epoch == Time(5, TimeUnit.EPOCH)
+        assert trainer.state.timestamp.iteration == Time(2, TimeUnit.ITERATION)
+
 
 @world_size(1, 2)
 @device('cpu', 'gpu', 'gpu-amp', precision=True)


### PR DESCRIPTION
# What does this PR do?
Adds ITERATION_START, ITERATION_END, and ITERATION_CHECKPOINT to Event, Engine, and Callback. Increments iteration during training based on iteration length defined in State. Iteration length is a private variable in State and should have no effect by default.

commit-id:bdbe33f2

---

**Stack**:
- #3087
- #3076 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
