### PR TITLE
Unpin pip

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,7 +172,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} - && \
-    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pip setuptools wheel
+    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pip 'setuptools<70.0.0'
 
 #################
 # Install Pytorch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,7 +172,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} - && \
-    pip${PYTHON_VERSION} install --no-cache-dir --upgrade 'pip<23' 'setuptools<70.0.0'
+    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pip setuptools wheel
 
 #################
 # Install Pytorch


### PR DESCRIPTION
Remove pins for pip and setuptools in Dockerfile and setup.py.

Previous related issues:
- pip was pinned because at some point in time pip 23 made installing from source not work. that seems to have been resolved, as I was able to install from source with the latest version of pip
- EDIT: nevermind, setuptools pin is still needed to install flash attention. 

Tested installing composer from source on:
2.1.2 + cpu image: try-it-cpu-2-1-2-3-V6m0Dz
2.1.2 + gpu image: try-it-gpu-2-1-2-3-BBle1N
2.2.2 + cpu image: try-it-cpu-2-2-2-3-tRu97O
2.2.2 + gpu image: try-it-gpu-2-2-2-3-sGaSyf
2.3.1 + cpu image: try-it-cpu-2-3-1-3-e5Dv41
2.3.1 + gpu image: try-it-gpu-2-3-1-3-pnHpZo