### PR TITLE
Remove close flush for mosaicml logger

### DIFF
--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -146,7 +146,8 @@ class MosaicMLLogger(LoggerDestination):
         self._flush_metadata(force_flush=True)
 
     def close(self, state: State, logger: Logger) -> None:
-        self._flush_metadata(force_flush=True, future=False)
+        # Skip flushing metadata as it should be logged by fit/eval/predict_end. Flushing here
+        # might schedule futures while interpreter is shutting down, which will raise an error.
         if self._enabled:
             wait(self._futures)  # Ignore raised errors on close
 


### PR DESCRIPTION
# What does this PR do?

Remove close flush for mosaicml logger. All data is force flushed on fit/predict/eval_end. Attempting to log on close may result in an error as it tries to schedule a future while the python interpreter is shutting down. Instead, we should only wait on existing futures already scheduled.

While we attempt to not schedule futures and do a blocking op currently, under the hood mcli still uses asyncio which uses futures.