### PR TITLE
 new dist_cp save planner to fix issue that each rank needs to download all checkpoint files 

### DIFF
--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -732,7 +732,7 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
     from torch.distributed.checkpoint.planner import SavePlan, WriteItem
     from torch.distributed.checkpoint.metadata import MetadataIndex, Metadata
 
-    def dedup_save_plans(all_plans: List[SavePlan]) -> List[SavePlan]:
+    def dedup_save_plans(all_plans: List[SavePlan]) -> List[SavePlan]:  # noqa: D103
         write_item_to_plan_indices: Dict[MetadataIndex, Set[int]] = defaultdict(set)
         write_item_idx_to_write_item: Dict[MetadataIndex, WriteItem] = {}
         for plan_idx, plan in enumerate(all_plans):

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -733,11 +733,6 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
     from torch.distributed.checkpoint.metadata import MetadataIndex, Metadata
 
     def dedup_save_plans(all_plans: List[SavePlan]) -> List[SavePlan]:
-        """
-        Removes duplicate entries from appearing on multiple SavePlans. For each duplicate across
-        a set of SavePlans, only the smallest SavePlan in terms of planned storage keeps the entry.
-        """
-
         write_item_to_plan_indices: Dict[MetadataIndex, Set[int]] = defaultdict(set)
         write_item_idx_to_write_item: Dict[MetadataIndex, WriteItem] = {}
         for plan_idx, plan in enumerate(all_plans):
@@ -773,7 +768,7 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
         return all_plans
 
 
-    class SavePlannerWithDedupFix(DefaultSavePlanner):
+    class SavePlannerWithDedupFix(DefaultSavePlanner):  # noqa: D101
         def create_global_plan(
             self, all_plans: List[SavePlan],
         ) -> Tuple[List[SavePlan], Metadata]:

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -719,6 +719,7 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
             _load_optim_state_dict(model, optimizers, optim_state_dict, info)
 
 
+    # torch2.3 patch to fix https://github.com/pytorch/pytorch/issues/125740
     from torch.distributed.checkpoint.default_planner import (
         create_default_global_save_plan,
         DefaultSavePlanner,
@@ -737,7 +738,6 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
         a set of SavePlans, only the smallest SavePlan in terms of planned storage keeps the entry.
         """
 
-        print(f"bigning debug my dedup save plan")
         write_item_to_plan_indices: Dict[MetadataIndex, Set[int]] = defaultdict(set)
         write_item_idx_to_write_item: Dict[MetadataIndex, WriteItem] = {}
         for plan_idx, plan in enumerate(all_plans):
@@ -775,7 +775,7 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
 
     class SavePlannerWithDedupFix(DefaultSavePlanner):
         def create_global_plan(
-            self, all_plans: List[SavePlan]
+            self, all_plans: List[SavePlan],
         ) -> Tuple[List[SavePlan], Metadata]:
             all_plans = dedup_save_plans(all_plans)
 
@@ -791,7 +791,7 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
                 metadata = dataclasses.replace(metadata, planner_data=merged_mappings)
 
             if not _validate_global_plan(global_plan, metadata):
-                raise ValueError("Failed to validate global plan")
+                raise ValueError('Failed to validate global plan')
 
             self.global_plan = global_plan
             self.metadata = metadata

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -169,15 +169,6 @@ class FileSystemReaderWithValidation(dist_cp.FileSystemReader):
         """
         path_to_specs: Dict[str, List[Tuple[int, int]]] = {}
         for read_item in plan.items:
-
-            relative_file_path = self.storage_data[read_item.storage_index].relative_path
-            rank = torch.distributed.get_rank()
-            if rank == 0:
-                if "__1_0" in relative_file_path:
-                    print(f"bigning debug rank 0 found 1 file: {read_item=}")
-                else:
-                    print(f"bigning debug no __1 file: {relative_file_path}")
-
             item_md = self.storage_data[read_item.storage_index]
             path = os.path.join(self.path, item_md.relative_path)
             path_to_specs.setdefault(path, []).append((item_md.offset, item_md.length))

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -175,6 +175,9 @@ class FileSystemReaderWithValidation(dist_cp.FileSystemReader):
             if rank == 0:
                 if "__1_0" in relative_file_path:
                     print(f"bigning debug rank 0 found 1 file: {read_item=}")
+                    raise RuntimeError(f"haha")
+                else:
+                    print(f"bigning debug no __1 file: {relative_file_path}")
 
             item_md = self.storage_data[read_item.storage_index]
             path = os.path.join(self.path, item_md.relative_path)

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -175,7 +175,6 @@ class FileSystemReaderWithValidation(dist_cp.FileSystemReader):
             if rank == 0:
                 if "__1_0" in relative_file_path:
                     print(f"bigning debug rank 0 found 1 file: {read_item=}")
-                    raise RuntimeError(f"haha")
                 else:
                     print(f"bigning debug no __1 file: {relative_file_path}")
 


### PR DESCRIPTION
# what's the issue
PyTorch Issue: https://github.com/pytorch/pytorch/issues/125740
When pytorch 2.3 saves checkpoint files, if there are duplicated tensors, it will do dedup. In the dedup, it tries to balance the storage needed for each rank, so the duplicated tensors are saved on different ranks. The consequest is that, when loading checkpoint, each rank needs to read files saved by different ranks even without resharding. Ideally, each rank_k only needs to download rank_k and rank_0 files. 

# what's the fix
we save the duplicated tensors to the smallest rank only. This is how torch2.1 and torch2.2 do the dedup. 

# test
Tested  on 512 GPUs. Save and load both work. 