### PR TITLE
Generalize PEFT state dict filter

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -208,13 +208,14 @@ class HuggingFaceModel(ComposerModel):
         full_state_dict = super().state_dict(*args, **kwargs)
 
         if self.using_peft and self.should_save_peft_only:
+            from peft.utils.save_and_load import get_peft_model_state_dict
+
             active_adapter = self.model.active_adapter
             assert isinstance(active_adapter, str)
-            full_state_dict = filter_state_dict_peft(
-                full_state_dict,
-                self.model.peft_config[active_adapter],
-                adapter_name='default',
-                remove_adapter_names=False,
+            full_state_dict = get_peft_model_state_dict(
+                model=self.model,
+                state_dict=full_state_dict,
+                adapter_name=active_adapter,
             )
 
         return full_state_dict


### PR DESCRIPTION
# What does this PR do?
In the original PEFT integration PR, I copied some of the logic from PEFT for state dict filtering. My logic at the time was a bit flawed (I thought passing the model to this function would be an issue for some reason, but realized its not), so updating now to use the PEFT utility directly.

