### PR TITLE
Upgrade Mofed with apt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -270,11 +270,10 @@ RUN if [ -n "$AWS_OFI_NCCL_VERSION" ] ; then \
 ARG MOFED_VERSION
 
 RUN if [ -n "$MOFED_VERSION" ] ; then \
-        mkdir -p /tmp/mofed && \
-        wget -nv -P /tmp/mofed http://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu20.04-x86_64.tgz && \
-        tar -zxvf /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu20.04-x86_64.tgz -C /tmp/mofed && \
-        /tmp/mofed/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu20.04-x86_64/mlnxofedinstall --user-space-only --without-fw-update --force && \
-        rm -rf /tmp/mofed ; \
+        wget -qO - http://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | sudo apt-key add - && \
+        wget -P /etc/apt/sources.list.d/ http://linux.mellanox.com/public/repo/mlnx_ofed/$MOFED_VERSION/ubuntu20.04/mellanox_mlnx_ofed.list && \
+        apt-get update && \
+        apt-get install -y mlnx-ofed-dpdk-upstream-libs-user-only  ; \
     fi
 
 ##########################

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -3,7 +3,7 @@
   BASE_IMAGE: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 12.1.1
   IMAGE_NAME: torch-2-3-0-cu121
-  MOFED_VERSION: latest-24.01
+  MOFED_VERSION: latest-23.10
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
     brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
@@ -74,7 +74,7 @@
   BASE_IMAGE: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 12.1.1
   IMAGE_NAME: torch-2-2-2-cu121
-  MOFED_VERSION: latest-24.01
+  MOFED_VERSION: latest-23.10
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
     brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
@@ -142,7 +142,7 @@
   BASE_IMAGE: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 12.1.1
   IMAGE_NAME: torch-2-1-2-cu121
-  MOFED_VERSION: latest-24.01
+  MOFED_VERSION: latest-23.10
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
     brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
@@ -211,7 +211,7 @@
   COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.22.0
   CUDA_VERSION: 12.1.1
   IMAGE_NAME: composer-0-22-0
-  MOFED_VERSION: latest-24.01
+  MOFED_VERSION: latest-23.10
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
     brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
@@ -240,7 +240,7 @@
   COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.22.0
   CUDA_VERSION: ''
   IMAGE_NAME: composer-0-22-0-cpu
-  MOFED_VERSION: latest-24.01
+  MOFED_VERSION: latest-23.10
   NVIDIA_REQUIRE_CUDA_OVERRIDE: ''
   PYTHON_VERSION: '3.11'
   PYTORCH_NIGHTLY_URL: ''

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -3,7 +3,7 @@
   BASE_IMAGE: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 12.1.1
   IMAGE_NAME: torch-2-3-0-cu121
-  MOFED_VERSION: 5.5-1.0.3.2
+  MOFED_VERSION: latest-24.01
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
     brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
@@ -74,7 +74,7 @@
   BASE_IMAGE: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 12.1.1
   IMAGE_NAME: torch-2-2-2-cu121
-  MOFED_VERSION: 5.5-1.0.3.2
+  MOFED_VERSION: latest-24.01
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
     brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
@@ -142,7 +142,7 @@
   BASE_IMAGE: nvidia/cuda:12.1.1-cudnn8-devel-ubuntu20.04
   CUDA_VERSION: 12.1.1
   IMAGE_NAME: torch-2-1-2-cu121
-  MOFED_VERSION: 5.5-1.0.3.2
+  MOFED_VERSION: latest-24.01
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
     brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
@@ -211,7 +211,7 @@
   COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.22.0
   CUDA_VERSION: 12.1.1
   IMAGE_NAME: composer-0-22-0
-  MOFED_VERSION: 5.5-1.0.3.2
+  MOFED_VERSION: latest-24.01
   NVIDIA_REQUIRE_CUDA_OVERRIDE: cuda>=12.1 brand=tesla,driver>=450,driver<451 brand=tesla,driver>=470,driver<471
     brand=unknown,driver>=470,driver<471 brand=nvidia,driver>=470,driver<471 brand=nvidiartx,driver>=470,driver<471
     brand=geforce,driver>=470,driver<471 brand=geforcertx,driver>=470,driver<471 brand=quadro,driver>=470,driver<471
@@ -240,7 +240,7 @@
   COMPOSER_INSTALL_COMMAND: mosaicml[all]==0.22.0
   CUDA_VERSION: ''
   IMAGE_NAME: composer-0-22-0-cpu
-  MOFED_VERSION: 5.5-1.0.3.2
+  MOFED_VERSION: latest-24.01
   NVIDIA_REQUIRE_CUDA_OVERRIDE: ''
   PYTHON_VERSION: '3.11'
   PYTORCH_NIGHTLY_URL: ''

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -218,7 +218,7 @@ def _main():
         if not cuda_version or interconnect == 'EFA':
             entry['MOFED_VERSION'] = ''
         else:
-            entry['MOFED_VERSION'] = '5.5-1.0.3.2'
+            entry['MOFED_VERSION'] = 'latest-24.01'
 
         # Skip EFA drivers if not using EFA
         if interconnect != 'EFA':
@@ -251,7 +251,7 @@ def _main():
             'PYTORCH_NIGHTLY_VERSION': '',
             'TARGET': 'composer_stage',
             'TORCHVISION_VERSION': _get_torchvision_version(pytorch_version),
-            'MOFED_VERSION': '5.5-1.0.3.2',
+            'MOFED_VERSION': 'latest-24.01',
             'AWS_OFI_NCCL_VERSION': '',
             'COMPOSER_INSTALL_COMMAND': f'mosaicml[all]=={composer_version}',
             'TAGS': _get_composer_tags(

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -218,7 +218,7 @@ def _main():
         if not cuda_version or interconnect == 'EFA':
             entry['MOFED_VERSION'] = ''
         else:
-            entry['MOFED_VERSION'] = 'latest-24.01'
+            entry['MOFED_VERSION'] = 'latest-23.10'
 
         # Skip EFA drivers if not using EFA
         if interconnect != 'EFA':
@@ -251,7 +251,7 @@ def _main():
             'PYTORCH_NIGHTLY_VERSION': '',
             'TARGET': 'composer_stage',
             'TORCHVISION_VERSION': _get_torchvision_version(pytorch_version),
-            'MOFED_VERSION': 'latest-24.01',
+            'MOFED_VERSION': 'latest-23.10',
             'AWS_OFI_NCCL_VERSION': '',
             'COMPOSER_INSTALL_COMMAND': f'mosaicml[all]=={composer_version}',
             'TAGS': _get_composer_tags(


### PR DESCRIPTION
# What does this PR do?

This PR changes the install methodology to utilize the mellanox debian package for installation vs the installer script. This should make it easier to both pin on the latest if we choose, or to ensure that the system can install the packages appropriately.
