### PR TITLE
Add zero grad before optimizer state dict calls

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -924,6 +924,7 @@ class State(Serializable):
                 )
 
             optimizer = ensure_tuple(self.optimizers)[0]
+            optimizer.zero_grad(set_to_none=True)
             optim_state_dict = get_optimizer_state_dict(
                 model=self.model,
                 optimizers=optimizer,
@@ -1328,6 +1329,8 @@ class State(Serializable):
                 # errors) before discarding the output. Accordingly, we mock the state dict.
                 # See: https://github.com/pytorch/pytorch/issues/125177
                 optim_state_dict = MagicMock() if optim_state_dict is None else optim_state_dict
+                print('ZEROOOOOO')
+                optimizer.zero_grad(set_to_none=True)
                 set_optimizer_state_dict(
                     model=self.model,
                     optimizers=optimizer,

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -1329,7 +1329,6 @@ class State(Serializable):
                 # errors) before discarding the output. Accordingly, we mock the state dict.
                 # See: https://github.com/pytorch/pytorch/issues/125177
                 optim_state_dict = MagicMock() if optim_state_dict is None else optim_state_dict
-                print('ZEROOOOOO')
                 optimizer.zero_grad(set_to_none=True)
                 set_optimizer_state_dict(
                     model=self.model,


### PR DESCRIPTION
# What does this PR do?
The `get_optimizer_state_dict` and `set_optimizer_state_dict` calls require that `optimizer.state` has been initialized if there are grads. `optimizer.state` gets initialized on the first call to `step`. When using `GradScaler`, if there is an inf (i.e. scaling needs to happen), the `step` might get skipped. So we can end up with grads but `optimizer.state` not initialized if we train for 1 batch and don't actually take any steps due to grad scaling needing to happen.

This PR adds `zero_grad` calls before using the optimizer state dict functions. This should be safe because you don't call the Composer get/set optimizer state dict functions in the middle of an optimization step.

This should fix the currently failing daily tests post torch 2.3 upgrade.