### PR TITLE
Load optimizer separately for all current torch versions

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -625,8 +625,10 @@ def load_sharded_checkpoint(
                 state_dict: Dict[str, Any] = {'state': {'model': state.get_model_state_dict()}}
             else:
                 cur_state_dict = state.state_dict()
-                # For older versions of torch, we load optimizer separately.
-                if version.parse(torch.__version__) < version.parse('2.2.9'):
+                # For all currently in-use versions of torch, we load optimizer separately.
+                # Torch recommends loading optimizer separately, see:
+                # See https://github.com/pytorch/pytorch/blob/f9fce110af428a600e597291a0ab80e43dc39e93/torch/distributed/checkpoint/optimizer.py#L215
+                if version.parse(torch.__version__) < version.parse('2.5.0'):
                     cur_state_dict.pop('optimizers')
                 num_rng_ranks = _get_num_ranks_that_saved_rng(storage_reader.read_metadata())
                 state_dict: Dict[str, Any] = {
@@ -668,8 +670,8 @@ def load_sharded_checkpoint(
             )
 
             # 2. Optionally load optimizer
-            # if we are using later than 2.2.9 then optimizer will already be loaded
-            if version.parse(torch.__version__) < version.parse('2.2.9') and not load_weights_only:
+            # For current versions of torch, we load optimizer separately.
+            if version.parse(torch.__version__) < version.parse('2.5.0') and not load_weights_only:
                 optim_state = load_sharded_optimizer_state_dict(
                     model_state_dict=state.state_dict()['model'],
                     optimizer_key='optimizers',
@@ -1067,12 +1069,12 @@ def _save_checkpoint(
         # Only rank 0 saves RNG
         if dist.get_global_rank() > 0:
             state_dict.pop('rng')
-        # To load optimizer states with 2.0 <= torch < 2.2.9 , the optimizer state must be at the top
+        # To load optimizer states with 2.0 <= torch < 2.5.0 , the optimizer state must be at the top
         # level of the state dict because the load_sharded_optimizer_state_dict function
         # requires a top level state dict key for the optimizer.
         # See https://github.com/pytorch/pytorch/blob/v2.0.1/torch/distributed/checkpoint/optimizer.py#L271
         # for more info.
-        if version.parse(torch.__version__) < version.parse('2.2.9'):
+        if version.parse(torch.__version__) < version.parse('2.5.0'):
             state_dict['optimizers'] = state_dict['state'].pop('optimizers')
 
     log.debug('State dict created.')

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -1069,7 +1069,8 @@ def _save_checkpoint(
         # requires a top level state dict key for the optimizer.
         # See https://github.com/pytorch/pytorch/blob/v2.0.1/torch/distributed/checkpoint/optimizer.py#L271
         # for more info.
-        state_dict['optimizers'] = state_dict['state'].pop('optimizers')
+        # TODO: test if commenting this out works or not
+        #state_dict['optimizers'] = state_dict['state'].pop('optimizers')
 
     log.debug('State dict created.')
     dirname = os.path.dirname(save_filename)


### PR DESCRIPTION
# What does this PR do?

Addresses a bug when loading optimizer state on resumption with torch >= 2.3.0, with `use_orig_params: False` and activation checkpointing. We currently do not load optimizer state separately when loading checkpoint for torch >=2.3.0, but according to torch's recommendation (see obscure comment [here](https://github.com/pytorch/pytorch/blob/f9fce110af428a600e597291a0ab80e43dc39e93/torch/distributed/checkpoint/optimizer.py#L215)), we should continue to load the optimizer state separately. This PR does that.

Filed an issue with PyTorch [here](https://github.com/pytorch/pytorch/issues/124546).

See Jira issue [here](https://databricks.atlassian.net/browse/GRT-2843).

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
