### PR TITLE
Fix the FSDP.optim_state_dict_to_load OOM

### DIFF
--- a/composer/trainer/mosaic_fsdp.py
+++ b/composer/trainer/mosaic_fsdp.py
@@ -47,12 +47,27 @@ def patch_pytorch():
         from torch.distributed.fsdp import _runtime_utils
         _runtime_utils._validate_and_get_hybrid_shard_state = lambda *args, **kwargs: None
 
+        # Fix memory leak for FSDP.optim_state_dict_to_load
+        # https://github.com/pytorch/pytorch/issues/116553
+        from torch.distributed.fsdp import _optim_utils
+
+        from composer.trainer.mosaic_fsdp_utils import _shard_orig_param_state
+        _optim_utils._shard_orig_param_state = _shard_orig_param_state
+
+
     elif version.parse(torch.__version__) < version.parse('2.1.3'):
         # Monkey patch for torch < 2.1.3 ie torch == 2.1.1, 2.1.2
 
         # Allow 2D HSDP
         from torch.distributed.fsdp import _runtime_utils
         _runtime_utils._validate_and_get_hybrid_shard_state = lambda *args, **kwargs: None
+
+        # Fix memory leak for FSDP.optim_state_dict_to_load
+        # https://github.com/pytorch/pytorch/issues/116553
+        from torch.distributed.fsdp import _optim_utils
+
+        from composer.trainer.mosaic_fsdp_utils import _shard_orig_param_state
+        _optim_utils._shard_orig_param_state = _shard_orig_param_state
 
     elif version.parse(torch.__version__) < version.parse('2.2.1'):
         # Monkey patch for torch < 2.2.1 ie torch == 2.2.0
@@ -61,9 +76,22 @@ def patch_pytorch():
         from torch.distributed.fsdp import _runtime_utils
         _runtime_utils._validate_and_get_hybrid_shard_state = lambda *args, **kwargs: None
 
+        # Fix memory leak for FSDP.optim_state_dict_to_load
+        # https://github.com/pytorch/pytorch/issues/116553
+        from torch.distributed.fsdp import _optim_utils
+
+        from composer.trainer.mosaic_fsdp_utils import _shard_orig_param_state
+        _optim_utils._shard_orig_param_state = _shard_orig_param_state
+
     elif version.parse(torch.__version__) < version.parse('2.2.9'):
         # Monkey patch for torch < 2.3.0 ie torch == 2.2.1/2.2.2 currently
-        pass
+
+        # Fix memory leak for FSDP.optim_state_dict_to_load
+        # https://github.com/pytorch/pytorch/issues/116553
+        from torch.distributed.fsdp import _optim_utils
+
+        from composer.trainer.mosaic_fsdp_utils import _shard_orig_param_state
+        _optim_utils._shard_orig_param_state = _shard_orig_param_state
 
     elif version.parse(torch.__version__) < version.parse('2.3.1'):
         # Monkey patch for torch < 2.3.1 ie torch == 2.3.0

--- a/composer/trainer/mosaic_fsdp.py
+++ b/composer/trainer/mosaic_fsdp.py
@@ -47,14 +47,6 @@ def patch_pytorch():
         from torch.distributed.fsdp import _runtime_utils
         _runtime_utils._validate_and_get_hybrid_shard_state = lambda *args, **kwargs: None
 
-        # Fix memory leak for FSDP.optim_state_dict_to_load
-        # https://github.com/pytorch/pytorch/issues/116553
-        from torch.distributed.fsdp import _optim_utils
-
-        from composer.trainer.mosaic_fsdp_utils import _shard_orig_param_state
-        _optim_utils._shard_orig_param_state = _shard_orig_param_state
-
-
     elif version.parse(torch.__version__) < version.parse('2.1.3'):
         # Monkey patch for torch < 2.1.3 ie torch == 2.1.1, 2.1.2
 
@@ -62,26 +54,12 @@ def patch_pytorch():
         from torch.distributed.fsdp import _runtime_utils
         _runtime_utils._validate_and_get_hybrid_shard_state = lambda *args, **kwargs: None
 
-        # Fix memory leak for FSDP.optim_state_dict_to_load
-        # https://github.com/pytorch/pytorch/issues/116553
-        from torch.distributed.fsdp import _optim_utils
-
-        from composer.trainer.mosaic_fsdp_utils import _shard_orig_param_state
-        _optim_utils._shard_orig_param_state = _shard_orig_param_state
-
     elif version.parse(torch.__version__) < version.parse('2.2.1'):
         # Monkey patch for torch < 2.2.1 ie torch == 2.2.0
 
         # Allow 2D HSDP
         from torch.distributed.fsdp import _runtime_utils
         _runtime_utils._validate_and_get_hybrid_shard_state = lambda *args, **kwargs: None
-
-        # Fix memory leak for FSDP.optim_state_dict_to_load
-        # https://github.com/pytorch/pytorch/issues/116553
-        from torch.distributed.fsdp import _optim_utils
-
-        from composer.trainer.mosaic_fsdp_utils import _shard_orig_param_state
-        _optim_utils._shard_orig_param_state = _shard_orig_param_state
 
     elif version.parse(torch.__version__) < version.parse('2.2.9'):
         # Monkey patch for torch < 2.3.0 ie torch == 2.2.1/2.2.2 currently

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -1134,6 +1134,7 @@ if version.parse(torch.__version__) >= version.parse('2.1.0') and version.parse(
     else:
         from torch.distributed.fsdp._shard_utils import _gather_state_dict
 
+    @no_type_check
     def _shard_orig_param_state(
         fsdp_param_info: FSDPParamInfo,
         fqn: str,

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -1165,6 +1165,8 @@ if version.parse(torch.__version__) >= version.parse('2.1.0') and version.parse(
                 and value.dim() > 0
                 and fsdp_state.sharding_strategy != ShardingStrategy.NO_SHARD
             ):
+                # This clone() is the patch to fix the OOM
+                # https://github.com/pytorch/pytorch/pull/117261
                 value = value.flatten()[intra_param_start_idx : intra_param_end_idx + 1].clone()  # type: ignore[operator]
             new_optim_state[state_name] = value
         return new_optim_state

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -1129,7 +1129,11 @@ if version.parse(torch.__version__) >= version.parse('2.1.0') and version.parse(
         torch.__version__,) < version.parse('2.2.9'):
 
     from torch.distributed.fsdp._optim_utils import FSDPParamInfo
-    from torch.distributed._state_dict_utils import _gather_state_dict
+    if version.parse(torch.__version__) >= version.parse('2.2.0'):
+        from torch.distributed.checkpoint._state_dict_utils import _gather_state_dict
+    else:
+        from torch.distributed.fsdp._shard_utils import _gather_state_dict
+
     def _shard_orig_param_state(
         fsdp_param_info: FSDPParamInfo,
         fqn: str,

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -1124,3 +1124,42 @@ if version.parse(torch.__version__) > version.parse('2.2.9') and version.parse(
         if isinstance(b, DTensor):
             b = b._local_tensor
         return a.untyped_storage().data_ptr() == b.untyped_storage().data_ptr()
+
+if version.parse(torch.__version__) >= version.parse('2.1.0') and version.parse(
+        torch.__version__,) < version.parse('2.2.9'):
+
+    from torch.distributed.fsdp._optim_utils import FSDPParamInfo
+    from torch.distributed._state_dict_utils import _gather_state_dict
+    def _shard_orig_param_state(
+        fsdp_param_info: FSDPParamInfo,
+        fqn: str,
+        optim_state: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Shard the optimizer state for the original parameter with the name ``fqn``.
+        This API should only be used when ``use_orig_params`` is True.
+        """
+        if not optim_state:
+            return {}
+        fsdp_state = fsdp_param_info.state
+        flat_param = fsdp_param_info.handle.flat_param
+        param_idx = fsdp_param_info.param_indices[fqn]
+        shard_param_info = flat_param._shard_param_infos[param_idx]  # type: ignore[attr-defined]
+        optim_state = _gather_state_dict(
+            optim_state, pg=fsdp_state.process_group, device=fsdp_state.compute_device
+        )
+        if not shard_param_info.in_shard:
+            return {}
+        # Flatten and shard the state.
+        new_optim_state: Dict[str, Any] = {}
+        intra_param_start_idx = shard_param_info.intra_param_start_idx
+        intra_param_end_idx = shard_param_info.intra_param_end_idx
+        for state_name, value in optim_state.items():
+            if (
+                torch.is_tensor(value)
+                and value.dim() > 0
+                and fsdp_state.sharding_strategy != ShardingStrategy.NO_SHARD
+            ):
+                value = value.flatten()[intra_param_start_idx : intra_param_end_idx + 1].clone()  # type: ignore[operator]
+            new_optim_state[state_name] = value
+        return new_optim_state

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -1148,7 +1148,7 @@ if version.parse(torch.__version__) >= version.parse('2.2.1') and version.parse(
         param_idx = fsdp_param_info.param_indices[fqn]
         shard_param_info = flat_param._shard_param_infos[param_idx]  # type: ignore[attr-defined]
         optim_state = _gather_state_dict(
-            optim_state, pg=fsdp_state.process_group, device=fsdp_state.compute_device
+            optim_state, pg=fsdp_state.process_group, device=fsdp_state.compute_device,
         )
         if not shard_param_info.in_shard:
             return {}

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -1137,10 +1137,6 @@ if version.parse(torch.__version__) >= version.parse('2.2.1') and version.parse(
         fqn: str,
         optim_state: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """
-        Shard the optimizer state for the original parameter with the name ``fqn``.
-        This API should only be used when ``use_orig_params`` is True.
-        """
         if not optim_state:
             return {}
         fsdp_state = fsdp_param_info.state

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -1125,14 +1125,11 @@ if version.parse(torch.__version__) > version.parse('2.2.9') and version.parse(
             b = b._local_tensor
         return a.untyped_storage().data_ptr() == b.untyped_storage().data_ptr()
 
-if version.parse(torch.__version__) >= version.parse('2.1.0') and version.parse(
+if version.parse(torch.__version__) >= version.parse('2.2.1') and version.parse(
         torch.__version__,) < version.parse('2.2.9'):
 
     from torch.distributed.fsdp._optim_utils import FSDPParamInfo
-    if version.parse(torch.__version__) >= version.parse('2.2.0'):
-        from torch.distributed.checkpoint._state_dict_utils import _gather_state_dict
-    else:
-        from torch.distributed.fsdp._shard_utils import _gather_state_dict
+    from torch.distributed.checkpoint._state_dict_utils import _gather_state_dict
 
     @no_type_check
     def _shard_orig_param_state(

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2376,7 +2376,6 @@ class Trainer:
             raise RuntimeError('max_duration must be specified when initializing the Trainer')
 
         log.debug('Starting training loop')
-
         while self.state.timestamp < self.state.max_duration:
             if int(self.state.timestamp.epoch_in_iteration) == 0 and int(self.state.timestamp.batch_in_epoch) == 0:
                 self.engine.run_event(Event.ITERATION_START)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -119,6 +119,7 @@ from composer.utils import (
     parse_uri,
     partial_format,
     reproducibility,
+    OCIObjectStore,
 )
 from composer.utils.misc import is_model_deepspeed
 from composer.utils.object_store.mlflow_object_store import MLFLOW_EXPERIMENT_ID_FORMAT_KEY, MLFLOW_RUN_ID_FORMAT_KEY

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -119,7 +119,6 @@ from composer.utils import (
     parse_uri,
     partial_format,
     reproducibility,
-    OCIObjectStore,
 )
 from composer.utils.misc import is_model_deepspeed
 from composer.utils.object_store.mlflow_object_store import MLFLOW_EXPERIMENT_ID_FORMAT_KEY, MLFLOW_RUN_ID_FORMAT_KEY
@@ -1548,13 +1547,6 @@ class Trainer:
         # If using FSDP, the model must be wrapped and then loaded unless loading a monolith
         # checkpoint on rank 0 only, in which case the model be loaded before it is wrapped.
 
-        log.info(f"bigning debug manualy record memory")
-        torch.cuda.memory._record_memory_history(
-            True,  # type: ignore
-            trace_alloc_max_entries=100000,
-            trace_alloc_record_context=True,
-        )
-
         # FSDP wrap if not using monolith checkpoint on rank 0 only
         if self.state.fsdp_config is not None and fsdp_auto_wrap and not self.state.load_fsdp_monolith_rank0_only:
             with reproducibility.seed_context(self.state.rank_zero_seed):
@@ -2385,15 +2377,6 @@ class Trainer:
 
         log.debug('Starting training loop')
 
-		# bigning debug
-        rank = torch.distributed.get_rank()
-        torch.cuda.memory._dump_snapshot(f"rank_{rank}.pickle")
-        log.info(f"bigning debug upload pickle for rank {rank}")
-
-        object_store = OCIObjectStore(bucket='ning-test', prefix='autoresume_trace/')
-        object_store.upload_object(object_name=f"memory_trace/after_fix_rank_{rank}.pickle", filename=f"rank_{rank}.pickle")
-        log.info(f"bigning debug upload pickle for rank {rank} done")
-        return
         while self.state.timestamp < self.state.max_duration:
             if int(self.state.timestamp.epoch_in_iteration) == 0 and int(self.state.timestamp.batch_in_epoch) == 0:
                 self.engine.run_event(Event.ITERATION_START)


### PR DESCRIPTION
# What does this PR do?

Fix the `FSDP.optim_state_dict_to_load` OOM, it's already in pytorch>=2.3.0 https://github.com/pytorch/pytorch/pull/117261

# test
1. **before** the change, it oom in the first forward dbrx-dense-20b-debug-autoresume-AdiVZi

here is the memory before the forward:
![image](https://github.com/mosaicml/composer/assets/2545820/1e244e0c-ff1e-452b-83d5-b7e35c7f4ac5)


2. **after** the change, it can train `dbrx-dense-20b-debug-autoresume-3QVblX`
<img width="2392" alt="image" src="https://github.com/mosaicml/composer/assets/2545820/7624d489-3755-444a-ad0a-aa3b2a17ff0b">
