### PR TITLE
Remove FSDP restriction from PyTorch 1.13

### DIFF
--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -328,7 +328,7 @@ def prepare_fsdp_module(
 
     mixed_precision = fsdp_config.mixed_precision
     keep_low_precision_grads = fsdp_config.keep_low_precision_grads
-    mixed_precision, param_dtype, _, _ = get_mixed_precision(
+    mixed_precision, _, _, _ = get_mixed_precision(
         precision,
         mixed_precision=mixed_precision,
         keep_low_precision_grads=keep_low_precision_grads,


### PR DESCRIPTION
# What does this PR do?

Remove FSDP restriction from PyTorch 1.13. We added this to give a friendlier error for users when PyTorch had a bug, but the corresponding issue is closed and fixed and has been patched for a while since PyTorch 2.