### PR TITLE
Corrected docs for MFU in SpeedMonitor

### DIFF
--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -223,10 +223,11 @@ class SpeedMonitor(Callback):
     | `throughput/device/flops_per_sec`   | logged when model has attribute `flops_per_batch`         |
     |                                     |                                                           |
     +-------------------------------------+-----------------------------------------------------------+
-    |                                     | `throughput/device/flops_per_sec` divided by world size.  |
-    | `throughput/device/mfu`             | Only logged when model has attribute `flops_per_batch`    |
-    |                                     | and `gpu_flops_available`, which can be passed as an      |
-    |                                     | argument if not automatically determined by SpeedMonitor  |
+    |                                     | `throughput/device/flops_per_sec` divided by flops        |
+    |                                     | available on the GPU device. Only logged when model has   |
+    | `throughput/device/mfu`             | attribute `flops_per_batch` and `gpu_flops_available`,    |
+    |                                     | which can be passed as an argument if not automatically   |
+    |                                     | determined by SpeedMonitor                                |
     +-------------------------------------+-----------------------------------------------------------+
     | `time/train`                        | Total elapsed training time                               |
     +-------------------------------------+-----------------------------------------------------------+


### PR DESCRIPTION
Corrected definition of `throughput/device/mfu` from "`throughput/device/flops_per_sec` divided by world size"  to "`throughput/device/flops_per_sec` divided by flops available on the GPU device."

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
