### PR TITLE
Passing rank and num_replicas to dist.get_sampler

### DIFF
--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -580,7 +580,12 @@ def initialize_dist(device: Union[str, Device], timeout: float = 300.0):
 
 
 def get_sampler(
-    dataset: torch.utils.data.Dataset, *, drop_last: bool = False, shuffle: bool = False, rank: Optional[int] = None
+    dataset: torch.utils.data.Dataset,
+    *,
+    drop_last: bool = False,
+    shuffle: bool = False,
+    num_replicas: Optional[int] = None,
+    rank: Optional[int] = None
 ):
     """Constructs a :class:`~torch.utils.data.distributed.DistributedSampler` for a dataset.
 
@@ -605,7 +610,7 @@ def get_sampler(
         dataset,
         drop_last=drop_last,
         shuffle=shuffle,
-        num_replicas=get_world_size(),
+        num_replicas=get_world_size() if num_replicas is None else num_replicas,
         rank=get_global_rank() if rank is None else rank,
     )
 

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -585,7 +585,7 @@ def get_sampler(
     drop_last: bool = False,
     shuffle: bool = False,
     num_replicas: Optional[int] = None,
-    rank: Optional[int] = None
+    rank: Optional[int] = None,
 ):
     """Constructs a :class:`~torch.utils.data.distributed.DistributedSampler` for a dataset.
 
@@ -602,6 +602,8 @@ def get_sampler(
         dataset (torch.utils.data.Dataset): The dataset.
         drop_last (bool): Whether to trop the last batch.
         shuffle (bool): Whether to shuffle the dataset.
+        num_replicas (int, optional): The number of replicas. If ``None``, defaults to the world size.
+        rank (int, optional): The rank. If ``None``, defaults to the global rank.
 
     Returns:
         torch.utils.data.distributed.DistributedSampler: The sampler.

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -579,7 +579,9 @@ def initialize_dist(device: Union[str, Device], timeout: float = 300.0):
         dist.init_process_group(device_obj.dist_backend, timeout=timeout_timedelta)
 
 
-def get_sampler(dataset: torch.utils.data.Dataset, *, drop_last: bool = False, shuffle: bool = False):
+def get_sampler(
+    dataset: torch.utils.data.Dataset, *, drop_last: bool = False, shuffle: bool = False, rank: Optional[int] = None
+):
     """Constructs a :class:`~torch.utils.data.distributed.DistributedSampler` for a dataset.
 
     The :class:`~torch.utils.data.distributed.DistributedSampler` assumes that each rank has a complete copy of the
@@ -604,7 +606,7 @@ def get_sampler(dataset: torch.utils.data.Dataset, *, drop_last: bool = False, s
         drop_last=drop_last,
         shuffle=shuffle,
         num_replicas=get_world_size(),
-        rank=get_global_rank(),
+        rank=get_global_rank() if rank is None else rank,
     )
 
 


### PR DESCRIPTION
# What does this PR do?

Allows for passing `rank` and `num_replicas` to `dist.get_sampler`