### PR TITLE
Add missing import for PyTorch 2.3.1 device mesh slicing

### DIFF
--- a/composer/trainer/_patch_pytorch.py
+++ b/composer/trainer/_patch_pytorch.py
@@ -933,6 +933,8 @@ if version.parse(torch.__version__) >= version.parse('2.3.0') and version.parse(
             return submesh
 
     else:
+        from torch.distributed.device_mesh import _mesh_resources
+
         def create_child_mesh(
             self, parent_mesh: 'DeviceMesh', submesh_dim_names: Tuple[str, ...],
         ) -> 'DeviceMesh':


### PR DESCRIPTION
# What does this PR do?

Add missing import for PyTorch 2.3.1 device mesh slicing
