### PR TITLE
Fix bug when subset of model parameters is passed into optimizer with FSDP

### DIFF
--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -176,7 +176,7 @@ def _recreate_fsdp_param_groups_from_unwrapped_opt_info(
         # if the parameter was included in the optimizer param_group pre fsdp wrapping, in order to support
         # passing a subset of model params in the optimizer
         if unwrapped_name in non_wrapped_param_names_to_group_num:
-            # need to have a 1:1 mapping between a fsdp param name and the non-wrapped vanilla param name
+            # Need to have a 1:1 mapping between a fsdp param name and the non-wrapped vanilla param name
             retrieved_group_num = non_wrapped_param_names_to_group_num[unwrapped_name]
             group_num_to_optimizer_info[retrieved_group_num]['params'].append(param)
 

--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -172,7 +172,7 @@ def _recreate_fsdp_param_groups_from_unwrapped_opt_info(
 
         unwrapped_name = clean_tensor_name(fsdp_name)
 
-        # since we are iterating over all model.named_parameters() after fsdp wrapping, we need to check
+        # Since we are iterating over all model.named_parameters() after fsdp wrapping, we need to check
         # if the parameter was included in the optimizer param_group pre fsdp wrapping, in order to support
         # passing a subset of model params in the optimizer
         if unwrapped_name in non_wrapped_param_names_to_group_num:

--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -207,6 +207,7 @@ def prepare_fsdp_module(
     precision: Precision,
     device: Device,
     auto_microbatching: bool,
+    using_tp: bool = False,
     te_rng_seed: int = 1234,
 ) -> None:
     """Prepare a module (assumed ComposerModel) and optimizer for use with :class:`torch.distributed.fsdp.FullyShardedDataParallel`.
@@ -218,6 +219,7 @@ def prepare_fsdp_module(
         precision: (Precision): The precision being used by the Trainer, used to fill in defaults for FSDP `mixed_precision` settings.
         device (Device): The device being used by the Trainer.
         auto_microbatching (bool, optional): Whether or not auto microbatching is enabled.
+        using_tp (bool, optional): Whether the model has been wrapped with Tensor Parallelism, in which case only a single optimizer param group is supported.
         te_rng_seed(int): The seed to use for the Transformer Engine activation checkpointing RNG. Defaults to 1234.
     """
     # Check sync_module_states is True for mixed initialization or HSDP
@@ -265,11 +267,12 @@ def prepare_fsdp_module(
         # that will be recreated at the end of prepare_fsdp_module
         optim = optimizers_tuple[0]
 
-        if fsdp_config.use_orig_params:
-            # optimizer.param_groups do not contain parameter names which are needed
-            # to keep track of the different parameters in each group
-            # so we use the pointers between model.parameters() and model.named_parameters()
-            # to get the names of the parameters within optimizer.param_groups
+        if fsdp_config.use_orig_params and not using_tp:
+            # this code block stores information about param groups pre-fsdp wrapping in order to recreate them post-wrapping
+            # to do so, it relies on the ptrs of the model.parameters() in a model and the names of the params
+            # for this to work, use_orig_params=True, as we need the names of the params post-wrapping
+            # TP is not supported, as the underlying parameters in the model differ from the params in the param groups after being dtensorified
+
             ptr_to_param_name = {id(p): n for n, p in model.named_parameters()}
             param_name_to_group_num = {}
             group_num_to_opt_group_info = {}
@@ -277,7 +280,6 @@ def prepare_fsdp_module(
                 # Need to in-line to avoid a reference which causes FSDP to allocate extra GPU memory
                 # group = optim.param_groups[group_num]
                 for param_num in range(len(optim.param_groups[group_num]['params'])):
-                    # Need to in-line to avoid a reference which causes FSDP to allocate extra GPU memory
                     param_ptr = id(optim.param_groups[group_num]['params'][param_num])
                     if param_ptr not in ptr_to_param_name:
                         raise ValueError('The same model must be passed to the optimizer and trainer.')
@@ -292,14 +294,14 @@ def prepare_fsdp_module(
         else:
             if len(optim.param_groups) > 1:
                 raise RuntimeError(
-                    'Multiple optimizer groups with FSDP are only supported with '
-                    'use_orig_params=True.',
+                    'Multiple optimizer groups with FSDP are not supported with tensor parallelism and/or use_orig_params=False.',
                 )
 
             if len(optim.param_groups[0]['params']) != len(list(model.parameters())):
                 raise ValueError(
-                    'Passing in a subset of model parameters to the optimizer is only supported with use_orig_params=True.',
+                    'Passing in a subset of model parameters to the optimizer is not supported with tensor parallelism and/or use_orig_params=False.',
                 )
+
             optimizer_specific_info = {k: v for k, v in optim.param_groups[0].items() if k != 'params'}
 
         optim.param_groups.clear()
@@ -719,7 +721,7 @@ def prepare_fsdp_module(
         optim = ensure_tuple(optimizers)[0]
         optim.param_groups.clear()
 
-        if fsdp_config.use_orig_params:
+        if fsdp_config.use_orig_params and not using_tp:
             assert param_name_to_group_num is not None
             assert group_num_to_opt_group_info is not None
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1661,6 +1661,7 @@ class Trainer:
             with reproducibility.seed_context(self.state.rank_zero_seed):
                 prepare_tp_module(
                     model,
+                    optimizers,
                     self.state.tp_config,
                 )
 
@@ -1675,7 +1676,6 @@ class Trainer:
                     precision,
                     device,
                     auto_microbatching,
-                    self.state.tp_config is not None,
                     self.state.seed,
                 )
 
@@ -1839,15 +1839,7 @@ class Trainer:
         ):
             # Init with globally fixed seed so all HSDP replicas have the same initial weights
             with reproducibility.seed_context(self.state.rank_zero_seed):
-                prepare_fsdp_module(
-                    model,
-                    optimizers,
-                    self.state.fsdp_config,
-                    precision,
-                    device,
-                    auto_microbatching,
-                    self.state.tp_config is not None,
-                )
+                prepare_fsdp_module(model, optimizers, self.state.fsdp_config, precision, device, auto_microbatching)
 
         self.engine.run_event(Event.AFTER_LOAD)
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1675,6 +1675,7 @@ class Trainer:
                     precision,
                     device,
                     auto_microbatching,
+                    self.state.tp_config is not None,
                     self.state.seed,
                 )
 
@@ -1838,7 +1839,15 @@ class Trainer:
         ):
             # Init with globally fixed seed so all HSDP replicas have the same initial weights
             with reproducibility.seed_context(self.state.rank_zero_seed):
-                prepare_fsdp_module(model, optimizers, self.state.fsdp_config, precision, device, auto_microbatching)
+                prepare_fsdp_module(
+                    model,
+                    optimizers,
+                    self.state.fsdp_config,
+                    precision,
+                    device,
+                    auto_microbatching,
+                    self.state.tp_config is not None,
+                )
 
         self.engine.run_event(Event.AFTER_LOAD)
 

--- a/tests/checkpoint/test_download.py
+++ b/tests/checkpoint/test_download.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from composer.checkpoint import download_monolithic_checkpoint
+from composer.checkpoint import download_monolithic_checkpoint, get_model_state_dict
 from composer.utils import dist
 from tests.checkpoint.helpers import init_model
 from tests.common.markers import world_size
@@ -26,8 +26,7 @@ def test_download_monolithic_checkpoint(world_size: int, rank_zero_only: bool):
         use_fsdp = True
     fsdp_model, _ = init_model(use_fsdp=use_fsdp)
 
-    from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
-    state = get_model_state_dict(fsdp_model, options=StateDictOptions(full_state_dict=True))
+    state = get_model_state_dict(fsdp_model, sharded_state_dict=False)
 
     checkpoint_filename = 'state_dict'
     save_filename = os.path.join(tmp_dir.name, checkpoint_filename)

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -276,7 +276,7 @@ def test_fsdp_subset_of_params_in_opt_without_orig_params(world_size: int):
     dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))
     optimizer = torch.optim.SGD(model.fc1.parameters(), lr=0.01)
 
-    expected_error = 'Passing in a subset of model parameters to the optimizer is not supported with tensor parallelism and/or use_orig_params=False.'
+    expected_error = 'Passing in a subset of model parameters to the optimizer is not supported with use_orig_params=False.'
 
     with pytest.raises(ValueError, match=expected_error):
         _ = Trainer(

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -276,7 +276,7 @@ def test_fsdp_subset_of_params_in_opt_without_orig_params(world_size: int):
     dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))
     optimizer = torch.optim.SGD(model.fc1.parameters(), lr=0.01)
 
-    expected_error = 'Passing in a subset of model parameters to the optimizer is only supported with use_orig_params=True.'
+    expected_error = 'Passing in a subset of model parameters to the optimizer is not supported with tensor parallelism and/or use_orig_params=False.'
 
     with pytest.raises(ValueError, match=expected_error):
         _ = Trainer(

--- a/tests/trainer/test_fsdp.py
+++ b/tests/trainer/test_fsdp.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import gc
 from unittest.mock import MagicMock
 
 import pytest
@@ -290,7 +289,6 @@ def test_fsdp_subset_of_params_in_opt_without_orig_params(world_size: int):
             },
             max_duration='3ba',
         )
-    gc.collect()
 
 
 class SimpleMLP(ComposerModel):

--- a/tests/trainer/test_fsdp_param_groups.py
+++ b/tests/trainer/test_fsdp_param_groups.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader
 
 from composer.trainer.trainer import Trainer
 from composer.utils import dist, misc
-from tests.common import RandomClassificationDataset, SimpleModel, device, world_size
+from tests.common import EmbeddedWeightTiedModel, RandomClassificationDataset, SimpleModel, device, world_size
 
 
 @pytest.mark.parametrize('mixed_precision', ['DEFAULT'])
@@ -23,7 +23,7 @@ def test_fsdp_param_groups_without_orig_params(mixed_precision: str, device: str
     # Ensure that FSDP with 'use_orig_params=False' raises an exception when passing in an optimizer
     # with multiple param groups
     num_classes = 10
-    model = SimpleModel(num_features=1, num_classes=num_classes)
+    model = SimpleModel(num_features=2, num_classes=num_classes)
     dataset = RandomClassificationDataset(shape=(num_classes,), size=2, num_classes=num_classes)
     dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))
 
@@ -77,6 +77,87 @@ def test_fsdp_with_param_groups(mixed_precision: str, device: str, reentrant: bo
     param_groups = [{'params': param, 'lr': (0.1 + 0.1 * i)} for i, param in enumerate(model.parameters())]
     optimizer = torch.optim.SGD(param_groups, lr=0)
 
+    unwrapped_optimizer = copy.deepcopy(optimizer)
+
+    optimizer_groups_pre_fsdp = optimizer.param_groups
+
+    trainer = Trainer(
+        model=model,
+        optimizers=optimizer,
+        train_dataloader=dataloader,
+        parallelism_config={
+            'fsdp': {
+                'activation_checkpointing_reentrant': reentrant,
+                'mixed_precision': mixed_precision,
+            },
+        },
+        max_duration='3ba',
+        device=device,
+    )
+    trainer.fit()
+
+    assert misc.is_model_fsdp(trainer.state.model)
+    trainer_optimizer = trainer.state.optimizers[0]
+    assert len(trainer_optimizer.param_groups) > 1
+    assert len(trainer_optimizer.param_groups) == len(optimizer_groups_pre_fsdp)
+
+    with trainer.state.model.module.summon_full_params(trainer.state.model.module):  # type: ignore
+        for unwrapped_param_group, wrapped_param_group in zip(
+            unwrapped_optimizer.param_groups,
+            trainer_optimizer.param_groups,
+        ):
+
+            unwrapped_param_list = unwrapped_param_group['params']
+            wrapped_param_list = wrapped_param_group['params']
+
+            assert len(unwrapped_param_list) == 1
+            assert len(wrapped_param_list) == 1
+
+            unwrapped_param = unwrapped_param_list[0]
+            wrapped_param = wrapped_param_list[0]
+
+            assert unwrapped_param.shape == wrapped_param.shape
+
+            # the underlying tensor is different because it has been recreated when FSDP wraps the model
+            assert id(unwrapped_param) != id(wrapped_param)
+
+            assert unwrapped_param_group['lr'] == wrapped_param_group['lr']
+
+
+@pytest.mark.parametrize('mixed_precision', ['FULL', 'DEFAULT', 'PURE'])
+@pytest.mark.parametrize('reentrant', [True, False])
+@pytest.mark.filterwarnings('ignore::UserWarning')
+@device('gpu')
+@world_size(2)
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse('2'),
+    reason='FSDP use_orig_params requires torch 2.0 or higher',
+)
+def test_fsdp_with_param_groups_with_subset_of_params_in_opt(
+    mixed_precision: str,
+    device: str,
+    reentrant: bool,
+    world_size: int,
+):
+    """
+    Test whether an optimizer with multiple param groups maintains the same param groups when
+    wrapped with FSDP.
+    """
+    num_classes = 10
+    model = EmbeddedWeightTiedModel(num_features=num_classes)
+    dataset = RandomClassificationDataset(shape=(num_classes,), size=2, num_classes=num_classes)
+    dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))
+
+    # create a different group per parameter
+    param_groups = [{
+        'params': model.net1.fc1.parameters(),
+        'lr': 0.1,
+    }, {
+        'params': model.net2.fc2.parameters(),
+        'lr': 0.5,
+    }]
+
+    optimizer = torch.optim.SGD(param_groups)
     unwrapped_optimizer = copy.deepcopy(optimizer)
 
     optimizer_groups_pre_fsdp = optimizer.param_groups

--- a/tests/trainer/test_fsdp_param_groups.py
+++ b/tests/trainer/test_fsdp_param_groups.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import gc
 
 import pytest
 import torch
@@ -48,7 +47,6 @@ def test_fsdp_param_groups_without_orig_params(mixed_precision: str, device: str
             max_duration='3ba',
             device=device,
         )
-    gc.collect()
 
 
 @pytest.mark.parametrize('mixed_precision', ['FULL', 'DEFAULT', 'PURE'])

--- a/tests/trainer/test_fsdp_param_groups.py
+++ b/tests/trainer/test_fsdp_param_groups.py
@@ -31,7 +31,7 @@ def test_fsdp_param_groups_without_orig_params(mixed_precision: str, device: str
     param_groups = [{'params': param, 'lr': (0.1 + 0.1 * i)} for i, param in enumerate(model.parameters())]
     optimizer = torch.optim.SGD(param_groups, lr=0)
 
-    expected_error = 'Multiple optimizer groups with FSDP are only supported with use_orig_params=True.'
+    expected_error = 'Multiple optimizer groups with FSDP are not supported with tensor parallelism and/or use_orig_params=False.'
 
     with pytest.raises(RuntimeError, match=expected_error):
         _ = Trainer(

--- a/tests/trainer/test_fsdp_param_groups.py
+++ b/tests/trainer/test_fsdp_param_groups.py
@@ -31,7 +31,7 @@ def test_fsdp_param_groups_without_orig_params(mixed_precision: str, device: str
     param_groups = [{'params': param, 'lr': (0.1 + 0.1 * i)} for i, param in enumerate(model.parameters())]
     optimizer = torch.optim.SGD(param_groups, lr=0)
 
-    expected_error = 'Multiple optimizer groups with FSDP are not supported with tensor parallelism and/or use_orig_params=False.'
+    expected_error = 'Multiple optimizer groups with FSDP are not supported with use_orig_params=False.'
 
     with pytest.raises(RuntimeError, match=expected_error):
         _ = Trainer(

--- a/tests/trainer/test_fsdp_param_groups.py
+++ b/tests/trainer/test_fsdp_param_groups.py
@@ -140,10 +140,12 @@ def test_fsdp_with_param_groups_with_subset_of_params_in_opt(
     world_size: int,
 ):
     """
-    Test whether an optimizer with multiple param groups maintains the same param groups when
-    wrapped with FSDP.
+    Test whether an optimizer with param groups and a subset of model variables in the param groups is correctly fsdp wrapped.
     """
     num_classes = 10
+
+    # Note that the EmbeddedWeightTiedModel is used instead of SimpleModel to ensure that some of the model parameters
+    # are excluded from the optimzier
     model = EmbeddedWeightTiedModel(num_features=num_classes)
     dataset = RandomClassificationDataset(shape=(num_classes,), size=2, num_classes=num_classes)
     dataloader = DataLoader(dataset, sampler=dist.get_sampler(dataset))

--- a/tests/trainer/test_tp.py
+++ b/tests/trainer/test_tp.py
@@ -1,8 +1,6 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-import gc
-
 import pytest
 import torch
 from packaging import version
@@ -90,7 +88,6 @@ def test_tp_with_param_groups(world_size: int):
             },
             max_duration='3ba',
         )
-    gc.collect()
 
 
 @pytest.mark.gpu
@@ -125,4 +122,3 @@ def test_tp_with_subset_of_params(world_size: int):
             },
             max_duration='3ba',
         )
-    gc.collect()

--- a/tests/trainer/test_tp.py
+++ b/tests/trainer/test_tp.py
@@ -1,6 +1,8 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
+
 import pytest
 import torch
 from packaging import version
@@ -47,3 +49,80 @@ def test_tp_train(world_size: int):
     )
 
     trainer.fit()
+
+
+@pytest.mark.gpu
+@world_size(4)
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.3'), reason='requires PyTorch 2.3+')
+@pytest.mark.filterwarnings(r'ignore:.*\(TP\) is experimental.*:FutureWarning')
+def test_tp_with_param_groups(world_size: int):
+    from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel
+
+    model = SimpleModel()
+    dataset = RandomClassificationDataset(size=8)
+    dataloader = DataLoader(dataset, batch_size=2, sampler=dist.get_sampler(dataset))
+    optimizer = torch.optim.SGD([{
+        'params': model.fc1.parameters(),
+        'lr': 0.1,
+    }, {
+        'params': model.fc2.parameters(),
+        'lr': 0.5,
+    }])
+
+    layer_plan = {
+        'fc1': ColwiseParallel(),
+        'fc2': RowwiseParallel(),
+    }
+
+    expected_error = 'Multiple optimizer groups are not supported with tensor parallelism.'
+
+    with pytest.raises(RuntimeError, match=expected_error):
+        _ = Trainer(
+            model=model,
+            optimizers=optimizer,
+            train_dataloader=dataloader,
+            parallelism_config={
+                'tp': {
+                    'layer_plan': layer_plan,
+                    'tensor_parallel_degree': 2,
+                },
+                'fsdp': {},
+            },
+            max_duration='3ba',
+        )
+    gc.collect()
+
+
+@pytest.mark.gpu
+@world_size(4)
+@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('2.3'), reason='requires PyTorch 2.3+')
+@pytest.mark.filterwarnings(r'ignore:.*\(TP\) is experimental.*:FutureWarning')
+def test_tp_with_subset_of_params(world_size: int):
+    from torch.distributed.tensor.parallel import ColwiseParallel
+
+    model = SimpleModel()
+    dataset = RandomClassificationDataset(size=8)
+    dataloader = DataLoader(dataset, batch_size=2, sampler=dist.get_sampler(dataset))
+    optimizer = torch.optim.SGD(model.fc1.parameters(), lr=0.1)
+
+    layer_plan = {
+        'fc1': ColwiseParallel(),
+    }
+
+    expected_error = 'Passing in a subset of model parameters to the optimizer is not supported with tensor parallelism.'
+
+    with pytest.raises(ValueError, match=expected_error):
+        _ = Trainer(
+            model=model,
+            optimizers=optimizer,
+            train_dataloader=dataloader,
+            parallelism_config={
+                'tp': {
+                    'layer_plan': layer_plan,
+                    'tensor_parallel_degree': 2,
+                },
+                'fsdp': {},
+            },
+            max_duration='3ba',
+        )
+    gc.collect()


### PR DESCRIPTION
# What does this PR do?

This PR addresses https://github.com/mosaicml/composer/issues/3493, where we were adding all model parameters into the optimizer state after FSDP wrapping. This change uses the previous flow for param_groups > 1, where we:
1. Get the mapping between params in the optimizer group and their names by using the pointers (found with `id`) of the tensors
2. Store the extra param group info, such as LR, wd, etc. in a separate dict
3. Iterate over the fsdp wrapped parameters, and populates the param_groups based on the names of the fsdp wrapped tensor and the mapping from before.

This change relies on `use_orig_params=True`, so an error is thrown if a subset of parameters is passed into the param_groups.
 
**NOTE**: at the moment, tensor parallelism breaks with multiple param_groups (as the ptrs of TP'd model.parameters() != ptrs of elements in optimizer param_groups), so a special case was added to handle this.

# What issue(s) does this change relate to?
Fixes https://github.com/mosaicml/composer/issues/3493

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
