### PR TITLE
Require 2 steps for GS object store 

### DIFF
--- a/tests/utils/object_store/test_gs_object_store.py
+++ b/tests/utils/object_store/test_gs_object_store.py
@@ -33,7 +33,7 @@ def test_gs_object_store_integration_json_auth(expected_use_gcs_sdk_val=True, cl
         train_dataloader=train_dataloader,
         save_folder='gs://mosaicml-internal-integration-testing/checkpoints/{run_name}',
         save_filename='test-model.pt',
-        max_duration='1ba',
+        max_duration='2ba',
     )
     run_name = trainer_save.state.run_name
     gcs_os = get_gcs_os_from_trainer(trainer_save)


### PR DESCRIPTION
# What does this PR do?

Require 2 steps for GS object store. Ensures optimizer step in case of all NaN on first step
