### PR TITLE
ARM Build Support

### DIFF
--- a/.github/workflows/docker-configure-build-push.yaml
+++ b/.github/workflows/docker-configure-build-push.yaml
@@ -36,15 +36,8 @@ on:
         required: true
 jobs:
   configure-build-push:
-    runs-on: ubuntu-latest
+    runs-on: mosaic-2wide
     steps:
-    - name: Maximize Build Space on Worker
-      uses: easimon/maximize-build-space@v4
-      with:
-        overprovision-lvm: true
-        remove-dotnet: true
-        remove-android: true
-        remove-haskell: true
 
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/docker-configure-build-push.yaml
+++ b/.github/workflows/docker-configure-build-push.yaml
@@ -88,6 +88,7 @@ jobs:
       with:
         context: ${{ inputs.context }}
         tags: ${{ env.IMAGE_TAG }}
+        platforms: linux/amd64,linux/arm64
         target: ${{ inputs.target }}
         push: ${{ inputs.push }}
         cache-from: type=registry,ref=${{ env.IMAGE_CACHE }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,9 @@ ARG CUDA_VERSION=11.3.1
 
 # Calculate the base image based on CUDA_VERSION
 ARG BASE_IMAGE=${CUDA_VERSION:+"nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu20.04"}
+ARG LINUX_DISTRO
+ARG LINUX_DISTRO_VERSION
 ARG BASE_IMAGE=${BASE_IMAGE:-"ubuntu:20.04"}
-
 # The Python version to install
 ARG PYTHON_VERSION=3.10
 
@@ -191,9 +192,14 @@ ARG PILLOW_SIMD_VERSION
 # so when pillow_simd is installed, other packages won't later override it
 COPY pillow_stub /tmp/pillow_stub
 
-RUN pip${PYTHON_VERSION} install --no-cache-dir --upgrade /tmp/pillow_stub && \
-    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pillow_simd==${PILLOW_SIMD_VERSION} && \
-    rm -rf /tmp/pillow_stub
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        pip${PYTHON_VERSION} install --no-cache-dir --upgrade /tmp/pillow_stub && \
+        pip${PYTHON_VERSION} install --no-cache-dir --upgrade pillow_simd==${PILLOW_SIMD_VERSION} && \
+        rm -rf /tmp/pillow_stub; \
+    # Install Pillow as arm64 is not supported by pillow-simd,
+        else \
+        pip${PYTHON_VERSION} install --no-cache-dir --upgrade Pillow==${PILLOW_PSEUDOVERSION}; \
+    fi
 
 #################
 # Install Pytorch
@@ -209,10 +215,16 @@ ENV PYTORCH_NIGHTLY_URL=${PYTORCH_NIGHTLY_URL}
 ENV PYTORCH_NIGHTLY_VERSION=${PYTORCH_NIGHTLY_VERSION}
 
 RUN if [ -z "$PYTORCH_NIGHTLY_URL" ] ; then \
-      CUDA_VERSION_TAG=$(python${PYTHON_VERSION} -c "print('cu' + ''.join('${CUDA_VERSION}'.split('.')[:2]) if '${CUDA_VERSION}' else 'cpu')") && \
-        pip${PYTHON_VERSION} install --no-cache-dir --find-links https://download.pytorch.org/whl/torch_stable.html \
-            torch==${PYTORCH_VERSION}+${CUDA_VERSION_TAG} \
-            torchvision==${TORCHVISION_VERSION}+${CUDA_VERSION_TAG} ; \
+        if [ "$TARGETARCH" = "amd64" ]; then \
+        CUDA_VERSION_TAG=$(python${PYTHON_VERSION} -c "print('cu' + ''.join('${CUDA_VERSION}'.split('.')[:2]) if '${CUDA_VERSION}' else 'cpu')") && \
+            pip${PYTHON_VERSION} install --no-cache-dir --find-links https://download.pytorch.org/whl/torch_stable.html \
+                torch==${PYTORCH_VERSION}+${CUDA_VERSION_TAG} \
+                torchvision==${TORCHVISION_VERSION}+${CUDA_VERSION_TAG} ; \
+        else \
+            pip${PYTHON_VERSION} install --no-cache-dir --find-links https://download.pytorch.org/whl/cpu/torch_stable.html \
+                torch==${PYTORCH_VERSION} \
+                torchvision==${TORCHVISION_VERSION} ; \
+        fi ; \
     else \
         pip${PYTHON_VERSION} install --no-cache-dir --pre --index-url ${PYTORCH_NIGHTLY_URL} \
             torch==${PYTORCH_VERSION}.${PYTORCH_NIGHTLY_VERSION} \
@@ -267,13 +279,17 @@ RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
 # Mellanox OFED driver installation
 ###################################
 
-ARG MOFED_VERSION
-
+ARG MOFED_PACKAGE
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        MOFED_PACKAGE="ubuntu20.04-x86_64"; \
+    else \
+        MOFED_PACKAGE="ubuntu20.04-aarch64"; \
+    fi
 RUN if [ -n "$MOFED_VERSION" ] ; then \
         mkdir -p /tmp/mofed && \
-        wget -nv -P /tmp/mofed http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu20.04-x86_64.tgz && \
-        tar -zxvf /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu20.04-x86_64.tgz -C /tmp/mofed && \
-        /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu20.04-x86_64/mlnxofedinstall --user-space-only --without-fw-update --force && \
+        wget -nv -P /tmp/mofed http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_PACKAGE}.tgz && \
+        tar -zxvf /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_PACKAGE}.tgz -C /tmp/mofed && \
+        /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_PACKAGE}/mlnxofedinstall --user-space-only --without-fw-update --force && \
         rm -rf /tmp/mofed ; \
     fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,11 +10,13 @@
 # ARG CUDA_VERSION=
 ARG CUDA_VERSION=11.3.1
 
+# Can use these to dynamically set the base image using the build matrix in the future.
+ARG LINUX_DISTRO='ubuntu'
+ARG LINUX_DISTRO_VERSION='20.04'
+
 # Calculate the base image based on CUDA_VERSION
-ARG BASE_IMAGE=${CUDA_VERSION:+"nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu20.04"}
-ARG LINUX_DISTRO
-ARG LINUX_DISTRO_VERSION
-ARG BASE_IMAGE=${BASE_IMAGE:-"ubuntu:20.04"}
+ARG BASE_IMAGE=${CUDA_VERSION}:+"nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-${LINUX_DISTRO}${LINUX_DISTRO_VERSION}"
+ARG BASE_IMAGE=${BASE_IMAGE}:-"${LINUX_DISTRO}:${LINUX_DISTRO_VERSION}"
 # The Python version to install
 ARG PYTHON_VERSION=3.10
 
@@ -81,10 +83,11 @@ RUN if [ -n "$CUDA_VERSION" ]; then \
         rm -f /usr/local/cuda-$(echo $CUDA_VERSION | cut -c -4)/cuda-$(echo $CUDA_VERSION | cut -c -4); \
     fi
 
-
 # update repository keys
 # https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
 RUN if [ -n "$CUDA_VERSION" ] ; then \
+        # remove . to format endpoint
+        LINIX_DISTRO_VERSION="${LINIX_DISTRO_VERSION//./}" && \
         rm -f /etc/apt/sources.list.d/cuda.list && \
         rm -f /etc/apt/sources.list.d/nvidia-ml.list && \
         apt-get update &&  \
@@ -94,7 +97,11 @@ RUN if [ -n "$CUDA_VERSION" ] ; then \
         rm -rf /var/lib/apt/lists/* \
         apt-key del 7fa2af80 && \
         mkdir -p /tmp/cuda-keyring && \
-        wget -P /tmp/cuda-keyring https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb && \
+        if [ $TARGETARCH = 'amd64']; then \
+            wget -P /tmp/cuda-keyring https://developer.download.nvidia.com/compute/cuda/repos/${LINIX_DISTRO}${LINIX_DISTRO_VERSION}/x86_64/cuda-keyring_1.0-1_all.deb && \
+        else \
+            wget -P /tmp/cuda-keyring https://developer.download.nvidia.com/compute/cuda/repos/${LINIX_DISTRO}${LINIX_DISTRO_VERSION}/arm64/cuda-keyring_1.0-1_all.deb && \
+        fi \
         dpkg -i /tmp/cuda-keyring/cuda-keyring_1.0-1_all.deb && \
         rm -rf /tmp/cuda-keyring ; \
     fi
@@ -221,6 +228,7 @@ RUN if [ -z "$PYTORCH_NIGHTLY_URL" ] ; then \
                 torch==${PYTORCH_VERSION}+${CUDA_VERSION_TAG} \
                 torchvision==${TORCHVISION_VERSION}+${CUDA_VERSION_TAG} ; \
         else \
+            # torch==<version>+cpu not working with arm for some reason, so using torch==<version> instead with the install from cpu package endpoint
             pip${PYTHON_VERSION} install --no-cache-dir --find-links https://download.pytorch.org/whl/cpu/torch_stable.html \
                 torch==${PYTORCH_VERSION} \
                 torchvision==${TORCHVISION_VERSION} ; \
@@ -279,17 +287,16 @@ RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
 # Mellanox OFED driver installation
 ###################################
 
-ARG MOFED_PACKAGE
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        MOFED_PACKAGE="ubuntu20.04-x86_64"; \
-    else \
-        MOFED_PACKAGE="ubuntu20.04-aarch64"; \
-    fi
 RUN if [ -n "$MOFED_VERSION" ] ; then \
+        if [ "$TARGETARCH" = "amd64" ]; then \
+                MOFED_PACKAGE="x86_64"; \
+            else \
+                MOFED_PACKAGE="aarch64"; \
+            fi \
         mkdir -p /tmp/mofed && \
-        wget -nv -P /tmp/mofed http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_PACKAGE}.tgz && \
-        tar -zxvf /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_PACKAGE}.tgz -C /tmp/mofed && \
-        /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${MOFED_PACKAGE}/mlnxofedinstall --user-space-only --without-fw-update --force && \
+        wget -nv -P /tmp/mofed http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-${LINUX_DISTRO}${LINUX_DISTRO_VERSION}-${MOFED_PACKAGE}.tgz && \
+        tar -zxvf /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${LINUX_DISTRO}${LINUX_DISTRO_VERSION}-${MOFED_PACKAGE}.tgz -C /tmp/mofed && \
+        /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-${LINUX_DISTRO}${LINUX_DISTRO_VERSION}-${MOFED_PACKAGE}/mlnxofedinstall --user-space-only --without-fw-update --force && \
         rm -rf /tmp/mofed ; \
     fi
 


### PR DESCRIPTION
# What does this PR do?

* Adding support for ARM images within Action and dynamic package builds within Dockerfile
* Using larger gh hosted runner to eliminate the need for `Maximize Build Space on Worker` action, which will save 2-5 min of build time.
