### PR TITLE
Fix: SAM not working with FSDP/DeepSpeed and LR scheduler.

### DIFF
--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -176,4 +176,5 @@ class SAM(Algorithm):
             ) for optimizer in ensure_tuple(state.optimizers)
         )
 
+        # Switch to ClosureGradScaler as SAM supports and requires it
         state.scaler = ClosureGradScaler()

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -121,7 +121,7 @@ class SAM(Algorithm):
     by wrapping an existing optimizer with a :class:`.SAMOptimizer`. SAM can improve model generalization
     and provide robustness to label noise.
 
-    Runs on :attr:`.Event.INIT`.
+    Runs on :attr:`.Event.AFTER_LOAD`.
 
     Args:
         rho (float, optional): The neighborhood size parameter of SAM. Must be greater than 0.
@@ -161,7 +161,7 @@ class SAM(Algorithm):
         self.interval = interval
 
     def match(self, event: Event, state: State) -> bool:
-        return event == Event.INIT
+        return event == Event.AFTER_LOAD
 
     def apply(self, event: Event, state: State, logger: Optional[Logger]) -> Optional[int]:
         assert state.optimizers is not None

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -13,6 +13,7 @@ import torch
 
 from composer.core import Algorithm, Event, State
 from composer.loggers import Logger
+from composer.trainer._scaler import ClosureGradScaler
 from composer.utils import ensure_tuple
 
 log = logging.getLogger(__name__)
@@ -174,3 +175,5 @@ class SAM(Algorithm):
                 interval=self.interval,
             ) for optimizer in ensure_tuple(state.optimizers)
         )
+
+        state.scaler = ClosureGradScaler()

--- a/tests/algorithms/test_sam.py
+++ b/tests/algorithms/test_sam.py
@@ -1,14 +1,19 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import pytest
+import torch
 from torch.utils.data import DataLoader
 
 from composer import Trainer
 from composer.algorithms import SAM
+from composer.algorithms.sam import SAMOptimizer
 from composer.loss import soft_cross_entropy
+from composer.optim import CosineAnnealingWithWarmupScheduler
 from composer.utils import dist
-from tests.common import RandomClassificationDataset, SimpleModel
+from tests.common import RandomClassificationDataset, SimpleModel, world_size
 
 
 class TestSAMLossDict():
@@ -47,3 +52,81 @@ class TestSAMLossDict():
 
         trainer = Trainer(**config)
         trainer.fit()
+
+
+@pytest.mark.gpu
+@world_size(1, 2)
+@pytest.mark.filterwarnings('ignore::UserWarning')
+class TestSAMParamGroups():
+
+    @pytest.fixture(params=['FSDP', 'DeepSpeed'])
+    def config(self, request):
+
+        distributed_mode = request.param
+
+        train_dataset = RandomClassificationDataset(size=16)
+
+        scheduler = CosineAnnealingWithWarmupScheduler(
+            alpha_f=0.1,
+            t_warmup='0.01dur',
+        )
+
+        config_dict = {
+            'algorithms':
+                SAM(),
+            'model':
+                SimpleModel(),
+            'train_dataloader':
+                DataLoader(
+                    dataset=train_dataset,
+                    batch_size=4,
+                    sampler=dist.get_sampler(train_dataset),
+                ),
+            'max_duration':
+                '2ep',
+            'schedulers':
+                scheduler,
+            'precision':
+                'amp_bf16',
+            'fsdp_config':
+                None,
+            'deepspeed_config':
+                None,
+        }
+
+        if distributed_mode == 'FSDP':
+            config_dict['fsdp_config'] = {'sharding_strategy': 'NO_SHARD'}
+        else:
+            config_dict['deepspeed_config'] = {'prescale_gradients': True}
+
+        # Simulate world_size checking as in LLMFoundry. See:
+        # * https://github.com/mosaicml/llm-foundry/blob/bfbb8c57053eaa3cb99a5d51ba602d1a6c872aa7/scripts/train/train.py#L519-L523
+        if dist.get_world_size(
+        ) == 1 and (config_dict['fsdp_config'] is not None or config_dict['deepspeed_config'] is not None):
+            config_dict['fsdp_config'] = config_dict['deepspeed_config'] = None
+
+        return config_dict
+
+    def test_param_groups_id_matching(self, config, world_size: int):
+        trainer = Trainer(**config)
+
+        sam_optimizer: SAMOptimizer = trainer.state.optimizers[0]
+        base_optimizer: torch.optim.Optimizer = sam_optimizer.base_optimizer
+
+        # Both SAMOptimizer and base_optimizer have to reference the same param groups
+        assert id(sam_optimizer.param_groups[0]) == id(base_optimizer.param_groups[0])
+
+    def test_params_value_close_after_updating(self, config, world_size: int):
+        trainer = Trainer(**config)
+        trainer.fit()
+
+        sam_optimizer: SAMOptimizer = trainer.state.optimizers[0]
+        base_optimizer: torch.optim.Optimizer = sam_optimizer.base_optimizer
+
+        # If SAMOptimizer and base_optimizer reference the same param groups, then
+        # the params are synchronized after updating (e.g. `lr` by a LR scheduler, 
+        # weights by an optimizer step, etc.)
+        assert math.isclose(
+            sam_optimizer.param_groups[0]['lr'],
+            base_optimizer.param_groups[0]['lr'],
+        )

--- a/tests/algorithms/test_sam.py
+++ b/tests/algorithms/test_sam.py
@@ -110,7 +110,7 @@ class TestSAMParamGroups():
     def test_param_groups_id_matching(self, config, world_size: int):
         trainer = Trainer(**config)
 
-        sam_optimizer: SAMOptimizer = trainer.state.optimizers[0]
+        sam_optimizer: SAMOptimizer = trainer.state.optimizers[0]  # type: ignore
         base_optimizer: torch.optim.Optimizer = sam_optimizer.base_optimizer
 
         # Both SAMOptimizer and base_optimizer have to reference the same param groups
@@ -120,11 +120,11 @@ class TestSAMParamGroups():
         trainer = Trainer(**config)
         trainer.fit()
 
-        sam_optimizer: SAMOptimizer = trainer.state.optimizers[0]
+        sam_optimizer: SAMOptimizer = trainer.state.optimizers[0]  # type: ignore
         base_optimizer: torch.optim.Optimizer = sam_optimizer.base_optimizer
 
         # If SAMOptimizer and base_optimizer reference the same param groups, then
-        # the params are synchronized after updating (e.g. `lr` by a LR scheduler, 
+        # the params are synchronized after updating (e.g. `lr` by a LR scheduler,
         # weights by an optimizer step, etc.)
         assert math.isclose(
             sam_optimizer.param_groups[0]['lr'],


### PR DESCRIPTION
## Description

I'm tracing this bug back to Composer coming from using LLMFoundry after we noticed that our models didn't learn anything when running distributed training with FSDP alongside SAM and a LR scheduler. If running the same setup but w/o distributed training (on a single GPU), everything works fine.

## Reproducibility

Just checkout the source branch at the commit `d882d8f4`, which contains only the tests (without the fix), and run:

```bash

## All tests pass (no distributed training with 1 GPU)
make test-dist-gpu WORLD_SIZE=1 EXTRA_ARGS="tests/algorithms/test_sam.py::TestSAMParamGroups"

## All tests failed (FSDP and DeepSpeed tests)
make test-dist-gpu WORLD_SIZE=2 EXTRA_ARGS="tests/algorithms/test_sam.py::TestSAMParamGroups"
```

## Problem (FSDP)

- When using SAM with a LR scheduler that resets the starting `param_groups[0]['lr']` to `0.0` (such as  `CosineAnnealingWithWarmupScheduler`),  it varies the learning rate at `SAMOptimizer.param_groups[0]['lr']`,  but not the one at `base_optimizer.param_groups[0]['lr']` (which is also reset to `0.0`).
- So the latter remains equal to `0.0` for the whole training process, which is why we don't see any learning.


### Cause (short answer)
- `SAMOptimizer.param_groups[i]` and `base_optimizer.param_groups[i]` are not referencing the same params because of the way Composer handles the sharding.


<details>
  <summary><h3>Cause (long answer)</h3></summary>
  
  
   * Right when triggering `Event.INIT`, `SAMOptimizer` binds references to the param groups in `base_optimizer`., so up to this point both optimizers reference the same param groups.
   * Later (after initializing optimizers and anything triggered by `Event.INIT`) Composer initializes FSDP ([here](https://github.com/mosaicml/composer/blob/2daa2b6dbf871b0f35aa6482a628d00065807268/composer/trainer/trainer.py#L1561-L1571)), which is weird since the [FSDP docs](https://pytorch.org/docs/stable/fsdp.html) warns about initializing the optimizer **after** doing the sharding, not the other way around.
   * Composer does the sharding by clearing the param groups from the `SAMOptimizer` and bounding to it the new sharded params.
   * At the end of the whole `Trainer` initialization, `SAMOptimizer` and `base_optimizer` reference different param groups:
       * `SAMOptimizer` the sharded ones.
       * `base_optimizer` the original ones.
   * During training, `state.schedulers[0].step()` is done on the `'lr'` param  of `SAMOptimizer`, which are not the ones referenced by `base_optimizer`, but the real optimizer step is done by the `base_optimizer`, not `SAMOptimizer`. So no learning.
</details>


## Problem (DeepSpeed)

- As far as a I debugged, the problem above is just related to PyTorch's FSDP and not DeepSpeed (it handles the sharding process on its own).
- But a problem arises when allocating the internal optimizer state when initializing the `DeepSpeedEngine` ([here]( https://github.com/microsoft/DeepSpeed/blob/f1e4fb0b878e48d6fe33dbb2e0969d791d698e86/deepspeed/runtime/bf16_optimizer.py#L237)).
	- `SAMOptimizer` does the optimizer step iff a closure is passed, while `BF16_Optimizer.initialize_optimizer_states()` needs to do an optimizer step without any closure.


## Solution
- Let any sharding-related initialization be done on the param groups of the _would-be_ `base_optimizer` optimizer instance, and just after all of this wrap the resulting optimizer with a `SAMOptimizer` instance, binding references to the sharded param groups.
- For DeepSpeed this works, even though the underlying `base_optimizer` is a DeepSpeed Zero `BF16_Optimizer` instance, since it uses the same underlying parameter groups as the original PyTorch optimizer (see [here](https://github.com/microsoft/DeepSpeed/blob/fee73135980e78f8be7e1a3ff556751623ef6aaa/deepspeed/runtime/zero/stage_1_and_2.py#L1911-L1917) and [here](https://github.com/microsoft/DeepSpeed/blob/ef17c89570ceae5b26a5f886e9d8cd0941afc0ac/deepspeed/runtime/zero/stage3.py#L2532-L2538)).

This fix is achieved by triggering the `SAMOptimizer` wrapping later in the code. After this, distributed training works as expected.



# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
