### PR TITLE
Disable gcs azure daily test

### DIFF
--- a/tests/utils/object_store/test_azure_object_store.py
+++ b/tests/utils/object_store/test_azure_object_store.py
@@ -9,6 +9,7 @@ from tests.common import RandomClassificationDataset, SimpleModel
 
 
 @pytest.mark.remote
+@pytest.mark.skip(reason="Waiting new Azure key to be approved")
 def test_azure_object_store_integration():
     model = SimpleModel()
     train_dataloader = DataLoader(dataset=RandomClassificationDataset())

--- a/tests/utils/object_store/test_azure_object_store.py
+++ b/tests/utils/object_store/test_azure_object_store.py
@@ -9,7 +9,7 @@ from tests.common import RandomClassificationDataset, SimpleModel
 
 
 @pytest.mark.remote
-@pytest.mark.skip(reason="Waiting new Azure key to be approved")
+@pytest.mark.skip(reason='Waiting new Azure key to be approved')
 def test_azure_object_store_integration():
     model = SimpleModel()
     train_dataloader = DataLoader(dataset=RandomClassificationDataset())

--- a/tests/utils/object_store/test_azure_object_store.py
+++ b/tests/utils/object_store/test_azure_object_store.py
@@ -9,7 +9,7 @@ from tests.common import RandomClassificationDataset, SimpleModel
 
 
 @pytest.mark.remote
-@pytest.mark.skip(reason='Waiting new Azure key to be approved')
+@pytest.mark.skip(reason='Waiting for new Azure key to be approved')
 def test_azure_object_store_integration():
     model = SimpleModel()
     train_dataloader = DataLoader(dataset=RandomClassificationDataset())

--- a/tests/utils/object_store/test_gs_object_store.py
+++ b/tests/utils/object_store/test_gs_object_store.py
@@ -25,6 +25,7 @@ def get_gcs_os_from_trainer(trainer: Trainer) -> GCSObjectStore:
 
 @pytest.mark.gpu  # json auth is hard to set up on github actions / CPU tests
 @pytest.mark.remote
+@pytest.mark.skip(reason="Waiting new GCP key to be approved")
 def test_gs_object_store_integration_hmac_auth(expected_use_gcs_sdk_val=False, client_should_be_none=True):
     model = SimpleModel()
     train_dataset = RandomClassificationDataset()
@@ -63,6 +64,7 @@ def test_gs_object_store_integration_hmac_auth(expected_use_gcs_sdk_val=False, c
 
 @pytest.mark.gpu
 @pytest.mark.remote
+@pytest.mark.skip(reason="Waiting new GCP key to be approved")
 def test_gs_object_store_integration_json_auth():
     with mock.patch.dict(os.environ):
         if 'GCS_KEY' in os.environ:

--- a/tests/utils/object_store/test_gs_object_store.py
+++ b/tests/utils/object_store/test_gs_object_store.py
@@ -64,7 +64,7 @@ def test_gs_object_store_integration_hmac_auth(expected_use_gcs_sdk_val=False, c
 
 @pytest.mark.gpu
 @pytest.mark.remote
-@pytest.mark.skip(reason='Waiting new GCP key to be approved')
+@pytest.mark.skip(reason='Waiting for new GCP key to be approved')
 def test_gs_object_store_integration_json_auth():
     with mock.patch.dict(os.environ):
         if 'GCS_KEY' in os.environ:

--- a/tests/utils/object_store/test_gs_object_store.py
+++ b/tests/utils/object_store/test_gs_object_store.py
@@ -25,7 +25,7 @@ def get_gcs_os_from_trainer(trainer: Trainer) -> GCSObjectStore:
 
 @pytest.mark.gpu  # json auth is hard to set up on github actions / CPU tests
 @pytest.mark.remote
-@pytest.mark.skip(reason="Waiting new GCP key to be approved")
+@pytest.mark.skip(reason='Waiting new GCP key to be approved')
 def test_gs_object_store_integration_hmac_auth(expected_use_gcs_sdk_val=False, client_should_be_none=True):
     model = SimpleModel()
     train_dataset = RandomClassificationDataset()
@@ -64,7 +64,7 @@ def test_gs_object_store_integration_hmac_auth(expected_use_gcs_sdk_val=False, c
 
 @pytest.mark.gpu
 @pytest.mark.remote
-@pytest.mark.skip(reason="Waiting new GCP key to be approved")
+@pytest.mark.skip(reason='Waiting new GCP key to be approved')
 def test_gs_object_store_integration_json_auth():
     with mock.patch.dict(os.environ):
         if 'GCS_KEY' in os.environ:

--- a/tests/utils/object_store/test_gs_object_store.py
+++ b/tests/utils/object_store/test_gs_object_store.py
@@ -25,7 +25,7 @@ def get_gcs_os_from_trainer(trainer: Trainer) -> GCSObjectStore:
 
 @pytest.mark.gpu  # json auth is hard to set up on github actions / CPU tests
 @pytest.mark.remote
-@pytest.mark.skip(reason='Waiting new GCP key to be approved')
+@pytest.mark.skip(reason='Waiting for new GCP key to be approved')
 def test_gs_object_store_integration_hmac_auth(expected_use_gcs_sdk_val=False, client_should_be_none=True):
     model = SimpleModel()
     train_dataset = RandomClassificationDataset()


### PR DESCRIPTION
For GCS key, we're waiting for the request https://databricks.atlassian.net/browse/SOPS-719?focusedCommentId=5299281

For Azure, @j316chuck  will start the request once we go through the GCS request process. 

# **before cpu test failure:**
https://github.com/mosaicml/composer/actions/runs/10207147591
<img width="453" alt="image" src="https://github.com/user-attachments/assets/08a86247-ebe2-4f1d-affb-fbcf29519c1a">


# **after cpu tests succeed:**
[gpu tests still running] https://github.com/mosaicml/composer/actions/runs/10207236494
<img width="418" alt="image" src="https://github.com/user-attachments/assets/fa21c38e-d757-4148-8d9c-07349334b951">

