### PR TITLE
fixing mlflow logging to Databricks workspace file paths with /Shared/ prefix

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -150,7 +150,9 @@ class MLFlowLogger(LoggerDestination):
                 )
             assert self.experiment_name is not None  # type hint
 
-            if os.getenv('DATABRICKS_TOKEN') is not None and not self.experiment_name.startswith('/Users/') and not self.experiment_name.startswith('/Shared/'):
+            if os.getenv('DATABRICKS_TOKEN') is not None and not self.experiment_name.startswith(
+                ('/Users/', '/Shared/')
+            ):
                 try:
                     from databricks.sdk import WorkspaceClient
                 except ImportError as e:

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -150,9 +150,12 @@ class MLFlowLogger(LoggerDestination):
                 )
             assert self.experiment_name is not None  # type hint
 
-            if os.getenv('DATABRICKS_TOKEN') is not None and not self.experiment_name.startswith(
-                ('/Users/', '/Shared/')
-            ):
+            if os.getenv(
+                'DATABRICKS_TOKEN',
+            ) is not None and not self.experiment_name.startswith((
+                '/Users/',
+                '/Shared/',
+            )):
                 try:
                     from databricks.sdk import WorkspaceClient
                 except ImportError as e:

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -160,10 +160,7 @@ class MLFlowLogger(LoggerDestination):
                         conda_channel='conda-forge',
                     ) from e
                 databricks_username = WorkspaceClient().current_user.me().user_name or ''
-                if self.experiment_name.startswith('/Shared/'):
-                    self.experiment_name = os.path.join('Users', databricks_username, self.experiment_name)
-                else:
-                    self.experiment_name = '/' + os.path.join('Users', databricks_username, self.experiment_name)
+                self.experiment_name = os.path.join('/Users', databricks_username, self.experiment_name.strip('/'))
 
             self._mlflow_client = MlflowClient(self.tracking_uri)
             # Set experiment

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -150,7 +150,7 @@ class MLFlowLogger(LoggerDestination):
                 )
             assert self.experiment_name is not None  # type hint
 
-            if os.getenv('DATABRICKS_TOKEN') is not None and not self.experiment_name.startswith('/Users/'):
+            if os.getenv('DATABRICKS_TOKEN') is not None and not self.experiment_name.startswith('/Users/') and not self.experiment_name.startswith('/Shared/'):
                 try:
                     from databricks.sdk import WorkspaceClient
                 except ImportError as e:

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -160,7 +160,10 @@ class MLFlowLogger(LoggerDestination):
                         conda_channel='conda-forge',
                     ) from e
                 databricks_username = WorkspaceClient().current_user.me().user_name or ''
-                self.experiment_name = '/' + os.path.join('Users', databricks_username, self.experiment_name)
+                if self.experiment_name.startswith('/Shared/'):
+                    self.experiment_name = os.path.join('Users', databricks_username, self.experiment_name)
+                else:
+                    self.experiment_name = '/' + os.path.join('Users', databricks_username, self.experiment_name)
 
             self._mlflow_client = MlflowClient(self.tracking_uri)
             # Set experiment


### PR DESCRIPTION
In mlflow logging, users that wanted to log into the "/Shared/" file directory had an extra slash in their modified experiment names, leading to Mlflow not recognizing existing experiments, trying to create them, and then claiming they already exist.

This PR accounts for that edge case and removes the extra slash added.

Prior to this PR, there was a bug where users who directly wanted to mlflow-log to the `/Shared/` workspace would be able to do so after the first run of an experiment name, but would not be able to for following runs of the same experiment name. We found that an extra '/' was prepended to the experiment name (yielding an experiment name of `//Shared/...` after `'/' + os.path.join('Users', databricks_username, experiment_name)`), leading to `get_experiment_by_name` not finding the existing experiment, and `create_experiment` claiming that it already exists (which it does). There are probably ways in which `get_experiment_name` and `create_experiment` name handle file directories differently, also contributing to this bug.

In the original code prior to this PR, inputting an experiment name starting with `/Shared/` would throw this error: `mlflow.exceptions.RestException: RESOURCE_ALREADY_EXISTS: Node named ___ already exists`

Now, mlflow logger correctly logs to the `/Shared/...` folder path as an absolute path.

Before:

- `/Shared/...` -> `/Users/Shared/...`
- `/Users/...` -> `/Users/...`
- `path` -> `/Users/path`

After:

- `/Shared/...` -> `/Shared/...`  (no change)
- `/Users/...` -> `/Users/...`
- `path` -> `/Users/path`

