### PR TITLE
Remove Log Exception

### DIFF
--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -97,10 +97,6 @@ class MosaicMLLogger(LoggerDestination):
     def log_metrics(self, metrics: dict[str, Any], step: Optional[int] = None) -> None:
         self.log_metadata(metrics)
 
-    def log_exception(self, exception: Exception):
-        self.log_metadata({'exception': exception_to_json_serializable_dict(exception)})
-        self._flush_metadata(force_flush=True)
-
     def after_load(self, state: State, logger: Logger) -> None:
         # Log model data downloaded and initialized for run events
         log.debug(f'Logging model initialized time to metadata')


### PR DESCRIPTION
# Remove Log Exception
- removes log exception from mosaicmllogger because we are no longer using it to record exceptions.
Dependent on foundry pr to merge first: https://github.com/mosaicml/llm-foundry/pull/1292