### PR TITLE
fix downloading all files

### DIFF
--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -425,7 +425,7 @@ class DecoupledAdamW(AdamW):
         beta1, beta2 = self.param_groups[0]['betas']
         if param in self.state:
             param_optim_state = self.state[param]
-            step = param_optim_state['step'].item()
+            step = param_optim_state['step']
             bias_correction1 = 1 - beta1**step
             bias_correction2 = 1 - beta2**step
             denom = (param_optim_state['exp_avg_sq'].sqrt() / math.sqrt(bias_correction2)).add_(eps)

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -14,7 +14,7 @@ import math
 from typing import Iterable, List, Optional, Tuple, Union
 
 import torch
-from torch.optim import SGD, AdamW
+from torch.optim import SGD, AdamW, Optimizer
 from torch.optim.optimizer import required  # type: ignore
 
 from composer.utils import dist
@@ -230,6 +230,16 @@ class DecoupledAdamW(AdamW):
         for group in self.param_groups:
             group['initial_lr'] = group['lr']
         self.amsgrad = amsgrad
+
+    def __setstate__(self, state):
+        Optimizer.__setstate__(self, state)
+        for group in self.param_groups:
+            group.setdefault("amsgrad", False)
+            group.setdefault("maximize", False)
+            group.setdefault("foreach", None)
+            group.setdefault("capturable", False)
+            group.setdefault("differentiable", False)
+            fused = group.setdefault("fused", None)
 
     @staticmethod
     def adamw(

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -269,7 +269,7 @@ class DecoupledAdamW(AdamW):
             grad = grads[i]
             exp_avg = exp_avgs[i]
             exp_avg_sq = exp_avg_sqs[i]
-            step = state_steps[i].item()
+            step = state_steps[i]
 
             # Perform stepweight decay
             if weight_decay != 0:
@@ -335,7 +335,7 @@ class DecoupledAdamW(AdamW):
 
                 # State initialization
                 if 'step' not in state:
-                    state['step'] = torch.zeros((), dtype=torch.float, device=p.device)
+                    state['step'] = 0 
                     # Exponential moving average of gradient values
                     state['exp_avg'] = torch.zeros_like(p, memory_format=torch.preserve_format)
                     # Exponential moving average of squared gradient values


### PR DESCRIPTION
Optimizer `DecoupledAdamW` has a tensor state `step` per parameter, which is a scalar, and replicated over all ranks.  When using torch.dist_cp to save the checkpointing, pytorch will [dedup the tensor type to save storage](https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/_dedup_save_plans.py#L28-L32), it also tried to balance the storage across ranks. So the consequence is that, the scalar tensors are save into different ranks. So when loading the checkpointing, each rank needs the files from other ranks, this is very bad. 

in this fix, we use a int, not tensor for `step`