### PR TITLE
Add option to stagger uploads based on local rank

### DIFF
--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -676,7 +676,7 @@ def _upload_worker(
         # the concurrency by a factor of num GPUs per node.
         local_rank = dist.get_local_rank()
         local_rank_stagger = int(os.environ.get('COMPOSER_LOCAL_RANK_STAGGER_SECONDS', 0))
-        log.debug(f'Staggering uploads by {local_rank * local_rank_stagger} seconds on local rank{local_rank}.')
+        log.debug(f'Staggering uploads by {local_rank * local_rank_stagger} seconds on local rank {local_rank}.')
         time.sleep(local_rank * local_rank_stagger)
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -671,8 +671,12 @@ def _upload_worker(
                 continue
         uri = remote_backend.get_uri(remote_file_name)
 
+        # When encountering issues with too much concurrency in uploads, staggering the uploads can help.
+        # This stagger is intended for use when uploading model shards from every rank, and will effectively reduce
+        # the concurrency by a factor of num GPUs per node.
         local_rank = dist.get_local_rank()
         local_rank_stagger = int(os.environ.get('COMPOSER_LOCAL_RANK_STAGGER_SECONDS', 0))
+        log.debug(f'Staggering uploads by {local_rank * local_rank_stagger} seconds on {local_rank} local rank.')
         time.sleep(local_rank * local_rank_stagger)
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -660,6 +660,11 @@ def _upload_worker(
     The worker will continuously poll ``file_queue`` for files to upload. Once ``is_finished`` is set, the worker will
     exit once ``file_queue`` is empty.
     """
+    from composer.utils import dist
+    # Stagger uploads by one minute per local rank
+    stagger_wait = dist.get_local_rank() * 60
+    time.sleep(stagger_wait)
+
     remote_backend = _build_remote_backend(remote_backend_name, backend_kwargs)
     while True:
         try:

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -672,11 +672,12 @@ def _upload_worker(
         uri = remote_backend.get_uri(remote_file_name)
 
         local_rank = dist.get_local_rank()
+        local_rank_stagger = os.environ.get('COMPOSER_LOCAL_RANK_STAGGER_SECONDS', 0)
+        time.sleep(local_rank * local_rank_stagger)
         if remote_file_name.endswith('.distcp'):
             filename = remote_file_name.split('/')[-1]
             rank = int(filename.split('_')[-2]) % 8
             assert local_rank == rank
-            time.sleep(rank * 60)
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument
         @retry(ObjectStoreTransientError, num_attempts=num_attempts)

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -674,7 +674,7 @@ def _upload_worker(
         if remote_file_name.endswith('.distcp'):
             filename = remote_file_name.split('/')[-1]
             rank = filename.split('_')[-2]
-            time.sleep(int(rank % 8) * 60)
+            time.sleep((int(rank) % 8) * 60)
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument
         @retry(ObjectStoreTransientError, num_attempts=num_attempts)

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -672,11 +672,11 @@ def _upload_worker(
         uri = remote_backend.get_uri(remote_file_name)
 
         local_rank = dist.get_local_rank()
-        assert local_rank != 0
         if remote_file_name.endswith('.distcp'):
             filename = remote_file_name.split('/')[-1]
-            rank = filename.split('_')[-2]
-            time.sleep((int(rank) % 8) * 60)
+            rank = int(filename.split('_')[-2]) % 8
+            assert local_rank == rank
+            time.sleep(rank * 60)
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument
         @retry(ObjectStoreTransientError, num_attempts=num_attempts)

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -672,7 +672,7 @@ def _upload_worker(
         uri = remote_backend.get_uri(remote_file_name)
 
         local_rank = dist.get_local_rank()
-        local_rank_stagger = os.environ.get('COMPOSER_LOCAL_RANK_STAGGER_SECONDS', 0)
+        local_rank_stagger = int(os.environ.get('COMPOSER_LOCAL_RANK_STAGGER_SECONDS', 0))
         time.sleep(local_rank * local_rank_stagger)
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -676,7 +676,7 @@ def _upload_worker(
         # the concurrency by a factor of num GPUs per node.
         local_rank = dist.get_local_rank()
         local_rank_stagger = int(os.environ.get('COMPOSER_LOCAL_RANK_STAGGER_SECONDS', 0))
-        log.debug(f'Staggering uploads by {local_rank * local_rank_stagger} seconds on {local_rank} local rank.')
+        log.debug(f'Staggering uploads by {local_rank * local_rank_stagger} seconds on local rank{local_rank}.')
         time.sleep(local_rank * local_rank_stagger)
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -671,6 +671,8 @@ def _upload_worker(
                 continue
         uri = remote_backend.get_uri(remote_file_name)
 
+        local_rank = dist.get_local_rank()
+        assert local_rank != 0
         if remote_file_name.endswith('.distcp'):
             filename = remote_file_name.split('/')[-1]
             rank = filename.split('_')[-2]

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -674,10 +674,6 @@ def _upload_worker(
         local_rank = dist.get_local_rank()
         local_rank_stagger = os.environ.get('COMPOSER_LOCAL_RANK_STAGGER_SECONDS', 0)
         time.sleep(local_rank * local_rank_stagger)
-        if remote_file_name.endswith('.distcp'):
-            filename = remote_file_name.split('/')[-1]
-            rank = int(filename.split('_')[-2]) % 8
-            assert local_rank == rank
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument
         @retry(ObjectStoreTransientError, num_attempts=num_attempts)


### PR DESCRIPTION
This PR adds support for adding a stagger based on local rank to the upload workers (i.e. the upload worker will wait by local rank * stagger). We are only exposing this via environment variable, as this is not something most users should be setting themselves.

Manual test:
- `stagger-upload-test-2-IggDEG` (note that each ranks file was uploaded 1 minute apart)
<img width="829" alt="Screenshot 2024-05-10 at 12 16 40 PM" src="https://github.com/mosaicml/composer/assets/43149077/88122e5e-67bf-4dab-8b13-51119a6729fa">
