### PR TITLE
Add ChunkedEncodingError exception handling for OCI

### DIFF
--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -14,8 +14,12 @@ from typing import Callable, List, Optional, Union
 
 from composer.utils.import_helpers import MissingConditionalImportError
 from composer.utils.object_store.object_store import ObjectStore
+from composer.utils.object_store.oci_object_store_utils import patch_oci
 
 __all__ = ['OCIObjectStore']
+import logging
+
+logging.getLogger('oci').setLevel(logging.DEBUG)
 
 
 def _reraise_oci_errors(uri: str, e: Exception):
@@ -68,6 +72,7 @@ class OCIObjectStore(ObjectStore):
                 extra_deps_group='oci',
                 conda_channel='conda-forge',
             ) from e
+        patch_oci()
 
         # Format paths
         self.bucket = bucket.strip('/')

--- a/composer/utils/object_store/oci_object_store_utils.py
+++ b/composer/utils/object_store/oci_object_store_utils.py
@@ -1,0 +1,81 @@
+# Copyright 2024 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for monkey patching OCI."""
+
+import logging
+import threading
+
+from composer.utils.import_helpers import MissingConditionalImportError
+
+log = logging.getLogger(__name__)
+
+
+def patch_oci():
+    """Monkey patches the OCI retry strategy to add BaseRequestException.
+
+    This is necessary because the OCI retry strategy does not handle BaseRequestException.
+    """
+    try:
+        import oci
+    except ImportError as e:
+        raise MissingConditionalImportError(
+            conda_package='oci',
+            extra_deps_group='oci',
+            conda_channel='conda-forge',
+        ) from e
+    oci.retry.retry_checkers.TimeoutConnectionAndServiceErrorRetryChecker.should_retry = should_retry
+
+
+def should_retry(self, exception=None, response=None, **kwargs):
+    """Uses OCI retry and adds BaseRequestException.
+
+    https://github.com/oracle/oci-python-sdk/blob/8ba39d63242fd406fb7a97fb6f9acdde81eb6dd9/src/oci/retry/retry_checkers.py#L166
+    """
+    log.warning('Using monkeypatched should_retry')
+    try:
+        from circuitbreaker import CircuitBreakerError
+        from oci._vendor.requests.exceptions import ConnectionError as RequestsConnectionError
+        from oci._vendor.requests.exceptions import RequestException as BaseRequestException
+        from oci._vendor.requests.exceptions import Timeout
+        from oci.exceptions import ConnectTimeout, RequestException, ServiceError
+    except ImportError as e:
+        raise MissingConditionalImportError(
+            conda_package='oci',
+            extra_deps_group='oci',
+            conda_channel='conda-forge',
+        ) from e
+    print(type(exception))
+    print(str(exception))
+    if isinstance(exception, Timeout):
+        return True
+    elif isinstance(exception, RequestsConnectionError):
+        return True
+    elif isinstance(exception, RequestException):
+        return True
+    elif isinstance(exception, BaseRequestException):
+        return True
+    elif isinstance(exception, ConnectTimeout):
+        return True
+    elif isinstance(exception, CircuitBreakerError):
+        if 'circuit_breaker_callback' in kwargs:
+            threading.Thread(target=kwargs['circuit_breaker_callback'], args=(exception,)).start()
+        return True
+    elif isinstance(exception, ServiceError):
+        if exception.status in self.service_error_retry_config:  # type: ignore
+            codes = self.service_error_retry_config[exception.status]  # type: ignore
+            if not codes:
+                return True
+            else:
+                return exception.code in codes  # type: ignore
+        elif self.retry_any_5xx and exception.status >= 500 and exception.status != 501:  # type: ignore
+            return True
+    else:
+        # This is inside a try block because ConnectionError exists in Python 3 and not in Python 2
+        try:
+            if isinstance(exception, ConnectionError):
+                return True
+        except NameError:
+            pass
+
+    return False


### PR DESCRIPTION
# What does this PR do?

OCI doesn't properly handle their exception `oci._vendor.requests.exceptions.ChunkedEncodingError`. This means that no retries happen following their default retry strategy. The issue is that they have two subclasses of the same base class, but attempt to compare the subclasses. This fix should be upstreamed to OCI, but this patch allows us to use retries while they work on the fix.

Tested with this script
```
from circuitbreaker import CircuitBreakerError
from oci._vendor.requests.exceptions import RequestException as BaseRequestException
from oci._vendor.requests.exceptions import Timeout
from oci._vendor.requests.exceptions import ConnectionError as RequestsConnectionError
from oci.exceptions import ServiceError, RequestException, ConnectTimeout
import threading


def should_retry(self, exception=None, response=None, **kwargs):
    if isinstance(exception, Timeout):
        return True
    elif isinstance(exception, RequestsConnectionError):
        return True
    elif isinstance(exception, RequestException):
        return True
    elif isinstance(exception, BaseRequestException):
        return True
    elif isinstance(exception, ConnectTimeout):
        return True
    elif isinstance(exception, CircuitBreakerError):
        if 'circuit_breaker_callback' in kwargs:
            threading.Thread(target=kwargs['circuit_breaker_callback'],
                             args=(exception, )).start()
        return True
    elif isinstance(exception, ServiceError):
        if exception.status in self.service_error_retry_config:
            codes = self.service_error_retry_config[exception.status]
            if not codes:
                return True
            else:
                return exception.code in codes
        elif self.retry_any_5xx and exception.status >= 500 and exception.status != 501:
            return True
    else:
        # This is inside a try block because ConnectionError exists in Python 3 and not in Python 2
        try:
            if isinstance(exception, ConnectionError):
                return True
        except NameError:
            pass

    return False


import oci

oci.retry.retry_checkers.TimeoutConnectionAndServiceErrorRetryChecker.should_retry = should_retry
retry_strategy = oci.retry.DEFAULT_RETRY_STRATEGY
print(
    retry_strategy.checkers.should_retry(
        exception=oci._vendor.requests.exceptions.ChunkedEncodingError()))

```

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
