### PR TITLE
Remove save overwrite

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1732,11 +1732,6 @@ class Trainer:
             error_message = ''
             if save_folder is None:
                 error_message += 'The `save_folder` must be specified when autoresume is enabled. '
-            if save_overwrite:
-                error_message += textwrap.dedent(
-                    'The flag `save_overwrite` must be False when autoresume is enabled as autoresume always loads the '
-                    'latest existing checkpoint in `save_folder`. ',
-                )
             if save_latest_filename is None:
                 error_message += 'The `save_latest_filename` must be specified so autoresume knows where to load checkpoints from. '
             if error_message != '':

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -730,11 +730,19 @@ class TestCheckpointLoading:
 
     @world_size(1, 2)
     @device('cpu', 'gpu')
-    @pytest.mark.parametrize('file_extension', ['.pt', '.tar.gz', '.pt.lz4'])
     @pytest.mark.parametrize('use_object_store', [True, False])
     @pytest.mark.parametrize('delete_local', [True, False])
     @pytest.mark.parametrize('test_slashed', [True, False])
-    @pytest.mark.parametrize('save_metrics', [True, False])
+    @pytest.mark.parametrize(
+        'file_extension,save_metrics,save_overwrite',
+        [
+            ['.pt', False, False, False],
+            ['.tar.gz', False, False],
+            ['.pt.lz4', False, False],
+            ['.pt', True, False],
+            ['.pt', False, True],
+        ]
+    )
     def test_autoresume(
         self,
         device: str,
@@ -744,6 +752,7 @@ class TestCheckpointLoading:
         delete_local: bool,
         test_slashed: bool,
         save_metrics: bool,
+        save_overwrite: bool,
         world_size: int,
     ):
         if delete_local and not use_object_store:
@@ -786,6 +795,7 @@ class TestCheckpointLoading:
             autoresume=True,
             load_path='ignore_me.pt',  # this should be ignored
             load_ignore_keys=['*'],  # this should be ignored
+            save_overwrite=save_overwrite,
             loggers=[self.get_logger(tmp_path)] if use_object_store else [],
         )
 


### PR DESCRIPTION
# What does this PR do?

Previously, we required `save_overwrite=False` as it was not clear if a user intended to overwrite or resume from a checkpoint. 

However, it turns out this situation is well defined. Autoresume = resume from symlink file. It is a transformation on load_path, and nothing else. So, you can actually set autoresume on and save_overwrite to True, which would be useful for partial checkpoint uploads where the symlink file is not added.