### PR TITLE
Revert "Use gloo as part of DeviceGPU's process group backend (#3509)"

### DIFF
--- a/composer/devices/device_gpu.py
+++ b/composer/devices/device_gpu.py
@@ -12,9 +12,7 @@ import torch.backends.cuda
 import torch.backends.cudnn
 import torch.cuda
 import torch.cuda.amp
-import torch.distributed as torch_dist
 import torch.utils.data
-from packaging import version
 
 from composer.devices.device import Device
 from composer.utils import dist
@@ -44,9 +42,6 @@ class DeviceGPU(Device):
     ):
         if not torch.cuda.is_available():
             raise ValueError('DeviceGPU cannot be created as torch.cuda is not available.')
-        if torch_dist.is_gloo_available() and version.parse(torch.__version__) >= version.parse('2.3.0'):
-            # Composer checkpoint load / save from before torch 2.3.0 is not compatible with gloo + nccl backends.
-            DeviceGPU.dist_backend = 'cuda:nccl,cpu:gloo'
         if device_id is None:
             device_id = dist.get_local_rank()
         self._device = torch.device(f'cuda:{device_id}')

--- a/tests/checkpoint/test_state_dict.py
+++ b/tests/checkpoint/test_state_dict.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import pytest
 import torch
-import torch.distributed as torch_dist
 from packaging import version
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
@@ -447,10 +446,7 @@ def test_get_metadata_sharded_model(model_type: str, tensor_type: str, world_siz
         assert 'model_name' in metadata_sd
 
     assert 'dist_backend' in metadata_sd
-    if torch_dist.is_gloo_available() and version.parse(torch.__version__) >= version.parse('2.3.0'):
-        assert metadata_sd['dist_backend'] == 'cuda:nccl,cpu:gloo'
-    else:
-        assert metadata_sd['dist_backend'] == 'nccl'
+    assert metadata_sd['dist_backend'] == 'nccl'
 
 
 @pytest.mark.filterwarnings('ignore:SWA has')


### PR DESCRIPTION
This reverts commit cccc8a7c02a8bab52263365cec1da87a7e2c9bdc.

Seeing errors with creating gloo PG on specific clusters. Will root cause and try to get this merged again. Props to @JackZ-db for first reporting!

# What does this PR do?

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/dev/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
