### PR TITLE
Add pynvml to mlflow dep group

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -225,6 +225,7 @@ extra_deps['onnx'] = [
 extra_deps['mlflow'] = [
     'mlflow>=2.11.1,<3.0',
     'databricks-sdk==0.28.0',
+    'pynvml>=11.5.0,<12',
 ]
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']


### PR DESCRIPTION
# What does this PR do?
If pynvml is not installed, mlflow will not record GPU system metrics.

Test run with GPU metrics: https://dbc-559ffd80-2bfc.cloud.databricks.com/ml/experiments/1021774554687852/runs/9cbe6daa2cb64297bf6b3b649312f462/system-metrics?o=7395834863327820