### PR TITLE
Fix HSDP with ShardDegree < 8 

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -290,7 +290,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
         if self.device_mesh is not None and self.device_mesh.ndim == 2:
             # Broadcast file to all replicas
             replicate_process_group = self.device_mesh.get_group(0)
-            hsdp_shard_process_group = self.device_mesh.get_group(1)
+            shard_process_group = self.device_mesh.get_group(1)
             shard_size = self.device_mesh.size(1)
             rank_in_first_replica = dist.get_global_rank() % shard_size
             sender = dist.get_global_rank() == rank_in_first_replica
@@ -307,7 +307,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
             # Send each file to the appropriate rank
             for file_name in file_list:
                 if dist.get_local_rank() == 0 or (
-                    torch_dist.get_rank(hsdp_shard_process_group) == 0
+                    torch_dist.get_rank(shard_process_group) == 0
                 ):  # Only 1 rank per node needs to transfer file
                     full_path = os.path.join(self.destination_path, file_name)
                     log.debug(f'Transferring {full_path=}')

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
+import torch.distributed as torch_dist
 from packaging import version
 from torch.distributed import checkpoint as dist_cp
 from torch.distributed._tensor import DeviceMesh
@@ -289,6 +290,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
         if self.device_mesh is not None and self.device_mesh.ndim == 2:
             # Broadcast file to all replicas
             replicate_process_group = self.device_mesh.get_group(0)
+            hsdp_shard_process_group = self.device_mesh.get_group(1)
             shard_size = self.device_mesh.size(1)
             rank_in_first_replica = dist.get_global_rank() % shard_size
             sender = dist.get_global_rank() == rank_in_first_replica
@@ -304,7 +306,9 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
 
             # Send each file to the appropriate rank
             for file_name in file_list:
-                if dist.get_local_rank() == 0:  # Only 1 rank per node needs to transfer file
+                if dist.get_local_rank() == 0 or (
+                    torch_dist.get_rank(hsdp_shard_process_group) == 0
+                ):  # Only 1 rank per node needs to transfer file
                     full_path = os.path.join(self.destination_path, file_name)
                     log.debug(f'Transferring {full_path=}')
                     file_object = [None]

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -306,7 +306,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
             # Send each file to the appropriate rank
             for file_name in file_list:
                 if dist.get_local_rank() == 0 or (
-                    dist.get_global_rank(shard_process_group) == 0
+                    dist.get_global_rank(shard_process_group) == 0  # pyright: ignore[reportGeneralTypeIssues]
                 ):  # Only 1 rank per node needs to transfer file
                     full_path = os.path.join(self.destination_path, file_name)
                     log.debug(f'Transferring {full_path=}')

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -322,7 +322,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
                     )
                     received_file_object = file_object[0]
                     assert received_file_object is not None
-                    if receiver and not os.path.exists(full_path):
+                    if receiver and not os.path.exists(full_path) and dist.get_local_rank() == 0:
                         with open(full_path, 'wb') as f:
                             f.write(received_file_object['content'])
 

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
-import torch.distributed as torch_dist
 from packaging import version
 from torch.distributed import checkpoint as dist_cp
 from torch.distributed._tensor import DeviceMesh
@@ -307,7 +306,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
             # Send each file to the appropriate rank
             for file_name in file_list:
                 if dist.get_local_rank() == 0 or (
-                    torch_dist.get_rank(shard_process_group) == 0
+                    dist.get_global_rank(shard_process_group) == 0
                 ):  # Only 1 rank per node needs to transfer file
                     full_path = os.path.join(self.destination_path, file_name)
                     log.debug(f'Transferring {full_path=}')

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -236,7 +236,10 @@ def get_global_rank(group: Optional[dist.ProcessGroup] = None) -> int:
     """
     if group is None:
         return _get_distributed_config_var(
-            env_var='RANK', human_name='global rank', default=0, fetch_fn_name='get_rank'
+            env_var='RANK',
+            human_name='global rank',
+            default=0,
+            fetch_fn_name='get_rank',
         )
     return dist.get_rank(group)
 

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -225,13 +225,20 @@ def get_world_size() -> int:
     )
 
 
-def get_global_rank() -> int:
-    """Returns the global rank of the current process, which is on ``[0; WORLD_SIZE - 1]``.
+def get_global_rank(group: dist.ProcessGroup = None) -> int:
+    """Returns the global rank of the current process in the input PG, which is on ``[0; group.WORLD_SIZE - 1]``.
+
+    Args:
+        group (ProcessGroup, optional): The process group. If ``None``, it will return env_var ``RANK``
 
     Returns:
-        int: The global rank.
+        int: The global rank in input process group.
     """
-    return _get_distributed_config_var(env_var='RANK', human_name='global rank', default=0, fetch_fn_name='get_rank')
+    if group is None:
+        return _get_distributed_config_var(
+            env_var='RANK', human_name='global rank', default=0, fetch_fn_name='get_rank'
+        )
+    return dist.get_rank(group)
 
 
 def get_local_world_size() -> int:

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -225,7 +225,7 @@ def get_world_size() -> int:
     )
 
 
-def get_global_rank(group: dist.ProcessGroup = None) -> int:
+def get_global_rank(group: Optional[dist.ProcessGroup] = None) -> int:
     """Returns the global rank of the current process in the input PG, which is on ``[0; group.WORLD_SIZE - 1]``.
 
     Args:


### PR DESCRIPTION
# what
@j316chuck found HSDP with 1 node 2X4 device mesh run can't resume. rank 0 failed [this checkpoint files broadcast](https://github.com/mosaicml/composer/blob/dev/composer/utils/checkpoint.py#L314-L318) . It's because rank 4 (which is in the same replica pg group as rank 0) doesn't join this collective call because of [this if condition](https://github.com/mosaicml/composer/blob/dev/composer/utils/checkpoint.py#L307). 
So the fix is to let all the first rank of shard pg group joins the broadcast , but only local rank 0 writes to file

# test

##  1 node device mesh: 2 X 4
before:
[nccl timeout] mpt-125m-hybrid-resumption-1-node-tYv2bB
after:
 mpt-125m-hybrid-resumption-1-node-pzWqX1
mpt-125m-hybrid-resumption-1-node-RV4ovO

## 2 node device mesh: 2 X 8 still works
mpt-125m-hybrid-resumption-1-node-NlOtP5

## 2 node device mesh: 4 x 4 works:
mpt-125m-hybrid-resumption-1-node-ajvSHb
checked the logging, rank 8 is not downloading any checkpoint files, but it got all files broadcast from rank 0
<img width="881" alt="image" src="https://github.com/mosaicml/composer/assets/2545820/df743636-b9f1-4624-803a-2fb6e5d297bf">
