### PR TITLE
add more retry to checkpoint downloading

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -227,6 +227,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
         metadata_destination = os.path.join(self.destination_path, '.metadata')
         if dist.get_local_rank() == 0:
             metadata_path = str(Path(source_path) / Path('.metadata'))
+            log.debug(f'bigning debug new download in init')
             download_object_or_file(metadata_path, metadata_destination, object_store)
         dist.barrier()
 
@@ -376,6 +377,7 @@ def is_checkpoint_legacy_sharded(object_store: Optional[Union[LoggerDestination,
             _, _, metadata_path = parse_uri(metadata_path)
             with tempfile.TemporaryDirectory() as temp_dir:
                 metadata_destination = os.path.join(str(temp_dir), '.metadata')
+                log.debug(f'bigning debug new download in is_checkpoint_legacy_sharded')
                 download_object_or_file(metadata_path, metadata_destination, object_store)
             return False
         except FileNotFoundError:

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -227,7 +227,6 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
         metadata_destination = os.path.join(self.destination_path, '.metadata')
         if dist.get_local_rank() == 0:
             metadata_path = str(Path(source_path) / Path('.metadata'))
-            log.debug(f'bigning debug new download in init')
             download_object_or_file(metadata_path, metadata_destination, object_store)
         dist.barrier()
 
@@ -377,7 +376,6 @@ def is_checkpoint_legacy_sharded(object_store: Optional[Union[LoggerDestination,
             _, _, metadata_path = parse_uri(metadata_path)
             with tempfile.TemporaryDirectory() as temp_dir:
                 metadata_destination = os.path.join(str(temp_dir), '.metadata')
-                log.debug(f'bigning debug new download in is_checkpoint_legacy_sharded')
                 download_object_or_file(metadata_path, metadata_destination, object_store)
             return False
         except FileNotFoundError:

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -227,16 +227,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
         metadata_destination = os.path.join(self.destination_path, '.metadata')
         if dist.get_local_rank() == 0:
             metadata_path = str(Path(source_path) / Path('.metadata'))
-            if isinstance(object_store, ObjectStore):
-                object_store.download_object(
-                    object_name=metadata_path,
-                    filename=metadata_destination,
-                )
-            else:
-                object_store.download_file(
-                    remote_file_name=metadata_path,
-                    destination=metadata_destination,
-                )
+            download_object_or_file(metadata_path, metadata_destination, object_store)
         dist.barrier()
 
         # FileSystemReader takes in a root directory in its constructor, which is the dir where
@@ -385,16 +376,7 @@ def is_checkpoint_legacy_sharded(object_store: Optional[Union[LoggerDestination,
             _, _, metadata_path = parse_uri(metadata_path)
             with tempfile.TemporaryDirectory() as temp_dir:
                 metadata_destination = os.path.join(str(temp_dir), '.metadata')
-                if isinstance(object_store, ObjectStore):
-                    object_store.download_object(
-                        object_name=metadata_path,
-                        filename=metadata_destination,
-                    )
-                else:
-                    object_store.download_file(
-                        remote_file_name=metadata_path,
-                        destination=metadata_destination,
-                    )
+                download_object_or_file(metadata_path, metadata_destination, object_store)
             return False
         except FileNotFoundError:
             return True


### PR DESCRIPTION
# what
When run diagnostic on r15z1, we found OCI download error in other two places. Adding the retry to those object store downloading. 

# test
bigning-debug-cp-loading-2-Cv5Bsh