### PR TITLE
Add version tag to local builds with git

### DIFF
--- a/composer/_version.py
+++ b/composer/_version.py
@@ -3,4 +3,16 @@
 
 """The Composer Version."""
 
+import os
+import subprocess
+
 __version__ = '0.21.2'
+
+# Add the git sha to the version if available
+cwd = os.path.dirname(os.path.abspath(__file__))
+sha = None
+try:
+    sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=cwd).decode('ascii').strip()
+    __version__ += '+' + sha[:7]
+except Exception:
+    pass

--- a/composer/_version.py
+++ b/composer/_version.py
@@ -3,13 +3,15 @@
 
 """The Composer Version."""
 
+import inspect
 import os
 import subprocess
 
 __version__ = '0.21.2'
 
 # Add the git sha to the version if available
-cwd = os.path.dirname(os.path.abspath(__file__))
+file_path = inspect.getfile(lambda: None)  # more robust than __file__
+cwd = os.path.dirname(file_path)
 sha = None
 try:
     sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=cwd).decode('ascii').strip()

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import os
 import site
 import sys
 import textwrap
+import subprocess
 
 import setuptools
 from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@
 
 import os
 import site
+import subprocess
 import sys
 import textwrap
-import subprocess
 
 import setuptools
 from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@
 
 import os
 import site
-import subprocess
 import sys
 import textwrap
 


### PR DESCRIPTION
# What does this PR do?

Add version tag to local builds

```
❯ python
Python 3.10.12 (main, Jun 20 2023, 19:43:52) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import composer
composer.__version>>> composer.__version__
'0.21.2+05e568b'
>>> quit()
```