### PR TITLE
Explicitly print checkpoint downloading exception

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -275,6 +275,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
                         log.debug(f'Finished downloading {relative_file_path} to {file_destination}.')
             except Exception as e:
                 log.error(f'Exception raised during downloading: {str(e)}')
+                log.error(f'Exception raised during downloading: exception type: {type(e)}')
                 raise e
 
         # 3. Wait for all ranks to finish.

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -274,7 +274,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
                             )
                         log.debug(f'Finished downloading {relative_file_path} to {file_destination}.')
             except Exception as e:
-                # PyTorch will capture any exception of this funciton,
+                # PyTorch will capture any exception of this function,
                 # and dist.all_gather_objects(exception) before raising it.
                 # If that all_gather_objects fails, the exception is never visible to user.
                 # We immediately print the exception to avoid that situation.

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -274,8 +274,11 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
                             )
                         log.debug(f'Finished downloading {relative_file_path} to {file_destination}.')
             except Exception as e:
-                log.error(f'Exception raised during downloading: {str(e)}')
-                log.error(f'Exception raised during downloading: exception type: {type(e)}')
+                # PyTorch will capture any exception of this funciton,
+                # and dist.all_gather_objects(exception) before raising it.
+                # If that all_gather_objects fails, the exception is never visible to user.
+                # We immediately print the exception to avoid that situation.
+                log.error(f'Exception {type(e)} raised during downloading: {str(e)}')
                 raise e
 
         # 3. Wait for all ranks to finish.

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -16,6 +16,9 @@ from composer.utils.import_helpers import MissingConditionalImportError
 from composer.utils.object_store.object_store import ObjectStore
 
 __all__ = ['OCIObjectStore']
+import oci
+import logging
+logging.getLogger('oci').setLevel(logging.DEBUG)
 
 
 def _reraise_oci_errors(uri: str, e: Exception):

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -16,9 +16,6 @@ from composer.utils.import_helpers import MissingConditionalImportError
 from composer.utils.object_store.object_store import ObjectStore
 
 __all__ = ['OCIObjectStore']
-import oci
-import logging
-#logging.getLogger('oci').setLevel(logging.DEBUG)
 
 
 def _reraise_oci_errors(uri: str, e: Exception):

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -18,7 +18,7 @@ from composer.utils.object_store.object_store import ObjectStore
 __all__ = ['OCIObjectStore']
 import oci
 import logging
-logging.getLogger('oci').setLevel(logging.DEBUG)
+#logging.getLogger('oci').setLevel(logging.DEBUG)
 
 
 def _reraise_oci_errors(uri: str, e: Exception):


### PR DESCRIPTION
# What does this PR do?

PyTorch will hold any exception raised during this [read_data](https://github.com/mosaicml/composer/blob/ee13deadef1935b6054d1458f340971e5af4a635/composer/utils/checkpoint.py#L227), torch code pointer: https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/utils.py#L246-L255

PyTorch only raise the exception after communicate the exception across ranks https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/utils.py#L251, but issue is that communication iteself might fail because comms mis-match across ranks. In this case, it raised NCCL error, and hide the real read_data exceptioin. 

This PR print the exception immediately. It still raise NCCL error, but at least, it prints the checkpoint downloading error. 

# test
on 8-gpu checkpoint load test, i manually raise exception on rank 1 in the for-loop, i can reproduce the `c10::DistBackendError`. With this PR, i can see the logging of the exception. 
