### PR TITLE
Rename metadata keys

### DIFF
--- a/composer/checkpoint/state_dict.py
+++ b/composer/checkpoint/state_dict.py
@@ -318,22 +318,12 @@ def get_metadata_state_dict(
     Returns:
         The state dict containing the metadata and any integrations for a training run.
     """
-    ced = get_composer_env_dict()
+    metadata_state_dict = get_composer_env_dict()
 
     python_version = '.'.join([str(getattr(sys.version_info, k)) for k in ['major', 'minor', 'micro']])
 
-    metadata_state_dict = {
-        'composer_version': ced['composer_version'],
-        'composer_commit_hash': ced['composer_commit_hash'],
-        'torch_version': torch.__version__,
-        'python_version': python_version,
-        'num_nodes': ced['node_world_size'],
-        'num_gpus_per_node': ced['local_world_size'],
-        'num_gpus': dist.get_world_size(),
-        'gpu_model': ced['accelerator_model_name'],
-        'cpu_model': ced['host_processor_model_name'],
-        'cpu_core_count': ced['host_processor_core_count'],
-    }
+    metadata_state_dict['torch_version'] = torch.__version__
+    metadata_state_dict['python_version'] = python_version
     if sharded_state_dict is not None:
         metadata_state_dict['sharded_state_dict'] = sharded_state_dict
 

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -276,7 +276,7 @@ CPU Model: {cpu_model}
 CPU Count: {cpu_count}
 Number of Nodes: {node_world_size}
 GPU Model: {gpu_model}
-GPUs per Node: {local_world_size}
+GPUs per Node: {num_gpus_per_node}
 GPU Count: {num_gpus}
 CUDA Device Count: {cuda_device_count}
 """.strip()
@@ -292,7 +292,7 @@ def get_composer_env_dict() -> dict:
         'cpu_count': get_cpu_count(),
         'num_nodes': get_node_world_size(),
         'gpu_model': get_gpu_model(),
-        'local_world_size': get_local_world_size(),
+        'num_gpus_per_node': get_local_world_size(),
         'num_gpus': dist.get_world_size(),
         'cuda_device_count': get_cuda_device_count(),
     }

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -44,7 +44,7 @@ import functools
 import json
 import sys
 import time
-from typing import NamedTuple, Optional, TextIO
+from typing import Optional, TextIO
 
 import cpuinfo
 import importlib_metadata
@@ -89,18 +89,6 @@ _EXCEPTHOOK_REGISTERED = False
 _ENV_EXCEPTION_REPORT = True
 
 
-# Same convention as Torch collect_env, create a NamedTuple to track collected fields
-class ComposerEnv(NamedTuple):
-    composer_version: str
-    composer_commit_hash: Optional[str]
-    node_world_size: int
-    host_processor_model_name: str
-    host_processor_core_count: int
-    local_world_size: int
-    accelerator_model_name: str
-    cuda_device_count: int
-
-
 def get_composer_commit_hash() -> Optional[str]:
     # Use PEP-610 to get the commit hash
     # See https://packaging.python.org/en/latest/specifications/direct-url/
@@ -132,13 +120,13 @@ def get_composer_version() -> str:
 
 
 @functools.lru_cache(maxsize=1)
-def get_host_processor_name() -> str:
+def get_cpu_model() -> str:
     """Query the host processor name."""
     cpu_info = cpuinfo.get_cpu_info()
     return str(cpu_info.get('brand_raw', 'CPU'))
 
 
-def get_host_processor_cores() -> int:
+def get_cpu_count() -> int:
     """Determines the number of physical host processor cores."""
     return psutil.cpu_count(logical=False)
 
@@ -148,7 +136,7 @@ def get_node_world_size() -> int:
     return int(dist.get_world_size() / dist.get_local_world_size())
 
 
-def get_accel_model_name() -> str:
+def get_gpu_model() -> str:
     """Query the accelerator name."""
     return accel_device_name(None) if cuda_available() else 'N/A'
 
@@ -282,13 +270,14 @@ def get_torch_env() -> str:
 
 # Composer environment information string output format
 _COMPOSER_ENV_INFO_FORMAT = """
-Composer version: {composer_version}
-Composer commit hash: {composer_commit_hash}
-Host processor model name: {host_processor_model_name}
-Host processor core count: {host_processor_core_count}
-Number of nodes: {node_world_size}
-Accelerator model name: {accelerator_model_name}
-Accelerators per node: {local_world_size}
+Composer Version: {composer_version}
+Composer Commit Hash: {composer_commit_hash}
+CPU Model: {cpu_model}
+CPU Count: {cpu_count}
+Number of Nodes: {node_world_size}
+GPU Model: {gpu_model}
+GPUs per Node: {local_world_size}
+GPU Count: {num_gpus}
 CUDA Device Count: {cuda_device_count}
 """.strip()
 
@@ -296,24 +285,23 @@ CUDA Device Count: {cuda_device_count}
 # Get composer environment info as a dictionary
 def get_composer_env_dict() -> dict:
     """Query Composer pertinent system information as a dict."""
-    mutable_dict = ComposerEnv(
-        composer_version=get_composer_version(),
-        composer_commit_hash=get_composer_commit_hash(),
-        host_processor_model_name=get_host_processor_name(),
-        host_processor_core_count=get_host_processor_cores(),
-        node_world_size=get_node_world_size(),
-        accelerator_model_name=get_accel_model_name(),
-        local_world_size=get_local_world_size(),
-        cuda_device_count=get_cuda_device_count(),
-    )._asdict()
-    return mutable_dict
+    return {
+        'composer_version': get_composer_version(),
+        'composer_commit_hash': get_composer_commit_hash(),
+        'cpu_model': get_cpu_model(),
+        'cpu_count': get_cpu_count(),
+        'num_nodes': get_node_world_size(),
+        'gpu_model': get_gpu_model(),
+        'local_world_size': get_local_world_size(),
+        'num_gpus': dist.get_world_size(),
+        'cuda_device_count': get_cuda_device_count(),
+    }
 
 
 # Get Composer environment info
 def get_composer_env() -> str:
     """Query Composer pertinent system information."""
-    mutable_dict = get_composer_env_dict()
-    return _COMPOSER_ENV_INFO_FORMAT.format(**mutable_dict)
+    return _COMPOSER_ENV_INFO_FORMAT.format(**get_composer_env_dict())
 
 
 # Generate and print environment report

--- a/tests/checkpoint/test_state_dict.py
+++ b/tests/checkpoint/test_state_dict.py
@@ -440,7 +440,7 @@ def test_get_metadata_empty_call(world_size):
         'num_gpus',
         'gpu_model',
         'cpu_model',
-        'cpu_core_count',
+        'cuda_device_count',
     ]:
         assert key in metadata_sd
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -172,7 +172,7 @@ def test_composer_metadata_in_state_dict(tmp_path, request: pytest.FixtureReques
         'cpu_count',
         'num_nodes',
         'gpu_model',
-        'local_world_size',
+        'num_gpus_per_node',
         'num_gpus',
         'cuda_device_count',
     }

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -168,11 +168,12 @@ def test_composer_metadata_in_state_dict(tmp_path, request: pytest.FixtureReques
     expected_env_info_keys = {
         'composer_version',
         'composer_commit_hash',
-        'node_world_size',
-        'host_processor_model_name',
-        'host_processor_core_count',
+        'cpu_model',
+        'cpu_count',
+        'num_nodes',
+        'gpu_model',
         'local_world_size',
-        'accelerator_model_name',
+        'num_gpus',
         'cuda_device_count',
     }
     actual_env_info_keys = set(loaded_state_dict['metadata']['composer_env_info'].keys())


### PR DESCRIPTION
# What does this PR do?

Renames keys in `get_composer_env_dict`, following up on naming discussion in https://github.com/mosaicml/composer/pull/3311. Also cleans up code, removing a NamedTuple class which is immediately converted to a dictionary