### PR TITLE
MLFlow better experiment defaults

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -30,8 +30,6 @@ log = logging.getLogger(__name__)
 
 __all__ = ['MLFlowLogger']
 
-DEFAULT_MLFLOW_EXPERIMENT_NAME = 'my-mlflow-experiment'
-
 
 class MLFlowLogger(LoggerDestination):
     """Log to `MLflow <https://www.mlflow.org/docs/latest/index.html>`_.
@@ -135,13 +133,10 @@ class MLFlowLogger(LoggerDestination):
             if self.experiment_name is None:
                 self.experiment_name = os.getenv(
                     mlflow.environment_variables.MLFLOW_EXPERIMENT_NAME.name,  # type: ignore
+                    self.run_name,
                 )
-                if self.experiment_name is None:
-                    raise ValueError(
-                        'MLFlow Logger requires an experiment name to be set either through the '
-                        '`experiment_name` argument or the MLFLOW_EXPERIMENT_NAME environment '
-                        'variable.',
-                    )
+            if os.getenv('DATABRICKS_TOKEN') is not None and not experiment_name.startswith('/'):
+                experiment_name = '/' + experiment_name
             self._mlflow_client = MlflowClient(self.tracking_uri)
             # Set experiment
             env_exp_id = os.getenv(

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -135,8 +135,13 @@ class MLFlowLogger(LoggerDestination):
             if self.experiment_name is None:
                 self.experiment_name = os.getenv(
                     mlflow.environment_variables.MLFLOW_EXPERIMENT_NAME.name,  # type: ignore
-                    DEFAULT_MLFLOW_EXPERIMENT_NAME,
                 )
+                if self.experiment_name is None:
+                    raise ValueError(
+                        'MLFlow Logger requires an experiment name to be set either through the '
+                        '`experiment_name` argument or the MLFLOW_EXPERIMENT_NAME environment '
+                        'variable.',
+                    )
             self._mlflow_client = MlflowClient(self.tracking_uri)
             # Set experiment
             env_exp_id = os.getenv(

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -88,6 +88,7 @@ class MLFlowLogger(LoggerDestination):
     ) -> None:
         try:
             import mlflow
+            from databricks.sdk import WorkspaceClient
             from mlflow import MlflowClient
         except ImportError as e:
             raise MissingConditionalImportError(
@@ -142,8 +143,9 @@ class MLFlowLogger(LoggerDestination):
                     DEFAULT_MLFLOW_EXPERIMENT_NAME,
                 )
             assert self.experiment_name is not None  # type hint
-            if os.getenv('DATABRICKS_TOKEN') is not None and not self.experiment_name.startswith('/'):
-                self.experiment_name = '/' + self.experiment_name
+            if os.getenv('DATABRICKS_TOKEN') is not None and not self.experiment_name.startswith('/Users/'):
+                databricks_username = WorkspaceClient().current_user.me().user_name or ''
+                self.experiment_name = '/' + os.path.join('Users', databricks_username, self.experiment_name)
             self._mlflow_client = MlflowClient(self.tracking_uri)
             # Set experiment
             env_exp_id = os.getenv(

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -125,8 +125,11 @@ class MLFlowLogger(LoggerDestination):
         self.run_url = None
 
         if self._enabled:
-            self.tracking_uri = str(tracking_uri or mlflow.get_tracking_uri())
-            mlflow.set_tracking_uri(self.tracking_uri)
+            if tracking_uri is None and os.getenv('DATABRICKS_TOKEN') is not None:
+                tracking_uri = 'databricks'
+            if tracking_uri is None:
+                tracking_uri = mlflow.get_tracking_uri(tracking_uri)
+            self.tracking_uri = str(tracking_uri)
 
             if self.model_registry_uri is not None:
                 mlflow.set_registry_uri(self.model_registry_uri)

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -30,6 +30,8 @@ log = logging.getLogger(__name__)
 
 __all__ = ['MLFlowLogger']
 
+DEFAULT_MLFLOW_EXPERIMENT_NAME = 'my-mlflow-experiment'
+
 
 class MLFlowLogger(LoggerDestination):
     """Log to `MLflow <https://www.mlflow.org/docs/latest/index.html>`_.
@@ -133,8 +135,9 @@ class MLFlowLogger(LoggerDestination):
             if self.experiment_name is None:
                 self.experiment_name = os.getenv(
                     mlflow.environment_variables.MLFLOW_EXPERIMENT_NAME.name,  # type: ignore
-                    self.run_name,
+                    DEFAULT_MLFLOW_EXPERIMENT_NAME,
                 )
+            assert self.experiment_name is not None  # type hint
             if os.getenv('DATABRICKS_TOKEN') is not None and not experiment_name.startswith('/'):
                 experiment_name = '/' + experiment_name
             self._mlflow_client = MlflowClient(self.tracking_uri)

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -130,6 +130,7 @@ class MLFlowLogger(LoggerDestination):
             if tracking_uri is None:
                 tracking_uri = mlflow.get_tracking_uri()
             self.tracking_uri = str(tracking_uri)
+            mlflow.set_tracking_uri(self.tracking_uri)
 
             if self.model_registry_uri is not None:
                 mlflow.set_registry_uri(self.model_registry_uri)

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -128,7 +128,7 @@ class MLFlowLogger(LoggerDestination):
             if tracking_uri is None and os.getenv('DATABRICKS_TOKEN') is not None:
                 tracking_uri = 'databricks'
             if tracking_uri is None:
-                tracking_uri = mlflow.get_tracking_uri(tracking_uri)
+                tracking_uri = mlflow.get_tracking_uri()
             self.tracking_uri = str(tracking_uri)
 
             if self.model_registry_uri is not None:
@@ -141,8 +141,8 @@ class MLFlowLogger(LoggerDestination):
                     DEFAULT_MLFLOW_EXPERIMENT_NAME,
                 )
             assert self.experiment_name is not None  # type hint
-            if os.getenv('DATABRICKS_TOKEN') is not None and not experiment_name.startswith('/'):
-                experiment_name = '/' + experiment_name
+            if os.getenv('DATABRICKS_TOKEN') is not None and not self.experiment_name.startswith('/'):
+                self.experiment_name = '/' + self.experiment_name
             self._mlflow_client = MlflowClient(self.tracking_uri)
             # Set experiment
             env_exp_id = os.getenv(

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ extra_deps['onnx'] = [
 
 extra_deps['mlflow'] = [
     'mlflow>=2.11.1,<3.0',
+    'databricks-sdk==0.28.0',
 ]
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']


### PR DESCRIPTION
# What does this PR do?

When running on MAIT or with a databricks secret, default to the databricks workspace. This lets the user skip specifying `tracking_uri`. 

Similarly, if specifying databricks secret, we now autopopulate `/Users/<username>` to experiment id, simplifying user experience.

Exmaple run name: ft-llama-3-8b-r4z14-v0-4roAvl