### PR TITLE
Fix torch version check

### DIFF
--- a/composer/trainer/mosaic_fsdp.py
+++ b/composer/trainer/mosaic_fsdp.py
@@ -61,7 +61,7 @@ def patch_pytorch():
         from torch.distributed.fsdp import _runtime_utils
         _runtime_utils._validate_and_get_hybrid_shard_state = lambda *args, **kwargs: None
 
-    elif version.parse(torch.__version__) < version.parse('2.3.0'):
+    elif version.parse(torch.__version__) < version.parse('2.2.9'):
         # Monkey patch for torch < 2.2.2 ie torch == 2.2.1
         pass
 

--- a/composer/trainer/mosaic_fsdp.py
+++ b/composer/trainer/mosaic_fsdp.py
@@ -62,7 +62,7 @@ def patch_pytorch():
         _runtime_utils._validate_and_get_hybrid_shard_state = lambda *args, **kwargs: None
 
     elif version.parse(torch.__version__) < version.parse('2.2.9'):
-        # Monkey patch for torch < 2.2.2 ie torch == 2.2.1
+        # Monkey patch for torch < 2.3.0 ie torch == 2.2.1/2.2.2 currently
         pass
 
     elif version.parse(torch.__version__) < version.parse('2.3.1'):


### PR DESCRIPTION
```
In [2]: version.parse('2.3.0.dev20240110+cu121') < version.parse('2.3.0')
Out[2]: True
```