### PR TITLE
Shashank/fix seq parallel eval

### DIFF
--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -94,6 +94,8 @@ class Evaluator:
         self._eval_interval = None
         self.eval_interval = eval_interval
         self.auto_microbatching = _is_auto_microbatching(device_eval_microbatch_size)
+        if self.auto_microbatching and hasattr(self.dataloader, 'seq_parallel_world_size'):
+            raise ValueError('`device_eval_microbatch_size="auto"` is not compatible with sequence parallelism.')
         self.device_eval_microbatch_size = _get_initial_device_eval_microbatch_size(
             device_eval_microbatch_size,
             self.auto_microbatching,
@@ -177,7 +179,7 @@ def _get_initial_device_eval_microbatch_size(
                     ),
                 ) from e
         return batch_size
-    elif isinstance(device_eval_microbatch_size, int):
+    elif isinstance(device_eval_microbatch_size, Union[int, float]):
         return device_eval_microbatch_size
     else:
         raise ValueError("device_eval_microbatch_size must be an int or ``'auto'``")

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -411,7 +411,7 @@ def _validate_evaluator(evaluator: Evaluator, device: Device):
         'seq_parallel_world_size',
     ) and evaluator.dataloader.seq_parallel_world_size > 1 and evaluator.dataloader.device_eval_batch_size * evaluator.dataloader.seq_parallel_world_size != 1:  # type: ignore
         raise ValueError(
-            f'Sequence parallelism requires a microbatch size of 1 distributed over the sequence parallel group.',
+            'Sequence parallelism requires a microbatch size of 1 distributed over the sequence parallel group.',
         )
 
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1449,6 +1449,7 @@ class Trainer:
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in eval_dataloader
             ]
+
             # match metric names to model metrics
             self.state.eval_metrics = {
                 evaluator.label: _filter_metrics(eval_metrics, evaluator.metric_names) for evaluator in evaluators

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1071,6 +1071,7 @@ class Trainer:
         # compile config for PyTorch 2.0 or higher
         compile_config: Optional[Dict[str, Any]] = None,
     ):
+
         self.auto_log_hparams = auto_log_hparams
         self.python_log_level = python_log_level
         if self.python_log_level is not None:
@@ -1449,7 +1450,6 @@ class Trainer:
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in eval_dataloader
             ]
-
             # match metric names to model metrics
             self.state.eval_metrics = {
                 evaluator.label: _filter_metrics(eval_metrics, evaluator.metric_names) for evaluator in evaluators

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -409,9 +409,9 @@ def _validate_evaluator(evaluator: Evaluator, device: Device):
     if hasattr(
         evaluator.dataloader,
         'seq_parallel_world_size',
-    ) and evaluator.dataloader.seq_parallel_world_size > 1 and evaluator.dataloader.dataloader.batch_size * evaluator.dataloader.seq_parallel_world_size != 1:  # type: ignore
+    ) and evaluator.dataloader.seq_parallel_world_size > 1 and evaluator.dataloader.device_eval_batch_size * evaluator.dataloader.seq_parallel_world_size != 1:  # type: ignore
         raise ValueError(
-            f'Sequence parallelism requires a microbatch size of 1 distributed over the sequence parallel group. {evaluator.dataloader.dataloader.batch_size=}, {evaluator.dataloader.seq_parallel_world_size=}',
+            f'Sequence parallelism requires a microbatch size of 1 distributed over the sequence parallel group.',
         )
 
 
@@ -1071,13 +1071,6 @@ class Trainer:
         # compile config for PyTorch 2.0 or higher
         compile_config: Optional[Dict[str, Any]] = None,
     ):
-
-        for evaluator in eval_dataloader:
-            print(f'{evaluator=}')
-            print(f'{evaluator.dataloader=}')
-            print(f'{evaluator.dataloader.dataloader=}')
-            print(f'{evaluator.dataloader.dataloader.batch_size=}')
-
         self.auto_log_hparams = auto_log_hparams
         self.python_log_level = python_log_level
         if self.python_log_level is not None:
@@ -1456,11 +1449,7 @@ class Trainer:
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in eval_dataloader
             ]
-            for evaluator in eval_dataloader:
-                print(f'{evaluator=}')
-                print(f'{evaluator.dataloader=}')
-                print(f'{evaluator.dataloader.dataloader=}')
-                print(f'{evaluator.dataloader.dataloader.batch_size=}')
+
             # match metric names to model metrics
             self.state.eval_metrics = {
                 evaluator.label: _filter_metrics(eval_metrics, evaluator.metric_names) for evaluator in evaluators

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1450,6 +1450,11 @@ class Trainer:
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in eval_dataloader
             ]
+            for evaluator in eval_dataloader:
+                print(f'{evaluator=}')
+                print(f'{evaluator.dataloader=}')
+                print(f'{evaluator.dataloader.dataloader=}')
+                print(f'{evaluator.dataloader.dataloader.batch_size=}')
             # match metric names to model metrics
             self.state.eval_metrics = {
                 evaluator.label: _filter_metrics(eval_metrics, evaluator.metric_names) for evaluator in evaluators

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1449,7 +1449,6 @@ class Trainer:
             evaluators = [
                 ensure_evaluator(evaluator, default_metric_names=model_metric_names) for evaluator in eval_dataloader
             ]
-
             # match metric names to model metrics
             self.state.eval_metrics = {
                 evaluator.label: _filter_metrics(eval_metrics, evaluator.metric_names) for evaluator in evaluators

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1072,6 +1072,12 @@ class Trainer:
         compile_config: Optional[Dict[str, Any]] = None,
     ):
 
+        for evaluator in eval_dataloader:
+            print(f'{evaluator=}')
+            print(f'{evaluator.dataloader=}')
+            print(f'{evaluator.dataloader.dataloader=}')
+            print(f'{evaluator.dataloader.dataloader.batch_size=}')
+
         self.auto_log_hparams = auto_log_hparams
         self.python_log_level = python_log_level
         if self.python_log_level is not None:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -409,7 +409,7 @@ def _validate_evaluator(evaluator: Evaluator, device: Device):
     if hasattr(
         evaluator.dataloader,
         'seq_parallel_world_size',
-    ) and evaluator.dataloader.seq_parallel_world_size > 1 and evaluator.dataloader.batch_size * evaluator.dataloader.seq_parallel_world_size != 1:  # type: ignore
+    ) and evaluator.dataloader.seq_parallel_world_size > 1 and evaluator.dataloader.dataloader.batch_size * evaluator.dataloader.seq_parallel_world_size != 1:  # type: ignore
         raise ValueError(
             'Sequence parallelism requires a microbatch size of 1 distributed over the sequence parallel group.',
         )

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -411,7 +411,7 @@ def _validate_evaluator(evaluator: Evaluator, device: Device):
         'seq_parallel_world_size',
     ) and evaluator.dataloader.seq_parallel_world_size > 1 and evaluator.dataloader.dataloader.batch_size * evaluator.dataloader.seq_parallel_world_size != 1:  # type: ignore
         raise ValueError(
-            'Sequence parallelism requires a microbatch size of 1 distributed over the sequence parallel group.',
+            f'Sequence parallelism requires a microbatch size of 1 distributed over the sequence parallel group. {evaluator.dataloader.dataloader.batch_size=}, {evaluator.dataloader.seq_parallel_world_size=}',
         )
 
 


### PR DESCRIPTION
# What does this PR do?

Fixes a bug where we were using the dataloader's batch size instead of device batch size in the error condition, which caues problems when using auto packing or any packing ratio > 1. Please also see https://github.com/mosaicml/llm-foundry/pull/1100 

Also adds a new error message for using auto microbatching with sequence parallelism when doing eval. 