### PR TITLE
Add checks to schedulers

### DIFF
--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -565,7 +565,7 @@ def _raise_if_max_duration_exceeds_t_max(t_max: Union[str, Time], state: State):
 def _raise_if_warmup_and_max_incompatible(t_warmup: Time[int], t_max: Time[int]):
     """Checks that t_warmup and t_max have the same units.
 
-    _convert_time should be called on both before this function is called. As a a result, t_warmup and t_max will not
+    _convert_time should be called on both `t_warmup` and `t_max` before this function is called. As a a result, t_warmup and t_max will not
     be TimeUnit.EPOCH.
     """
     assert t_warmup.unit != TimeUnit.EPOCH and t_max.unit != TimeUnit.EPOCH, 't_warmup and t_max cannot be in units of EPOCH'

--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -521,26 +521,63 @@ class PolynomialScheduler(ComposerScheduler):
         t_max = _convert_time(self.t_max, state, ssr=ssr)
         current_time = state.timestamp.get(t_max.unit)
         frac_of_total = (current_time / t_max).value
+        frac_of_total = min(1.0, frac_of_total)
 
         coeff = (1 - frac_of_total)**self.power
         current_factor = self.alpha_f + coeff * (1.0 - self.alpha_f)
         return current_factor
 
 
-def _raise_if_warmup_and_max_duration_incompatible(t_warmup: Union[str, Time], t_max: Union[str, Time]):
+def _raise_if_max_duration_exceeds_t_max(t_max: Union[str, Time], state: State):
+    assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
+    max_dur = state.max_duration
+    if isinstance(t_max, str):
+        t_max = Time.from_timestring(t_max)
+    if isinstance(max_dur, str):
+        max_dur = Time.from_timestring(max_dur)
+
+    max_dur_exceeds_t_max = False
+    if t_max.unit == max_dur.unit and t_max.value < max_dur.value:
+        max_dur_exceeds_t_max = True
+    elif (
+        t_max.unit == TimeUnit.BATCH and max_dur.unit == TimeUnit.EPOCH and state.dataloader_len is not None and
+        t_max.value < max_dur.value * int(state.dataloader_len)
+    ):
+        max_dur_exceeds_t_max = True
+    elif (
+        t_max.unit == TimeUnit.EPOCH and max_dur.unit == TimeUnit.BATCH and state.dataloader_len is not None and
+        t_max.value * int(state.dataloader_len) < max_dur.value
+    ):
+        max_dur_exceeds_t_max = True
+    elif t_max.unit != max_dur.unit:
+        log.info(
+            f'Since max_duration {max_dur} with units {max_dur.unit} and t_max {t_max} with units {t_max.unit} are not '
+            'comparable, make sure that your LR schedule is defined at all points in the training duration.',
+        )
+
+    if max_dur_exceeds_t_max:
+        raise ValueError(
+            f't_max {t_max} must be greater than or equal to max_duration {max_dur}. Otherwise, the LR schedule will '
+            'not be defined for the entire training duration.',
+        )
+
+
+def _raise_if_warmup_and_max_incompatible(t_warmup: Time[int], t_max: Time[int]):
+    """Checks that t_warmup and t_max have the same units.
+
+    _convert_time should be called on both before this function is called. As a a result, t_warmup and t_max will not
+    be TimeUnit.EPOCH.
+    """
+    assert t_warmup.unit != TimeUnit.EPOCH and t_max.unit != TimeUnit.EPOCH, 't_warmup and t_max cannot be in units of EPOCH'
     if isinstance(t_warmup, str):
         t_warmup = Time.from_timestring(t_warmup)
     if isinstance(t_max, str):
         t_max = Time.from_timestring(t_max)
     units_same = t_warmup.unit == t_max.unit
-    warmup_is_dur = t_warmup.unit == TimeUnit('dur')
-    batches_vs_epochs = (t_warmup.unit == TimeUnit('ba') and t_max.unit
-                         == TimeUnit('ep')) or (t_warmup.unit == TimeUnit('ep') and t_max.unit == TimeUnit('ba'))
-    if not units_same and not warmup_is_dur and not batches_vs_epochs:
+    if not units_same:
         raise ValueError(
-            f'Cannot use warmup scheduler with max_duration {t_max} and warmup {t_warmup}. '
-            't_warmup units must be the same as max_duration units, warmup must be in units "dur", '
-            'max_duration must be "ba" and t_warmup "ep", or max_duration must be "ep" and t_warmup "ba".',
+            f'Cannot use warmup scheduler with t_max {t_max} with units {t_max.unit} and t_warmup {t_warmup} with '
+            f'units {t_warmup.unit}. t_warmup and t_max must use the same units.',
         )
 
 
@@ -595,7 +632,6 @@ class MultiStepWithWarmupScheduler(ComposerScheduler):
 
     def __call__(self, state: State, ssr: float = 1.0):
         assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
-        _raise_if_warmup_and_max_duration_incompatible(self.t_warmup, state.max_duration)
         t_warmup = _convert_time(self.t_warmup, state)
         if t_warmup.value == 0:
             warnings.warn(
@@ -724,8 +760,10 @@ class LinearWithWarmupScheduler(ComposerScheduler):
 
     def __call__(self, state: State, ssr: float = 1.0):
         assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
-        _raise_if_warmup_and_max_duration_incompatible(self.t_warmup, state.max_duration)
         t_warmup = _convert_time(self.t_warmup, state)
+        t_max = _convert_time(self.t_max, state, ssr=ssr)
+        _raise_if_warmup_and_max_incompatible(t_warmup, t_max)
+        _raise_if_max_duration_exceeds_t_max(t_max, state)
         if t_warmup.value == 0:
             warnings.warn(
                 textwrap.dedent(
@@ -741,7 +779,6 @@ class LinearWithWarmupScheduler(ComposerScheduler):
                 return self.warmup_scheduler(state, ssr)
             return self.warmup_scheduler(state)
 
-        t_max = _convert_time(self.t_max, state, ssr=ssr)
         current_time = state.timestamp.get(t_warmup.unit)
         frac_of_total = ((current_time - t_warmup) / (t_max - t_warmup)).value if (t_max > t_warmup) else 0.0
         frac_of_total = min(1.0, frac_of_total)
@@ -799,8 +836,10 @@ class CosineAnnealingWithWarmupScheduler(ComposerScheduler):
 
     def __call__(self, state: State, ssr: float = 1.0):
         assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
-        _raise_if_warmup_and_max_duration_incompatible(self.t_warmup, state.max_duration)
         t_warmup = _convert_time(self.t_warmup, state)
+        t_max = _convert_time(self.t_max, state, ssr=ssr)
+        _raise_if_warmup_and_max_incompatible(t_warmup, t_max)
+        _raise_if_max_duration_exceeds_t_max(t_max, state)
         if t_warmup.value == 0:
             warnings.warn(
                 textwrap.dedent(
@@ -816,7 +855,6 @@ class CosineAnnealingWithWarmupScheduler(ComposerScheduler):
                 return self.warmup_scheduler(state, ssr)
             return self.warmup_scheduler(state)
 
-        t_max = _convert_time(self.t_max, state, ssr=ssr)
         current_time = state.timestamp.get(t_warmup.unit)
         frac_of_total = ((current_time - t_warmup) / (t_max - t_warmup)).value if (t_max > t_warmup) else 0.0
         frac_of_total = min(1.0, frac_of_total)
@@ -876,8 +914,10 @@ class PolynomialWithWarmupScheduler(ComposerScheduler):
 
     def __call__(self, state: State, ssr: float = 1.0):
         assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
-        _raise_if_warmup_and_max_duration_incompatible(self.t_warmup, state.max_duration)
         t_warmup = _convert_time(self.t_warmup, state)
+        t_max = _convert_time(self.t_max, state, ssr=ssr)
+        _raise_if_warmup_and_max_incompatible(t_warmup, t_max)
+        _raise_if_max_duration_exceeds_t_max(t_max, state)
         if t_warmup.value == 0:
             warnings.warn(
                 textwrap.dedent(
@@ -893,7 +933,6 @@ class PolynomialWithWarmupScheduler(ComposerScheduler):
                 return self.warmup_scheduler(state, ssr)
             return self.warmup_scheduler(state)
 
-        t_max = _convert_time(self.t_max, state, ssr=ssr)
         current_time = state.timestamp.get(t_warmup.unit)
         frac_of_total = ((current_time - t_warmup) / (t_max - t_warmup)).value if (t_max > t_warmup) else 0.0
         frac_of_total = min(1.0, frac_of_total)


### PR DESCRIPTION
# What does this PR do?

Changes the error checking in scheduler to check
1. if max_duration is greater than t_max
2. if t_warmup and t_max are different units

Previously it only checked if t_warmup and max_duration were different units which is incorrect because a valid schedule can have t_warmup and max_duration as different units.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
