### PR TITLE
Add backward compatibility checkpoint tests for v0.25.0

### DIFF
--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -533,8 +533,9 @@ def test_fsdp_load_old_checkpoint(
     if composer_version == '0.18.1' and state_dict_type == 'full' and precision == 'amp_bf16' and sharding_strategy == 'FULL_SHARD':
         pytest.skip('TODO: This checkpoint is missing')
 
-    if (composer_version in ['0.22.0', '0.23.0'] and version.parse(torch.__version__) < version.parse('2.3.0')
-       ) or (composer_version == '0.24.0' and version.parse(torch.__version__) < version.parse('2.4.0')):
+    if (composer_version in ['0.22.0', '0.23.0'] and version.parse(torch.__version__) < version.parse('2.3.0')) or (
+        composer_version == '0.24.0' and version.parse(torch.__version__) < version.parse('2.4.0')
+    ) or (composer_version == '0.25.0' and version.parse(torch.__version__) < version.parse('2.5.0')):
         pytest.skip('Current torch version is older than torch version that checkpoint was written with.')
 
     if composer_version in ['0.13.5', '0.14.0', '0.14.1', '0.15.1']:

--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -513,6 +513,7 @@ def test_fsdp_mixed_with_sync(
         '0.22.0',
         '0.23.0',
         '0.24.0',
+        '0.25.0',
     ],
 )
 @pytest.mark.filterwarnings(r'ignore:.*metrics are not saved with sharded state dict.*:UserWarning')


### PR DESCRIPTION
As title

Daily test run: https://github.com/mosaicml/composer/actions/runs/11024942307