### PR TITLE
Move pillow dep as required

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,13 +25,6 @@ ARG PYTORCH_VERSION=1.13.1
 # version that corresponds to the PyTorch version
 ARG TORCHVISION_VERSION=0.14.1
 
-# In the Dockerimage, Pillow-SIMD is installed instead of Pillow. To trick pip into thinking that
-# Pillow is also installed (so it won't override it with a future pip install), a Pillow stub is included
-# PILLOW_PSEUDOVERSION is the Pillow version that pip thinks is installed
-# PILLOW_SIMD_VERSION is the actual version of pillow-simd that is installed.
-ARG PILLOW_PSEUDOVERSION=9.3.0
-ARG PILLOW_SIMD_VERSION=9.0.0.post1
-
 # Version of the Mellanox Drivers to install (for InfiniBand support)
 # Leave blank for no Mellanox Drivers
 ARG MOFED_VERSION=5.5-1.0.3.2
@@ -180,20 +173,6 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
 
 RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} - && \
     pip${PYTHON_VERSION} install --no-cache-dir --upgrade 'pip<23' 'setuptools<70.0.0'
-
-#####################
-# Install pillow-simd
-#####################
-ARG PILLOW_PSEUDOVERSION
-ARG PILLOW_SIMD_VERSION
-
-# pillow_stub tricks pip into thinking that it installed pillow,
-# so when pillow_simd is installed, other packages won't later override it
-COPY pillow_stub /tmp/pillow_stub
-
-RUN pip${PYTHON_VERSION} install --no-cache-dir --upgrade /tmp/pillow_stub && \
-    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pillow_simd==${PILLOW_SIMD_VERSION} && \
-    rm -rf /tmp/pillow_stub
 
 #################
 # Install Pytorch

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ install_requires = [
     'packaging>=21.3.0,<24.2',
     'importlib-metadata>=5.0.0,<7',
     'mosaicml-cli>=0.5.25,<0.7',
+    'pillow>=10.3.0,<11',
 ]
 extra_deps = {}
 
@@ -142,7 +143,6 @@ extra_deps['dev'] = [
     'cryptography==42.0.8',
     'pytest-httpserver>=1.0.4,<1.1',
     'setuptools<=59.5.0',
-    'pillow>=10.3.0,<11',
 ]
 
 extra_deps['system_metrics_monitor'] = {
@@ -280,17 +280,3 @@ setup(
     ext_package='composer',
     cmdclass={'develop': develop},
 )
-
-# only visible if user installs with verbose -v flag
-# Printing to stdout as not to interfere with setup.py CLI flags (e.g. --version)
-print('*' * 20, file=sys.stderr)
-print(
-    textwrap.dedent(
-        """\
-    NOTE: For best performance, we recommend installing Pillow-SIMD
-    for accelerated image processing operations. To install:
-    \t pip uninstall pillow && pip install pillow-simd""",
-    ),
-    file=sys.stderr,
-)
-print('*' * 20, file=sys.stderr)


### PR DESCRIPTION
# What does this PR do?

Move pillow dep as required. Previously, we had pillow as only under `dev`, but it is required for the import tree as several algorithms use it.