### PR TITLE
Fix RNG key checking

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -148,10 +148,22 @@ def _get_write_mode(name: str) -> str:
     raise ValueError(f'{name} does not end with a valid tarfile extension.')
 
 
+def _is_rng_key(key: str) -> bool:
+    """Check if the key is an RNG key."""
+    starts_with_rng = key.startswith('rng')
+    ends_with_expected = key.endswith('cuda') or key.endswith('torch') or key.endswith(
+        'python',
+    ) or key.endswith('numpy')
+    if starts_with_rng and ends_with_expected:
+        return True
+
+    return False
+
+
 def _get_num_ranks_that_saved_rng(metadata: Metadata):
     rng_inds = []
     for field_name, field_value in metadata.planner_data.items():
-        if 'rng' in field_name:
+        if _is_rng_key(field_name):
             _, rng_rank_index, _ = field_value
             rng_inds.append(rng_rank_index)
     rng_inds = set(rng_inds)

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -148,13 +148,14 @@ def _get_write_mode(name: str) -> str:
     raise ValueError(f'{name} does not end with a valid tarfile extension.')
 
 
-def _is_rng_key(key: str) -> bool:
+def _is_rng_key(key: str, value: tuple) -> bool:
     """Check if the key is an RNG key."""
     starts_with_rng = key.startswith('rng')
     ends_with_expected = key.endswith('cuda') or key.endswith('torch') or key.endswith(
         'python',
     ) or key.endswith('numpy')
-    if starts_with_rng and ends_with_expected:
+    three_parts = isinstance(value, tuple) and len(value) == 3
+    if starts_with_rng and ends_with_expected and three_parts:
         return True
 
     return False
@@ -163,7 +164,7 @@ def _is_rng_key(key: str) -> bool:
 def _get_num_ranks_that_saved_rng(metadata: Metadata):
     rng_inds = []
     for field_name, field_value in metadata.planner_data.items():
-        if _is_rng_key(field_name):
+        if _is_rng_key(field_name, field_value):
             _, rng_rank_index, _ = field_value
             rng_inds.append(rng_rank_index)
     rng_inds = set(rng_inds)

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -149,11 +149,13 @@ def _get_write_mode(name: str) -> str:
 
 
 def _is_rng_key(key: str, value: tuple) -> bool:
-    """Check if the key is an RNG key."""
+    """Check if the key is an RNG key.
+
+    We expect the RNG key to be of the form 'rng.{rank}.cuda|torch|python|numpy'.
+    This function ensures that we don't accidentally pick up other keys.
+    """
     starts_with_rng = key.startswith('rng')
-    ends_with_expected = key.endswith('cuda') or key.endswith('torch') or key.endswith(
-        'python',
-    ) or key.endswith('numpy')
+    ends_with_expected = key.endswith(('cuda', 'torch', 'python', 'numpy'))
     three_parts = isinstance(value, tuple) and len(value) == 3
     if starts_with_rng and ends_with_expected and three_parts:
         return True

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -132,7 +132,7 @@ def _assert_checkpoints_equivalent(file1, file2, atol=0.0, rtol=0.0):
 
 
 @pytest.mark.parametrize(
-    'key,expected_value',
+    'key,value,expected_result',
     [
         ('rng.0.cuda', ('rng', '0', 'cuda'), True),
         ('rng.0.torch', ('rng', '0', 'torch'), True),
@@ -144,8 +144,8 @@ def _assert_checkpoints_equivalent(file1, file2, atol=0.0, rtol=0.0):
         ('test.notatuple.test', 0, False),
     ],
 )
-def test_is_rng_key(key: str, value: tuple, expected_value: bool):
-    assert _is_rng_key(key, value) == expected_value
+def test_is_rng_key(key: str, value: tuple, expected_result: bool):
+    assert _is_rng_key(key, value) == expected_result
 
 
 @pytest.mark.parametrize(

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -134,17 +134,18 @@ def _assert_checkpoints_equivalent(file1, file2, atol=0.0, rtol=0.0):
 @pytest.mark.parametrize(
     'key,expected_value',
     [
-        ('rng.0.cuda', True),
-        ('rng.0.torch', True),
-        ('rng.0.numpy', True),
-        ('rng.0.python', True),
-        ('rng.0', False),
-        ('test.test.rng', False),
-        ('test.rng.test', False),
+        ('rng.0.cuda', ('rng', '0', 'cuda'), True),
+        ('rng.0.torch', ('rng', '0', 'torch'), True),
+        ('rng.0.numpy', ('rng', '0', 'numpy'), True),
+        ('rng.0.python', ('rng', '0', 'python'), True),
+        ('rng.0', ('rng', '0'), False),
+        ('test.test.rng', ('test', 'test', 'rng'), False),
+        ('test.rng.test', ('test', 'rng', 'test'), False),
+        ('test.notatuple.test', 0, False),
     ],
 )
-def test_is_rng_key(key: str, expected_value: bool):
-    assert _is_rng_key(key) == expected_value
+def test_is_rng_key(key: str, value: tuple, expected_value: bool):
+    assert _is_rng_key(key, value) == expected_value
 
 
 @pytest.mark.parametrize(

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -35,6 +35,7 @@ from composer.utils.checkpoint import (
     _COMPOSER_STATES_FILENAME,
     PartialFilePath,
     _ensure_valid_checkpoint,
+    _is_rng_key,
     _write_checkpoint_file,
     glob_filter,
 )
@@ -128,6 +129,22 @@ def _assert_checkpoints_equivalent(file1, file2, atol=0.0, rtol=0.0):
         'optimizers' in checkpoint_2['state'],
     )
     assert all(keys_in) or not any(keys_in)
+
+
+@pytest.mark.parametrize(
+    'key,expected_value',
+    [
+        ('rng.0.cuda', True),
+        ('rng.0.torch', True),
+        ('rng.0.numpy', True),
+        ('rng.0.python', True),
+        ('rng.0', False),
+        ('test.test.rng', False),
+        ('test.rng.test', False),
+    ],
+)
+def test_is_rng_key(key: str, expected_value: bool):
+    assert _is_rng_key(key) == expected_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do?
Likely with pytorch 2.4, the keys in the state dict include lots of things, and they end up in the planner.

This means that the keys that include the string "rng" in a checkpoint can be like this

```
['state.integrations.huggingface.tokenizer.tokenizer.json.content.model.vocab.Ġrng',
 'state.integrations.huggingface.tokenizer.tokenizer.json.content.model.vocab._rng',
 'state.integrations.huggingface.tokenizer.tokenizer.json.content.model.vocab.rng',
 'state.integrations.huggingface.tokenizer.tokenizer.json.content.model.vocab.(rng',
 'rng.0.python',
 'rng.0.numpy',
 'rng.0.torch',
 'rng.0.cuda',
 'rng.1.python',
 'rng.1.numpy',
 'rng.1.torch',
 'rng.1.cuda',
 'rng.2.python',
 'rng.2.numpy',
 'rng.2.torch',
 'rng.2.cuda',
 'rng.3.python',
 'rng.3.numpy',
 'rng.3.torch',
 'rng.3.cuda',
 'rng.4.python',
 'rng.4.numpy',
 'rng.4.torch',
 'rng.4.cuda',
 'rng.5.python',
 'rng.5.numpy',
 'rng.5.torch',
 'rng.5.cuda',
 'rng.6.python',
 'rng.6.numpy',
 'rng.6.torch',
 'rng.6.cuda',
 'rng.7.python',
 'rng.7.numpy',
 'rng.7.torch',
 'rng.7.cuda']
 ```

The check in our code for processing rng keys is way too lenient, and tries to process the state integrations keys in this example. This PR makes the check stricter.

Manual test:
Run that fails on dev resuming: `resumption-metadata-resume-1-EzxHw6`
Run that success on this PR resuming: `resumption-metadata-resume-fix-1-vhfchJ`