### PR TITLE
[Not for merge] refactor the object_store.download_object retry and add more retry

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -104,6 +104,7 @@ from composer.utils import (
     Transform,
     checkpoint,
     dist,
+    download_object_or_file,
     ensure_tuple,
     export_with_logger,
     extract_hparams,
@@ -1627,7 +1628,11 @@ class Trainer:
                                 self.state.run_name,
                             ) + '.symlink'
                             try:
-                                ar_object_store.download_object(symlink_file_name, local_symlink_file)
+                                download_object_or_file(
+                                    object_store=ar_object_store,
+                                    object_name=symlink_file_name,
+                                    file_destination=local_symlink_file,
+                                )
                                 with open(local_symlink_file, 'r') as f:
                                     real_path = f.read()
                                     log.debug(f'Read path {real_path} from symlink file')

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -35,6 +35,7 @@ from composer.utils.file_helpers import (
     FORMAT_NAME_WITH_DIST_AND_TIME_TABLE,
     FORMAT_NAME_WITH_DIST_TABLE,
     create_symlink_file,
+    download_object_or_file,
     ensure_folder_has_no_conflicting_files,
     ensure_folder_is_empty,
     format_name_with_dist,
@@ -141,4 +142,5 @@ __all__ = [
     'CliCompressor',
     'get_compressor',
     'KNOWN_COMPRESSORS',
+    'download_object_or_file',
 ]

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -62,15 +62,11 @@ def download_object_or_file(
     progress_bar: bool = False,
 ):
     if isinstance(object_store, ObjectStore):
-        if progress_bar:
-            callback = _get_callback(f'Downloading {object_name}')
-        else:
-            callback = None
         object_store.download_object(
             object_name=object_name,
             filename=file_destination,
             overwrite=overwrite,
-            callback=callback,
+            callback=_get_callback(f'Downloading {object_name}') if progress_bar else None,
         )
     elif isinstance(object_store, LoggerDestination):
         object_store.download_file(
@@ -80,7 +76,7 @@ def download_object_or_file(
             progress_bar=progress_bar,
         )
     else:
-        raise RuntimeError(f'Unrecognized type: {type(object_store)}')
+        raise RuntimeError(f'Unrecognized type: {type(object_store)} when attempting to download object')
 
 
 def extract_path_from_symlink(

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -64,7 +64,7 @@ def download_object_or_file(
     log.debug(f'bigning debug using new code path')
     if isinstance(object_store, ObjectStore):
         if progress_bar:
-            callback = _get_callback(f'Downloading {object_name}') if progress_bar else None
+            callback = _get_callback(f'Downloading {object_name}')
         else:
             callback = None
         object_store.download_object(

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -61,6 +61,7 @@ def download_object_or_file(
     overwrite: bool = False,
     progress_bar: bool = False,
 ):
+    log.debug(f'bigning debug using new code path')
     if isinstance(object_store, ObjectStore):
         if progress_bar:
             callback = _get_callback(f'Downloading {object_name}') if progress_bar else None

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -61,7 +61,6 @@ def download_object_or_file(
     overwrite: bool = False,
     progress_bar: bool = False,
 ):
-    log.debug(f'bigning debug using new code path')
     if isinstance(object_store, ObjectStore):
         if progress_bar:
             callback = _get_callback(f'Downloading {object_name}')

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -61,6 +61,7 @@ def download_object_or_file(
     overwrite: bool = False,
     progress_bar: bool = False,
 ):
+    from composer.loggers import LoggerDestination
     if isinstance(object_store, ObjectStore):
         object_store.download_object(
             object_name=object_name,


### PR DESCRIPTION
# What
1. searched the repo, replace ALL object_store.download_object() with the retry version to avoid potential downloading error in future.
2. moved the `download_object_or_file` function to `file_helpers.py` to make 1 easy.

# Test
bigning-debug-cp-loading-2-ntUAon
bigning-debug-cp-loading-2-rhJJm0
