### PR TITLE
Bump release to 0.21.1

### DIFF
--- a/composer/_version.py
+++ b/composer/_version.py
@@ -3,4 +3,4 @@
 
 """The Composer Version."""
 
-__version__ = '0.21.0'
+__version__ = '0.21.1'


### PR DESCRIPTION
# What does this PR do?
Fix release bump.  

# What issue(s) does this change relate to?
`dbrx-tiny-2-lANzEk` fails on installation. This should fix it. 

