### PR TITLE
Allow overwrite on upload retry in remote uploader downloader

### DIFF
--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -673,7 +673,7 @@ def _upload_worker(
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument
         @retry(ObjectStoreTransientError, num_attempts=num_attempts)
-        def upload_file(retry_index: int):
+        def upload_file(retry_index: int = 0):
             if retry_index == 0 and not overwrite:
                 try:
                     remote_backend.get_object_size(remote_file_name)

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -673,8 +673,8 @@ def _upload_worker(
 
         # defining as a function-in-function to use decorator notation with num_attempts as an argument
         @retry(ObjectStoreTransientError, num_attempts=num_attempts)
-        def upload_file():
-            if not overwrite:
+        def upload_file(retry_index: int):
+            if retry_index == 0 and not overwrite:
                 try:
                     remote_backend.get_object_size(remote_file_name)
                 except FileNotFoundError:

--- a/composer/utils/retrying.py
+++ b/composer/utils/retrying.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import collections.abc
 import functools
+import inspect
 import logging
 import random
 import time
@@ -46,18 +47,16 @@ def retry(  # type: ignore
 
     Attempts are spaced out with ``initial_backoff + 2**num_attempts + random.random() * max_jitter`` seconds.
 
+    Optionally, the decorated function can specify `retry_index` as an argument to receive the current attempt number.
+
     Example:
     .. testcode::
 
         from composer.utils import retry
 
-        num_tries = 0
-
         @retry(RuntimeError, num_attempts=3, initial_backoff=0.1)
-        def flaky_function():
-            global num_tries
-            if num_tries < 2:
-                num_tries += 1
+        def flaky_function(retry_index: int):
+            if retry_index < 2:
                 raise RuntimeError("Called too soon!")
             return "Third time's a charm."
 
@@ -84,9 +83,12 @@ def retry(  # type: ignore
 
         @functools.wraps(func)
         def new_func(*args: Any, **kwargs: Any):
+            retry_index_param = 'retry_index'
             i = 0
             while True:
                 try:
+                    if retry_index_param in inspect.signature(func).parameters:
+                        kwargs[retry_index_param] = i
                     return func(*args, **kwargs)
                 except exc_class as e:
                     log.debug(f'Attempt {i} failed. Exception type: {type(e)}, message: {str(e)}.')

--- a/tests/loggers/test_remote_uploader_downloader.py
+++ b/tests/loggers/test_remote_uploader_downloader.py
@@ -202,7 +202,7 @@ def test_allow_overwrite_on_retry(tmp_path: pathlib.Path, dummy_state: State):
 
         def __init__(
             self,
-            dir: pathlib.Path | None = None,
+            dir: Optional[pathlib.Path] = None,
             always_fail: bool = False,
             **kwargs: Dict[str, Any],
         ) -> None:
@@ -212,8 +212,8 @@ def test_allow_overwrite_on_retry(tmp_path: pathlib.Path, dummy_state: State):
         def upload_object(
             self,
             object_name: str,
-            filename: str | pathlib.Path,
-            callback: Callable[[int, int], None] | None = None,
+            filename: Union[str, pathlib.Path],
+            callback: Optional[Callable[[int, int], None]] = None,
         ) -> None:
             if self._retry < 2:
                 self._retry += 1  # Takes two retries to upload the file


### PR DESCRIPTION
# What does this PR do?
Allows overwrite on upload retries.

If an upload fails and results in a partial upload, we should allow overwriting. 
<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
