### PR TITLE
Bump mlflow min pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -221,7 +221,7 @@ extra_deps['onnx'] = [
 ]
 
 extra_deps['mlflow'] = [
-    'mlflow>=2.11.0,<3.0',
+    'mlflow>=2.11.1,<3.0',
 ]
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']


### PR DESCRIPTION
There was an issue with mlflow 2.11 related to serving models that was fixed in 2.11.1