### PR TITLE
Fix error on HYBRID_SHARD misconfiguraiton

### DIFF
--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -772,7 +772,7 @@ if version.parse(torch.__version__) > version.parse('2.2.9') and version.parse(
             else:
                 raise ValueError(
                     'Expected device_mesh to have ndim=2 '
-                    f'but got {len(device_mesh.get_group())}',
+                    f'but got {device_mesh.ndim}',
                 )
         elif process_group is None:
             default_group = _get_default_group()


### PR DESCRIPTION
# What does this PR do?

If you use `HYBRID_SHARD` but only specify a single element list for `device_mesh`, it gets to this ValueError, but then the message within the `ValueError` fails, because apparently when `DeviceMesh` is 1-D, `device_mesh.get_group()` returns a `ProcessGroup` object rather than a `List[ProcessGroup]`.

Using `device_mesh.ndim` for the error reporting sidesteps the problem.
