### PR TITLE
Make sharded checkpoint loading backwards-compatible

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -620,13 +620,21 @@ def load_sharded_checkpoint(
 
         # We need no_grad because we overwrite tensor values with set_() when we do elastic loading and we don't want the set_ op recorded in the computation graph.
         with torch.no_grad():
-            # 1. Load model and metadata first
+            # 1. Load metadata first for backwards compatability check
+            # We need to check if the "optimizers" is at the root of the state dict to determine
+            # how to load the optimizer state.
+            metadata = storage_reader.read_metadata()
+            # Retrieve all top-level keys of the metadata.
+            top_level_keys = [v[0] for v in metadata.planner_data.values()]
+            optimizers_at_root = 'optimizers' in top_level_keys
+
+            # 2. Load model and metadata
             if load_weights_only:
                 state_dict: Dict[str, Any] = {'state': {'model': state.get_model_state_dict()}}
             else:
                 cur_state_dict = state.state_dict()
-                # For older versions of torch, we load optimizer separately.
-                if version.parse(torch.__version__) < version.parse('2.2.3'):
+                # If 'optimizers' is at root-level, we load it separately.
+                if optimizers_at_root:
                     cur_state_dict.pop('optimizers')
                 num_rng_ranks = _get_num_ranks_that_saved_rng(storage_reader.read_metadata())
                 state_dict: Dict[str, Any] = {
@@ -661,9 +669,9 @@ def load_sharded_checkpoint(
                 algorithm_passes=algorithm_passes,
             )
 
-            # 2. Optionally load optimizer
-            # if we are using later than 2.2.3 then optimizer will already be loaded
-            if version.parse(torch.__version__) < version.parse('2.2.3') and not load_weights_only:
+            # 3. Optionally load optimizer
+            # If 'optimizers' was not at root-level, then it will already be loaded
+            if optimizers_at_root and not load_weights_only:
                 optim_state = load_sharded_optimizer_state_dict(
                     model_state_dict=state.state_dict()['model'],
                     optimizer_key='optimizers',

--- a/tests/utils/object_store/test_gs_object_store.py
+++ b/tests/utils/object_store/test_gs_object_store.py
@@ -10,9 +10,9 @@ from botocore.exceptions import ClientError
 from torch.utils.data import DataLoader
 
 from composer.loggers import RemoteUploaderDownloader
+from composer.optim import DecoupledSGDW
 from composer.trainer import Trainer
 from composer.utils import GCSObjectStore
-from composer.optim import DecoupledSGDW
 from tests.common import RandomClassificationDataset, SimpleModel
 
 
@@ -61,6 +61,7 @@ def test_gs_object_store_integration_json_auth(expected_use_gcs_sdk_val=True, cl
     trainer_load.close()
 
 
+@pytest.mark.gpu
 @pytest.mark.remote
 def test_gs_object_store_integration_hmac_auth():
     with mock.patch.dict(os.environ):


### PR DESCRIPTION
# What does this PR do?

Loads metadata before loading sharded checkpoint state to check if 'optimizers' is a root-level key. This is for backwards compatability with older torch/composer versions, where the recommended sharded checkpoint loading/saving required us to put 'optimizers' as a top-level key. With newer torch (>=2.3.0), we don't do this anymore, but we still need checkpoints to be backwards compatible.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
