### PR TITLE
Deprecate deepspeed

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1108,7 +1108,7 @@ class Trainer:
     ):
         if deepspeed_config is not None:
             raise VersionedDeprecationWarning(
-                'The use of DeepSpeed in Composer is deprecated. Composer is tightly integrated with PyTorch FSDP ' +
+                'The use of DeepSpeed for training new models in Composer is deprecated. Composer is tightly integrated with PyTorch FSDP ' +
                 'which provides similar functionality. Please use the `parallelism_config` parameter instead. Please open '
                 + 'a GitHub issue if you need help migrating from DeepSpeed to FSDP.',
                 remove_version='0.28.0',

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1103,13 +1103,15 @@ class Trainer:
         compile_config: Optional[dict[str, Any]] = None,
     ):
         if deepspeed_config is not None:
-            warnings.warn(VersionedDeprecationWarning(
-                'The use of DeepSpeed for training new models in Composer is deprecated. Composer is tightly integrated with PyTorch FSDP '
-                +
-                'which provides similar functionality. Please use the `parallelism_config` parameter instead. Please open '
-                + 'a GitHub issue if you need help migrating from DeepSpeed to FSDP.',
-                remove_version='0.28.0',
-            ))
+            warnings.warn(
+                VersionedDeprecationWarning(
+                    'The use of DeepSpeed for training new models in Composer is deprecated. Composer is tightly integrated with PyTorch FSDP '
+                    +
+                    'which provides similar functionality. Please use the `parallelism_config` parameter instead. Please open '
+                    + 'a GitHub issue if you need help migrating from DeepSpeed to FSDP.',
+                    remove_version='0.28.0',
+                )
+            )
 
         self.auto_log_hparams = auto_log_hparams
         self.python_log_level = python_log_level

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1108,7 +1108,8 @@ class Trainer:
     ):
         if deepspeed_config is not None:
             raise VersionedDeprecationWarning(
-                'The use of DeepSpeed for training new models in Composer is deprecated. Composer is tightly integrated with PyTorch FSDP ' +
+                'The use of DeepSpeed for training new models in Composer is deprecated. Composer is tightly integrated with PyTorch FSDP '
+                +
                 'which provides similar functionality. Please use the `parallelism_config` parameter instead. Please open '
                 + 'a GitHub issue if you need help migrating from DeepSpeed to FSDP.',
                 remove_version='0.28.0',

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1106,6 +1106,14 @@ class Trainer:
         # compile config for PyTorch 2.0 or higher
         compile_config: Optional[dict[str, Any]] = None,
     ):
+        if deepspeed_config is not None:
+            raise VersionedDeprecationWarning(
+                'The use of DeepSpeed in Composer is deprecated. Composer is tightly integrated with PyTorch FSDP ' +
+                'which provides similar functionality. Please use the `parallelism_config` parameter instead. Please open '
+                + 'a GitHub issue if you need help migrating from DeepSpeed to FSDP.',
+                remove_version='0.28.0',
+            )
+
         self.auto_log_hparams = auto_log_hparams
         self.python_log_level = python_log_level
         if self.python_log_level is not None:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1103,13 +1103,13 @@ class Trainer:
         compile_config: Optional[dict[str, Any]] = None,
     ):
         if deepspeed_config is not None:
-            raise VersionedDeprecationWarning(
+            warnings.warn(VersionedDeprecationWarning(
                 'The use of DeepSpeed for training new models in Composer is deprecated. Composer is tightly integrated with PyTorch FSDP '
                 +
                 'which provides similar functionality. Please use the `parallelism_config` parameter instead. Please open '
                 + 'a GitHub issue if you need help migrating from DeepSpeed to FSDP.',
                 remove_version='0.28.0',
-            )
+            ))
 
         self.auto_log_hparams = auto_log_hparams
         self.python_log_level = python_log_level

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1110,7 +1110,7 @@ class Trainer:
                     'which provides similar functionality. Please use the `parallelism_config` parameter instead. Please open '
                     + 'a GitHub issue if you need help migrating from DeepSpeed to FSDP.',
                     remove_version='0.28.0',
-                )
+                ),
             )
 
         self.auto_log_hparams = auto_log_hparams

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ filterwarnings = [
     # Ignore mlflow warnings about transformers versions,
     '''ignore:The 'transformers' MLflow Models integration.*:UserWarning''',
     # Ignore our own deprecation warnings,
-    '''ignore:VersionedDeprecationWarning''',
+    '''ignore::composer.utils.warnings.VersionedDeprecationWarning''',
 ]
 
 # Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ filterwarnings = [
     # Ignore mlflow warnings about transformers versions,
     '''ignore:The 'transformers' MLflow Models integration.*:UserWarning''',
     # Ignore our own deprecation warnings,
-    '''ignore:.*is deprecated and will be removed in a future version.*:VersionedDeprecationWarning''',
+    '''ignore:.*is deprecated and will be removed in a future version.*:DeprecationWarning''',
 ]
 
 # Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,8 @@ filterwarnings = [
     '''ignore:'.*_state_dict' is deprecated and will be removed in future versions.*:UserWarning''',
     # Ignore mlflow warnings about transformers versions,
     '''ignore:The 'transformers' MLflow Models integration.*:UserWarning''',
+    # Ignore our own deprecation warnings,
+    '''ignore:.*is deprecated and will be removed in a future version.*:VersionedDeprecationWarning''',
 ]
 
 # Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ filterwarnings = [
     # Ignore mlflow warnings about transformers versions,
     '''ignore:The 'transformers' MLflow Models integration.*:UserWarning''',
     # Ignore our own deprecation warnings,
-    '''ignore:.*is deprecated and will be removed in a future version.*:composer.utils.warnings.VersionedDeprecationWarning''',
+    '''ignore:VersionedDeprecationWarning''',
 ]
 
 # Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ filterwarnings = [
     # Ignore mlflow warnings about transformers versions,
     '''ignore:The 'transformers' MLflow Models integration.*:UserWarning''',
     # Ignore our own deprecation warnings,
-    '''ignore:.*is deprecated and will be removed in a future version.*:DeprecationWarning''',
+    '''ignore:.*is deprecated and will be removed in a future version.*:composer.utils.warnings.VersionedDeprecationWarning''',
 ]
 
 # Coverage


### PR DESCRIPTION
# What does this PR do?
This PR deprecates the usage of DeepSpeed in Composer. We have not updated DeepSpeed in a long time and do not actively maintain the integration. Composer is tightly coupled to PyTorch FSDP which provides similar functionality, and we are developing all new functionality on top of FSDP and PyTorch native, not DeepSpeed, for parallelism. Before removal we will provide a migration guide for anyone still using DeepSpeed. In the meantime, users are welcome to open a GitHub issue if they have any trouble.