### PR TITLE
Raise the daily test timeout

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -127,7 +127,7 @@ jobs:
       composer_package_name: ${{ matrix.composer_package_name }}
       container: ${{ matrix.container }}
       git_repo: mosaicml/composer
-      mcloud-timeout: 3600
+      mcloud-timeout: 5400
       name: ${{ matrix.name }}
       pip_deps: "[all]"
       pytest-command: ${{ matrix.pytest_command }}


### PR DESCRIPTION
Torch 2.3 daily tests take a long time. Going to raise the timeout for now.