### PR TITLE
Don't close the engine if its already closed

### DIFF
--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -531,7 +531,8 @@ class Engine():
         This method does not re-raise any exceptions from :meth:`.Callback.close` and :meth:`.Callback.post_close`.
         Instead, these exceptions are logged as errors.
         """
-        self._close(self.state, self.logger)
+        if not self._is_closed:
+            self._close(self.state, self.logger)
         # The self._is_closed flag would not be set if `_close` is called via atexit
         # However, in these cases, the engine would never be used again, as Python is shutting
         # down. It is only required to set the flag if the user manually calls `close()` and still holds


### PR DESCRIPTION
# What does this PR do?
Currently produces duplicate print statements cause it may close both when you call `.close()` and `atexit`
