### PR TITLE
[WIP] [checkpoint v2] Use remote uploader v2 for checkpointing

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -580,12 +580,16 @@ class CheckpointSaver(Callback):  # noqa: D101
                     shutil.rmtree(prefix_dir)
     # RemoteUploader v2
     def batch_end(self, state: State, logger: Logger) -> None:
+        # Periodically check to see if any of the upload workers crashed
         del state, logger  # unused
-        raise 
+        if self.use_remote_uploader_v2 and self.remote_uploader is not None:
+            self.remote_uploader.check_workers()
 
     def epoch_end(self, state: State, logger: Logger) -> None:
         del state, logger  # unused
-        raise
+        if self.use_remote_uploader_v2 and self.remote_uploader is not None:
+            self.remote_uploader.check_workers()
 
     def post_close(self):
-        raise
+        if self.use_remote_uploader_v2 and self.remote_uploader is not None:
+            self.remote_uploader.wait_and_close()

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1374,6 +1374,7 @@ class Trainer:
                 ignore_keys=save_ignore_keys,
                 save_interval=save_interval,
                 num_checkpoints_to_keep=save_num_checkpoints_to_keep,
+                save_folder=save_folder,
             )
             self.state.callbacks.append(self._checkpoint_saver)
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1047,6 +1047,7 @@ class Trainer:
         save_ignore_keys: Optional[Union[List[str], Callable[[Dict], None]]] = None,
         save_num_checkpoints_to_keep: int = -1,
         save_metrics: bool = False,
+        use_remote_uploader_v2: bool = False,
 
         # Graceful Resumption
         autoresume: bool = False,
@@ -1375,6 +1376,7 @@ class Trainer:
                 save_interval=save_interval,
                 num_checkpoints_to_keep=save_num_checkpoints_to_keep,
                 save_folder=save_folder,
+                use_remote_uploader_v2=use_remote_uploader_v2,
             )
             self.state.callbacks.append(self._checkpoint_saver)
 

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -70,6 +70,7 @@ from composer.utils.object_store import (
     SFTPObjectStore,
     UCObjectStore,
 )
+from composer.utils.remote_uploader import RemoteUploader
 from composer.utils.retrying import retry
 from composer.utils.string_enum import StringEnum
 from composer.utils.warnings import VersionedDeprecationWarning
@@ -145,4 +146,5 @@ __all__ = [
     'get_compressor',
     'KNOWN_COMPRESSORS',
     'STR_TO_DTYPE',
+    'RemoteUploader',
 ]


### PR DESCRIPTION
# what?

Composer change to use the new RemoteUploader for saving checkpoing

# Test
llm-foundry PR: https://github.com/mosaicml/llm-foundry/pull/1237
## 1-node small model OCI test
test-uploader-wfA8Vz
## 1-node small model S3 test
save: test-uploader-10udLt e2e time: 3 min 40s
resume: test-uploader-TDGgTs

use old remote_uploader_downloader `test-uploader-racGuC` e2e time: 3 min 42s


