### PR TITLE
Autoresume Validation with Max Duration

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1723,10 +1723,11 @@ class Trainer:
         # Load Checkpoint
         self._rng_state = None
         # If autoresume is enabled, first check for existing checkpoints to load
-        if autoresume:
+        self.autoresume = autoresume
+        if self.autoresume:
             log.info('Searching for a previous checkpoint to autoresume')
             error_message = ''
-            if max_duration is not None:
+            if max_duration is None:
                 error_message += 'The `max_duration` must be specified on trainer.__init__ when autoresume is enabled. '
             if save_folder is None:
                 error_message += 'The `save_folder` must be specified when autoresume is enabled. '
@@ -2190,10 +2191,21 @@ class Trainer:
 
         # Reset Time
         if reset_time:
+            if self.autoresume:
+                raise ValueError(
+                    'Cannot specify `reset_time=True` when autoresume is enabled. Please instead '
+                    'specify `load_ignore_keys` when constructing the Trainer, which will only '
+                    'run on the initial load and not any subsequent autoresumptions.',
+                )
             self.state.timestamp = Timestamp()
 
         # Max Duration
         if duration is not None:
+            if self.autoresume:
+                raise ValueError(
+                    '`duration` cannot be specified when autoresume is enabled. Please instead '
+                    'specify `max_duration` when constructing the Trainer.',
+                )
             duration = ensure_time(duration, TimeUnit.EPOCH)
             if duration.unit == TimeUnit.SECOND:
                 raise ValueError('Wall clock time not an allowed time unit.')

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1726,6 +1726,8 @@ class Trainer:
         if autoresume:
             log.info('Searching for a previous checkpoint to autoresume')
             error_message = ''
+            if max_duration is not None:
+                error_message += 'The `max_duration` must be specified on trainer.__init__ when autoresume is enabled. '
             if save_folder is None:
                 error_message += 'The `save_folder` must be specified when autoresume is enabled. '
             if save_overwrite:

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1212,21 +1212,23 @@ class TestCheckpointLoading:
         )
 
     @pytest.mark.parametrize(
-        'run_name,save_folder,save_overwrite,latest_filename',
+        'run_name,save_folder,save_overwrite,latest_filename,max_duration',
         [
-            [None, 'first', False, 'latest-rank{rank}.pt'],
-            ['big-chungus', None, False, 'latest-rank{rank}.pt'],
-            ['big-chungus', 'first', True, 'latest-rank{rank}.pt'],
-            ['big-chungus', 'first', False, None],
+            [None, 'first', False, 'latest-rank{rank}.pt', '2ep'],
+            ['big-chungus', None, False, 'latest-rank{rank}.pt', '2ep'],
+            ['big-chungus', 'first', True, 'latest-rank{rank}.pt', '2ep'],
+            ['big-chungus', 'first', False, None, '2ep'],
+            ['big-chungus', 'first', False, 'latest-rank{rank}.pt', None],
         ],
     )
-    def test_autoresume_fail(self, run_name, save_folder, save_overwrite, latest_filename):
+    def test_autoresume_fail(self, run_name, save_folder, save_overwrite, latest_filename, max_duration):
         with pytest.raises(ValueError):
             self.get_trainer(
                 latest_filename=latest_filename,
                 save_overwrite=save_overwrite,
                 save_folder=save_folder,
                 run_name=run_name,
+                max_duration=max_duration,
                 autoresume=True,
             )
 

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1235,11 +1235,11 @@ class TestCheckpointLoading:
             )
 
     @pytest.mark.parametrize(
-            'duration,reset_time',
-            [
-                ['1ep', False],
-                [None, True],
-            ]
+        'duration,reset_time',
+        [
+            ['1ep', False],
+            [None, True],
+        ],
     )
     def test_autoresume_fail_fit(self, duration: Optional[str], reset_time: bool):
         trainer = self.get_trainer(

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -667,6 +667,7 @@ class TestCheckpointLoading:
         max_duration: str = '2ep',
         latest_filename: str = 'latest-rank{rank}.pt',
         file_extension: str = '.pt',
+        use_scheduler: bool = True,
         **kwargs,
     ):
         if model is None:
@@ -704,7 +705,7 @@ class TestCheckpointLoading:
             save_filename='ep{epoch}' + file_extension,
             max_duration=max_duration,
             optimizers=optimizer,
-            schedulers=ExponentialScheduler(gamma=0.9),
+            schedulers=ExponentialScheduler(gamma=0.9) if use_scheduler else None,
             callbacks=callbacks,
             **kwargs,
         )
@@ -1221,7 +1222,7 @@ class TestCheckpointLoading:
             ['big-chungus', 'first', False, 'latest-rank{rank}.pt', None],
         ],
     )
-    def test_autoresume_fail(self, run_name, save_folder, save_overwrite, latest_filename, max_duration):
+    def test_autoresume_fail_init(self, run_name, save_folder, save_overwrite, latest_filename, max_duration):
         with pytest.raises(ValueError):
             self.get_trainer(
                 latest_filename=latest_filename,
@@ -1230,7 +1231,24 @@ class TestCheckpointLoading:
                 run_name=run_name,
                 max_duration=max_duration,
                 autoresume=True,
+                use_scheduler=False,
             )
+
+    @pytest.mark.parametrize(
+            'duration,reset_time',
+            [
+                ['1ep', False],
+                [None, True],
+            ]
+    )
+    def test_autoresume_fail_fit(self, duration: Optional[str], reset_time: bool):
+        trainer = self.get_trainer(
+            run_name='bigtrainer',
+            save_folder='first',
+            autoresume=True,
+        )
+        with pytest.raises(ValueError):
+            trainer.fit(duration=duration, reset_time=reset_time)
 
     def test_different_run_names(self):
 


### PR DESCRIPTION
# What does this PR do?

Additional checks based on https://github.com/mosaicml/composer/issues/3357:
- Autoresume requires max_duration be specified on init and cannot accept `duration` in `fit`. Otherwise, Composer will autoresume from last checkpoint, and then the specified value of `max_duration` from `fit` will be incremented to the loaded max duration. In short, `fit(duration=...)` is not idempotent with autoresume.
- `reset_time` in `fit` does not work with autoresume as it will force a restart in training. Instead, time should be ignored on load, which is used in initial load and not on autoresume load
- Implicitly prevents multiple calls to fit -- if you cannot increment duration in fit or reset time, it is not possible to call fit twice. 