### PR TITLE
Add checkpoint events to mosaicml logger

### DIFF
--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -92,30 +92,30 @@ class MosaicMLLogger(LoggerDestination):
                 self._enabled = False
 
     def log_hyperparameters(self, hyperparameters: Dict[str, Any]):
-        self._log_metadata(hyperparameters)
+        self.log_metadata(hyperparameters)
 
     def log_metrics(self, metrics: Dict[str, Any], step: Optional[int] = None) -> None:
-        self._log_metadata(metrics)
+        self.log_metadata(metrics)
 
     def log_exception(self, exception: Exception):
-        self._log_metadata({'exception': exception_to_json_serializable_dict(exception)})
+        self.log_metadata({'exception': exception_to_json_serializable_dict(exception)})
         self._flush_metadata(force_flush=True)
 
     def after_load(self, state: State, logger: Logger) -> None:
         # Log model data downloaded and initialized for run events
         log.debug(f'Logging model initialized time to metadata')
-        self._log_metadata({'model_initialized_time': time.time()})
+        self.log_metadata({'model_initialized_time': time.time()})
         # Log WandB run URL if it exists. Must run on after_load as WandB is setup on event init
         for callback in state.callbacks:
             if isinstance(callback, WandBLogger):
                 run_url = callback.run_url
                 if run_url is not None:
-                    self._log_metadata({'wandb/run_url': run_url})
+                    self.log_metadata({'wandb/run_url': run_url})
                     log.debug(f'Logging WandB run URL to metadata: {run_url}')
                 else:
                     log.debug('WandB run URL not found, not logging to metadata')
             if isinstance(callback, MLFlowLogger) and callback._enabled:
-                self._log_metadata({'mlflow/run_url': callback.run_url})
+                self.log_metadata({'mlflow/run_url': callback.run_url})
                 log.debug(f'Logging MLFlow run URL to metadata: {callback.run_url}')
         self._flush_metadata(force_flush=True)
 
@@ -125,7 +125,7 @@ class MosaicMLLogger(LoggerDestination):
 
     def batch_end(self, state: State, logger: Logger) -> None:
         training_progress_data = self._get_training_progress_metrics(state)
-        self._log_metadata(training_progress_data)
+        self.log_metadata(training_progress_data)
         self._flush_metadata()
 
     def epoch_end(self, state: State, logger: Logger) -> None:
@@ -133,10 +133,10 @@ class MosaicMLLogger(LoggerDestination):
 
     def fit_end(self, state: State, logger: Logger) -> None:
         # Log model training finished time for run events
-        self._log_metadata({'train_finished_time': time.time()})
+        self.log_metadata({'train_finished_time': time.time()})
         training_progress_data = self._get_training_progress_metrics(state)
         log.debug(f'\nLogging FINAL training progress data to metadata:\n{dict_to_str(training_progress_data)}')
-        self._log_metadata(training_progress_data)
+        self.log_metadata(training_progress_data)
         self._flush_metadata(force_flush=True)
 
     def eval_end(self, state: State, logger: Logger) -> None:
@@ -150,14 +150,14 @@ class MosaicMLLogger(LoggerDestination):
         if self._enabled:
             wait(self._futures)  # Ignore raised errors on close
 
-    def _log_metadata(self, metadata: Dict[str, Any]) -> None:
+    def log_metadata(self, metadata: Dict[str, Any], force_flush: bool = False) -> None:
         """Buffer metadata and prefix keys with mosaicml."""
         if self._enabled:
             for key, val in metadata.items():
                 if self.ignore_keys and any(fnmatch.fnmatch(key, pattern) for pattern in self.ignore_keys):
                     continue
                 self.buffered_metadata[f'mosaicml/{key}'] = format_data_to_json_serializable(val)
-            self._flush_metadata()
+            self._flush_metadata(force_flush=force_flush)
 
     def _flush_metadata(self, force_flush: bool = False, future: bool = True) -> None:
         """Flush buffered metadata to MosaicML if enough time has passed since last flush."""

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -22,7 +22,7 @@ from urllib.parse import urlparse
 
 import torch
 
-from composer.loggers.logger import Logger
+from composer.loggers import Logger, MosaicMLLogger
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import (
     GCSObjectStore,
@@ -343,12 +343,12 @@ class RemoteUploaderDownloader(LoggerDestination):
         return self._remote_backend
 
     def init(self, state: State, logger: Logger) -> None:
-        del logger  # unused
         if self._worker_flag is not None:
             raise RuntimeError('The RemoteUploaderDownloader is already initialized.')
         self._worker_flag = self._finished_cls()
         self._run_name = state.run_name
         file_name_to_test = self._remote_file_name('.credentials_validated_successfully')
+        self._logger = logger
 
         # Create the enqueue thread
         self._enqueue_thread_flag = self._finished_cls()
@@ -461,6 +461,9 @@ class RemoteUploaderDownloader(LoggerDestination):
                         break
                     self._enqueued_objects.remove(object_name)
                     self._completed_queue.task_done()
+                    for destination in self._logger.destinations:
+                        if isinstance(destination, MosaicMLLogger):
+                            destination.log_metadata({'checkpoint_uploaded_time': time.time()}, force_flush=True)
 
                 # Enqueue all objects that are in self._logged_objects but not in self._file_upload_queue
                 objects_to_delete = []


### PR DESCRIPTION
# What does this PR do?

Adds metadata logging to mosaicml logger for when checkpoint upload starts when a checkpoint is done loading. The information logged is the timestamp and the training duration of the checkpoint.

Tested in `events-test-8ReCjx`

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
