### PR TITLE
Update ci-testing to 0.2.2

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ref: ee73688ebed3852932da5d5800889889cf54cae1
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 53965d9417983a49003182cfca64286b448f80b3
+        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ref: v0.2.2
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
+        ref: 53965d9417983a49003182cfca64286b448f80b3
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 9735b60f7532e373beb3b5c626f1222efe9392c0
+        ref: e1bebbb96e2114dca5d421c3a9611971e6fc1c59
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 891ad202e7377a0e3eb592c523a3876dc877779c
+        ref: 9735b60f7532e373beb3b5c626f1222efe9392c0
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: v0.0.9
+        ref: 891ad202e7377a0e3eb592c523a3876dc877779c
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: e1bebbb96e2114dca5d421c3a9611971e6fc1c59
+        ref: 36f97444f8cde4913ab5f7228201d48c7178601b
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 36f97444f8cde4913ab5f7228201d48c7178601b
+        ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ref: ee73688ebed3852932da5d5800889889cf54cae1
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ref: v0.2.2
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 53965d9417983a49003182cfca64286b448f80b3
+        ref: try-again
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
+        ref: 53965d9417983a49003182cfca64286b448f80b3
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,7 +9,6 @@ jobs:
   coverage:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: mosaicml/pytorch:2.4.0_cpu-python3.11-ubuntu20.04
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3
@@ -17,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: try-again
+        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: v0.0.9
+        ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/coverage
       with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,6 +9,7 @@ jobs:
   coverage:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    container: mosaicml/pytorch:2.4.0_cpu-python3.11-ubuntu20.04
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -165,7 +165,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -179,4 +179,4 @@ jobs:
         gpu_num: ${{ matrix.gpu_num }}
         mcloud_api_key: ${{ secrets.MCLOUD_DAILY_API_KEY }}
         gha_timeout: 5400
-        ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
+        ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -72,7 +72,7 @@ jobs:
           composer_package_name: mosaicml
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@v0.2.2
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"
@@ -165,7 +165,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.2.2
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -179,4 +179,4 @@ jobs:
         gpu_num: ${{ matrix.gpu_num }}
         mcloud_api_key: ${{ secrets.MCLOUD_DAILY_API_KEY }}
         gha_timeout: 5400
-        ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ci_repo_gpu_test_ref: v0.2.2

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -72,7 +72,7 @@ jobs:
           composer_package_name: mosaicml
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"
@@ -165,7 +165,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -179,4 +179,4 @@ jobs:
         gpu_num: ${{ matrix.gpu_num }}
         mcloud_api_key: ${{ secrets.MCLOUD_DAILY_API_KEY }}
         gha_timeout: 5400
-        ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -72,7 +72,7 @@ jobs:
           composer_package_name: mosaicml
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"
@@ -165,7 +165,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -179,4 +179,4 @@ jobs:
         gpu_num: ${{ matrix.gpu_num }}
         mcloud_api_key: ${{ secrets.MCLOUD_DAILY_API_KEY }}
         gha_timeout: 5400
-        ci_repo_gpu_test_ref: v0.1.2
+        ci_repo_gpu_test_ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -72,7 +72,7 @@ jobs:
           composer_package_name: mosaicml
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"
@@ -165,7 +165,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -179,4 +179,4 @@ jobs:
         gpu_num: ${{ matrix.gpu_num }}
         mcloud_api_key: ${{ secrets.MCLOUD_DAILY_API_KEY }}
         gha_timeout: 5400
-        ci_repo_gpu_test_ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
+        ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@v0.2.2
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/coverage.yaml
     name: Coverage Results
     if: github.repository_owner == 'mosaicml'
+    runs-on: ubuntu-latest
     container: mosaicml/pytorch:2.4.0_cpu-python3.11-ubuntu20.04
     needs: [pytest-cpu]
     with:

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@d5c0ca3db8187cff973d92d14fffae0f5bf9f0bb
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@69c86d888f15a740585c2f3cec203148899ab5a2
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/coverage.yaml
     name: Coverage Results
     if: github.repository_owner == 'mosaicml'
+    container: mosaicml/pytorch:2.4.0_cpu-python3.11-ubuntu20.04
     needs: [pytest-cpu]
     with:
       download-path: artifacts

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@80e6ca4f4849eb3b75577ecb393d682ee5b3bf28
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@d5c0ca3db8187cff973d92d14fffae0f5bf9f0bb
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -47,8 +47,6 @@ jobs:
     uses: ./.github/workflows/coverage.yaml
     name: Coverage Results
     if: github.repository_owner == 'mosaicml'
-    runs-on: ubuntu-latest
-    container: mosaicml/pytorch:2.4.0_cpu-python3.11-ubuntu20.04
     needs: [pytest-cpu]
     with:
       download-path: artifacts

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@68b9b9497f2aa6e32ddaa800b0f6dd99fd458873
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@80e6ca4f4849eb3b75577ecb393d682ee5b3bf28
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-cpu.yaml
+++ b/.github/workflows/pr-cpu.yaml
@@ -34,7 +34,7 @@ jobs:
           pytest_command: coverage run -m pytest tests/test_docs.py
     steps:
     - name: Run PR CPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@69c86d888f15a740585c2f3cec203148899ab5a2
+      uses: mosaicml/ci-testing/.github/actions/pytest-cpu@68b9b9497f2aa6e32ddaa800b0f6dd99fd458873
       with:
         name: ${{ matrix.name }}
         pip_deps: "[all]"

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -1,6 +1,6 @@
 name: PR GPU tests
 on:
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
 # Cancel old runs when a new commit is pushed to the same branch if not on main
 # or dev

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -37,7 +37,7 @@ jobs:
         python_version: 3.9
         gpu_num: 1
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
+        ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
   pytest-gpu-2:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -67,7 +67,7 @@ jobs:
         python_version: 3.9
         gpu_num: 2
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
+        ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
   pytest-gpu-4:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -97,4 +97,4 @@ jobs:
         python_version: 3.9
         gpu_num: 4
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
+        ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -37,7 +37,7 @@ jobs:
         python_version: 3.9
         gpu_num: 1
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
   pytest-gpu-2:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -67,7 +67,7 @@ jobs:
         python_version: 3.9
         gpu_num: 2
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
   pytest-gpu-4:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -97,4 +97,4 @@ jobs:
         python_version: 3.9
         gpu_num: 4
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -37,7 +37,7 @@ jobs:
         python_version: 3.9
         gpu_num: 1
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
+        ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
   pytest-gpu-2:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -67,7 +67,7 @@ jobs:
         python_version: 3.9
         gpu_num: 2
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
+        ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
   pytest-gpu-4:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@53965d9417983a49003182cfca64286b448f80b3
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -97,4 +97,4 @@ jobs:
         python_version: 3.9
         gpu_num: 4
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: 53965d9417983a49003182cfca64286b448f80b3
+        ci_repo_gpu_test_ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -1,6 +1,6 @@
 name: PR GPU tests
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 # Cancel old runs when a new commit is pushed to the same branch if not on main
 # or dev
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.2.2
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -37,7 +37,7 @@ jobs:
         python_version: 3.9
         gpu_num: 1
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ci_repo_gpu_test_ref: v0.2.2
   pytest-gpu-2:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.2.2
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -67,7 +67,7 @@ jobs:
         python_version: 3.9
         gpu_num: 2
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ci_repo_gpu_test_ref: v0.2.2
   pytest-gpu-4:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@ee73688ebed3852932da5d5800889889cf54cae1
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.2.2
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -97,4 +97,4 @@ jobs:
         python_version: 3.9
         gpu_num: 4
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ci_repo_gpu_test_ref: v0.2.2

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -37,7 +37,7 @@ jobs:
         python_version: 3.9
         gpu_num: 1
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: v0.1.2
+        ci_repo_gpu_test_ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
   pytest-gpu-2:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -67,7 +67,7 @@ jobs:
         python_version: 3.9
         gpu_num: 2
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: v0.1.2
+        ci_repo_gpu_test_ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
   pytest-gpu-4:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@863864b00bb5e3a9d6df5fa040a3d035f648b11f
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -97,4 +97,4 @@ jobs:
         python_version: 3.9
         gpu_num: 4
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
-        ci_repo_gpu_test_ref: v0.1.2
+        ci_repo_gpu_test_ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: v0.0.9
+        ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/smoketest
       with:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
+        ref: ee73688ebed3852932da5d5800889889cf54cae1
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/smoketest
       with:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: ee73688ebed3852932da5d5800889889cf54cae1
+        ref: v0.2.2
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/smoketest
       with:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 863864b00bb5e3a9d6df5fa040a3d035f648b11f
+        ref: 53965d9417983a49003182cfca64286b448f80b3
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/smoketest
       with:

--- a/.github/workflows/smoketest.yaml
+++ b/.github/workflows/smoketest.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: 53965d9417983a49003182cfca64286b448f80b3
+        ref: a4cdd8b21b00adb8c9e13f9e7f56aa0f858072dd
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/smoketest
       with:

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,7 @@ extra_deps['slack'] = {
 }
 
 extra_deps['deepspeed'] = [
+    'numpy<2',
     'deepspeed==0.8.3',
     'pydantic>=1.0,<2',
 ]


### PR DESCRIPTION
Updates the ci-testing to 0.2.2, which includes the switch to uv from pip. It also adds a numpy<2 pin to our deepspeed dependency group, as the version of deepspeed we have pinned requires numpy<2