### PR TITLE
fix mlflow logger

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -42,6 +42,8 @@ class MLFlowLogger(LoggerDestination):
         run_name: (str, optional): MLflow run name. If not set it will be the same as the
             Trainer run name
         tags: (dict, optional): MLflow tags to log with the run
+        tracking_uri (str | pathlib.Path, optional): MLflow tracking uri, the URI to the
+            remote or local endpoint where logs are stored (If none it is set to MLflow default)
         rank_zero_only (bool, optional): Whether to log only on the rank-zero process
             (default: ``True``).
         flush_interval (int): The amount of time, in seconds, that MLflow must wait between
@@ -74,6 +76,7 @@ class MLFlowLogger(LoggerDestination):
         experiment_name: Optional[str] = None,
         run_name: Optional[str] = None,
         tags: Optional[dict[str, Any]] = None,
+        tracking_uri: Optional[str] = None,
         rank_zero_only: bool = True,
         flush_interval: int = 10,
         model_registry_prefix: str = '',

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -105,6 +105,7 @@ class MLFlowLogger(LoggerDestination):
         self.run_name = run_name
         self.run_group = run_group
         self.tags = tags or {}
+        self.tracking_uri = tracking_uri
         self.model_registry_prefix = model_registry_prefix
         self.model_registry_uri = model_registry_uri
         self.synchronous = synchronous


### PR DESCRIPTION
Right now when a user explicitly passes a tracking uri into mlflow logger that isn't databricks df1, they get a `mlflow.exceptions.RestException: 401: Unauthorized error` when they try to read or write to that workspace, even when their environment `DATABRICKS_HOST` and `DATABRICKS_TOKEN` are correctly configured to that non-df1 workspace. 

The reason why this has gone unnoticed is because when the user sets the tracking uri to "databricks" or just leaves it blank, they don't log to df1 and still log to the intended databricks host their environment variables are set to, because initializing `mlflow_client = MlflowClient('databricks')` just automatically uses the environment's `DATABRICKS_HOST`. However, initializing `mlflow_client = MlflowClient('other_tracking_uri')` and then trying to log or read yields `mlflow.exceptions.RestException: 401: Unauthorized error`.

Because the only workspace that the user is able to read/write to is their environment's `DATABRICKS_HOST`, passing `tracking_uri` to mlflow logger seems completely redundant. Additionally, from the Mlflow team, this is the generally accepted way to initialize the mlflow client. 

```
mlflow.login()
mlflow_client = mlflow.tracking.MlflowClient()
```

After this PR, `tracking_uri` is no longer a parameter to be passed in, and mlflow logger will just log to `DATABRICKS_HOST`.

This is a breaking change, given that `tracking_uri` is no longer going to be accepted, so we can keep accepting it as a dummy parameter to prevent widespread breaking.