### PR TITLE
Remove CPU offload for DDP/single-gpu

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -890,7 +890,7 @@ class State(Serializable):
                 submodules=None,
                 options=StateDictOptions(
                     full_state_dict=self.fsdp_state_dict_type == 'full',
-                    cpu_offload=True,
+                    cpu_offload=self.fsdp_enabled,
                 ),
             )
         else:
@@ -930,7 +930,7 @@ class State(Serializable):
                 submodules=None,
                 options=StateDictOptions(
                     full_state_dict=self.fsdp_state_dict_type == 'full',
-                    cpu_offload=True,
+                    cpu_offload=self.fsdp_enabled,
                 ),
             )
             return {type(optimizer).__qualname__: optim_state_dict}
@@ -1242,7 +1242,7 @@ class State(Serializable):
                     options=StateDictOptions(
                         full_state_dict=self.fsdp_state_dict_type == 'full',
                         strict=strict,
-                        cpu_offload=True,
+                        cpu_offload=self.fsdp_enabled,
                     ),
                 )
             else:
@@ -1335,7 +1335,7 @@ class State(Serializable):
                     options=StateDictOptions(
                         full_state_dict=self.fsdp_state_dict_type == 'full',
                         strict=strict,
-                        cpu_offload=True,
+                        cpu_offload=self.fsdp_enabled,
                     ),
                 )
             else:


### PR DESCRIPTION
# What does this PR do?

Remove CPU offload for DDP/single-gpu. With the unified API, we added this in, but it is not needed / does not exist in prior versions. This really slows down GPU tests.