### PR TITLE
Fix UCObjectStore.list_objects

### DIFF
--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -242,7 +242,6 @@ class UCObjectStore(ObjectStore):
         from databricks.sdk.core import DatabricksError
         try:
             ls_results = [entry.path for entry in self.client.files.list_directory_contents(os.path.join('/', prefix))]
-            print(len(ls_results))
             return ls_results
 
         except DatabricksError as e:

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -241,7 +241,8 @@ class UCObjectStore(ObjectStore):
 
         from databricks.sdk.core import DatabricksError
         try:
-            ls_results = [entry.path for entry in self.client.files.list_directory_contents(prefix)]
+            ls_results = [entry.path for entry in self.client.files.list_directory_contents(os.path.join('/', prefix))]
+            print(len(ls_results))
             return ls_results
 
         except DatabricksError as e:

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -265,7 +265,6 @@ class UCObjectStore(ObjectStore):
                     else:
                         all_files.append(path)
 
-            print(len(all_files))
             return all_files
 
         except DatabricksError as e:

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -100,7 +100,7 @@ class UCObjectStore(ObjectStore):
 
         Args:
             object_name (optional, str): Absolute or relative path of the object w.r.t. the
-            UC Volumes root.
+            UC Volumes root. If None, the prefix path is returned.
         """
         # convert object name to relative path if prefix is included
         if object_name is not None and os.path.commonprefix([object_name, self.prefix]) == self.prefix:

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -263,6 +263,7 @@ class UCObjectStore(ObjectStore):
                     else:
                         all_files.append(path)
 
+            print(len(all_files))
             return all_files
 
         except DatabricksError as e:

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -252,7 +252,7 @@ class UCObjectStore(ObjectStore):
                 current_path = stack.pop()
 
                 ls_results = self.client.files.list_directory_contents(
-                    directory_path=self._get_object_path(current_path)
+                    directory_path=self._get_object_path(current_path),
                 )
 
                 for dir_entry in ls_results:

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -251,7 +251,9 @@ class UCObjectStore(ObjectStore):
             while len(stack) > 0:
                 current_path = stack.pop()
 
-                ls_results = self.client.files.list_directory_contents(self._get_object_path(current_path))
+                ls_results = self.client.files.list_directory_contents(
+                    directory_path=self._get_object_path(current_path)
+                )
 
                 for dir_entry in ls_results:
                     path = dir_entry.path

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -260,6 +260,7 @@ class UCObjectStore(ObjectStore):
                     data=json.dumps({'path': self._get_object_path(current_path)}),
                     headers={'Source': 'mosaicml/composer'},
                 )
+                print(resp)
 
                 assert isinstance(resp, dict), 'Response is not a dictionary'
 

--- a/tests/utils/object_store/test_uc_object_store.py
+++ b/tests/utils/object_store/test_uc_object_store.py
@@ -218,7 +218,7 @@ def test_list_objects_nested_folders(ws_client, uc_object_store):
     prefix = 'Volumes/catalog/schema/volume/path/to/folder'
 
     ws_client.files.list_directory_contents = MagicMock(
-        side_effect=[uc_list_api_responses[0], uc_list_api_responses[1]]
+        side_effect=[uc_list_api_responses[0], uc_list_api_responses[1]],
     )
     actual_files = uc_object_store.list_objects(prefix=prefix)
 

--- a/tests/utils/object_store/test_uc_object_store.py
+++ b/tests/utils/object_store/test_uc_object_store.py
@@ -180,6 +180,8 @@ def test_download_object(ws_client, uc_object_store, tmp_path, result: str):
 
 
 def test_list_objects_nested_folders(ws_client, uc_object_store):
+    from databricks.sdk.service.files import DirectoryEntry
+
     expected_files = [
         '/Volumes/catalog/volume/schema/path/to/folder/file1.txt',
         '/Volumes/catalog/volume/schema/path/to/folder/file2.txt',
@@ -187,51 +189,46 @@ def test_list_objects_nested_folders(ws_client, uc_object_store):
         '/Volumes/catalog/volume/schema/path/to/folder/subdir/file2.txt',
     ]
     uc_list_api_responses = [
-        {
-            'files': [
-                {
-                    'path': '/Volumes/catalog/volume/schema/path/to/folder/file1.txt',
-                    'is_dir': False,
-                },
-                {
-                    'path': '/Volumes/catalog/volume/schema/path/to/folder/file2.txt',
-                    'is_dir': False,
-                },
-                {
-                    'path': '/Volumes/catalog/volume/schema/path/to/folder/subdir',
-                    'is_dir': True,
-                },
-            ],
-        },
-        {
-            'files': [
-                {
-                    'path': '/Volumes/catalog/volume/schema/path/to/folder/subdir/file1.txt',
-                    'is_dir': False,
-                },
-                {
-                    'path': '/Volumes/catalog/volume/schema/path/to/folder/subdir/file2.txt',
-                    'is_dir': False,
-                },
-            ],
-        },
+        [
+            DirectoryEntry(
+                path='/Volumes/catalog/volume/schema/path/to/folder/file1.txt',
+                is_directory=False,
+            ),
+            DirectoryEntry(
+                path='/Volumes/catalog/volume/schema/path/to/folder/file2.txt',
+                is_directory=False,
+            ),
+            DirectoryEntry(
+                path='/Volumes/catalog/volume/schema/path/to/folder/subdir',
+                is_directory=True,
+            ),
+        ],
+        [
+            DirectoryEntry(
+                path='/Volumes/catalog/volume/schema/path/to/folder/subdir/file1.txt',
+                is_directory=False,
+            ),
+            DirectoryEntry(
+                path='/Volumes/catalog/volume/schema/path/to/folder/subdir/file2.txt',
+                is_directory=False,
+            ),
+        ],
     ]
 
     prefix = 'Volumes/catalog/schema/volume/path/to/folder'
 
-    ws_client.api_client.do = MagicMock(side_effect=[uc_list_api_responses[0], uc_list_api_responses[1]])
+    ws_client.files.list_directory_contents = MagicMock(
+        side_effect=[uc_list_api_responses[0], uc_list_api_responses[1]]
+    )
     actual_files = uc_object_store.list_objects(prefix=prefix)
 
     assert actual_files == expected_files
 
-    ws_client.api_client.do.assert_called_with(
-        method='GET',
-        path=uc_object_store._UC_VOLUME_LIST_API_ENDPOINT,
-        data='{"path": "/Volumes/catalog/volume/schema/path/to/folder/subdir"}',
-        headers={'Source': 'mosaicml/composer'},
+    ws_client.files.list_directory_contents.assert_called_with(
+        directory_path='/Volumes/catalog/volume/schema/path/to/folder/subdir',
     )
 
-    assert ws_client.api_client.do.call_count == 2
+    assert ws_client.files.list_directory_contents.call_count == 2
 
 
 @pytest.mark.parametrize('result', ['success', 'prefix_none', 'not_found', 'error'])


### PR DESCRIPTION
# What does this PR do?
Previously, the databricks SDK did not have `ls` built in, and we discovered a bug where we were not properly handling the truncation of the `ls` results (truncated to 999 elements). This PR fixes that bug by switching over to the built in `ls` in the databricks SDK.

Manual test, ran the convert to MDS script before and after, before it returns 999 elements, after it returns the full correct number (1350 from the directory I was testing)