### PR TITLE
Get a shared file system safe signal file name

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1986,7 +1986,7 @@ class Trainer:
 
             signal_file_path = os.path.join(
                 os.path.dirname(latest_checkpoint_path),
-                f'.node_{dist.get_node_rank()}_local_rank0_completed_autoresume',
+                dist.get_node_signal_file_name(),
             )
             if dist.get_local_rank() == 0:
                 os.makedirs(os.path.dirname(signal_file_path), exist_ok=True)

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -819,7 +819,7 @@ def download_checkpoint(
         if not checkpoint_is_sharded:
             signal_file_path = os.path.join(
                 node_checkpoint_folder,
-                f'.node_{dist.get_node_rank()}_local_rank0_completed',
+                dist.get_node_signal_file_name(),
             )
             if dist.get_local_rank() == 0:
                 with open(signal_file_path, 'wb') as f:

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -644,8 +644,7 @@ def get_node_signal_file_name(rng: Optional[random.Random] = None) -> str:
     random_string = ''.join(rng.choices(string.ascii_letters + string.digits, k=6))
     node_rank = get_node_rank()
     file_name_list = [f'._signal_file_node{node_rank}_{random_string}']
-    if dist.is_available() and dist.is_initialized():
-        dist.broadcast_object_list(file_name_list, src=0)
+    broadcast_object_list(file_name_list, src=0)
     return file_name_list[0]
 
 

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -644,7 +644,8 @@ def get_node_signal_file_name(rng: Optional[random.Random] = None) -> str:
     random_string = ''.join(rng.choices(string.ascii_letters + string.digits, k=6))
     node_rank = get_node_rank()
     file_name_list = [f'._signal_file_node{node_rank}_{random_string}']
-    dist.broadcast_object_list(file_name_list, src=0)
+    if dist.is_available() and dist.is_initialized():
+        dist.broadcast_object_list(file_name_list, src=0)
     return file_name_list[0]
 
 


### PR DESCRIPTION
# What does this PR do?
Use the previously added utils to get a signal file name that is safe on shared file systems. Previously the name would clash.

Tested simple train and load (don't have a multinode shared fs to actually test that part on):
train: `dist-utils-train-1-UExzEF`
load: `dist-utils-load-2-Uoq35b`