### PR TITLE
Clear caplog and use as context manager in test_logging

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -306,24 +306,25 @@ def test_logging(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test that engine logs statements as expected"""
-    caplog.set_level(logging.DEBUG, logger=Engine.__module__)
-    # Include a callback, since most logging happens around callback events
-    dummy_state.callbacks = [EventCounterCallback()]
+    caplog.clear()
+    with caplog.set_level(logging.DEBUG, logger=Engine.__module__):
+        # Include a callback, since most logging happens around callback events
+        dummy_state.callbacks = [EventCounterCallback()]
 
-    monkeypatch.setenv('ENGINE_DEBUG', '1')
-    engine = Engine(dummy_state, dummy_logger)
-    engine.run_event('INIT')
-    engine.close()
+        monkeypatch.setenv('ENGINE_DEBUG', '1')
+        engine = Engine(dummy_state, dummy_logger)
+        engine.run_event('INIT')
+        engine.close()
 
-    # Validate that we have the expected log entries
-    assert caplog.record_tuples == [
-        ('composer.core.engine', 10, '[ep=0][ba=0][event=INIT]: Running event'),
-        ('composer.core.engine', 10, '[ep=0][ba=0][event=INIT]: Running callback EventCounterCallback'),
-        ('composer.core.engine', 10, 'Closing the engine.'),
-        ('composer.core.engine', 10, 'Closing callback EventCounterCallback'),
-        ('composer.core.engine', 10, 'Post-closing callback EventCounterCallback'),
-        ('composer.core.engine', 10, 'Engine closed.'),
-    ]
+        # Validate that we have the expected log entries
+        assert caplog.record_tuples == [
+            ('composer.core.engine', 10, '[ep=0][ba=0][event=INIT]: Running event'),
+            ('composer.core.engine', 10, '[ep=0][ba=0][event=INIT]: Running callback EventCounterCallback'),
+            ('composer.core.engine', 10, 'Closing the engine.'),
+            ('composer.core.engine', 10, 'Closing callback EventCounterCallback'),
+            ('composer.core.engine', 10, 'Post-closing callback EventCounterCallback'),
+            ('composer.core.engine', 10, 'Engine closed.'),
+        ]
 
 
 def _worker():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -307,7 +307,7 @@ def test_logging(
 ):
     """Test that engine logs statements as expected"""
     caplog.clear()
-    with caplog.set_level(logging.DEBUG, logger=Engine.__module__):
+    with caplog.at_level(logging.DEBUG, logger=Engine.__module__):
         # Include a callback, since most logging happens around callback events
         dummy_state.callbacks = [EventCounterCallback()]
 


### PR DESCRIPTION
# What does this PR do?

To prevent other logs from polluting the logs captured in `test_logging`, calls `caplog.clear()` and uses it as a context manager instead.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
