### PR TITLE
Bugfixes to FSDP + TP

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -200,6 +200,10 @@ def _create_device_mesh(
     fsdp_config: Optional[Dict[str, Any]],
     tp_config: Optional[Dict[str, Any]],
 ) -> Optional[DeviceMesh]:
+    if version.parse(torch.__version__.split('.dev')[0]) < version.parse('2.3.0'):
+        # Device mesh has correctness issues before torch 2.3.0
+        return None
+
     if fsdp_config is None:
         return None
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1192,7 +1192,7 @@ class Trainer:
                 raise ValueError(
                     'fsdp_config is specified in both fsdp_config and parallelism_config. Please specify it in only in parallelism_config.',
                 )
-            parallelism_config['fsdp_config'] = fsdp_config
+            parallelism_config['fsdp'] = fsdp_config
         if not fsdp_auto_wrap:
             warnings.warn(
                 VersionedDeprecationWarning(

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -236,9 +236,10 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
 
     def read_data(self, plan: LoadPlan, planner: LoadPlanner):
         # Download files if not using HSDP or if on first replica with HSDP enabled
-        first_replica = self.device_mesh is None or self.device_mesh.ndim == 1 or (
-            self.device_mesh.ndim >= 2 and self.device_mesh.get_local_rank(mesh_dim=0) == 0
-        )
+        first_replica = True
+        if self.device_mesh is not None and self.device_mesh.mesh_dim_names is not None and ParallelismType.DATA_PARALLEL_REPLICATE.value in self.device_mesh.mesh_dim_names:
+            hsdp_index = self.device_mesh.mesh_dim_names.index(ParallelismType.DATA_PARALLEL_REPLICATE.value)
+            first_replica = self.device_mesh.get_local_rank(mesh_dim=hsdp_index) == 0
 
         # 1. Collect the relative paths to download for all ranks for deduplication
         relative_file_paths = set()
@@ -287,11 +288,13 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
         log.debug('Done waiting for all ranks to finish downloading files.')
 
         # 4. Broadcast files to all other replicas if HSDP
-        if self.device_mesh is not None and self.device_mesh.ndim == 2:
+        if self.device_mesh is not None and self.device_mesh.mesh_dim_names is not None and ParallelismType.DATA_PARALLEL_REPLICATE.value in self.device_mesh.mesh_dim_names:
             # Broadcast file to all replicas
-            replicate_process_group = self.device_mesh.get_group(0)
-            shard_process_group = self.device_mesh.get_group(1)
-            shard_size = self.device_mesh.size(1)
+            replicate_index = self.device_mesh.mesh_dim_names.index(ParallelismType.DATA_PARALLEL_REPLICATE.value)
+            shard_index = self.device_mesh.mesh_dim_names.index(ParallelismType.DATA_PARALLEL_SHARD.value)
+            replicate_process_group = self.device_mesh.get_group(replicate_index)
+            shard_process_group = self.device_mesh.get_group(shard_index)
+            shard_size = self.device_mesh.size(shard_index)
             rank_in_first_replica = dist.get_global_rank() % shard_size
             sender = dist.get_global_rank() == rank_in_first_replica
             receiver = dist.get_global_rank() != rank_in_first_replica


### PR DESCRIPTION
# What does this PR do?

Fixes:
- [x] Fixes checkpointing issue with HSDP + TP where the right process group might not correctly be sliced (as previously, HSDP dimension was hardcoded)
- [x] Fixes torch <2.3 support, which does not support default. Now, it does not autocreate device mesh

Save: `0-16gpu-save-NTsI27`
Load: `0-16gpu-save-AVhYVg`