### PR TITLE
Replace errors with warnings for eval args

### DIFF
--- a/composer/core/__init__.py
+++ b/composer/core/__init__.py
@@ -12,7 +12,7 @@ from composer.core.algorithm import Algorithm
 from composer.core.callback import Callback
 from composer.core.data_spec import DataSpec, ensure_data_spec
 from composer.core.engine import Engine, Trace
-from composer.core.evaluator import Evaluator, ensure_evaluator, validate_evaluator
+from composer.core.evaluator import Evaluator, ensure_evaluator
 from composer.core.event import Event
 from composer.core.passes import AlgorithmPass
 from composer.core.precision import Precision, get_precision_context
@@ -45,5 +45,4 @@ __all__ = [
     'JSON',
     'MemoryFormat',
     'TrainerMode',
-    'validate_evaluator',
 ]

--- a/composer/core/__init__.py
+++ b/composer/core/__init__.py
@@ -12,7 +12,7 @@ from composer.core.algorithm import Algorithm
 from composer.core.callback import Callback
 from composer.core.data_spec import DataSpec, ensure_data_spec
 from composer.core.engine import Engine, Trace
-from composer.core.evaluator import Evaluator, ensure_evaluator, validate_eval_automicrobatching
+from composer.core.evaluator import Evaluator, ensure_evaluator, validate_evaluator
 from composer.core.event import Event
 from composer.core.passes import AlgorithmPass
 from composer.core.precision import Precision, get_precision_context
@@ -45,5 +45,5 @@ __all__ = [
     'JSON',
     'MemoryFormat',
     'TrainerMode',
-    'validate_eval_automicrobatching',
+    'validate_evaluator',
 ]

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -13,10 +13,9 @@ from composer.core.data_spec import DataSpec, ensure_data_spec
 from composer.core.event import Event
 from composer.core.state import State
 from composer.core.time import Time
-from composer.devices import Device, DeviceGPU
 from composer.utils import create_interval_scheduler
 
-__all__ = ['Evaluator', 'ensure_evaluator', 'validate_evaluator']
+__all__ = ['Evaluator', 'ensure_evaluator']
 
 
 class Evaluator:

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -141,29 +141,6 @@ def ensure_evaluator(evaluator: Union[Evaluator, DataSpec, Iterable, Dict[str, A
         )
 
 
-def validate_evaluator(evaluator: Evaluator, device: Device):
-    """Ensure automicrobatching is only on GPU.
-
-    Unlike `device_train_microbatch_size`, this validation must be done separately from the
-    `_is_auto_microbatching` check because `device` is not available during `Evaluator`
-    initialization.
-    """
-    auto_microbatching = evaluator.auto_microbatching
-    if auto_microbatching and not isinstance(device, DeviceGPU):
-        raise ValueError(
-            'Can only use adaptive device_eval_microbatch_size on GPU. Please set device_eval_microbatch_size >= 1.',
-        )
-    if evaluator.auto_microbatching and hasattr(evaluator.dataloader, 'seq_parallel_world_size'):
-        raise ValueError('Auto microbatching on evaluators is not compatible with sequence parallelism.')
-    if isinstance(evaluator.dataloader.get_num_samples_in_batch, int) and hasattr(
-        evaluator.dataloader,
-        'seq_parallel_world_size',
-    ) and evaluator.dataloader.get_num_samples_in_batch * evaluator.dataloader.seq_parallel_world_size != 1:  # type: ignore
-        raise ValueError(
-            '`Sequence parallelism requires a microbatch size of 1 distributed over the sequence parallel group.',
-        )
-
-
 def _is_auto_microbatching(device_eval_microbatch_size: Optional[Union[int, str]]):
     if device_eval_microbatch_size == 'auto':
         warnings.warn((

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -404,7 +404,7 @@ def _validate_evaluator(evaluator: Evaluator, device: Device):
     if evaluator.auto_microbatching and hasattr(evaluator.dataloader, 'seq_parallel_world_size'):
         raise ValueError(
             'Auto microbatching on evaluators is not compatible with sequence parallelism. '
-            'Please manually set device_eval_microbatch_size or disable sequence parallelism .'
+            'Please manually set device_eval_microbatch_size or disable sequence parallelism .',
         )
     if isinstance(evaluator.dataloader.get_num_samples_in_batch, int) and hasattr(
         evaluator.dataloader,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1428,7 +1428,7 @@ class Trainer:
             )
 
             for evaluator in evaluators:
-                validate_evaluator(evaluator.auto_microbatching, self.state.device)
+                validate_evaluator(evaluator, self.state.device)
         if len(evaluators) == 0:
             if eval_subset_num_batches != -1:
                 warnings.warn(
@@ -2107,7 +2107,7 @@ class Trainer:
             )
 
             for evaluator in evaluators:
-                validate_evaluator(evaluator.auto_microbatching, self.state.device)
+                validate_evaluator(evaluator, self.state.device)
 
             if len(evaluators) == 0:
                 if eval_subset_num_batches != -1:


### PR DESCRIPTION
# What does this PR do?

Replace errors with warnings for eval args. 

Along for the ride, cleans up some of the seq parallel stuff by centralizing validation