### PR TITLE
Restore Azure Tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ filterwarnings = [
     # Some unit tests use ShardedTensor, though by default we use DTensor
     '''ignore:.*Please use DTensor instead and we are deprecating.*:FutureWarning''',
     # Ignore NeptuneLogger warnings
-    '''ignore:.*NVML Shared Library Not Found. GPU usage metrics may not be reported.*:NeptuneWarning''',
+    '''ignore:.*NVML Shared Library Not Found. GPU usage metrics may not be reported.*''',
 ]
 
 # Coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,8 @@ filterwarnings = [
     '''ignore:.*The `NO_SHARD` sharding strategy is deprecated.*:FutureWarning''',
     # Some unit tests use ShardedTensor, though by default we use DTensor
     '''ignore:.*Please use DTensor instead and we are deprecating.*:FutureWarning''',
+    # Ignore NeptuneLogger warnings
+    '''ignore:.*NVML Shared Library Not Found. GPU usage metrics may not be reported.*:NeptuneWarning''',
 ]
 
 # Coverage

--- a/tests/utils/object_store/test_azure_object_store.py
+++ b/tests/utils/object_store/test_azure_object_store.py
@@ -9,7 +9,6 @@ from tests.common import RandomClassificationDataset, SimpleModel
 
 
 @pytest.mark.remote
-@pytest.mark.skip(reason='Waiting for new Azure key to be approved')
 def test_azure_object_store_integration():
     model = SimpleModel()
     train_dataloader = DataLoader(dataset=RandomClassificationDataset())


### PR DESCRIPTION
# What does this PR do?

Restore Azure tests. Key is re-enabled.

Along for the ride, ignores new warnings raised by latest Neptune Logger release.