### PR TITLE
Append to gpu rank log files instead of throwing error

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -14,7 +14,6 @@ import sys
 import tempfile
 import time
 import traceback
-import warnings
 from argparse import ArgumentParser
 from typing import Any, Dict, List, Union
 
@@ -368,12 +367,6 @@ def _launch_processes(
                         local_world_size=nproc,
                         node_rank=node_rank,
                     )
-                    if os.path.exists(filename):
-                        warnings.warn(
-                            f'Log file {filename} already exists for a previous train; Appending additional Composer logs to the same file.',
-                            UserWarning,
-                        )
-
                     return open(filename, 'a+')
 
                 stdout_file = _get_file(stdout_file_format)

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import time
 import traceback
+import warnings
 from argparse import ArgumentParser
 from typing import Any, Dict, List, Union
 
@@ -367,7 +368,13 @@ def _launch_processes(
                         local_world_size=nproc,
                         node_rank=node_rank,
                     )
-                    return open(filename, 'x+')
+                    if os.path.exists(filename):
+                        warnings.warn(
+                            f'Log file {filename} already exists for a previous train; Appending additional Composer logs to the same file.',
+                            UserWarning,
+                        )
+
+                    return open(filename, 'a+')
 
                 stdout_file = _get_file(stdout_file_format)
                 stderr_file = _get_file(stderr_file_format) if stderr_file_format is not None else None


### PR DESCRIPTION
# What does this PR do?
For runs that call composer commands twice, we would error on creating a new log file because an existing log file had already been created on the first composer command. This changes the behavior to append to the existing or write a new file if doesn't exist already.

# Testing 
Ran a yaml that calls composer twice, verified that logs append
<img width="1229" alt="image" src="https://github.com/mosaicml/composer/assets/29712344/19bc340b-6589-43d4-8fb8-a76a6c757ad4">
