### PR TITLE
Fix token logging

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2539,7 +2539,7 @@ class Trainer:
             'time/batch_in_epoch': self.state.timestamp.batch_in_epoch.value,
             'time/sample_in_epoch': self.state.timestamp.sample_in_epoch.value,
         })
-        if self.state.previous_timestamp is not None and self.state.timestamp.token.value - self.state.previous_timestamp.token.value > 0:
+        if self.state.timestamp.token.value > 0:
             self.logger.log_metrics({'time/token': self.state.timestamp.token.value})
             self.logger.log_metrics({'time/token_in_epoch': self.state.timestamp.token_in_epoch.value})
 


### PR DESCRIPTION
# What does this PR do?

Fix token logging. Previously, if max duration was set in epochs, the previous timestamp would also be set to have the same token value as current timestamp (it has a different epoch value). This meant the final token value would not be logged.

Instead, we just log the token value as long as non-zero number of tokens have been logged, as is consistent with logging in batch loop

Before: 0-8gpu-baseline-1zCALJ
```
mosaicml/time/batch                            1
mosaicml/time/batch_in_epoch                   0
mosaicml/time/epoch                            1
mosaicml/time/remaining_estimate_unit          hours
mosaicml/time/sample                           8
mosaicml/time/sample_in_epoch                  0
mosaicml/time/token                            0
mosaicml/time/token_in_epoch                   0
```

After: 0-8gpu-baseline-MFct2b
```
mosaicml/time/batch                            1
mosaicml/time/batch_in_epoch                   0
mosaicml/time/epoch                            1
mosaicml/time/remaining_estimate_unit          hours
mosaicml/time/sample                           8
mosaicml/time/sample_in_epoch                  0
mosaicml/time/token                            32768
mosaicml/time/token_in_epoch                   0
```