### PR TITLE
Fix typo in `composer_collect_env`

### DIFF
--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -274,7 +274,7 @@ Composer Version: {composer_version}
 Composer Commit Hash: {composer_commit_hash}
 CPU Model: {cpu_model}
 CPU Count: {cpu_count}
-Number of Nodes: {node_world_size}
+Number of Nodes: {num_nodes}
 GPU Model: {gpu_model}
 GPUs per Node: {num_gpus_per_node}
 GPU Count: {num_gpus}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import subprocess
 import pytest
 
 import composer
+from composer.utils.collect_env import print_env
 
 
 @pytest.mark.parametrize(
@@ -20,3 +21,7 @@ import composer
 def test_cli_version(args: list[str]):
     version_str = subprocess.check_output(args, text=True)
     assert version_str == f'MosaicML Composer {composer.__version__}\n'
+
+
+def test_collect_env():
+    print_env()


### PR DESCRIPTION
Previous PR introduced a typo into `composer_collect_env` that caused it to crash. This PR fixes that and adds a simple test that makes sure it runs without error.