### PR TITLE
Remove tokens for `to_next_epoch`

### DIFF
--- a/composer/core/time.py
+++ b/composer/core/time.py
@@ -850,7 +850,6 @@ class Timestamp(Serializable):
 
     def to_next_epoch(
         self,
-        tokens: Union[int, Time] = 0,
         duration: Optional[datetime.timedelta] = None,
     ):
         """Create a new :class:`.Timestamp`, advanced to the next epoch.
@@ -891,7 +890,6 @@ class Timestamp(Serializable):
         return self.copy(
             epoch=self.epoch + 1,
             epoch_in_iteration=self.epoch_in_iteration + 1,
-            token_in_iteration=self.token_in_iteration + tokens,
             batch_in_epoch=0,
             sample_in_epoch=0,
             token_in_epoch=0,


### PR DESCRIPTION
# What does this PR do?

Remove tokens for `to_next_epoch`. It should not be possible to process additional tokens between epochs -- this is tracked between batches. See `to_next_batch` as an example. 