### PR TITLE
Add upload timeout patch to mlflow on azure

### DIFF
--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -132,7 +132,7 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
     data = read_chunk(local_file, size, start_byte)
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
-    timeout = int(os.environ['MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT'])
+    timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
     debug_requests_on()
     with rest_utils.cloud_storage_http_request(
         'patch',
@@ -201,9 +201,8 @@ class MLFlowObjectStore(ObjectStore):
         except ImportError as e:
             raise MissingConditionalImportError('databricks', conda_package='databricks-sdk>=0.15.0,<1.0') from e
 
-        if 'MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT' in os.environ:
-            log.debug('Patching MLflow Azure client to include timeout in ADLS file upload')
-            mlflow.azure.client.patch_adls_file_upload = _patch_adls_file_upload_with_timeout  # type: ignore
+        log.debug('Patching MLflow Azure client to include timeout in ADLS file upload')
+        mlflow.azure.client.patch_adls_file_upload = _patch_adls_file_upload_with_timeout  # type: ignore
 
         tracking_uri = os.getenv(
             mlflow.environment_variables.MLFLOW_TRACKING_URI.name,  # pyright: ignore[reportGeneralTypeIssues]

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -121,6 +121,7 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
         rest_utils.augmented_raise_for_status(response)
         response.close()
 
+
 def _put_adls_file_creation_with_timeout(sas_url, headers):
     """
     Performs an ADLS Azure file create `Put` operation
@@ -133,7 +134,7 @@ def _put_adls_file_creation_with_timeout(sas_url, headers):
     from mlflow.azure.client import _append_query_parameters, _is_valid_adls_put_header, _logger
     from mlflow.utils import rest_utils
 
-    request_url = _append_query_parameters(sas_url, {"resource": "file"})
+    request_url = _append_query_parameters(sas_url, {'resource': 'file'})
 
     request_headers = {}
     for name, value in headers.items():
@@ -148,7 +149,10 @@ def _put_adls_file_creation_with_timeout(sas_url, headers):
     import socket
     socket.setdefaulttimeout(60.0)
     with rest_utils.cloud_storage_http_request(
-        "put", request_url, headers=request_headers, timeout=timeout,
+        'put',
+        request_url,
+        headers=request_headers,
+        timeout=timeout,
     ) as response:
         rest_utils.augmented_raise_for_status(response)
 

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -108,9 +108,12 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
     ### And to set the socket timeout
-    timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
-    import socket
-    socket.setdefaulttimeout(60.0)
+    timeout = os.environ.get('MLFLOW_PATCHED_FILE_UPLOAD_TIMEOUT', None)
+    if timeout is not None:
+        timeout = int(timeout)
+    if timeout is not None:
+        import socket
+        socket.setdefaulttimeout(timeout)
     with rest_utils.cloud_storage_http_request(
         'patch',
         request_url,
@@ -123,8 +126,8 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
 
 
 def _put_adls_file_creation_with_timeout(sas_url, headers):
-    """Performs an ADLS Azure file create `Put` operation
-    
+    """Performs an ADLS Azure file create `Put` operation.
+
     (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create)
 
     :param sas_url: A shared access signature URL referring to the Azure ADLS server
@@ -145,9 +148,12 @@ def _put_adls_file_creation_with_timeout(sas_url, headers):
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
     ### And to set the socket timeout
-    timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
-    import socket
-    socket.setdefaulttimeout(60.0)
+    timeout = os.environ.get('MLFLOW_PATCHED_FILE_UPLOAD_TIMEOUT', None)
+    if timeout is not None:
+        timeout = int(timeout)
+    if timeout is not None:
+        import socket
+        socket.setdefaulttimeout(timeout)
     with rest_utils.cloud_storage_http_request(
         'put',
         request_url,

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -133,7 +133,7 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
     timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
-    print(f"Patch timeout is {timeout}")
+    print(f'Patch timeout is {timeout}')
     debug_requests_on()
     with rest_utils.cloud_storage_http_request(
         'patch',
@@ -203,7 +203,7 @@ class MLFlowObjectStore(ObjectStore):
             raise MissingConditionalImportError('databricks', conda_package='databricks-sdk>=0.15.0,<1.0') from e
 
         log.debug('Patching MLflow Azure client to include timeout in ADLS file upload')
-        mlflow.azure.client.patch_adls_file_upload = _patch_adls_file_upload_with_timeout  # type: ignore
+        mlflow.store.artifact.databricks_artifact_repo.patch_adls_file_upload = _patch_adls_file_upload_with_timeout  # type: ignore
 
         tracking_uri = os.getenv(
             mlflow.environment_variables.MLFLOW_TRACKING_URI.name,  # pyright: ignore[reportGeneralTypeIssues]

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -122,7 +122,6 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
         timeout=timeout,
     ) as response:
         rest_utils.augmented_raise_for_status(response)
-        response.close()
 
 
 def _put_adls_file_creation_with_timeout(sas_url, headers):

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -109,6 +109,8 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
     timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
+    import socket
+    socket.setdefaulttimeout(60.0)
     print(f'Patch timeout is {timeout}')
     with rest_utils.cloud_storage_http_request(
         'patch',
@@ -177,8 +179,6 @@ class MLFlowObjectStore(ObjectStore):
             raise MissingConditionalImportError('databricks', conda_package='databricks-sdk>=0.15.0,<1.0') from e
 
         log.debug('Patching MLflow Azure client to include timeout in ADLS file upload')
-        import socket
-        socket.setdefaulttimeout(60.0)
         mlflow.store.artifact.databricks_artifact_repo.patch_adls_file_upload = _patch_adls_file_upload_with_timeout  # type: ignore
 
         tracking_uri = os.getenv(

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -216,6 +216,8 @@ class MLFlowObjectStore(ObjectStore):
         except ImportError as e:
             raise MissingConditionalImportError('databricks', conda_package='databricks-sdk>=0.15.0,<1.0') from e
 
+        # This is a temporary workaround for an intermittent hang we have encountered when uploading files to ADLS.
+        # MLflow is working on an upstream fix, but in the meantime, patching in timeouts works around the hang.
         log.debug('Patching MLflow Azure client to include timeout in ADLS file upload')
         mlflow.store.artifact.databricks_artifact_repo.patch_adls_file_upload = _patch_adls_file_upload_with_timeout  # type: ignore
         mlflow.store.artifact.databricks_artifact_repo.put_adls_file_creation = _put_adls_file_creation_with_timeout  # type: ignore

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -88,7 +88,6 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
         headers: Additional headers to include in the Patch request body
         is_single: Whether this is the only patch operation for this file
     """
-    print('Inside patched adls upload function')
     from mlflow.azure.client import _append_query_parameters, _is_valid_adls_patch_header, _logger
     from mlflow.utils import rest_utils
     from mlflow.utils.file_utils import read_chunk
@@ -108,10 +107,10 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
     data = read_chunk(local_file, size, start_byte)
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
+    ### And to set the socket timeout
     timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
     import socket
     socket.setdefaulttimeout(60.0)
-    print(f'Patch timeout is {timeout}')
     with rest_utils.cloud_storage_http_request(
         'patch',
         request_url,
@@ -131,7 +130,6 @@ def _put_adls_file_creation_with_timeout(sas_url, headers):
                     to which the file creation command should be issued.
     :param headers: Additional headers to include in the Put request body
     """
-    print('Inside patched adls put function')
     from mlflow.azure.client import _append_query_parameters, _is_valid_adls_put_header, _logger
     from mlflow.utils import rest_utils
 
@@ -145,12 +143,12 @@ def _put_adls_file_creation_with_timeout(sas_url, headers):
             _logger.debug("Removed unsupported '%s' header for ADLS Gen2 Put operation", name)
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
+    ### And to set the socket timeout
     timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
     import socket
     socket.setdefaulttimeout(60.0)
-    print(f'Patch timeout is {timeout}')
     with rest_utils.cloud_storage_http_request(
-        "put", request_url, headers=request_headers
+        "put", request_url, headers=request_headers, timeout=timeout,
     ) as response:
         rest_utils.augmented_raise_for_status(response)
 
@@ -158,7 +156,7 @@ def _put_adls_file_creation_with_timeout(sas_url, headers):
 class MLFlowObjectStore(ObjectStore):
     """Utility class for uploading and downloading artifacts from MLflow.
 
-    It can be initializd for an existing run, a new run in an existing experiment, the active run used by the `mlflow`
+    It can be initialized for an existing run, a new run in an existing experiment, the active run used by the `mlflow`
     module, or a new run in a new experiment. See the documentation for ``path`` for more details.
 
     .. note::

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -72,30 +72,6 @@ def _wrap_mlflow_exceptions(uri: str, e: Exception):
     raise e
 
 
-from http.client import HTTPConnection
-
-
-def debug_requests_on():
-    HTTPConnection.debuglevel = 1
-
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
-    requests_log = logging.getLogger('requests.packages.urllib3')
-    requests_log.setLevel(logging.DEBUG)
-    requests_log.propagate = True
-
-
-def debug_requests_off():
-    HTTPConnection.debuglevel = 0
-
-    root_logger = logging.getLogger()
-    root_logger.setLevel(logging.WARNING)
-    root_logger.handlers = []
-    requests_log = logging.getLogger('requests.packages.urllib3')
-    requests_log.setLevel(logging.WARNING)
-    requests_log.propagate = False
-
-
 # Original source: https://github.com/mlflow/mlflow/blob/a85081631eb665fa25046cb0b7daf0fbbdd5949f/mlflow/azure/client.py#L42
 def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, position, headers, is_single):
     """Performs an ADLS Azure file create `Patch` operation.
@@ -134,7 +110,6 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
     ### Changed here to pass a timeout along to cloud_storage_http_request
     timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
     print(f'Patch timeout is {timeout}')
-    debug_requests_on()
     with rest_utils.cloud_storage_http_request(
         'patch',
         request_url,
@@ -143,8 +118,6 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
         timeout=timeout,
     ) as response:
         rest_utils.augmented_raise_for_status(response)
-
-    debug_requests_off()
 
 
 class MLFlowObjectStore(ObjectStore):

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -118,6 +118,7 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
         timeout=timeout,
     ) as response:
         rest_utils.augmented_raise_for_status(response)
+        response.close()
 
 
 class MLFlowObjectStore(ObjectStore):
@@ -176,6 +177,8 @@ class MLFlowObjectStore(ObjectStore):
             raise MissingConditionalImportError('databricks', conda_package='databricks-sdk>=0.15.0,<1.0') from e
 
         log.debug('Patching MLflow Azure client to include timeout in ADLS file upload')
+        import socket
+        socket.setdefaulttimeout(60.0)
         mlflow.store.artifact.databricks_artifact_repo.patch_adls_file_upload = _patch_adls_file_upload_with_timeout  # type: ignore
 
         tracking_uri = os.getenv(

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -112,6 +112,7 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
         headers: Additional headers to include in the Patch request body
         is_single: Whether this is the only patch operation for this file
     """
+    log.debug('Inside patched adls upload function')
     from mlflow.azure.client import _append_query_parameters, _is_valid_adls_patch_header, _logger
     from mlflow.utils import rest_utils
     from mlflow.utils.file_utils import read_chunk
@@ -131,7 +132,7 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
     data = read_chunk(local_file, size, start_byte)
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
-    timeout = os.environ['MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT']
+    timeout = int(os.environ['MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT'])
     debug_requests_on()
     with rest_utils.cloud_storage_http_request(
         'patch',

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -75,9 +75,8 @@ def _wrap_mlflow_exceptions(uri: str, e: Exception):
 def _get_timeout_and_set_socket_default() -> Optional[int]:
     timeout = os.environ.get('MLFLOW_PATCHED_FILE_UPLOAD_TIMEOUT', None)
     if timeout is not None:
-        timeout = int(timeout)
-    if timeout is not None:
         import socket
+        timeout = int(timeout)
         socket.setdefaulttimeout(timeout)
     return timeout
 

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -123,8 +123,8 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
 
 
 def _put_adls_file_creation_with_timeout(sas_url, headers):
-    """
-    Performs an ADLS Azure file create `Put` operation
+    """Performs an ADLS Azure file create `Put` operation
+    
     (https://docs.microsoft.com/en-us/rest/api/storageservices/datalakestoragegen2/path/create)
 
     :param sas_url: A shared access signature URL referring to the Azure ADLS server

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -112,7 +112,7 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
         headers: Additional headers to include in the Patch request body
         is_single: Whether this is the only patch operation for this file
     """
-    log.debug('Inside patched adls upload function')
+    print('Inside patched adls upload function')
     from mlflow.azure.client import _append_query_parameters, _is_valid_adls_patch_header, _logger
     from mlflow.utils import rest_utils
     from mlflow.utils.file_utils import read_chunk
@@ -133,6 +133,7 @@ def _patch_adls_file_upload_with_timeout(sas_url, local_file, start_byte, size, 
 
     ### Changed here to pass a timeout along to cloud_storage_http_request
     timeout = int(os.environ.get('MLFLOW_PATCH_ADLS_FILE_UPLOAD_TIMEOUT', 30))
+    print(f"Patch timeout is {timeout}")
     debug_requests_on()
     with rest_utils.cloud_storage_http_request(
         'patch',


### PR DESCRIPTION
# What does this PR do?
We are fixing an occasional hang during artifact upload by patching mlflow to pass a request timeout along, and to set the default socket timeout in the upload worker function. This will be fixed upstream by mlflow in the next release, at which point we can remove the patch.

Manual tests:
- upload without the timeout flag set: `upload-timeout-test-without-2-xlw9bk`
- upload with the timeout flag set: `upload-timeout-test-3-UzoDmx`
- upload with the timeout flag set (and seemingly did something, as this run took longer to complete than the others): `upload-timeout-test-2-sVfbkw`
