### PR TITLE
[Not for merge] Deprecate and bump verstion to 0.23.0 (#3359)

### DIFF
--- a/composer/_version.py
+++ b/composer/_version.py
@@ -3,4 +3,4 @@
 
 """The Composer Version."""
 
-__version__ = '0.24.0.dev0'
+__version__ = '0.23.0'

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1723,12 +1723,9 @@ class Trainer:
         # Load Checkpoint
         self._rng_state = None
         # If autoresume is enabled, first check for existing checkpoints to load
-        self.autoresume = autoresume
-        if self.autoresume:
+        if autoresume:
             log.info('Searching for a previous checkpoint to autoresume')
             error_message = ''
-            if max_duration is None:
-                error_message += 'The `max_duration` must be specified on trainer.__init__ when autoresume is enabled. '
             if save_folder is None:
                 error_message += 'The `save_folder` must be specified when autoresume is enabled. '
             if save_overwrite:
@@ -2191,21 +2188,10 @@ class Trainer:
 
         # Reset Time
         if reset_time:
-            if self.autoresume:
-                raise ValueError(
-                    'Cannot specify `reset_time=True` when autoresume is enabled. Please instead '
-                    'specify `load_ignore_keys` when constructing the Trainer, which will only '
-                    'run on the initial load and not any subsequent autoresumptions.',
-                )
             self.state.timestamp = Timestamp()
 
         # Max Duration
         if duration is not None:
-            if self.autoresume:
-                raise ValueError(
-                    '`duration` cannot be specified when autoresume is enabled. Please instead '
-                    'specify `max_duration` when constructing the Trainer.',
-                )
             duration = ensure_time(duration, TimeUnit.EPOCH)
             if duration.unit == TimeUnit.SECOND:
                 raise ValueError('Wall clock time not an allowed time unit.')

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -667,7 +667,6 @@ class TestCheckpointLoading:
         max_duration: str = '2ep',
         latest_filename: str = 'latest-rank{rank}.pt',
         file_extension: str = '.pt',
-        use_scheduler: bool = True,
         **kwargs,
     ):
         if model is None:
@@ -705,7 +704,7 @@ class TestCheckpointLoading:
             save_filename='ep{epoch}' + file_extension,
             max_duration=max_duration,
             optimizers=optimizer,
-            schedulers=ExponentialScheduler(gamma=0.9) if use_scheduler else None,
+            schedulers=ExponentialScheduler(gamma=0.9),
             callbacks=callbacks,
             **kwargs,
         )
@@ -1213,42 +1212,23 @@ class TestCheckpointLoading:
         )
 
     @pytest.mark.parametrize(
-        'run_name,save_folder,save_overwrite,latest_filename,max_duration',
+        'run_name,save_folder,save_overwrite,latest_filename',
         [
-            [None, 'first', False, 'latest-rank{rank}.pt', '2ep'],
-            ['big-chungus', None, False, 'latest-rank{rank}.pt', '2ep'],
-            ['big-chungus', 'first', True, 'latest-rank{rank}.pt', '2ep'],
-            ['big-chungus', 'first', False, None, '2ep'],
-            ['big-chungus', 'first', False, 'latest-rank{rank}.pt', None],
+            [None, 'first', False, 'latest-rank{rank}.pt'],
+            ['big-chungus', None, False, 'latest-rank{rank}.pt'],
+            ['big-chungus', 'first', True, 'latest-rank{rank}.pt'],
+            ['big-chungus', 'first', False, None],
         ],
     )
-    def test_autoresume_fail_init(self, run_name, save_folder, save_overwrite, latest_filename, max_duration):
+    def test_autoresume_fail(self, run_name, save_folder, save_overwrite, latest_filename):
         with pytest.raises(ValueError):
             self.get_trainer(
                 latest_filename=latest_filename,
                 save_overwrite=save_overwrite,
                 save_folder=save_folder,
                 run_name=run_name,
-                max_duration=max_duration,
                 autoresume=True,
-                use_scheduler=False,
             )
-
-    @pytest.mark.parametrize(
-        'duration,reset_time',
-        [
-            ['1ep', False],
-            [None, True],
-        ],
-    )
-    def test_autoresume_fail_fit(self, duration: Optional[str], reset_time: bool):
-        trainer = self.get_trainer(
-            run_name='bigtrainer',
-            save_folder='first',
-            autoresume=True,
-        )
-        with pytest.raises(ValueError):
-            trainer.fit(duration=duration, reset_time=reset_time)
 
     def test_different_run_names(self):
 


### PR DESCRIPTION
composer regression test is all green: https://databricks.slack.com/archives/C05T1A4UMT8/p1717531031511519
daily test: https://github.com/mosaicml/composer/actions/runs/9372818703

regression test: https://databricks.slack.com/archives/C05T1A4UMT8/p1717611038549159