### PR TITLE
Move hooks and fsdp modules onto state rather than trainer

### DIFF
--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -139,7 +139,8 @@ def load_checkpoint(
         assert model is not None
         assert model_child_path is not None
         model_load_path = os.path.join(load_path, model_child_path)
-        state.automicrobatch_fsdp_hook_handles, state.fsdp_modules = load_model_checkpoint(model, load_path=model_load_path, load_options=load_options)
+        if state:
+            state.automicrobatch_fsdp_hook_handles, state.fsdp_modules = load_model_checkpoint(model, load_path=model_load_path, load_options=load_options)
 
     if load_options.load_optimizer:
         assert optim_child_path is not None

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -11,7 +11,7 @@ import tempfile
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, Sequence, Union, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.distributed.checkpoint as DCP
@@ -140,7 +140,9 @@ def load_checkpoint(
         assert model_child_path is not None
         model_load_path = os.path.join(load_path, model_child_path)
         if state:
-            state.automicrobatch_fsdp_hook_handles, state.fsdp_modules = load_model_checkpoint(model, load_path=model_load_path, load_options=load_options)
+            state.automicrobatch_fsdp_hook_handles, state.fsdp_modules = load_model_checkpoint(
+                model, load_path=model_load_path, load_options=load_options
+            )
 
     if load_options.load_optimizer:
         assert optim_child_path is not None
@@ -209,8 +211,11 @@ def load_model_checkpoint(
                 load_options.fsdp_config.update({'sync_module_states': True})
             else:
                 load_options.fsdp_config.sync_module_states = True
-            automicrobatch_fsdp_hook_handles, fsdp_modules = _shard_with_fsdp(model, fsdp_config=load_options.fsdp_config, precision=load_options.precision, seed=seed)
+            automicrobatch_fsdp_hook_handles, fsdp_modules = _shard_with_fsdp(
+                model, fsdp_config=load_options.fsdp_config, precision=load_options.precision, seed=seed
+            )
     return automicrobatch_fsdp_hook_handles, fsdp_modules
+
 
 def _shard_with_fsdp(
     model: Union[ComposerModel, nn.Module],
@@ -218,7 +223,7 @@ def _shard_with_fsdp(
     fsdp_config: Optional[Union[FSDPConfig, dict]] = None,
     precision: Optional[str] = None,
     seed: int = 42,
-) ->  Tuple[list, dict]:
+) -> Tuple[list, dict]:
     if fsdp_config is None:
         fsdp_config = FSDPConfig()
     if isinstance(fsdp_config, dict):

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -178,6 +178,8 @@ def load_model_checkpoint(
     if load_options.include_keys is not None or load_options.ignore_keys is not None:
         load_options.strict = False
 
+    automicrobatch_fsdp_hook_handles, fsdp_modules = [], {}
+
     if load_options.sharded_checkpoint:
         if not _is_model_fsdp(model):
             if load_options.shard_as_needed_during_load:

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -139,8 +139,12 @@ def load_checkpoint(
         assert model is not None
         assert model_child_path is not None
         model_load_path = os.path.join(load_path, model_child_path)
-        if state:
+        if state is not None:
             state.automicrobatch_fsdp_hook_handles, state.fsdp_modules = load_model_checkpoint(
+                model, load_path=model_load_path, load_options=load_options
+            )
+        else:
+            load_model_checkpoint(
                 model, load_path=model_load_path, load_options=load_options
             )
 

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -141,11 +141,15 @@ def load_checkpoint(
         model_load_path = os.path.join(load_path, model_child_path)
         if state is not None:
             state.automicrobatch_fsdp_hook_handles, state.fsdp_modules = load_model_checkpoint(
-                model, load_path=model_load_path, load_options=load_options
+                model,
+                load_path=model_load_path,
+                load_options=load_options,
             )
         else:
             load_model_checkpoint(
-                model, load_path=model_load_path, load_options=load_options
+                model,
+                load_path=model_load_path,
+                load_options=load_options,
             )
 
     if load_options.load_optimizer:
@@ -216,7 +220,10 @@ def load_model_checkpoint(
             else:
                 load_options.fsdp_config.sync_module_states = True
             automicrobatch_fsdp_hook_handles, fsdp_modules = _shard_with_fsdp(
-                model, fsdp_config=load_options.fsdp_config, precision=load_options.precision, seed=seed
+                model,
+                fsdp_config=load_options.fsdp_config,
+                precision=load_options.precision,
+                seed=seed,
             )
     return automicrobatch_fsdp_hook_handles, fsdp_modules
 

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -209,7 +209,6 @@ def load_model_checkpoint(
             else:
                 load_options.fsdp_config.sync_module_states = True
             automicrobatch_fsdp_hook_handles, fsdp_modules = _shard_with_fsdp(model, fsdp_config=load_options.fsdp_config, precision=load_options.precision, seed=seed)
-    print(f"debug log {automicrobatch_fsdp_hook_handles}, {type(automicrobatch_fsdp_hook_handles)}")
     return automicrobatch_fsdp_hook_handles, fsdp_modules
 
 def _shard_with_fsdp(

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -209,7 +209,7 @@ def load_model_checkpoint(
             else:
                 load_options.fsdp_config.sync_module_states = True
             automicrobatch_fsdp_hook_handles, fsdp_modules = _shard_with_fsdp(model, fsdp_config=load_options.fsdp_config, precision=load_options.precision, seed=seed)
-    print(f"{automicrobatch_fsdp_hook_handles}, {type(automicrobatch_fsdp_hook_handles)}")
+    print(f"debug log {automicrobatch_fsdp_hook_handles}, {type(automicrobatch_fsdp_hook_handles)}")
     return automicrobatch_fsdp_hook_handles, fsdp_modules
 
 def _shard_with_fsdp(

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -209,6 +209,7 @@ def load_model_checkpoint(
             else:
                 load_options.fsdp_config.sync_module_states = True
             automicrobatch_fsdp_hook_handles, fsdp_modules = _shard_with_fsdp(model, fsdp_config=load_options.fsdp_config, precision=load_options.precision, seed=seed)
+    print(f"{automicrobatch_fsdp_hook_handles}, {type(automicrobatch_fsdp_hook_handles)}")
     return automicrobatch_fsdp_hook_handles, fsdp_modules
 
 def _shard_with_fsdp(

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -178,7 +178,8 @@ def load_model_checkpoint(
     if load_options.include_keys is not None or load_options.ignore_keys is not None:
         load_options.strict = False
 
-    automicrobatch_fsdp_hook_handles, fsdp_modules = [], {}
+    automicrobatch_fsdp_hook_handles = []
+    fsdp_modules = {}
 
     if load_options.sharded_checkpoint:
         if not _is_model_fsdp(model):

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -547,7 +547,7 @@ class State(Serializable):
         self.fsdp_config = parallelism_config.fsdp if parallelism_config is not None else None
         self.tp_config = parallelism_config.tp if parallelism_config is not None else None
 
-        self.automicrobatch_fsdp_hook_handles = [] 
+        self.automicrobatch_fsdp_hook_handles = []
         self.fsdp_modules = {}
 
         self._validate_parallelism_configs()

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -547,6 +547,9 @@ class State(Serializable):
         self.fsdp_config = parallelism_config.fsdp if parallelism_config is not None else None
         self.tp_config = parallelism_config.tp if parallelism_config is not None else None
 
+        self.automicrobatch_fsdp_hook_handles = [] 
+        self.fsdp_modules = {}
+
         self._validate_parallelism_configs()
 
         self.device_mesh: Optional[DeviceMesh] = _create_device_mesh(self.device, self.fsdp_config, self.tp_config)
@@ -1387,7 +1390,7 @@ class State(Serializable):
             with reproducibility.seed_context(self.rank_zero_seed):
                 from composer.distributed import prepare_fsdp_module
 
-                prepare_fsdp_module(
+                self.automicrobatch_fsdp_hook_handles, self.fsdp_modules = prepare_fsdp_module(
                     self.model,
                     self.optimizers,
                     self.fsdp_config,

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -3753,10 +3753,11 @@ class Trainer:
             self.state.dataloader_len = original_num_batches
 
         # If training occurs after evaluation, readd hooks in case of memory spike
-        sync_hook = _create_sync_hook(self.state)
-        if self.state.fsdp_enabled and len(self.automicrobatch_fsdp_hook_handles) == 0:
-            self.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(self.fsdp_modules, sync_hook)
-        self.num_consecutive_non_OOM_batches = 0
+        if self.state.auto_microbatching:
+            sync_hook = _create_sync_hook(self.state)
+            if self.state.fsdp_enabled and len(self.automicrobatch_fsdp_hook_handles) == 0:
+                self.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(self.fsdp_modules, sync_hook)
+            self.num_consecutive_non_OOM_batches = 0
 
     def _use_grad_scaling(self, precision: Union[str, Precision], scaler: Optional[GradScaler]) -> bool:
         """Determines based on precision when to use grad scaling.

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1261,7 +1261,6 @@ class Trainer:
         self.cumulative_alloc_retries = 0
         self.num_consecutive_thrashes = 0
         self.num_consecutive_non_OOM_batches = 0
-        self.state.automicrobatch_fsdp_hook_handles = []
 
         if auto_microbatching and profiler:
             raise ValueError(

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -3753,11 +3753,10 @@ class Trainer:
             self.state.dataloader_len = original_num_batches
 
         # If training occurs after evaluation, readd hooks in case of memory spike
-        if self.state.auto_microbatching:
-            sync_hook = _create_sync_hook(self.state)
-            if self.state.fsdp_enabled and len(self.automicrobatch_fsdp_hook_handles) == 0:
-                self.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(self.fsdp_modules, sync_hook)
-            self.num_consecutive_non_OOM_batches = 0
+        sync_hook = _create_sync_hook(self.state)
+        if self.state.fsdp_enabled and len(self.automicrobatch_fsdp_hook_handles) == 0:
+            self.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(self.fsdp_modules, sync_hook)
+        self.num_consecutive_non_OOM_batches = 0
 
     def _use_grad_scaling(self, precision: Union[str, Precision], scaler: Optional[GradScaler]) -> bool:
         """Determines based on precision when to use grad scaling.

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2918,7 +2918,8 @@ class Trainer:
                     # Readd sync hooks if they were previously turned off
                     if self.state.fsdp_enabled and len(self.state.automicrobatch_fsdp_hook_handles) == 0:
                         self.state.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(
-                            self.state.fsdp_modules, sync_hook
+                            self.state.fsdp_modules,
+                            sync_hook,
                         )
                     _adjust_device_train_microbatch_size(self.state)
                     self.num_consecutive_thrashes = 0
@@ -2937,7 +2938,8 @@ class Trainer:
                     # Readd sync hooks if they were previously turned off
                     if self.state.fsdp_enabled and len(self.state.automicrobatch_fsdp_hook_handles) == 0:
                         self.state.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(
-                            self.state.fsdp_modules, sync_hook
+                            self.state.fsdp_modules,
+                            sync_hook,
                         )
                     _adjust_device_train_microbatch_size(self.state)
                     self.num_consecutive_thrashes = 0

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2917,7 +2917,9 @@ class Trainer:
                 if found_cuda_oom == 1:
                     # Readd sync hooks if they were previously turned off
                     if self.state.fsdp_enabled and len(self.state.automicrobatch_fsdp_hook_handles) == 0:
-                        self.state.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(self.state.fsdp_modules, sync_hook)
+                        self.state.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(
+                            self.state.fsdp_modules, sync_hook
+                        )
                     _adjust_device_train_microbatch_size(self.state)
                     self.num_consecutive_thrashes = 0
                     self.num_consecutive_non_OOM_batches = 0
@@ -2934,7 +2936,9 @@ class Trainer:
                 if self.num_consecutive_thrashes >= 2:
                     # Readd sync hooks if they were previously turned off
                     if self.state.fsdp_enabled and len(self.state.automicrobatch_fsdp_hook_handles) == 0:
-                        self.state.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(self.state.fsdp_modules, sync_hook)
+                        self.state.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(
+                            self.state.fsdp_modules, sync_hook
+                        )
                     _adjust_device_train_microbatch_size(self.state)
                     self.num_consecutive_thrashes = 0
                     continue

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -350,12 +350,6 @@ def test_load_checkpoint(
         # Loading a sharded checkpoint into a sharded model in distributed setting
         pytest.param(2, True, True, False, marks=pytest.mark.world_size(2)),
 
-        # SHOULD FAIL: Loading an unsharded checkpoint into a sharded model
-        pytest.param(2, True, False, False, marks=pytest.mark.world_size(2)),
-
-        # SHOULD FAIL: Attempting to load a sharded checkpoint into an unsharded model without sharding
-        pytest.param(2, False, True, False, marks=pytest.mark.world_size(2)),
-
         # Loading a sharded checkpoint into an unsharded model (sharding it before load)
         pytest.param(2, False, True, True, marks=pytest.mark.world_size(2)),
 

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -432,7 +432,7 @@ def test_load_model_checkpoint_and_eval(
                 dataset=dataset,
                 sampler=dist.get_sampler(dataset),
             ),
-            model=ComposerModel(new_model),
+            model=new_model, # type: ignore
         )
 
         # Evaluate the model

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -344,7 +344,7 @@ def test_load_checkpoint(
 @pytest.mark.parametrize(
     'world_size,sharded_model,sharded_checkpoint,shard_as_needed_during_load',
     [
-        #Loading an unsharded checkpoint into an unsharded model on a single GPU (not sharding after)
+        # Loading an unsharded checkpoint into an unsharded model on a single GPU (not sharding after)
         pytest.param(1, False, False, False, marks=pytest.mark.world_size(1)),
 
         # Loading a sharded checkpoint into a sharded model in distributed setting

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -384,7 +384,6 @@ def test_load_model_checkpoint_and_eval(
 
     # Save a model checkpoint
     model, _ = init_model(use_composer_model=True, use_fsdp=sharded_checkpoint, device='cuda')
-    print("Type: " + str(type(model)))
     save_path = os.path.join(destination_dir, 'model.pt') if not sharded_checkpoint else destination_dir
     saved_path = save_model_to_disk(model, save_path, sharded_checkpoint=sharded_checkpoint)
 

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -29,6 +29,7 @@ from composer.checkpoint.state_dict import (
 )
 from composer.utils import dist
 from composer.trainer import Trainer
+from composer.models import ComposerModel
 from tests.checkpoint.helpers import init_model, init_model_and_optimizer, init_state
 from tests.common.compare import deep_compare
 from tests.common import (
@@ -426,6 +427,8 @@ def test_load_model_checkpoint_and_eval(
             num_classes=3
         )
         
+        assert isinstance(model, ComposerModel), "Model must be an instance of ComposerModel"
+
         trainer = Trainer(
             eval_dataloader=DataLoader(
                 dataset=dataset,

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -28,13 +28,13 @@ from composer.checkpoint.state_dict import (
     get_resumption_state_dict,
 )
 from composer.utils import dist
+from composer.trainer import Trainer
 from tests.checkpoint.helpers import init_model, init_model_and_optimizer, init_state
 from tests.common.compare import deep_compare
 from tests.common import (
     EventCounterCallback,
     RandomClassificationDataset,
     SimpleModel,
-    Trainer,
 )
 
 

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -34,7 +34,6 @@ from tests.common.compare import deep_compare
 from tests.common import (
     EventCounterCallback,
     RandomClassificationDataset,
-    SimpleModel,
 )
 
 
@@ -428,7 +427,7 @@ def test_load_checkpoint_and_eval(
                 dataset=dataset,
                 sampler=dist.get_sampler(dataset),
             ),
-            model=SimpleModel(),
+            model=new_state.model,
             callbacks=[event_counter_callback],
         )
 

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -29,7 +29,6 @@ from composer.checkpoint.state_dict import (
 )
 from composer.utils import dist
 from composer.trainer import Trainer
-from composer.models import ComposerModel
 from tests.checkpoint.helpers import init_model, init_model_and_optimizer, init_state
 from tests.common.compare import deep_compare
 from tests.common import (

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -7,6 +7,7 @@ import uuid
 from pathlib import Path
 
 import pytest
+from torch.utils.data import DataLoader
 
 from composer.checkpoint.load import (
     load_checkpoint,
@@ -29,6 +30,12 @@ from composer.checkpoint.state_dict import (
 from composer.utils import dist
 from tests.checkpoint.helpers import init_model, init_model_and_optimizer, init_state
 from tests.common.compare import deep_compare
+from tests.common import (
+    EventCounterCallback,
+    RandomClassificationDataset,
+    SimpleModel,
+    Trainer,
+)
 
 
 @pytest.mark.gpu
@@ -333,3 +340,97 @@ def test_load_checkpoint(
             deep_compare(original_model_state_dict, new_state_dict)
             deep_compare(original_optim_state_dict, new_optim_state_dict)
             deep_compare(original_resumption_state, new_resumption_state, ignore_keys=['rng', 'run_name'])
+
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    'world_size,sharded_model,sharded_checkpoint,shard_as_needed_during_load',
+    [
+        # Loading an unsharded checkpoint into an unsharded model on a single GPU (not sharding after)
+        pytest.param(1, False, False, False, marks=pytest.mark.world_size(1)),
+
+        # Loading a sharded checkpoint into a sharded model in distributed setting
+        pytest.param(2, True, True, False, marks=pytest.mark.world_size(2)),
+
+        # SHOULD FAIL: Loading an unsharded checkpoint into a sharded model
+        pytest.param(2, True, False, False, marks=pytest.mark.world_size(2)),
+
+        # SHOULD FAIL: Attempting to load a sharded checkpoint into an unsharded model without sharding
+        pytest.param(2, False, True, False, marks=pytest.mark.world_size(2)),
+    ],
+)
+def test_load_checkpoint_and_eval(
+    world_size: int,
+    tmp_path: Path,
+    sharded_model: bool,
+    sharded_checkpoint: bool,
+    shard_as_needed_during_load: bool,
+):
+
+    if sharded_model and not sharded_checkpoint:
+        pytest.xfail(
+            'Loading an unsharded checkpoint into a sharded model is not supported and causes OOMs when running with these tests',
+        )
+    # Ensure all ranks use the same path
+    destination_dir = os.path.join(tmp_path, str(uuid.uuid4())[:8])
+    destination_dir = dist.all_gather_object(destination_dir)[0]
+
+    # Save an optimizer checkpoint
+    state = init_state(
+        use_fsdp=sharded_checkpoint,
+        device='cuda',
+        take_step=True,
+    )
+    load_path = save_checkpoint_to_disk(
+        destination_dir=destination_dir,
+        state=state,
+        options={
+            'sharded_checkpoint': sharded_checkpoint,
+            'save_model': True,
+            'save_optimizer': True,
+            'save_resumption_state': True,
+        },
+    )
+    original_model_state_dict = get_model_state_dict(state.model, sharded_state_dict=False)
+    original_optim_state_dict = get_optim_state_dict(state.model, state.optimizers[0], sharded_state_dict=False)
+    original_resumption_state = get_resumption_state_dict(state)
+    new_state = init_state(use_fsdp=sharded_model, device='cuda', take_step=True)
+    if not sharded_model and sharded_checkpoint and not shard_as_needed_during_load:
+        context_manager = pytest.raises(ValueError)
+    else:
+        context_manager = contextlib.nullcontext()
+    with context_manager:
+        load_checkpoint(
+            load_path=load_path,
+            state=new_state,
+            load_options={
+                'sharded_checkpoint': sharded_checkpoint,
+                'load_optimizer': True,
+                'load_resumption_state': True,
+                'shard_as_needed_during_load': shard_as_needed_during_load,
+            },
+        )
+        if shard_as_needed_during_load:
+            assert _is_model_fsdp(new_state.model), 'Model should be sharded after load'
+        # Get the new model's state dict
+        new_state_dict = get_model_state_dict(new_state.model, sharded_state_dict=False)
+        new_optim_state_dict = get_optim_state_dict(new_state.model, new_state.optimizers[0], sharded_state_dict=False)
+        new_resumption_state = get_resumption_state_dict(new_state)
+
+        if dist.get_global_rank() == 0:
+            deep_compare(original_model_state_dict, new_state_dict)
+            deep_compare(original_optim_state_dict, new_optim_state_dict)
+            deep_compare(original_resumption_state, new_resumption_state, ignore_keys=['rng', 'run_name'])
+        # Construct the trainer
+        event_counter_callback = EventCounterCallback()
+        dataset = RandomClassificationDataset()
+        trainer = Trainer(
+            eval_dataloader=DataLoader(
+                dataset=dataset,
+                sampler=dist.get_sampler(dataset),
+            ),
+            model=SimpleModel(),
+            callbacks=[event_counter_callback],
+        )
+
+        # Evaluate the model
+        trainer.eval()

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -426,15 +426,13 @@ def test_load_model_checkpoint_and_eval(
             size=100,
             num_classes=3
         )
-        
-        assert isinstance(model, ComposerModel), "Model must be an instance of ComposerModel"
 
         trainer = Trainer(
             eval_dataloader=DataLoader(
                 dataset=dataset,
                 sampler=dist.get_sampler(dataset),
             ),
-            model=new_model,
+            model=ComposerModel(new_model),
         )
 
         # Evaluate the model

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -27,13 +27,13 @@ from composer.checkpoint.state_dict import (
     get_optim_state_dict,
     get_resumption_state_dict,
 )
-from composer.utils import dist
 from composer.trainer import Trainer
+from composer.utils import dist
 from tests.checkpoint.helpers import init_model, init_model_and_optimizer, init_state
-from tests.common.compare import deep_compare
 from tests.common import (
     RandomClassificationDataset,
 )
+from tests.common.compare import deep_compare
 
 
 @pytest.mark.gpu
@@ -339,6 +339,7 @@ def test_load_checkpoint(
             deep_compare(original_optim_state_dict, new_optim_state_dict)
             deep_compare(original_resumption_state, new_resumption_state, ignore_keys=['rng', 'run_name'])
 
+
 @pytest.mark.gpu
 @pytest.mark.parametrize(
     'world_size,sharded_model,sharded_checkpoint,shard_as_needed_during_load',
@@ -423,7 +424,7 @@ def test_load_model_checkpoint_and_eval(
         dataset = RandomClassificationDataset(
             shape=(8,),
             size=100,
-            num_classes=3
+            num_classes=3,
         )
 
         trainer = Trainer(
@@ -431,7 +432,7 @@ def test_load_model_checkpoint_and_eval(
                 dataset=dataset,
                 sampler=dist.get_sampler(dataset),
             ),
-            model=new_model, # type: ignore
+            model=new_model,  # type: ignore
         )
 
         # Evaluate the model


### PR DESCRIPTION
Eval'ing after resuming from checkpointing broke since calls to `prepare_fsdp_module` in `state.py` didn't modify the handles and FSDP modules in modules. We fix this by moving `automicrobatch_fsdp_hook_handles` and `fsdp_modules` into `State` instance variables instead of `Trainer` instance variables.

Fixed regression test that previously broken: `mpt-7b-composer-eval-regression-KkY29t`