### PR TITLE
Pin pillow for code quality workflow

### DIFF
--- a/composer/algorithms/utils/augmentation_primitives.py
+++ b/composer/algorithms/utils/augmentation_primitives.py
@@ -155,7 +155,7 @@ def rotate(pil_img: Image.Image, level: float):
     degrees = _int_parameter(_sample_level(level), 30)
     if np.random.uniform() > 0.5:
         degrees = -degrees
-    return pil_img.rotate(degrees, resample=Image.Resampling.BILINEAR)
+    return pil_img.rotate(degrees, resample=Image.BILINEAR)
 
 
 def solarize(pil_img: Image.Image, level: float):
@@ -183,12 +183,7 @@ def shear_x(pil_img: Image.Image, level: float):
     level = _float_parameter(_sample_level(level), 0.3)
     if np.random.uniform() > 0.5:
         level = -level
-    return pil_img.transform(
-        pil_img.size,
-        Image.Transform.AFFINE,
-        (1, level, 0, 0, 1, 0),
-        resample=Image.Resampling.BILINEAR,
-    )
+    return pil_img.transform(pil_img.size, Image.AFFINE, (1, level, 0, 0, 1, 0), resample=Image.BILINEAR)
 
 
 def shear_y(pil_img: Image.Image, level: float):
@@ -202,12 +197,7 @@ def shear_y(pil_img: Image.Image, level: float):
     level = _float_parameter(_sample_level(level), 0.3)
     if np.random.uniform() > 0.5:
         level = -level
-    return pil_img.transform(
-        pil_img.size,
-        Image.Transform.AFFINE,
-        (1, 0, 0, level, 1, 0),
-        resample=Image.Resampling.BILINEAR,
-    )
+    return pil_img.transform(pil_img.size, Image.AFFINE, (1, 0, 0, level, 1, 0), resample=Image.BILINEAR)
 
 
 def translate_x(pil_img: Image.Image, level: float):
@@ -221,12 +211,7 @@ def translate_x(pil_img: Image.Image, level: float):
     level = _int_parameter(_sample_level(level), pil_img.size[0] / 3)
     if np.random.random() > 0.5:
         level = -level
-    return pil_img.transform(
-        pil_img.size,
-        Image.Transform.AFFINE,
-        (1, 0, level, 0, 1, 0),
-        resample=Image.Resampling.BILINEAR,
-    )
+    return pil_img.transform(pil_img.size, Image.AFFINE, (1, 0, level, 0, 1, 0), resample=Image.BILINEAR)
 
 
 def translate_y(pil_img: Image.Image, level: float):
@@ -240,12 +225,7 @@ def translate_y(pil_img: Image.Image, level: float):
     level = _int_parameter(_sample_level(level), pil_img.size[1] / 3)
     if np.random.random() > 0.5:
         level = -level
-    return pil_img.transform(
-        pil_img.size,
-        Image.Transform.AFFINE,
-        (1, 0, 0, 0, 1, level),
-        resample=Image.Resampling.BILINEAR,
-    )
+    return pil_img.transform(pil_img.size, Image.AFFINE, (1, 0, 0, 0, 1, level), resample=Image.BILINEAR)
 
 
 # The following augmentations overlap with corruptions in the ImageNet-C/CIFAR10-C test

--- a/composer/algorithms/utils/augmentation_primitives.py
+++ b/composer/algorithms/utils/augmentation_primitives.py
@@ -155,7 +155,7 @@ def rotate(pil_img: Image.Image, level: float):
     degrees = _int_parameter(_sample_level(level), 30)
     if np.random.uniform() > 0.5:
         degrees = -degrees
-    return pil_img.rotate(degrees, resample=Image.BILINEAR)
+    return pil_img.rotate(degrees, resample=Image.Resampling.BILINEAR)
 
 
 def solarize(pil_img: Image.Image, level: float):
@@ -183,7 +183,9 @@ def shear_x(pil_img: Image.Image, level: float):
     level = _float_parameter(_sample_level(level), 0.3)
     if np.random.uniform() > 0.5:
         level = -level
-    return pil_img.transform(pil_img.size, Image.AFFINE, (1, level, 0, 0, 1, 0), resample=Image.BILINEAR)
+    return pil_img.transform(
+        pil_img.size, Image.Transform.AFFINE, (1, level, 0, 0, 1, 0), resample=Image.Resampling.BILINEAR
+    )
 
 
 def shear_y(pil_img: Image.Image, level: float):
@@ -197,7 +199,9 @@ def shear_y(pil_img: Image.Image, level: float):
     level = _float_parameter(_sample_level(level), 0.3)
     if np.random.uniform() > 0.5:
         level = -level
-    return pil_img.transform(pil_img.size, Image.AFFINE, (1, 0, 0, level, 1, 0), resample=Image.BILINEAR)
+    return pil_img.transform(
+        pil_img.size, Image.Transform.AFFINE, (1, 0, 0, level, 1, 0), resample=Image.Resampling.BILINEAR
+    )
 
 
 def translate_x(pil_img: Image.Image, level: float):
@@ -211,7 +215,9 @@ def translate_x(pil_img: Image.Image, level: float):
     level = _int_parameter(_sample_level(level), pil_img.size[0] / 3)
     if np.random.random() > 0.5:
         level = -level
-    return pil_img.transform(pil_img.size, Image.AFFINE, (1, 0, level, 0, 1, 0), resample=Image.BILINEAR)
+    return pil_img.transform(
+        pil_img.size, Image.Transform.AFFINE, (1, 0, level, 0, 1, 0), resample=Image.Resampling.BILINEAR
+    )
 
 
 def translate_y(pil_img: Image.Image, level: float):
@@ -225,7 +231,9 @@ def translate_y(pil_img: Image.Image, level: float):
     level = _int_parameter(_sample_level(level), pil_img.size[1] / 3)
     if np.random.random() > 0.5:
         level = -level
-    return pil_img.transform(pil_img.size, Image.AFFINE, (1, 0, 0, 0, 1, level), resample=Image.BILINEAR)
+    return pil_img.transform(
+        pil_img.size, Image.Transform.AFFINE, (1, 0, 0, 0, 1, level), resample=Image.Resampling.BILINEAR
+    )
 
 
 # The following augmentations overlap with corruptions in the ImageNet-C/CIFAR10-C test

--- a/composer/algorithms/utils/augmentation_primitives.py
+++ b/composer/algorithms/utils/augmentation_primitives.py
@@ -184,7 +184,10 @@ def shear_x(pil_img: Image.Image, level: float):
     if np.random.uniform() > 0.5:
         level = -level
     return pil_img.transform(
-        pil_img.size, Image.Transform.AFFINE, (1, level, 0, 0, 1, 0), resample=Image.Resampling.BILINEAR
+        pil_img.size,
+        Image.Transform.AFFINE,
+        (1, level, 0, 0, 1, 0),
+        resample=Image.Resampling.BILINEAR,
     )
 
 
@@ -200,7 +203,10 @@ def shear_y(pil_img: Image.Image, level: float):
     if np.random.uniform() > 0.5:
         level = -level
     return pil_img.transform(
-        pil_img.size, Image.Transform.AFFINE, (1, 0, 0, level, 1, 0), resample=Image.Resampling.BILINEAR
+        pil_img.size,
+        Image.Transform.AFFINE,
+        (1, 0, 0, level, 1, 0),
+        resample=Image.Resampling.BILINEAR,
     )
 
 
@@ -216,7 +222,10 @@ def translate_x(pil_img: Image.Image, level: float):
     if np.random.random() > 0.5:
         level = -level
     return pil_img.transform(
-        pil_img.size, Image.Transform.AFFINE, (1, 0, level, 0, 1, 0), resample=Image.Resampling.BILINEAR
+        pil_img.size,
+        Image.Transform.AFFINE,
+        (1, 0, level, 0, 1, 0),
+        resample=Image.Resampling.BILINEAR,
     )
 
 
@@ -232,7 +241,10 @@ def translate_y(pil_img: Image.Image, level: float):
     if np.random.random() > 0.5:
         level = -level
     return pil_img.transform(
-        pil_img.size, Image.Transform.AFFINE, (1, 0, 0, 0, 1, level), resample=Image.Resampling.BILINEAR
+        pil_img.size,
+        Image.Transform.AFFINE,
+        (1, 0, 0, 0, 1, level),
+        resample=Image.Resampling.BILINEAR,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ extra_deps['dev'] = [
     'cryptography==41.0.5',
     'pytest-httpserver>=1.0.4,<1.1',
     'setuptools<=59.5.0',
+    'pillow==9.3.0',  # Matches the Pillow version listed in the Dockerfile
 ]
 
 extra_deps['system_metrics_monitor'] = {


### PR DESCRIPTION
Seems they deprecated the old imports at some point and we didn't notice. Now they are gone. The code quality workflow was continuously upgrading pil even though we have the expected version pinned in dockerfile.