### PR TITLE
Create new Mlflow run by default and introduce `run_group`

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -181,7 +181,7 @@ class MLFlowLogger(LoggerDestination):
             )
             self._run_id = new_run.info.run_id
 
-        tags = self.tags
+        tags = self.tags or {}
         if self.run_group:
             tags['run_group'] = self.run_group
         mlflow.start_run(

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -62,7 +62,7 @@ class MLFlowLogger(LoggerDestination):
         ignore_hyperparameters (List[str], optional): A list of glob patterns for hyperparameters to ignore when logging. (default: ``None``)
         run_group (str, optional): A string to group runs together. (default: ``None``)
         resume (bool, optional): If ``True``, Composer will search for an existing run tagged with
-            the `run_name` and resume it, if no existing run is found, a new run will be created.
+            the `run_name` and resume it. If no existing run is found, a new run will be created.
             If ``False``, Composer will create a new run. (default: ``False``)
     """
 

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -62,8 +62,8 @@ class MLFlowLogger(LoggerDestination):
         ignore_hyperparameters (List[str], optional): A list of glob patterns for hyperparameters to ignore when logging. (default: ``None``)
         run_group (str, optional): A string to group runs together. (default: ``None``)
         resume (bool, optional): If ``True``, Composer will search for an existing run tagged with
-            the `run_name` and resume it. If ``False``, Composer will create a new run. (default:
-            ``False``)
+            the `run_name` and resume it, if no existing run is found, a new run will be created.
+            If ``False``, Composer will create a new run. (default: ``False``)
     """
 
     def __init__(
@@ -167,7 +167,12 @@ class MLFlowLogger(LoggerDestination):
 
             if len(existing_runs) > 0:
                 self._run_id = existing_runs[0].info.run_id
+                log.debug(f'Resuming mlflow run with run id: {self._run_id}')
             else:
+                log.debug(
+                    'Creating a new mlflow run as `resume` was set to True but no previous run was '
+                    'found.',
+                )
                 new_run = self._mlflow_client.create_run(
                     experiment_id=self._experiment_id,
                     run_name=self.run_name,

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -100,7 +100,7 @@ class MLFlowLogger(LoggerDestination):
         self.experiment_name = experiment_name
         self.run_name = run_name
         self.run_group = run_group
-        self.tags = tags
+        self.tags = tags or {}
         self.model_registry_prefix = model_registry_prefix
         self.model_registry_uri = model_registry_uri
         self.synchronous = synchronous
@@ -207,8 +207,7 @@ class MLFlowLogger(LoggerDestination):
         if self.run_name is None:
             self.run_name = state.run_name
 
-        # Store the Composer run name in the MLFlow run tags so it can be retrieved for autoresume.
-        self.tags = self.tags or {}
+        # Store the Composer run name in the MLFlow run tags so it can be retrieved for autoresume
         self.tags['run_name'] = os.environ.get('RUN_NAME', state.run_name)
 
         # Adjust name and group based on `rank_zero_only`.

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -796,6 +796,7 @@ class TestMlflowMetrics:
         metric_file = file_path / Path('metrics') / Path('loss/train/total')
         assert not os.path.exists(metric_file)
 
+
 def test_mlflow_resume_run(tmp_path):
     mlflow = pytest.importorskip('mlflow')
 

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -185,7 +185,7 @@ def test_mlflow_experiment_init_existing_composer_run(monkeypatch):
     mock_search_runs = MagicMock(return_value=[MagicMock(info=MagicMock(run_id=existing_id))])
     monkeypatch.setattr(mlflow, 'search_runs', mock_search_runs)
 
-    test_logger = MLFlowLogger()
+    test_logger = MLFlowLogger(resume=True)
     test_logger.init(state=mock_state, logger=MagicMock())
     assert test_logger._run_id == existing_id
 
@@ -872,6 +872,7 @@ def test_mlflow_resume_run(tmp_path):
 
     assert first_run.info.run_id != non_resumed_run.info.run_id
 
+
 def test_mlflow_run_group(tmp_path):
     mlflow = pytest.importorskip('mlflow')
 
@@ -886,7 +887,7 @@ def test_mlflow_run_group(tmp_path):
         experiment_name=experiment_name,
         log_system_metrics=True,
         run_name='test_run',
-        run_group="test_group",
+        run_group='test_group',
     )
     logger1.init(state=mock_state, logger=mock_logger)
     first_run = mlflow.active_run()
@@ -898,7 +899,7 @@ def test_mlflow_run_group(tmp_path):
         experiment_name=experiment_name,
         log_system_metrics=True,
         run_name='test_run',
-        run_group="test_group",
+        run_group='test_group',
     )
     logger2.init(state=mock_state, logger=mock_logger)
     second_run = mlflow.active_run()
@@ -906,8 +907,8 @@ def test_mlflow_run_group(tmp_path):
 
     # Fetch runs with the `run_group` tag, we should see the two runs created above get fetched.
     runs_with_group_tag = mlflow.search_runs(
-        experiment_ids=[experiment_id], 
-        filter_string=f"tags.run_group = 'test_group'",
+        experiment_ids=[experiment_id],
+        filter_string=f'tags.run_group = "test_group"',
     )
     fetched_run_ids = set(runs_with_group_tag.run_id.tolist())
     assert fetched_run_ids == {first_run.info.run_id, second_run.info.run_id}


### PR DESCRIPTION
# What does this PR do?

Create new Mlflow run by default and introduce `run_group`. Currently the default behavior is to resume the Mlflow run by searching for existing run with the same name. As we discussed we should make the default behavior start a new run. Additionally to mirror the `group` in wandb, we are introducing the `run_group` tag.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
