### PR TITLE
Fix rounding issue in interval calculation

### DIFF
--- a/composer/callbacks/eval_output_logging_callback.py
+++ b/composer/callbacks/eval_output_logging_callback.py
@@ -104,12 +104,12 @@ class EvalOutputLogging(Callback):
         self.rows.extend(rows)
 
     def eval_end(self, state: State, logger: Logger) -> None:
+        if not self.name or self.columns is None:
+            return
+
         list_of_rows = all_gather_object(self.rows)
         rows = [row for rows in list_of_rows for row in rows]
         for dest_logger in logger.destinations:
-            assert self.name is not None
-            assert self.columns is not None
-
             if not isinstance(dest_logger, ConsoleLogger):
                 dest_logger.log_table(self.columns, rows, name=self.name, step=state.timestamp.batch.value)
 

--- a/composer/callbacks/eval_output_logging_callback.py
+++ b/composer/callbacks/eval_output_logging_callback.py
@@ -104,9 +104,6 @@ class EvalOutputLogging(Callback):
         self.rows.extend(rows)
 
     def eval_end(self, state: State, logger: Logger) -> None:
-        if not self.name or self.columns is None:
-            return
-
         list_of_rows = all_gather_object(self.rows)
         rows = [row for rows in list_of_rows for row in rows]
         for dest_logger in logger.destinations:

--- a/composer/callbacks/eval_output_logging_callback.py
+++ b/composer/callbacks/eval_output_logging_callback.py
@@ -18,9 +18,9 @@ class EvalOutputLogging(Callback):
     """Logs eval outputs for each sample of each ICL evaluation dataset.
 
     ICL metrics are required to support caching the model's responses including information on whether model was correct.
-    Metrics are responsible for returning the results of individual datapoints in a dictionary of lists.
+    Metrics are responsible for returning the results of individual data points in a dictionary of lists.
     The callback will log the metric name, the depadded and detokenized input, any data stored in state.metric_outputs, and
-    any keys from the batch pased into `batch_keys_to_log`. It will do so after every eval batch.
+    any keys from the batch passed into `batch_keys_to_log`. It will do so after every eval batch.
     """
 
     def __init__(self, log_tokens=False, *args, **kwargs):
@@ -107,6 +107,9 @@ class EvalOutputLogging(Callback):
         list_of_rows = all_gather_object(self.rows)
         rows = [row for rows in list_of_rows for row in rows]
         for dest_logger in logger.destinations:
+            assert self.name is not None
+            assert self.columns is not None
+
             if not isinstance(dest_logger, ConsoleLogger):
                 dest_logger.log_table(self.columns, rows, name=self.name, step=state.timestamp.batch.value)
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -531,8 +531,8 @@ class HuggingFaceModel(ComposerModel):
 
             # don't remove prefix space to sentencepiece models
             if len(
-                self.tokenizer(' a', add_special_tokens=False)['input_ids'],
-            ) == 1:  # pyright: ignore[reportGeneralTypeIssues]
+                self.tokenizer(' a', add_special_tokens=False)['input_ids'],  # pyright: ignore[reportGeneralTypeIssues]
+            ) == 1:
                 return self.tokenizer.batch_decode(
                     generation[:, batch['input_ids'].shape[1]:],
                     skip_special_tokens=True,
@@ -658,8 +658,8 @@ class HuggingFaceModel(ComposerModel):
                                 conda_package='sentencepiece',
                             ) from e
                         s = spm.SentencePieceProcessor(
-                            model_file=str(tokenizer_file_path),
-                        )  # pyright: ignore[reportGeneralTypeIssues]
+                            model_file=str(tokenizer_file_path),  # pyright: ignore[reportGeneralTypeIssues]
+                        )
                         tokenizer_file_content = s.serialized_model_proto()
                     else:
                         raise ValueError(

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -25,6 +25,11 @@ __all__ = [
 ]
 
 
+def int_cast_except_zero(x: float) -> int:
+    """Cast a float to an int, except when the float would round to zero."""
+    return int(x) if x >= 1.0 else 1
+
+
 def create_interval_scheduler(
     interval: Union[str, int, 'Time'],
     include_end_of_training: bool = True,
@@ -110,15 +115,8 @@ def create_interval_scheduler(
                 )
 
             if event == interval_event:
-                print(state.max_duration.value, time_interval, state.dataloader_len, state.timestamp.batch)
-                print(int(state.timestamp.batch))
-                print(float(time_interval))
-                print(state.max_duration.value * float(time_interval) * state.dataloader_len)
-                print(math.ceil(state.max_duration.value * float(time_interval) * state.dataloader_len))
-                print(int(state.timestamp.batch) % math.ceil(state.max_duration.value * float(time_interval) * state.dataloader_len))
-                print(int(state.timestamp.batch) % math.ceil(state.max_duration.value * float(time_interval) * state.dataloader_len) == 0)
                 if state.max_duration.unit == TimeUnit.EPOCH and int(state.timestamp.batch) % math.ceil(
-                    state.max_duration.value * float(time_interval) * state.dataloader_len,
+                    state.max_duration.value * float(time_interval) * state.dataloader_len.value,
                 ) == 0:
                     last_batch_seen = state.timestamp.batch
                     return True

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -113,6 +113,8 @@ def create_interval_scheduler(
                 print(state.max_duration.value, time_interval, state.dataloader_len, state.timestamp.batch)
                 print(int(state.timestamp.batch))
                 print(float(time_interval))
+                print(state.max_duration.value * float(time_interval) * state.dataloader_len)
+                print(math.ceil(state.max_duration.value * float(time_interval) * state.dataloader_len))
                 if state.max_duration.unit == TimeUnit.EPOCH and int(state.timestamp.batch) % math.ceil(
                     state.max_duration.value * float(time_interval) * state.dataloader_len,
                 ) == 0:

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -25,11 +25,6 @@ __all__ = [
 ]
 
 
-def int_cast_except_zero(x: float) -> int:
-    """Cast a float to an int, except when the float would round to zero."""
-    return int(x) if x >= 1.0 else 1
-
-
 def create_interval_scheduler(
     interval: Union[str, int, 'Time'],
     include_end_of_training: bool = True,

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -110,6 +110,7 @@ def create_interval_scheduler(
                 )
 
             if event == interval_event:
+                print(state.max_duration.value, time_interval, state.dataloader_len)
                 if state.max_duration.unit == TimeUnit.EPOCH and int(state.timestamp.batch) % math.ceil(
                     state.max_duration.value * float(time_interval) * state.dataloader_len,
                 ) == 0:

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -110,7 +110,9 @@ def create_interval_scheduler(
                 )
 
             if event == interval_event:
-                print(state.max_duration.value, time_interval, state.dataloader_len)
+                print(state.max_duration.value, time_interval, state.dataloader_len, state.timestamp.batch)
+                print(int(state.timestamp.batch))
+                print(float(time_interval))
                 if state.max_duration.unit == TimeUnit.EPOCH and int(state.timestamp.batch) % math.ceil(
                     state.max_duration.value * float(time_interval) * state.dataloader_len,
                 ) == 0:

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -115,6 +115,8 @@ def create_interval_scheduler(
                 print(float(time_interval))
                 print(state.max_duration.value * float(time_interval) * state.dataloader_len)
                 print(math.ceil(state.max_duration.value * float(time_interval) * state.dataloader_len))
+                print(int(state.timestamp.batch) % math.ceil(state.max_duration.value * float(time_interval) * state.dataloader_len))
+                print(int(state.timestamp.batch) % math.ceil(state.max_duration.value * float(time_interval) * state.dataloader_len) == 0)
                 if state.max_duration.unit == TimeUnit.EPOCH and int(state.timestamp.batch) % math.ceil(
                     state.max_duration.value * float(time_interval) * state.dataloader_len,
                 ) == 0:

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -164,8 +164,8 @@ class OCIObjectStore(ObjectStore):
         try:
             head_object_response = self.client.head_object(self.namespace, self.bucket, object_name)
             object_size = int(
-                head_object_response.headers['content-length'],
-            )  # pyright: ignore[reportOptionalMemberAccess]
+                head_object_response.headers['content-length'],  # pyright: ignore[reportOptionalMemberAccess]
+            )
         except Exception as e:
             _reraise_oci_errors(self.get_uri(object_name), e)
 

--- a/docs/source/trainer/file_uploading.rst
+++ b/docs/source/trainer/file_uploading.rst
@@ -169,7 +169,7 @@ Neptune File upload
     The :class:`~composer.loggers.neptune_logger.NeptuneLogger` API Reference.
 
 .. testcode::
-    :skipif: not _NEPTUNE_INSTALLED
+    :skipif: True
 
     from composer.loggers import NeptuneLogger
     from composer import Trainer

--- a/docs/source/trainer/file_uploading.rst
+++ b/docs/source/trainer/file_uploading.rst
@@ -169,7 +169,7 @@ Neptune File upload
     The :class:`~composer.loggers.neptune_logger.NeptuneLogger` API Reference.
 
 .. testcode::
-    :skipif: True
+    :skipif: not _NEPTUNE_INSTALLED
 
     from composer.loggers import NeptuneLogger
     from composer import Trainer

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -1,7 +1,22 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-from composer.utils.misc import partial_format
+import pytest
+
+from composer.core import Event, Time, Timestamp
+from composer.utils.misc import create_interval_scheduler, partial_format
+
+
+class DummyState:
+
+    def __init__(self, current_batches: int, max_duration: str, dataloader_len: str):
+        self.previous_timestamp = Timestamp(batch=current_batches - 1)
+        self.timestamp = Timestamp(batch=current_batches)
+        self.max_duration = Time.from_timestring(max_duration)
+        self.dataloader_len = Time.from_timestring(dataloader_len)
+
+    def get_elapsed_duration(self):
+        return 0
 
 
 def test_partial_format():
@@ -20,3 +35,32 @@ def test_partial_format():
     assert partial_format('{foo} {}', 'World') == '{foo} World'
     assert partial_format('{foo} {}', foo='Hello') == 'Hello {}'
     assert partial_format('{foo} {}', 'World', foo='Hello') == 'Hello World'
+
+
+@pytest.mark.parametrize(
+    'interval,current_batches,max_duration,dataloader_len,expected',
+    [
+        ('0.25dur', 1, '1ep', '1ba', True),
+        ('0.25dur', 1, '1ep', '4ba', True),
+        ('0.25dur', 2, '1ep', '5ba', True),
+        ('0.25dur', 1, '1ep', '5ba', False),
+        ('0.25dur', 1, '1ba', '1ba', True),
+        ('0.25dur', 1, '4ba', '4ba', True),
+        ('0.25dur', 2, '5ba', '5ba', True),
+        ('0.25dur', 1, '5ba', '5ba', False),
+    ],
+)
+def test_interval_scheduler(
+    interval: str,
+    current_batches: int,
+    max_duration: str,
+    dataloader_len: str,
+    expected: bool,
+):
+    interval_scheduler = create_interval_scheduler(interval)
+    dummy_state = DummyState(current_batches, max_duration, dataloader_len)
+
+    event = Event.BATCH_CHECKPOINT
+
+    actual = interval_scheduler(dummy_state, event)  # type: ignore (intentional)
+    assert actual == expected


### PR DESCRIPTION
# What does this PR do?
Previously we were implicitly rounding down in the interval calculation because we were multiplying a decimal with a `Time`. The subsequent `math.ceil` therefore did not have the intended effect. This PR remedies that by using `.value` on the time, so the `math.ceil` properly applies to the unrounded decimal. Note: this will slightly change the exact pattern of when the interval scheduler returns true, but it will bring the implementation into line whether your max duration is in epochs or batches. Previously they were different.

The impetus for this is that it resolves a div by zero error if you only have one batch and have a `0.XXdur` interval. Manually tested it is resolved in addition to unit tests.

Along for the ride, fixes some typing that was complaining locally. 

