### PR TITLE
Immediately kill the training if checkpoint downloading fails

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -285,8 +285,7 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
                 proc = psutil.Process(pid)
                 for child_process in proc.children(recursive=True):
                     os.kill(child_process.pid, signal.SIGKILL)
-                os.kill(pid, signal.SIGTERM)
-                #os.kill(pid, signal.SIGTERM)
+                os.kill(pid, signal.SIGKILL)
 
         # 3. Wait for all ranks to finish.
         log.debug(f'Rank {dist.get_global_rank()} finished downloading all files.')

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -16,6 +16,7 @@ import textwrap
 import warnings
 from importlib import import_module
 from pathlib import Path
+import signal
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -276,9 +277,9 @@ class DistCPObjectStoreReader(FileSystemReaderWithValidation):
                 # PyTorch will capture any exception of this function,
                 # and dist.all_gather_objects(exception) before raising it.
                 # If that all_gather_objects fails, the exception is never visible to user.
-                # We immediately print the exception to avoid that situation.
-                log.error(f'Exception {type(e)} raised during downloading: {str(e)}')
-                raise e
+                # We immediately kill the process and print the exception 
+                log.error(f'Exception {type(e)} raised during downloading: {str(e)}, terminating the process')
+                os.kill(os.getpid(), signal.SIGTERM)
 
         # 3. Wait for all ranks to finish.
         log.debug(f'Rank {dist.get_global_rank()} finished downloading all files.')


### PR DESCRIPTION
# What does this PR do?
pytorch issue: https://github.com/pytorch/pytorch/issues/122529

Basically, for remote checkpoint downloading, if the download failes, pytorch may fail to raise the correct exception, instead if might just raise nccl timeout. 

Previously, we added a log.error immediately, but in above case, the timeout takes very long time. Here, we just immediately kill the training process if the downloading error happens