### PR TITLE
Improving memory snapshot 

### DIFF
--- a/composer/callbacks/memory_snapshot.py
+++ b/composer/callbacks/memory_snapshot.py
@@ -141,11 +141,9 @@ class MemorySnapshot(Callback):
 
         log.info('Starting snapshot record_memory_history')
         torch.cuda.memory._record_memory_history(
-            True,  # type: ignore
-            trace_alloc_max_entries=self.max_entries,
-            trace_alloc_record_context=True,
+            'all',  # type: ignore
+            max_entries=self.max_entries,
         )
-
     def stop_record_memory_history(self) -> None:
 
         log.info('Stopping snapshot record_memory_history')

--- a/composer/callbacks/memory_snapshot.py
+++ b/composer/callbacks/memory_snapshot.py
@@ -144,6 +144,7 @@ class MemorySnapshot(Callback):
             'all',  # type: ignore
             max_entries=self.max_entries,
         )
+        
     def stop_record_memory_history(self) -> None:
 
         log.info('Stopping snapshot record_memory_history')

--- a/composer/callbacks/memory_snapshot.py
+++ b/composer/callbacks/memory_snapshot.py
@@ -144,7 +144,7 @@ class MemorySnapshot(Callback):
             'all',  # type: ignore
             max_entries=self.max_entries,
         )
-        
+
     def stop_record_memory_history(self) -> None:
 
         log.info('Stopping snapshot record_memory_history')


### PR DESCRIPTION
# What does this PR do?

This PR uses `_record_memory_history_impl` instead of `_record_memory_history_legacy` (previous) to capture memory snapshot. See https://github.com/pytorch/pytorch/blob/main/torch/cuda/memory.py#L698-L738. With `enabled =all`, this captures all (c++ and python) alloc/free events and gives better memory timeline and stack trace information. 

`_record_memory_history_impl` exists for pytorch 2.1, 2.2, 2.0, no version gating is needed. 

# What issue(s) does this change relate to?
![image](https://github.com/mosaicml/composer/assets/17418037/07d0e965-b8eb-4f77-b4f3-cfa155139354)