### PR TITLE
Fix FSDP Config Validation

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -645,8 +645,8 @@ class State(Serializable):
             raise ValueError('activation_cpu_offload=True is not supported with use_orig_params=False.')
 
         # Validate FSDP state dict type
-        if self.fsdp_state_dict_type not in [None, 'full', 'sharded']:
-            if self.fsdp_state_dict_type == 'local':
+        if self.fsdp_config.fsdp_state_dict_type not in [None, 'full', 'sharded']:
+            if self.fsdp_config.fsdp_state_dict_type == 'local':
                 raise ValueError(
                     'Composer and PyTorch no longer support saving or loading local state dicts. '
                     'To upgrade an older checkpoint, use Composer version 0.18.1 and export as '

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -645,8 +645,8 @@ class State(Serializable):
             raise ValueError('activation_cpu_offload=True is not supported with use_orig_params=False.')
 
         # Validate FSDP state dict type
-        if self.fsdp_config is not None and self.fsdp_config.fsdp_state_dict_type not in [None, 'full', 'sharded']:
-            if self.fsdp_config.fsdp_state_dict_type == 'local':
+        if self.fsdp_config is not None and self.fsdp_config.state_dict_type not in [None, 'full', 'sharded']:
+            if self.fsdp_config.state_dict_type == 'local':
                 raise ValueError(
                     'Composer and PyTorch no longer support saving or loading local state dicts. '
                     'To upgrade an older checkpoint, use Composer version 0.18.1 and export as '
@@ -654,7 +654,7 @@ class State(Serializable):
                 )
             raise ValueError(
                 f'fsdp_state_dict_type must be one of [None, "full", "sharded"], but got '
-                f'{self.fsdp_state_dict_type}',
+                f'{self.fsdp_config.state_dict_type}',
             )
         if self.fsdp_sharded_state_dict_enabled and self.save_metrics:
             # Sharded state dict breaks in many different ways with torchmetrics, due to both sharding

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -641,11 +641,11 @@ class State(Serializable):
                 raise ValueError(error_message)
 
         # Validate FSDP config parameters.
-        if self.fsdp_config and self.fsdp_config.activation_cpu_offload and not self.fsdp_config.use_orig_params:
+        if self.fsdp_config is not None and self.fsdp_config.activation_cpu_offload and not self.fsdp_config.use_orig_params:
             raise ValueError('activation_cpu_offload=True is not supported with use_orig_params=False.')
 
         # Validate FSDP state dict type
-        if self.fsdp_config.fsdp_state_dict_type not in [None, 'full', 'sharded']:
+        if self.fsdp_config is not None and self.fsdp_config.fsdp_state_dict_type not in [None, 'full', 'sharded']:
             if self.fsdp_config.fsdp_state_dict_type == 'local':
                 raise ValueError(
                     'Composer and PyTorch no longer support saving or loading local state dicts. '


### PR DESCRIPTION
# What does this PR do?

Previously, FSDP config validation only checked the state dict type if FSDP was enabled. As FSDP can be enabled later on after this validation check, e.g. via load_monolith_rank0_only=True or by manual wrapping in a callback, we should instead check the true value of state dict type in the config.