### PR TITLE
Making default_split_batch public

### DIFF
--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -114,6 +114,9 @@ def _default_split_batch(batch: Any, microbatch_size: int) -> Sequence:
     )
 
 
+default_split_batch = _default_split_batch
+
+
 class DataSpec:
     """Specifications for operating and training on data.
 
@@ -184,7 +187,7 @@ class DataSpec:
         self.dataloader: Union[Iterable, torch.utils.data.DataLoader] = dataloader
         self.num_tokens = num_tokens
         self.device_transforms = self._default_device_transforms if device_transforms is None else device_transforms
-        self.split_batch = _default_split_batch if split_batch is None else split_batch
+        self.split_batch = default_split_batch if split_batch is None else split_batch
         self.get_num_samples_in_batch = self._default_get_num_samples_in_batch if get_num_samples_in_batch is None else get_num_samples_in_batch
         self.get_num_tokens_in_batch = self._default_get_num_tokens_in_batch if get_num_tokens_in_batch is None else get_num_tokens_in_batch
 

--- a/composer/datasets/in_context_learning_evaluation.py
+++ b/composer/datasets/in_context_learning_evaluation.py
@@ -14,7 +14,7 @@ import torch
 from torch.utils.data import DataLoader, Dataset
 
 from composer.core import DataSpec
-from composer.core.data_spec import _default_split_batch, _split_list
+from composer.core.data_spec import _split_list, default_split_batch
 from composer.datasets.utils import stop_sequences_criteria
 from composer.utils import MissingConditionalImportError, dist, get_file
 
@@ -652,7 +652,7 @@ class InContextLearningDataset(Dataset):
             elif k in self.list_keys:
                 chunked[k] = _split_list(v, microbatch_size)
             elif k in self.tensor_keys:
-                chunked[k] = _default_split_batch(v, microbatch_size)
+                chunked[k] = default_split_batch(v, microbatch_size)
             else:
                 raise ValueError(f'Unexpected key {k} in batch splitting')
         num_chunks = len(chunked['input_ids'])
@@ -1058,11 +1058,11 @@ class InContextLearningMultipleChoiceTaskDataset(InContextLearningDataset):
                     chunked[k] = _split_list(v, microbatch_size)
                 # list - 'gold_indices'
                 elif k in self.list_of_primitives:
-                    chunked[k] = _default_split_batch(v, microbatch_size)
+                    chunked[k] = default_split_batch(v, microbatch_size)
                 else:
                     raise ValueError(f'Unexpected key {k} in list splitting')
             elif k in self.tensor_keys:
-                chunked[k] = _default_split_batch(v, microbatch_size * self.num_choices)
+                chunked[k] = default_split_batch(v, microbatch_size * self.num_choices)
             else:
                 raise ValueError(f'Unexpected key {k} in batch splitting')
         num_chunks = len(chunked['input_ids'])

--- a/tests/test_split_batch.py
+++ b/tests/test_split_batch.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Mapping, Tuple, Union
 import pytest
 import torch
 
-from composer.core.data_spec import _default_split_batch, _split_list, _split_tensor
+from composer.core.data_spec import _split_list, _split_tensor, default_split_batch
 
 
 def dummy_tensor_batch(batch_size=12) -> torch.Tensor:
@@ -103,7 +103,7 @@ def dummy_batches(batch_size=12):
 
 @pytest.mark.parametrize('batch', dummy_batches(12))
 def test_split_without_error(batch):
-    microbatches = _default_split_batch(batch, microbatch_size=3)
+    microbatches = default_split_batch(batch, microbatch_size=3)
     assert len(microbatches) == 4
 
 
@@ -118,7 +118,7 @@ def test_tensor_vs_list_chunking(batch):
 
 @pytest.mark.parametrize('batch', [dummy_tuple_batch(12)])
 def test_split_tuple(batch):
-    microbatches = _default_split_batch(batch, microbatch_size=4)
+    microbatches = default_split_batch(batch, microbatch_size=4)
     # should be 3 microbatches of size 4 tensors pairs
     # should split into [(x, y), (x, y), (x, y)]
     assert len(microbatches[0]) == 2
@@ -126,13 +126,13 @@ def test_split_tuple(batch):
 
 @pytest.mark.parametrize('batch', [dummy_tuple_batch_long(12)])
 def test_split_tuple_long(batch):
-    microbatches = _default_split_batch(batch, microbatch_size=4)
+    microbatches = default_split_batch(batch, microbatch_size=4)
     assert len(microbatches[0]) == 4
 
 
 @pytest.mark.parametrize('batch', dummy_batches(6))
 def test_batch_sizes(batch):
-    microbatches = _default_split_batch(batch, microbatch_size=2)
+    microbatches = default_split_batch(batch, microbatch_size=2)
     # should split into [len(2), len(2), len(1)]
     assert len(microbatches) == 3
     for microbatch in microbatches:
@@ -147,7 +147,7 @@ def test_batch_sizes(batch):
 
 @pytest.mark.parametrize('batch', dummy_batches(5))
 def test_odd_batch_sizes(batch):
-    microbatches = _default_split_batch(batch, microbatch_size=2)
+    microbatches = default_split_batch(batch, microbatch_size=2)
     # should split into [len(2), len(2), len(1)]
     assert len(microbatches) == 3
     last_microbatch = microbatches[-1]
@@ -163,7 +163,7 @@ def test_odd_batch_sizes(batch):
 @pytest.mark.parametrize('batch', dummy_batches(2))
 def test_microbatch_size_greater_than_batch_size(batch):
     with pytest.warns(UserWarning):
-        microbatches = _default_split_batch(batch, microbatch_size=3)
+        microbatches = default_split_batch(batch, microbatch_size=3)
         assert len(microbatches) == 1
 
 
@@ -175,7 +175,7 @@ def test_microbatch_size_split_maskrcnn(batch):
 
 @pytest.mark.parametrize('batch', [dummy_dict_batch_with_common_metadata(12)])
 def test_primitive_broadcast(batch):
-    microbatches = _default_split_batch(batch, microbatch_size=3)
+    microbatches = default_split_batch(batch, microbatch_size=3)
     assert len(microbatches) == 4
     for mb in microbatches:
         assert mb['meta'] == 'this is a string'


### PR DESCRIPTION
# What does this PR do?

This PR makes the _default_split_batch public. It is already being used outside the file it is defined in (see composer/datasets/in_context_learning_evaluation.py) and it also has unit tests (see tests/test_split_batch.py). This function can be used as a base function to write other batch splitting functions.

