### PR TITLE
hasattr check for Wandb 0.17.6

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -77,13 +77,10 @@ jobs:
       pytest-command: ${{ matrix.pytest_command }}
       pytest-markers: ${{ matrix.markers }}
       composer_package_name: ${{ matrix.composer_package_name }}
-      pytest-wandb-entity: "mosaicml-public-integration-tests"
-      pytest-wandb-project: "integration-tests-${{ github.sha }}"
       safe_directory: composer
     secrets:
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      wandb-api-key: ${{ secrets.WANDB_API_KEY }}
       code-eval-device: ${{ secrets.CODE_EVAL_DEVICE }}
       code-eval-url: ${{ secrets.CODE_EVAL_URL }}
       code-eval-apikey: ${{ secrets.CODE_EVAL_APIKEY }}

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -203,8 +203,8 @@ class WandBLogger(LoggerDestination):
             if hasattr(wandb.run, 'entity') and hasattr(wandb.run, 'project'):
                 entity_and_project = [str(wandb.run.entity), str(wandb.run.project)]
             else:
-                # Run does not have attribtues if wandb is in disabled mode
-                entity_and_project = [None, None]
+                # Run does not have attribtues if wandb is in disabled mode, so we must mock it
+                entity_and_project = ['disabled', 'disabled']
             self.run_dir = wandb.run.dir
             self.run_url = wandb.run.get_url()
             atexit.register(self._set_is_in_atexit)

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -200,7 +200,11 @@ class WandBLogger(LoggerDestination):
         if self._enabled:
             wandb.init(**self._init_kwargs)
             assert wandb.run is not None, 'The wandb run is set after init'
-            entity_and_project = [str(wandb.run.entity), str(wandb.run.project)]
+            if hasattr(wandb.run, 'entity') and hasattr(wandb.run, 'project'):
+                entity_and_project = [str(wandb.run.entity), str(wandb.run.project)]
+            else:
+                # Run does not have attribtues if wandb is in disabled mode
+                entity_and_project = [None, None]
             self.run_dir = wandb.run.dir
             self.run_url = wandb.run.get_url()
             atexit.register(self._set_is_in_atexit)


### PR DESCRIPTION
# What does this PR do?

Wandb 0.17.6 changed disabled mode in this PR: https://github.com/wandb/wandb/pull/8037, which breaks wandb logger when running with disabled mode as certain attributes (entity, project) are not set. This wraps these attributes in a check to see if they exist.

This should not break any internal workflows as we have churned from WandB completely in favor of MLFlow, but it may affect open source users so we should prioritize including in patch release.