### PR TITLE
change ComposerModel output type

### DIFF
--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -90,14 +90,14 @@ class ComposerModel(torch.nn.Module, abc.ABC):
         return state
 
     @abc.abstractmethod
-    def forward(self, batch: Batch) -> Union[Tensor, Sequence[Tensor]]:
+    def forward(self, batch: Batch) -> Any:
         """Compute model output given a batch from the dataloader.
 
         Args:
             batch (~composer.core.types.Batch): The output batch from dataloader.
 
         Returns:
-            Tensor | Sequence[Tensor]:
+            Any:
                 The result that is passed to :meth:`loss` as the parameter :attr:`outputs`.
 
         .. warning:: This method is different from vanilla PyTorch ``model.forward(x)`` or ``model(x)`` as it takes a


### PR DESCRIPTION
# What does this PR do?

This PR changes the output type of the `ComposerModel`. As long as the output type is a tensor, a tensor list, a dictionary of tensors or has a method `cpu()` (to satisfy [this](https://github.com/mosaicml/composer/blob/dev/composer/trainer/trainer.py#L3357), note that if you return a list of non-tensors it will not break the pipeline) we should be able to return any type.

# What issue(s) does this change relate to?

No issue has been opened yet.

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

cc: @JAEarly 
<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
