### PR TITLE
Add a torch.cuda.empty_cache() in utils.save_checkpoint

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -14,6 +14,8 @@ import textwrap
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
+import torch.cuda
+
 from composer.core import Callback, Event, State, Time, Timestamp
 from composer.loggers import Logger, MLFlowLogger
 from composer.utils import (
@@ -412,6 +414,9 @@ class CheckpointSaver(Callback):  # noqa: D101
                 self.all_saved_checkpoints_to_timestamp[save_filename] = load_timestamp
 
     def _save_checkpoint(self, state: State, logger: Logger):
+        # Clear the cache in case we are near the memory limit to give some space for NCCL.
+        torch.cuda.empty_cache()
+
         self.last_checkpoint_batch = state.timestamp.batch
 
         is_deepspeed = is_model_deepspeed(state.model)

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -14,8 +14,6 @@ import textwrap
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
-import torch.cuda
-
 from composer.core import Callback, Event, State, Time, Timestamp
 from composer.loggers import Logger, MLFlowLogger
 from composer.utils import (
@@ -414,9 +412,6 @@ class CheckpointSaver(Callback):  # noqa: D101
                 self.all_saved_checkpoints_to_timestamp[save_filename] = load_timestamp
 
     def _save_checkpoint(self, state: State, logger: Logger):
-        # Clear the cache in case we are near the memory limit to give some space for NCCL.
-        torch.cuda.empty_cache()
-
         self.last_checkpoint_batch = state.timestamp.batch
 
         is_deepspeed = is_model_deepspeed(state.model)

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -1192,6 +1192,8 @@ def save_checkpoint(
     weights_only: bool = False,
     ignore_keys: Optional[Union[List[str], Callable[[Dict], None]]] = None,
 ) -> Union[str, None]:  # noqa: D103
+    # Clear the cache in case we are near the memory limit to give some space for NCCL.
+    torch.cuda.empty_cache()
     save_filename = get_save_filename(state, filename)
     return _save_checkpoint(state, save_filename, weights_only=weights_only, ignore_keys=ignore_keys)
 


### PR DESCRIPTION
# What does this PR do?

Adds a empty_cache() to clear the cache right before checkpointing. Some amount of memory is used by NCCL during checkpointing and if we are operating near the total memory of the GPU, empty_cache() can help clear unused memory and allow checkpointing to succeed.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
