### PR TITLE
Optional `CheckpointSaver` instantiation inside the `Trainer`

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1337,7 +1337,28 @@ class Trainer:
         # Checkpoint Saving
         self._checkpoint_saver = None
         latest_remote_file_name = None
-        if save_folder is not None:
+
+        _checkpoint_savers = [cb for cb in self.state.callbacks if isinstance(cb, CheckpointSaver)]
+        if len(_checkpoint_savers) >= 1:
+            if len(_checkpoint_savers) > 1:
+                log.info('Multiple CheckpointSaver provided as callbacks. Using the first one as reference.')
+            self._checkpoint_saver = _checkpoint_savers[0]
+
+            if self._checkpoint_saver.folder != save_folder:
+                log.info(f'Using {self._checkpoint_saver.folder} as save_folder.')
+                save_folder = self._checkpoint_saver.folder
+
+            if self._checkpoint_saver.latest_filename is None:
+                save_latest_filename = None
+                log.info(f'Using {save_latest_filename} as latest_filename.')
+            elif self._checkpoint_saver.latest_filename.filename != save_latest_filename:
+                save_latest_filename = str(self._checkpoint_saver.latest_filename.filename)
+                log.info(f'Using {save_latest_filename} as latest_filename.')
+
+            if self._checkpoint_saver.latest_remote_file_name is not None:
+                latest_remote_file_name = str(self._checkpoint_saver.latest_remote_file_name.filename)
+
+        if self._checkpoint_saver is None and save_folder is not None:
             if save_weights_only:
                 log.info(
                     'save_weights_only=True now also saves metadata and integrations! Please adjust your workflow accordingly.',


### PR DESCRIPTION
# What does this PR do?

By making the instantiation of the `CheckpointSaver` optional inside the `Trainer`, the user can provide a (custom) callback used for saving, loading and resumption.

# What issue(s) does this change relate to?

- Fixes https://github.com/mosaicml/composer/issues/3317
