### PR TITLE
Add _get_fqn monkeypatch to enable TE checkpointing for extra_state attribute

### DIFF
--- a/composer/trainer/mosaic_fsdp.py
+++ b/composer/trainer/mosaic_fsdp.py
@@ -68,7 +68,9 @@ def patch_pytorch():
         _flat_param._same_storage = _same_storage
 
         # Monkeypatch state_dict to get FQNs correctly.
-        # Issue: https://github.com/pytorch/pytorch/pull/124698
+        # Issue 1: https://github.com/pytorch/pytorch/pull/124698
+        # Issue 2: https://github.com/pytorch/pytorch/issues/122946
+        #  - PR 2: https://github.com/pytorch/pytorch/pull/125336
         from torch.distributed.checkpoint import state_dict
 
         from composer.trainer.mosaic_fsdp_utils import _get_fqns, set_model_state_dict, set_optimizer_state_dict

--- a/composer/trainer/mosaic_fsdp_utils.py
+++ b/composer/trainer/mosaic_fsdp_utils.py
@@ -630,7 +630,11 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
                     fqn_obj_names.append(curr_obj_name)
             else:
                 fqn_obj_names.append(curr_obj_name)
-                curr_obj = getattr(curr_obj, curr_obj_name)
+                if curr_obj_name == nn.modules.module._EXTRA_STATE_KEY_SUFFIX:
+                    if i != len(obj_names) - 1:
+                        raise RuntimeError("Expect `_extra_state` to be the last obj name")
+                else:
+                    curr_obj = getattr(curr_obj, curr_obj_name)
 
         return {'.'.join(fqn_obj_names).replace(_CHECKPOINT_PREFIX, '')}
 


### PR DESCRIPTION
# What does this PR do?
Add _get_fqn monkeypatch to enable TE checkpointing for extra_state attribute. This PR will work with torch nightly for 2.4.0 

# What issue(s) does this change relate to?
Related to: https://github.com/pytorch/pytorch/pull/125336 and https://github.com/pytorch/pytorch/issues/122946 

