### PR TITLE
load_checkpoint defaults to strict weight match

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -388,7 +388,7 @@ def load_checkpoint(
     logger: Logger,
     object_store: Optional[Union[ObjectStore, LoggerDestination]] = None,
     load_weights_only: bool = False,
-    strict_model_weights: bool = False,
+    strict_model_weights: bool = True,
     progress_bar: bool = True,
     ignore_keys: Optional[Union[list[str], Callable[[dict], None]]] = None,
     exclude_algorithms: Optional[list[str]] = None,
@@ -440,7 +440,7 @@ def load_checkpoint(
         load_weights_only (bool, optional): Whether or not to only restore the model weights from the checkpoint without
             restoring the associated state. (default: ``False``)
         strict_model_weights (bool, optional): Whether or not to force that the checkpointed weights must exactly
-            match the model weights. (default: ``False``)
+            match the model weights. (default: ``True``)
         progress_bar (bool, optional): Whether or not to show a progress bar when downloading checkpoints.
             Ignored if the checkpoint is a local file path. (default: ``True``)
         ignore_keys (list[str] | (dict) -> None, optional): A list of paths for the ``state_dict`` of the checkpoint,


### PR DESCRIPTION
# What does this PR do?

Trainer has an argument `load_strict_model_weights` which defaults to `True`. However, the same argument in `load_checkpoint` defaults to `False`, whereas it should be consistent with the Trainer argument.