### PR TITLE
Fix backwards compatibility tests, raise error for torch version mismatch

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -623,11 +623,14 @@ def load_sharded_checkpoint(
             # how to load the optimizer state.
             try:
                 metadata = storage_reader.read_metadata()
-            except AttributeError:
-                raise ValueError(
-                    'Unable to read checkpoint metadata. The checkpoint was likely saved with a '
-                    'newer version of torch. Upgrade your torch version to load this checkpoint.',
-                )
+            except AttributeError as e:
+                if '_MEM_FORMAT_ENCODING' in str(e):
+                    raise ValueError(
+                        'Unable to read checkpoint metadata. The checkpoint was likely saved with a '
+                        'newer version of torch. Upgrade your torch version to load this checkpoint.',
+                    )
+                else:
+                    raise
             # Retrieve all top-level keys of the metadata.
             top_level_keys = [v[0] for v in metadata.planner_data.values()]
             optimizers_at_root = 'optimizers' in top_level_keys

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -621,7 +621,13 @@ def load_sharded_checkpoint(
             # 1. Load metadata first for backwards compatability check
             # We need to check if the "optimizers" is at the root of the state dict to determine
             # how to load the optimizer state.
-            metadata = storage_reader.read_metadata()
+            try:
+                metadata = storage_reader.read_metadata()
+            except AttributeError:
+                raise ValueError(
+                    'Unable to read checkpoint metadata. The checkpoint was likely saved with a '
+                    'newer version of torch. Upgrade your torch version to load this checkpoint.',
+                )
             # Retrieve all top-level keys of the metadata.
             top_level_keys = [v[0] for v in metadata.planner_data.values()]
             optimizers_at_root = 'optimizers' in top_level_keys

--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -449,6 +449,9 @@ def test_fsdp_load_old_checkpoint(
     if composer_version == '0.18.1' and state_dict_type == 'full' and precision == 'amp_bf16' and sharding_strategy == 'FULL_SHARD':
         pytest.skip('TODO: This checkpoint is missing')
 
+    if composer_version in ['0.22.0'] and version.parse(torch.__version__) < version.parse('2.3.0'):
+        pytest.skip('Current torch version is older than torch version that checkpoint was written with.')
+
     if composer_version in ['0.13.5', '0.14.0', '0.14.1', '0.15.1']:
         rank = 0 if state_dict_type == 'full' else '{rank}'
 


### PR DESCRIPTION
# What does this PR do?

Fixes FSDP checkpoint backwards compatibility tests, and raises a helpful error for likely torch version mismatch on checkpoint load. For context, the test that was failing was when trying to load a checkpoint written with torch 2.3.0 when using torch < 2.3.0, since the older torch versions could not correctly read the new metadata file. 

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
