### PR TITLE
Removal of metrics deepcopy before computing the metrics

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2239,7 +2239,7 @@ class Trainer:
         return metrics
 
     def _compute_and_log_metrics(self, dataloader_label: str, metrics: Dict[str, Metric]):
-        """Computes metrics, logs the results, and updates the state with the deep-copied metrics.
+        """Computes metrics, logs the results, and updates the state with the metrics.
 
         Args:
             dataloader_label (str): The dataloader label.

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2245,8 +2245,6 @@ class Trainer:
             dataloader_label (str): The dataloader label.
             metrics (Dict[str, Metric]): The metrics to compute.
         """
-        metrics = deepcopy(metrics)
-
         # log computed metrics
         computed_metrics = {}
         for metric_name, metric in metrics.items():


### PR DESCRIPTION
# What does this PR do?

This PR removes the deep copy of the `metrics: Dict[str, Metric]` object in the function `_compute_and_log_metrics`.

This function does the following:
- Copy of the metrics (using `copy.deepcopy`)
- Computation of the values of the metrics on the copy

It is called 3 times in `composer.trainer.Trainer`:
- [At every batch in the training loop](https://github.com/mosaicml/composer/blob/dev/composer/trainer/trainer.py#L2454) to compute the metrics on this batch, and [at the end of the epoch](https://github.com/mosaicml/composer/blob/dev/composer/trainer/trainer.py#L2490)
- [At the end of the evaluation loop](https://github.com/mosaicml/composer/blob/dev/composer/trainer/trainer.py#L3417) to compute the metrics on the evaluation dataset

I don't see the need for copying the metrics before calling metric.compute(). In particular, the metrics are reset with metric.reset() at the start of the training on each batch, and at the start of the evaluation loop, making this copy useless. Is there a specific reason I am missing?

# What issue(s) does this change relate to?

Related to issue #3153 describing that copying the metrics results in a memory leak in a specific use-case I'm working on.

# Before submitting
- [X] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [X] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [X] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [X] Did you run the tests locally to make sure they pass?
- [X] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))