### PR TITLE
Skip compression check with symlink files

### DIFF
--- a/composer/utils/compression.py
+++ b/composer/utils/compression.py
@@ -22,7 +22,7 @@ def is_compressed_pt(filename: str) -> bool:
     of a single pt file without a container (like tar).
     """
     parts = filename.split('.')
-    return len(parts) >= 2 and parts[-2] == 'pt'
+    return len(parts) >= 2 and parts[-2] == 'pt' and parts[-1] != 'symlink'
 
 
 class CliCompressor:

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -26,6 +26,7 @@ def test_is_compressed_pt() -> None:
     assert not is_compressed_pt('')
     assert not is_compressed_pt('x.lz4')
     assert not is_compressed_pt('x.tar.lz4')
+    assert not is_compressed_pt('x.pt.symlink')
 
 
 def test_get_invalid_compressor() -> None:


### PR DESCRIPTION
# What does this PR do?

Skip compression check with symlink files. Add unit tests.

Fixes an issue where some previous checkpoints where `.pt.symlink`