### PR TITLE
Prevent crash if signal handler cannot be set

### DIFF
--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -123,8 +123,11 @@ def sigterm_handler(signal, frame):
     sys.exit(128 + signal)
 
 
-signal.signal(signal.SIGTERM, sigterm_handler)
-signal.signal(signal.SIGINT, sigterm_handler)
+try:
+    signal.signal(signal.SIGTERM, sigterm_handler)
+    signal.signal(signal.SIGINT, sigterm_handler)
+except ValueError:
+    log.warning('Failed to set signal handler. Checkpoints may not be flushed if the process is killed.')
 
 
 def _get_default_passes():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,11 +1,13 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
 import logging
 import os
 import subprocess
 import sys
 import textwrap
+import threading
 from pathlib import Path
 from typing import List
 from unittest.mock import Mock
@@ -323,3 +325,15 @@ def test_logging(
         ('composer.core.engine', 10, 'Post-closing callback EventCounterCallback'),
         ('composer.core.engine', 10, 'Engine closed.'),
     ]
+
+
+def _worker():
+    import composer.core.engine
+    importlib.reload(composer.core.engine)
+
+
+def test_graceful_fallback_when_signal_handler_cannot_be_set():
+    # https://github.com/mosaicml/composer/issues/3151#issue-2205981731
+    t = threading.Thread(target=_worker)
+    t.start()
+    t.join()


### PR DESCRIPTION
# What does this PR do?

This is a workaround for https://github.com/mosaicml/composer/issues/3151 that at least prevents the import from crashing. A better long term solution may be possible.

# Before submitting
- [X] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [X] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [X] Did you update any related docs and document your change?
- [X] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [X] Did you run the tests locally to make sure they pass?
- [X] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
