### PR TITLE
Lower the system metrics logging frequency to reduce MLflow server's load

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -123,6 +123,13 @@ class MLFlowLogger(LoggerDestination):
         if logging_buffer_seconds:
             os.environ['MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS'] = str(logging_buffer_seconds)
 
+        if log_system_metrics:
+            # Set system metrics sampling interval and samples before logging so that system metrics
+            # are collected every 10s, and aggregated over 3 samples before being logged
+            # (logging per 30s).
+            mlflow.set_system_metrics_samples_before_logging(3)
+            mlflow.set_system_metrics_sampling_interval(10)
+
         self._rank_zero_only = rank_zero_only
         self._last_flush_time = time.time()
         self._flush_interval = flush_interval

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -125,10 +125,10 @@ class MLFlowLogger(LoggerDestination):
 
         if log_system_metrics:
             # Set system metrics sampling interval and samples before logging so that system metrics
-            # are collected every 10s, and aggregated over 3 samples before being logged
-            # (logging per 30s).
+            # are collected every 5s, and aggregated over 3 samples before being logged
+            # (logging per 15s).
             mlflow.set_system_metrics_samples_before_logging(3)
-            mlflow.set_system_metrics_sampling_interval(10)
+            mlflow.set_system_metrics_sampling_interval(5)
 
         self._rank_zero_only = rank_zero_only
         self._last_flush_time = time.time()


### PR DESCRIPTION
# What does this PR do?

Lower the system metrics logging frequency to reduce MLflow server's load. System metrics logging is using a different async logging queue from normal metrics, so the time buffering doesn't apply to system metrics. This design was by intention so that MLflow can terminate system metrics separately. 30s is the logging frequency of wandb, so there should be no user experience regression.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
