### PR TITLE
Fixes to TP Docs

### DIFF
--- a/docs/source/notes/distributed_training.rst
+++ b/docs/source/notes/distributed_training.rst
@@ -540,23 +540,24 @@ Composer integrates Pytorch's `Tensor Parallel <https://pytorch.org/docs/stable/
 API with some syntactic sugar to make it easy to write custom models that work with Composer + TP.
 
 To enable Tensor Parallel, a tensor parallel config must be passed to the Composer Trainer. The
-full spec and defaults for Composer's tensor parallelism_config is here:
+full spec and defaults for Composer's tensor parallelism config is here:
 
 .. code:: python
 
     tp_config = {
         tensor_parallel_degree: int = 1, # Default: 1
-        pipeline_parallel_degree: int = 1, # Default: None
+        layer_plan: dict = None, # Default: None, maps to torch's `parallelize_plan`
     }
 
 All values come with defaults and can be optionally defined in the :code:`tp_config`. Most parameters
 map directly to parameters in the
 `Tensor Parallel documentation <https://pytorch.org/docs/stable/distributed.tensor.parallel.html#torch.distributed.tensor.parallel.parallelize_module>`__.
-This config is passed under `parallelism_config['tp']` to the Composer Trainer. An important parameters
-which do not map include `tensor_parallel_degree`, which dictates the number of devices to shard across.
+This config is passed under `parallelism_config['tp']` to the Composer Trainer. Important parameters
+which do not directly map include `tensor_parallel_degree`, which dictates the number of devices to shard across,
+and `layer_plan`, which simply corresponds to torch's `parallelize_plan`.
 
 
-An example code snippet for using FSDP with composer is provided below:
+An example code snippet for using TP and FSDP with Composer is provided below:
 
 .. code:: python
 
@@ -624,10 +625,12 @@ An example code snippet for using FSDP with composer is provided below:
         }
     }
 
-
     trainer = Trainer(
         model=composer_model,
-        parallelism_config={'fsdp': fsdp_config},
+        parallelism_config={
+            'fsdp': fsdp_config,
+            'tp': tp_config,
+        },
         ...
     )
 


### PR DESCRIPTION
# What does this PR do?

Fixes a few typos / mistakes in TP docs.

Manual docs build succeeded:
<img width="1728" alt="Screenshot 2024-06-28 at 11 22 53 AM" src="https://github.com/mosaicml/composer/assets/28932043/60564267-da13-4ebe-88c0-8e6d0cdf6561">

Modifications to docs are correctly reflected:
<img width="992" alt="Screenshot 2024-06-28 at 11 23 30 AM" src="https://github.com/mosaicml/composer/assets/28932043/baa27591-51af-45cf-960d-c23ac0cd3c36">


<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
