### PR TITLE
Fix checkpoint events

### DIFF
--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -22,7 +22,7 @@ from urllib.parse import urlparse
 
 import torch
 
-from composer.loggers import Logger, MosaicMLLogger
+from composer.loggers import Logger
 from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import (
     MLFlowObjectStore,
@@ -308,12 +308,13 @@ class RemoteUploaderDownloader(LoggerDestination):
         return self._remote_backend
 
     def init(self, state: State, logger: Logger) -> None:
+        del logger  # unused
+
         if self._worker_flag is not None:
             raise RuntimeError('The RemoteUploaderDownloader is already initialized.')
         self._worker_flag = self._finished_cls()
         self._run_name = state.run_name
         file_name_to_test = self._remote_file_name('.credentials_validated_successfully')
-        self._logger = logger
 
         # Create the enqueue thread
         self._enqueue_thread_flag = self._finished_cls()
@@ -426,9 +427,6 @@ class RemoteUploaderDownloader(LoggerDestination):
                         break
                     self._enqueued_objects.remove(object_name)
                     self._completed_queue.task_done()
-                    for destination in self._logger.destinations:
-                        if isinstance(destination, MosaicMLLogger):
-                            destination.log_metadata({'checkpoint_uploaded_time': time.time()}, force_flush=True)
 
                 # Enqueue all objects that are in self._logged_objects but not in self._file_upload_queue
                 objects_to_delete = []


### PR DESCRIPTION
# What does this PR do?

Move checkpoint event to emit a run event when the symlink is uploaded. This means that the run event will accurately track when a checkpoint upload finishes.

A previous approximation was merged in #3316 

e2e test `checkpoint-events-test-rd9zih`

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
