### PR TITLE
Roll back ci-testing for daillies

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -107,12 +107,12 @@ jobs:
         include:
         # Unlike CPU tests, we run daily tests together with GPU tests to minimize launch time
         # on MCLOUD and not eat up all GPUs at once
-        # - name: "gpu-3.11-2.2-1-gpu"
-        #   container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
-        #   markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
-        #   pytest_command: "coverage run -m pytest"
-        #   composer_package_name: "mosaicml"
-        #   gpu_num: 1
+        - name: "gpu-3.11-2.2-1-gpu"
+          container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
+          markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
+          pytest_command: "coverage run -m pytest"
+          composer_package_name: "mosaicml"
+          gpu_num: 1
         - name: "gpu-3.11-2.3-1-gpu"
           container: mosaicml/pytorch:2.3.1_cu121-python3.11-ubuntu20.04
           markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
@@ -125,12 +125,12 @@ jobs:
           pytest_command: "coverage run -m pytest"
           composer_package_name: "mosaicml"
           gpu_num: 1
-        # - name: "gpu-3.11-2.2-2-gpu"
-        #   container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
-        #   markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
-        #   pytest_command: "coverage run -m pytest"
-        #   composer_package_name: "mosaicml"
-        #   gpu_num: 2
+        - name: "gpu-3.11-2.2-2-gpu"
+          container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
+          markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
+          pytest_command: "coverage run -m pytest"
+          composer_package_name: "mosaicml"
+          gpu_num: 2
         - name: "gpu-3.11-2.3-2-gpu"
           container: mosaicml/pytorch:2.3.1_cu121-python3.11-ubuntu20.04
           markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
@@ -143,12 +143,12 @@ jobs:
           pytest_command: "coverage run -m pytest"
           composer_package_name: "mosaicml"
           gpu_num: 2
-        # - name: "gpu-3.11-2.2-4-gpu"
-        #   container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
-        #   markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
-        #   pytest_command: "coverage run -m pytest"
-        #   composer_package_name: "mosaicml"
-        #   gpu_num: 4
+        - name: "gpu-3.11-2.2-4-gpu"
+          container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
+          markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
+          pytest_command: "coverage run -m pytest"
+          composer_package_name: "mosaicml"
+          gpu_num: 4
         - name: "gpu-3.11-2.3-4-gpu"
           container: mosaicml/pytorch:2.3.1_cu121-python3.11-ubuntu20.04
           markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
@@ -165,7 +165,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run PR GPU Tests
-      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.2.2
+      uses: mosaicml/ci-testing/.github/actions/pytest-gpu@v0.1.2
       with:
         name: ${{ matrix.name }}
         composer_package_name: ${{ matrix.composer_package_name }}
@@ -179,4 +179,4 @@ jobs:
         gpu_num: ${{ matrix.gpu_num }}
         mcloud_api_key: ${{ secrets.MCLOUD_DAILY_API_KEY }}
         gha_timeout: 5400
-        ci_repo_gpu_test_ref: v0.2.2
+        ci_repo_gpu_test_ref: v0.1.2

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -107,12 +107,12 @@ jobs:
         include:
         # Unlike CPU tests, we run daily tests together with GPU tests to minimize launch time
         # on MCLOUD and not eat up all GPUs at once
-        - name: "gpu-3.11-2.2-1-gpu"
-          container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
-          markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
-          pytest_command: "coverage run -m pytest"
-          composer_package_name: "mosaicml"
-          gpu_num: 1
+        # - name: "gpu-3.11-2.2-1-gpu"
+        #   container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
+        #   markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
+        #   pytest_command: "coverage run -m pytest"
+        #   composer_package_name: "mosaicml"
+        #   gpu_num: 1
         - name: "gpu-3.11-2.3-1-gpu"
           container: mosaicml/pytorch:2.3.1_cu121-python3.11-ubuntu20.04
           markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
@@ -125,12 +125,12 @@ jobs:
           pytest_command: "coverage run -m pytest"
           composer_package_name: "mosaicml"
           gpu_num: 1
-        - name: "gpu-3.11-2.2-2-gpu"
-          container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
-          markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
-          pytest_command: "coverage run -m pytest"
-          composer_package_name: "mosaicml"
-          gpu_num: 2
+        # - name: "gpu-3.11-2.2-2-gpu"
+        #   container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
+        #   markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
+        #   pytest_command: "coverage run -m pytest"
+        #   composer_package_name: "mosaicml"
+        #   gpu_num: 2
         - name: "gpu-3.11-2.3-2-gpu"
           container: mosaicml/pytorch:2.3.1_cu121-python3.11-ubuntu20.04
           markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
@@ -143,12 +143,12 @@ jobs:
           pytest_command: "coverage run -m pytest"
           composer_package_name: "mosaicml"
           gpu_num: 2
-        - name: "gpu-3.11-2.2-4-gpu"
-          container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
-          markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
-          pytest_command: "coverage run -m pytest"
-          composer_package_name: "mosaicml"
-          gpu_num: 4
+        # - name: "gpu-3.11-2.2-4-gpu"
+        #   container: mosaicml/pytorch:2.2.1_cu121-python3.11-ubuntu20.04
+        #   markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"
+        #   pytest_command: "coverage run -m pytest"
+        #   composer_package_name: "mosaicml"
+        #   gpu_num: 4
         - name: "gpu-3.11-2.3-4-gpu"
           container: mosaicml/pytorch:2.3.1_cu121-python3.11-ubuntu20.04
           markers: "(daily or not daily) and (remote or not remote) and gpu and (doctest or not doctest)"

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -1,6 +1,6 @@
 name: PR GPU tests
 on:
-  pull_request_target:
+  pull_request:
   workflow_dispatch:
 # Cancel old runs when a new commit is pushed to the same branch if not on main
 # or dev
@@ -34,7 +34,7 @@ jobs:
         pip_deps: "[all]"
         pytest_command: ${{ matrix.pytest_command }}
         pytest_markers: ${{ matrix.markers }}
-        python_version: 3.9
+        python_version: 3.11
         gpu_num: 1
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
         ci_repo_gpu_test_ref: v0.2.2
@@ -64,7 +64,7 @@ jobs:
         pip_deps: "[all]"
         pytest_command: ${{ matrix.pytest_command }}
         pytest_markers: ${{ matrix.markers }}
-        python_version: 3.9
+        python_version: 3.11
         gpu_num: 2
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
         ci_repo_gpu_test_ref: v0.2.2
@@ -94,7 +94,7 @@ jobs:
         pip_deps: "[all]"
         pytest_command: ${{ matrix.pytest_command }}
         pytest_markers: ${{ matrix.markers }}
-        python_version: 3.9
+        python_version: 3.11
         gpu_num: 4
         mcloud_api_key: ${{ secrets.MCLOUD_API_KEY }}
         ci_repo_gpu_test_ref: v0.2.2

--- a/.github/workflows/pr-gpu.yaml
+++ b/.github/workflows/pr-gpu.yaml
@@ -1,6 +1,6 @@
 name: PR GPU tests
 on:
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 # Cancel old runs when a new commit is pushed to the same branch if not on main
 # or dev


### PR DESCRIPTION
# What does this PR do?

Dailies are broken with `uv` due to mellanox versioning. Rolls back to older version with `pip` for now.