### PR TITLE
Add docstring to _iteration_length

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -615,6 +615,10 @@ class State(Serializable):
 
     @_iteration_length.setter
     def _iteration_length(self, iteration_length: Optional[Union[str, Time[int]]]):
+        """Sets the length of an iteration.
+
+        An iteration must be defined as multiple epochs. See composer/core/event.py.
+        """
         if iteration_length is None:
             self.__iteration_length = None
             return


### PR DESCRIPTION
# What does this PR do?

Adds a docstring to _iteration_length in state to clarify how an iteration is defined and where it's used in the training loop.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
