### PR TITLE
[Checkpoint V2] Upload API

### DIFF
--- a/composer/checkpoint/__init__.py
+++ b/composer/checkpoint/__init__.py
@@ -4,13 +4,13 @@
 """Module for checkpointing API."""
 
 from composer.checkpoint.download import download_monolithic_checkpoint
-from composer.checkpoint.upload import upload_file
 from composer.checkpoint.state_dict import (
     get_metadata_state_dict,
     get_model_state_dict,
     get_optim_state_dict,
     get_resumption_state_dict,
 )
+from composer.checkpoint.upload import upload_file
 
 __all__ = [
     'get_model_state_dict',

--- a/composer/checkpoint/__init__.py
+++ b/composer/checkpoint/__init__.py
@@ -4,6 +4,7 @@
 """Module for checkpointing API."""
 
 from composer.checkpoint.download import download_monolithic_checkpoint
+from composer.checkpoint.upload import upload_file
 from composer.checkpoint.state_dict import (
     get_metadata_state_dict,
     get_model_state_dict,
@@ -17,4 +18,5 @@ __all__ = [
     'get_metadata_state_dict',
     'get_resumption_state_dict',
     'download_monolithic_checkpoint',
+    'upload_file',
 ]

--- a/composer/checkpoint/upload.py
+++ b/composer/checkpoint/upload.py
@@ -82,6 +82,7 @@ class CheckpointUploadCallback(Callback):
             else:
                 result = check_remote_files_exist_future.result()
                 if result == RemoteFilesExistingCheckStatus.EXIST:
+                    assert remote_symlink_file is not None
                     self.remote_uploader.upload_file_async(
                         remote_file_name=remote_symlink_file,
                         file_path=pathlib.Path(local_symlink_file),
@@ -102,6 +103,7 @@ class CheckpointUploadCallback(Callback):
             check_remote_files_exist_future, local_symlink_file, remote_symlink_file = self.symlink_upload_tasks[-1]
             result = check_remote_files_exist_future.result()
             if result == RemoteFilesExistingCheckStatus.EXIST:
+                assert remote_symlink_file is not None
                 symlink_upload_future = self.remote_uploader.upload_file_async(
                     remote_file_name=remote_symlink_file,
                     file_path=pathlib.Path(local_symlink_file),

--- a/composer/checkpoint/upload.py
+++ b/composer/checkpoint/upload.py
@@ -37,6 +37,10 @@ class CheckpointUploadCallback(Callback):
         else:
             self.rank_saves_symlinks = False
 
+        # Each Tuple contains information of:
+        # the future of checking if checkpoint files upload finish
+        # local symlink file name
+        # remote symlink file name
         self.symlink_upload_tasks: list[tuple[Future[RemoteFilesExistingCheckStatus], str, Optional[str]]] = []
         self.upload_timeout_in_seconds: int = upload_timeout_in_seconds
 

--- a/composer/checkpoint/upload.py
+++ b/composer/checkpoint/upload.py
@@ -1,0 +1,207 @@
+# Copyright 2024 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Useful functions for uploading checkpoints to remote object store."""
+
+import logging
+import os
+import pathlib
+import tempfile
+from concurrent.futures import Future
+from typing import Optional
+
+import composer.utils.dist as dist
+from composer.core import Callback, State
+from composer.loggers import Logger, MosaicMLLogger
+from composer.utils import (
+    RemoteUploader,
+    create_symlink_file,
+    parse_uri,
+    RemoteFilesExistingCheckStatus,
+)
+
+log = logging.getLogger(__name__)
+
+
+class CheckpointUploadCallback(Callback):
+
+    def __init__(
+        self,
+        remote_uploader: RemoteUploader,
+        upload_timeout_in_seconds: int = 3600,
+    ):
+        self.remote_uploader = remote_uploader
+        if dist.get_global_rank() == 0:
+            self.rank_saves_symlinks = True
+        else:
+            self.rank_saves_symlinks = False
+
+        self.symlink_upload_tasks: list[tuple[Future, str, str]] = []
+        self.upload_timeout_in_seconds: int = upload_timeout_in_seconds
+
+        # Allow unit test to override this to make it faster
+        self._symlink_upload_wait_before_next_try_in_seconds = 30.0
+
+    def add_symlink_upload_task(
+        self,
+        remote_file_names: list[str],
+        symlink_file_name: Optional[str] = None,
+        symlink_remote_file_name: Optional[str] = None,
+    ):
+        check_remote_files_exist_future = None
+        if self.rank_saves_symlinks and symlink_file_name is not None:
+            check_remote_files_exist_future = self.remote_uploader.check_remote_files_exist_async(
+                remote_checkpoint_file_names=remote_file_names,
+                max_wait_time_in_seconds=self.upload_timeout_in_seconds,
+                wait_before_next_try_in_seconds=self._symlink_upload_wait_before_next_try_in_seconds,
+            )
+            self.symlink_upload_tasks.append(
+                (check_remote_files_exist_future, symlink_file_name, symlink_remote_file_name)
+            )
+
+    def _log_checkpoint_upload(self, logger: Logger):
+        for destination in logger.destinations:
+            if isinstance(destination, MosaicMLLogger):
+                destination.log_metadata({'checkpoint_uploaded_time': time.time()}, force_flush=True)
+
+    def batch_end(self, state: State, logger: Logger) -> None:
+        del state  # unused
+        self.remote_uploader.check_workers()
+        if not self.rank_saves_symlinks:
+            return
+        undone_symlink_upload_tasks = []
+        for (check_remote_files_exist_future, local_symlink_file,
+             remote_symlink_file) in reversed(self.symlink_upload_tasks):
+            if not check_remote_files_exist_future.done():
+                undone_symlink_upload_tasks.insert(
+                    0,
+                    (check_remote_files_exist_future, local_symlink_file, remote_symlink_file),
+                )
+                continue
+            else:
+                result = check_remote_files_exist_future.result()
+                if result == RemoteFilesExistingCheckStatus.EXIST:
+                    self.remote_uploader.upload_file_async(
+                        remote_file_name=remote_symlink_file,
+                        file_path=local_symlink_file,
+                        overwrite=True,
+                    )
+                    self._log_checkpoint_upload(logger)
+                    break
+                else:
+                    raise RuntimeError(f'Failed to check if checkpoint files upload finish: {result}')
+        self.symlink_upload_tasks = undone_symlink_upload_tasks
+
+    def wait(self) -> None:
+        log.info('Waiting for checkpoint uploading to finish')
+        self.remote_uploader.wait()
+        if self.rank_saves_symlinks and len(self.symlink_upload_tasks) > 0:
+            log.debug('Uploading symlink to the latest checkpoint')
+            # We only need to upload a symlink pointing to the latest checkpoint files, so we can ignore successful uploads of older checkpoints.
+            check_remote_files_exist_future, local_symlink_file, remote_symlink_file = self.symlink_upload_tasks[-1]
+            result = check_remote_files_exist_future.result()
+            if result == RemoteFilesExistingCheckStatus.EXIST:
+                symlink_upload_future = self.remote_uploader.upload_file_async(
+                    remote_file_name=remote_symlink_file,
+                    file_path=local_symlink_file,
+                    overwrite=True,
+                )
+                symlink_upload_future.result()
+            else:
+                raise RuntimeError(f'Failed to check if checkpoint files upload finish: {result}')
+            self.symlink_upload_tasks = []
+        log.info('Checkpoint uploading finished!')
+
+    def fit_end(self, state: State, logger: Logger) -> None:
+        del state  # unused
+        self.wait()
+        self._log_checkpoint_upload(logger)
+
+    def post_close(self):
+        # Wait the symlink file upload to finish and close remote uploader
+        try:
+            self.remote_uploader.wait_and_close()
+        except Exception as e:
+            log.error(f'RemoteUploader run into exception {e}')
+
+
+
+def upload_file(
+    dest_dir: str,
+    source_path: Optional[str]=None,
+    symlink_granularity: Optional[str]=None, # file, dir, or None
+    symlink_name: Optional[str]='latest.symlink',
+    async_upload: bool = True,
+    state: Optional[State] = None,
+    overwrite: bool = False,
+):
+    """Standalone function for uploading a checkpoint file.
+    This function does not actually upload the checkpoint; it initiates the RemoteUploader's uploading of it
+    Gets from state.callbacks or intializes RUD (and adds to callbacks) and calls upload_file
+    Args:
+        source_path (str): The path to the file to upload.
+        dest_dir (str): The directory/uri to upload the file to.
+        symlink_granularity (Optional[str]): The granularity to use for symlinking. One of 'file', 'dir', or None.
+            if None: no symlink uploaded
+            if 'file': command remoteuploader to wait until the file (specificied by source_path) is uploaded and then uploads a symlink pointing to the uploaded file
+            if 'dir': command remoteuploader  to wait until all files across all ranks are uploaded to dest_dir and then uploads a symlink
+                pointing to the remote directory (prefix in object_store terminology).
+        symlink_name (Optional[str]): The name to use for the symlink. Defaults to 'latest.symlink'.
+        async_upload (bool): If True, the uploads will be done asynchronously via the RemoteUploader and this function will return immediately.
+        state (Optional[State]): If async_upload is True, then state must be specified so that the remote_uploader can be
+            either extracted from state.callbacks or initialized and added to state.callbacks.
+        overwrite (bool): If allow overwrite existing remote checkpoint files
+"""
+
+    remote_uploader = RemoteUploader(remote_folder=dest_dir)
+    dest_path = ''
+    if source_path is not None:
+        _, _, dest_path = parse_uri(dest_dir)
+        remote_file_name = os.path.join(dest_path, os.path.basename(source_path))
+    else:
+        remote_file_name = None
+    all_remote_file_names = dist.all_gather_object([remote_file_name] if remote_file_name is not None else [])
+    remote_file_names = []
+    for filenames in all_remote_file_names:
+        remote_file_names += filenames 
+
+    checkpoint_file_upload_future = None
+    if source_path is not None:
+        assert remote_uploader is not None
+        checkpoint_file_upload_future = remote_uploader.upload_file_async(
+            remote_file_name=remote_file_name,
+            file_path=source_path,
+            overwrite=overwrite,
+        )
+    symlink_remote_file_name = None
+    if dist.get_global_rank() == 0:
+        if symlink_name is not None:
+            symlink_remote_file_name = os.path.join(dest_path, symlink_name)
+            if symlink_granularity == 'file':
+                create_symlink_file(dest_path, symlink_name)
+            elif symlink_granularity == 'dir':
+                create_symlink_file(str(pathlib.Path(dest_path).parent), symlink_name)
+            elif symlink_granularity is not None:
+                raise ValueError(f'Unrecognized symlink granularity: {symlink_granularity}')
+    else:
+        symlink_remote_file_name = None
+        symlink_name = None
+
+    upload_callback = None
+    if state is not None:
+        for callback in state.callbacks:
+            if isinstance(callback, CheckpointUploadCallback):
+                upload_callback = callback
+                break
+    if upload_callback is None:
+        upload_callback = CheckpointUploadCallback(remote_uploader=remote_uploader)
+        if state is not None:
+            state.callbacks.append(upload_callback)
+    upload_callback.add_symlink_upload_task(
+        remote_file_names=remote_file_names,
+        symlink_file_name=symlink_name,
+        symlink_remote_file_name=symlink_remote_file_name,
+    )
+
+    if not async_upload:
+        upload_callback.wait()

--- a/composer/checkpoint/upload.py
+++ b/composer/checkpoint/upload.py
@@ -177,7 +177,6 @@ def upload_file(
         if symlink_name is not None:
             symlink_remote_file_name = os.path.join(dest_path, symlink_name)
             if symlink_granularity == 'file':
-                print(f'bigning debug {dest_path=}')
                 create_symlink_file(dest_path, symlink_name)
             elif symlink_granularity == 'dir':
                 create_symlink_file(str(pathlib.Path(dest_path).parent), symlink_name)

--- a/composer/checkpoint/upload.py
+++ b/composer/checkpoint/upload.py
@@ -37,7 +37,7 @@ class CheckpointUploadCallback(Callback):
         else:
             self.rank_saves_symlinks = False
 
-        self.symlink_upload_tasks: list[tuple[Future, str, str]] = []
+        self.symlink_upload_tasks: list[tuple[Future[RemoteFilesExistingCheckStatus], str, Optional[str]]] = []
         self.upload_timeout_in_seconds: int = upload_timeout_in_seconds
 
         # Allow unit test to override this to make it faster
@@ -84,7 +84,7 @@ class CheckpointUploadCallback(Callback):
                 if result == RemoteFilesExistingCheckStatus.EXIST:
                     self.remote_uploader.upload_file_async(
                         remote_file_name=remote_symlink_file,
-                        file_path=local_symlink_file,
+                        file_path=pathlib.Path(local_symlink_file),
                         overwrite=True,
                     )
                     self._log_checkpoint_upload(logger)
@@ -104,7 +104,7 @@ class CheckpointUploadCallback(Callback):
             if result == RemoteFilesExistingCheckStatus.EXIST:
                 symlink_upload_future = self.remote_uploader.upload_file_async(
                     remote_file_name=remote_symlink_file,
-                    file_path=local_symlink_file,
+                    file_path=pathlib.Path(local_symlink_file),
                     overwrite=True,
                 )
                 symlink_upload_future.result()
@@ -167,9 +167,10 @@ def upload_file(
 
     if source_path is not None:
         assert remote_uploader is not None
+        assert remote_file_name is not None
         remote_uploader.upload_file_async(
             remote_file_name=remote_file_name,
-            file_path=source_path,
+            file_path=pathlib.Path(source_path),
             overwrite=overwrite,
         )
     symlink_remote_file_name = None

--- a/tests/checkpoint/test_upload.py
+++ b/tests/checkpoint/test_upload.py
@@ -1,0 +1,72 @@
+# Copyright 2024 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import tempfile
+from unittest.mock import patch
+import multiprocessing
+
+import pytest
+import torch
+
+from composer.checkpoint import upload_file 
+from composer.utils import dist
+from composer.core import State, Event, Engine
+from composer.loggers import Logger
+from tests.checkpoint.helpers import init_model
+from tests.common.markers import world_size
+from tests.utils.test_remote_uploader import DummyObjectStore
+from unittest.mock import patch
+
+
+#@world_size(1, 2)
+#@pytest.mark.gpu
+#def test_upload_file(world_size: int):
+@pytest.mark.parametrize(('async_upload'), [True, False])
+def test_upload_file(async_upload, dummy_state: State):
+    world_size = 1
+    # Prepare local file to upload
+    local_file_path = tempfile.TemporaryDirectory()
+    rank = dist.get_global_rank() if world_size > 1 else 0
+    file_name = f'checkpoint_file_rank_{rank}'
+    local_file_full_name = os.path.join(local_file_path.name, file_name)
+    with open(local_file_full_name, 'w') as f:
+        f.write(str(rank))
+
+    # Prepare remote path
+    remote_path = tempfile.TemporaryDirectory()
+    if world_size > 1:
+        if rank == 0:
+            remote_path_list = [remote_path]
+        else:
+            remote_path_list = []
+        remote_path_list = dist.broadcast_object_list(remote_path_list)
+        remote_path = remote_path_list[0]
+    def _get_tmp_dir(self):
+        return remote_path
+
+    fork_context = multiprocessing.get_context('fork')
+    with patch('composer.utils.object_store.utils.S3ObjectStore', DummyObjectStore):
+        with patch('tests.utils.test_remote_uploader.DummyObjectStore.get_tmp_dir', _get_tmp_dir):
+            with patch('composer.utils.remote_uploader.multiprocessing.get_context', lambda _: fork_context):
+                symlink_file_name = 'latest.symlink'
+                if async_upload:
+                    logger = Logger(dummy_state)
+                    engine = Engine(state=dummy_state, logger=logger)
+                upload_file(
+                    source_path=local_file_full_name,
+                    dest_dir='S3://bucket_name/',
+                    symlink_granularity='file',
+                    async_upload = async_upload,
+                    state=dummy_state,
+                )
+                if async_upload:
+                    engine.run_event(Event.FIT_END)
+
+                remote_file_name = os.path.join(remote_path.name, file_name)
+                assert os.path.isfile(remote_file_name)
+                with open(remote_file_name, 'r') as f:
+                    assert f.read() == str(rank)
+                remote_symlink_file_name = os.path.join(remote_path.name, symlink_file_name)
+                print(f"bigning debug expected filename: {remote_symlink_file_name}")
+                assert os.path.isfile(remote_symlink_file_name)


### PR DESCRIPTION
Adding upload API, [design doc](https://docs.google.com/document/d/14ruvosCcVgqDMJGPPmi6HRm6YvJO3BKUiZFN0KhBGR4/edit#bookmark=id.qzhhpmitypba). This API uploads the input files to remote object store, interface design:

```
def upload_file(
    dest_dir: str,
    source_path: Optional[str]=None,
    symlink_granularity: Optional[str]=None, # file, dir, or None
    symlink_name: Optional[str]='latest.symlink',
    async_upload: bool = True,
    state: Optional[State] = None,
    overwrite: bool = False,
):
    """Standalone function for uploading a checkpoint file.
    This function does not actually upload the checkpoint; it initiates the RemoteUploader's uploading of it
    Args:
        source_path (str): The path to the file to upload.
        dest_dir (str): The directory/uri to upload the file to.
        symlink_granularity (Optional[str]): The granularity to use for symlinking. One of 'file', 'dir', or None.
            if None: no symlink uploaded
            if 'file': command remoteuploader to wait until the file (specificied by source_path) is uploaded and then uploads a symlink pointing to the uploaded file
            if 'dir': command remoteuploader  to wait until all files across all ranks are uploaded to dest_dir and then uploads a symlink
                pointing to the remote directory (prefix in object_store terminology).
        symlink_name (Optional[str]): The name to use for the symlink. Defaults to 'latest.symlink'.
        async_upload (bool): If True, the uploads will be done asynchronously via the RemoteUploader and this function will return immediately.
        state (Optional[State]): If async_upload is True, then state must be specified so that the remote_uploader can be
            either extracted from state.callbacks or initialized and added to state.callbacks.
        overwrite (bool): If allow overwrite existing remote checkpoint files
    """ 
```

# unit test
python3   -m composer.cli.launcher -n 2 --master_port 26000 -m pytest -v --durations=20 -m 'not daily and not remote and gpu and (doctest or not doctest)' tests/checkpoint/test_upload.py