### PR TITLE
Add fit start to mosaicmllogger

### DIFF
--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -135,6 +135,11 @@ class MosaicMLLogger(LoggerDestination):
         self.log_metadata(training_progress_data)
         self._flush_metadata(force_flush=True)
 
+    def fit_start(self, state: State, logger: Logger) -> None:
+        # Log model training started time for run events
+        self.log_metadata({'train_started_time': time.time()})
+        self._flush_metadata(force_flush=True)
+
     def eval_end(self, state: State, logger: Logger) -> None:
         self._flush_metadata(force_flush=True)
 

--- a/tests/loggers/test_mosaicml_logger.py
+++ b/tests/loggers/test_mosaicml_logger.py
@@ -321,6 +321,7 @@ def test_run_events_logged(monkeypatch):
     assert metadata['mosaicml/training_progress'] == '[batch=4/4]'
     assert 'mosaicml/training_sub_progress' not in metadata
     assert isinstance(metadata['mosaicml/train_finished_time'], float)
+    assert isinstance(metadata['mosaicml/train_started_time'], float)
 
 
 def test_token_training_progress_metrics():


### PR DESCRIPTION
# What does this PR do?
Goal is to add new TRAIN_START run event outlined in this doc:
https://docs.google.com/document/d/1Rk43aTNFXIUULs0OvTMQGXrV8bJkITmjICyGmMrF2Zc/edit

This will correspond to the FIT_START composer event
<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
