### PR TITLE
Enforce async logging flush in mlflow logger at `post_close` call

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -437,6 +437,7 @@ class MLFlowLogger(LoggerDestination):
             import mlflow
 
             assert isinstance(self._run_id, str)
+            mlflow.flush_async_logging()
             self._mlflow_client.set_terminated(self._run_id)
             mlflow.end_run()
 

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,7 @@ extra_deps['onnx'] = [
 ]
 
 extra_deps['mlflow'] = [
-    'mlflow>=2.9.2,<3.0',
+    'mlflow>=2.11.0,<3.0',
 ]
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -587,8 +587,8 @@ def test_mlflow_logging_works(tmp_path, device):
                       eval_interval=eval_interval,
                       device=device)
     trainer.fit()
-    # Allow async logging to finish.
-    time.sleep(3)
+    # Allow system metrics to be collected.
+    time.sleep(2)
     test_mlflow_logger.post_close()
 
     run = _get_latest_mlflow_run(
@@ -707,8 +707,6 @@ def test_mlflow_ignore_metrics(tmp_path, device):
                       eval_interval=eval_interval,
                       device=device)
     trainer.fit()
-    # Allow async logging to finish.
-    time.sleep(3)
     test_mlflow_logger.post_close()
 
     run = _get_latest_mlflow_run(
@@ -751,8 +749,6 @@ def test_mlflow_ignore_hyperparameters(tmp_path):
                                       ignore_hyperparameters=['num*', 'mlflow_run_id', 'nothing'])
 
     Trainer(model=SimpleConvModel(), loggers=test_mlflow_logger, max_duration=f'4ba')
-    # Allow async logging to finish.
-    time.sleep(3)
     test_mlflow_logger.post_close()
 
     run = _get_latest_mlflow_run(


### PR DESCRIPTION
# What does this PR do?

Enforce async logging flush in mlflow logger at `post_close` call so that there is no left over logging data.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
