### PR TITLE
Fix torch 2.3 GPU tests

### DIFF
--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -95,10 +95,6 @@ def test_fsdp_device_initialization(
 @pytest.mark.parametrize('device', _INIT_DEVICES)
 @world_size(2)
 @pytest.mark.gpu
-@pytest.mark.skipif(
-    version.parse(torch.__version__) < version.parse('2.1.0'),
-    reason='This has only been fixed and tested starting with torch 2.1.0',
-)
 def test_fsdp_inits_params_once(model: ComposerClassifier, device: str, world_size: int, expected_param_inits: int):
     resolved_device = device
     if device == 'mixed':
@@ -132,7 +128,7 @@ def test_fsdp_inits_params_once(model: ComposerClassifier, device: str, world_si
         train_dataloader=dataloader,
         fsdp_config={
             'mixed_precision': 'PURE',
-            'sharding_strategy': 'NO_SHARD',
+            'sharding_strategy': 'SHARD_GRAD_OP',
             'sync_module_states': True if device == 'mixed' else False,
         },
         max_duration='3ba',
@@ -173,7 +169,7 @@ def test_fsdp_meta_initialization_none(model: ComposerClassifier, mixed_precisio
         train_dataloader=dataloader,
         fsdp_config={
             'mixed_precision': mixed_precision,
-            'sharding_strategy': 'NO_SHARD',
+            'sharding_strategy': 'SHARD_GRAD_OP',
         },
         max_duration='3ba',
     )
@@ -235,12 +231,12 @@ def test_fsdp_process_group(world_size: int):
 @pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.2.0'), reason='Device mesh requires Torch 2.2')
 @pytest.mark.parametrize(
     'sharding_strategy',
-    ['NO_SHARD', 'SHARD_GRAD_OP', 'FULL_SHARD', 'HYBRID_SHARD', '_HYBRID_SHARD_ZERO2'],
+    ['SHARD_GRAD_OP', 'FULL_SHARD', 'HYBRID_SHARD', '_HYBRID_SHARD_ZERO2'],
 )
 @pytest.mark.parametrize('device_mesh', [[2], [1, 2]])
 def test_wrong_size_device_mesh_error(world_size: int, sharding_strategy: str, device_mesh: list[int]):
     context = contextlib.nullcontext()
-    if sharding_strategy in ['NO_SHARD', 'SHARD_GRAD_OP', 'FULL_SHARD'] and len(device_mesh) != 1:
+    if sharding_strategy in ['SHARD_GRAD_OP', 'FULL_SHARD'] and len(device_mesh) != 1:
         context = pytest.raises(ValueError, match='.*requires a device mesh of size 1.*')
     if sharding_strategy in ['HYBRID_SHARD', '_HYBRID_SHARD_ZERO2'] and len(device_mesh) != 2:
         context = pytest.raises(ValueError, match='.*requires a device mesh of size 2.*')


### PR DESCRIPTION
# What does this PR do?

Fix torch 2.3 GPU tests
- Removes NO_SHARD in some tests (deprecated)