### PR TITLE
Create callback to load checkpoint

### DIFF
--- a/composer/callbacks/__init__.py
+++ b/composer/callbacks/__init__.py
@@ -13,6 +13,7 @@ from composer.callbacks.export_for_inference import ExportForInferenceCallback
 from composer.callbacks.free_outputs import FreeOutputs
 from composer.callbacks.generate import Generate
 from composer.callbacks.image_visualizer import ImageVisualizer
+from composer.callbacks.load_checkpoint import LoadCheckpoint
 from composer.callbacks.lr_monitor import LRMonitor
 from composer.callbacks.memory_monitor import MemoryMonitor
 from composer.callbacks.memory_snapshot import MemorySnapshot
@@ -44,4 +45,5 @@ __all__ = [
     'FreeOutputs',
     'MemorySnapshot',
     'OOMObserver',
+    'LoadCheckpoint',
 ]

--- a/composer/callbacks/load_checkpoint.py
+++ b/composer/callbacks/load_checkpoint.py
@@ -10,6 +10,7 @@ from composer.core.event import Event
 from composer.loggers import Logger
 from composer.models.huggingface import HuggingFaceModel
 from composer.utils.checkpoint import load_checkpoint
+from composer.utils.file_helpers import maybe_create_object_store_from_uri, parse_uri
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +34,9 @@ class LoadCheckpoint(Callback):
     ):
         super().__init__()
         self.load_path = load_path
+        self.load_object_store = maybe_create_object_store_from_uri(load_path)
+        _, _, self.parsed_path = parse_uri(load_path)
+
         self.load_weights_only = load_weights_only
         self.strict_model_weights = strict_model_weights
         self.ignore_keys = ignore_keys
@@ -58,9 +62,10 @@ class LoadCheckpoint(Callback):
             model.should_save_peft_only = False
 
         load_checkpoint(
-            path=self.load_path,
+            path=self.parsed_path,
             state=state,
             logger=logger,
+            object_store=self.load_object_store,
             strict_model_weights=self.strict_model_weights,
             ignore_keys=self.ignore_keys,
             load_weights_only=self.load_weights_only,

--- a/composer/callbacks/load_checkpoint.py
+++ b/composer/callbacks/load_checkpoint.py
@@ -3,7 +3,7 @@
 
 """Load a checkpoint."""
 import logging
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from composer.core import Callback, State
 from composer.core.event import Event
@@ -28,7 +28,7 @@ class LoadCheckpoint(Callback):
         load_path: str,
         load_weights_only: bool = False,
         strict_model_weights: bool = True,
-        ignore_keys: Optional[List[str]] = None,
+        ignore_keys: Optional[list[str]] = None,
         event: Union[str, Event] = Event.BEFORE_LOAD,
     ):
         super().__init__()
@@ -37,7 +37,7 @@ class LoadCheckpoint(Callback):
         self.strict_model_weights = strict_model_weights
         self.ignore_keys = ignore_keys
 
-        self.event = event if isinstance(event, Event) else Event[event.lower()]
+        self.event = event if isinstance(event, Event) else Event[event.upper()]
 
     def run_event(self, event: Event, state: State, logger: Logger) -> None:
         if event == self.event:

--- a/composer/callbacks/load_checkpoint.py
+++ b/composer/callbacks/load_checkpoint.py
@@ -1,0 +1,33 @@
+# Copyright 2024 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load a checkpoint."""
+from typing import Optional
+
+from composer.checkpoint.load import CheckpointLoadOptions, load_checkpoint
+from composer.core import Callback, State
+from composer.loggers import Logger
+
+
+class LoadCheckpoint(Callback):
+    """Callback that loads a checkpoint after other checkpoints have been loaded.
+
+    Args:
+        load_path: The path to the checkpoint to load.
+        load_options: A dictionary of options to pass to the checkpoint loading function.
+    """
+
+    def __init__(self, load_path: str, load_options: Optional[dict] = None):
+        super().__init__()
+        self.load_path = load_path
+        self.load_options = CheckpointLoadOptions(**(load_options or {}))
+
+    def after_load(self, state: State, logger: Logger) -> None:
+        load_checkpoint(
+            load_path=self.load_path,
+            load_options=self.load_options,
+            state=state,
+            model_child_path=None,
+            optim_child_path=None,
+        )
+        return super().after_load(state, logger)

--- a/composer/callbacks/load_checkpoint.py
+++ b/composer/callbacks/load_checkpoint.py
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Load a checkpoint."""
+import logging
 from typing import Optional, Union
 
 from composer.checkpoint.load import CheckpointLoadOptions, load_checkpoint
 from composer.core import Callback, State
 from composer.core.event import Event
 from composer.loggers import Logger
+
+log = logging.getLogger(__name__)
 
 
 class LoadCheckpoint(Callback):
@@ -38,6 +41,8 @@ class LoadCheckpoint(Callback):
     def _load(self, state: State, logger: Logger) -> None:
         del logger  # unused
 
+        log.info(f'Loading checkpoint from {self.load_path} at event {self.event}.')
+
         load_checkpoint(
             load_path=self.load_path,
             load_options=self.load_options,
@@ -45,3 +50,5 @@ class LoadCheckpoint(Callback):
             model_child_path='',
             optim_child_path='',
         )
+
+        log.info(f'Finished loading checkpoint from {self.load_path} at event {self.event}.')

--- a/composer/callbacks/load_checkpoint.py
+++ b/composer/callbacks/load_checkpoint.py
@@ -11,7 +11,7 @@ from composer.loggers import Logger
 
 
 class LoadCheckpoint(Callback):
-    """Callback that loads a checkpoint at the specified event..
+    """Callback that loads a checkpoint at the specified event.
 
     Args:
         load_path: The path to the checkpoint to load.
@@ -19,7 +19,12 @@ class LoadCheckpoint(Callback):
         event: The event at which to load the checkpoint. Defaults to ``Event.BEFORE_LOAD``.
     """
 
-    def __init__(self, load_path: str, load_options: Optional[dict] = None, event: Union[str, Event] = Event.BEFORE_LOAD):
+    def __init__(
+        self,
+        load_path: str,
+        load_options: Optional[dict] = None,
+        event: Union[str, Event] = Event.BEFORE_LOAD,
+    ):
         super().__init__()
         self.load_path = load_path
         self.load_options = CheckpointLoadOptions(**(load_options or {}))
@@ -29,7 +34,7 @@ class LoadCheckpoint(Callback):
         if event == self.event:
             self._load(state, logger)
         return super().run_event(event, state, logger)
-    
+
     def _load(self, state: State, logger: Logger) -> None:
         del logger  # unused
 

--- a/composer/callbacks/load_checkpoint.py
+++ b/composer/callbacks/load_checkpoint.py
@@ -2,32 +2,41 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Load a checkpoint."""
-from typing import Optional
+from typing import Optional, Union
 
 from composer.checkpoint.load import CheckpointLoadOptions, load_checkpoint
 from composer.core import Callback, State
+from composer.core.event import Event
 from composer.loggers import Logger
 
 
 class LoadCheckpoint(Callback):
-    """Callback that loads a checkpoint after other checkpoints have been loaded.
+    """Callback that loads a checkpoint at the specified event..
 
     Args:
         load_path: The path to the checkpoint to load.
         load_options: A dictionary of options to pass to the checkpoint loading function.
+        event: The event at which to load the checkpoint. Defaults to ``Event.BEFORE_LOAD``.
     """
 
-    def __init__(self, load_path: str, load_options: Optional[dict] = None):
+    def __init__(self, load_path: str, load_options: Optional[dict] = None, event: Union[str, Event] = Event.BEFORE_LOAD):
         super().__init__()
         self.load_path = load_path
         self.load_options = CheckpointLoadOptions(**(load_options or {}))
+        self.event = event if isinstance(event, Event) else Event[event.lower()]
 
-    def after_load(self, state: State, logger: Logger) -> None:
+    def run_event(self, event: Event, state: State, logger: Logger) -> None:
+        if event == self.event:
+            self._load(state, logger)
+        return super().run_event(event, state, logger)
+    
+    def _load(self, state: State, logger: Logger) -> None:
+        del logger  # unused
+
         load_checkpoint(
             load_path=self.load_path,
             load_options=self.load_options,
             state=state,
-            model_child_path=None,
-            optim_child_path=None,
+            model_child_path='',
+            optim_child_path='',
         )
-        return super().after_load(state, logger)

--- a/composer/callbacks/load_checkpoint.py
+++ b/composer/callbacks/load_checkpoint.py
@@ -17,9 +17,9 @@ class LoadCheckpoint(Callback):
     """Callback that loads a checkpoint at the specified event.
 
     Args:
-        load_path: The path to the checkpoint to load.
-        load_options: A dictionary of options to pass to the checkpoint loading function.
-        event: The event at which to load the checkpoint. Defaults to ``Event.BEFORE_LOAD``.
+        load_path (str): The path to the checkpoint to load.
+        load_options (Optional[dict]): A dictionary of options to pass to the checkpoint loading function.
+        event (Union[str, Event]): The event at which to load the checkpoint. Defaults to ``Event.BEFORE_LOAD``.
     """
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,8 @@ filterwarnings = [
     # Ignore mlflow warnings about transformers versions,
     '''ignore:The 'transformers' MLflow Models integration.*:UserWarning''',
     # Ignore our own deprecation warnings,
+    '''ignore:To use flash-attn v3*:UserWarning''',
+    # Ignore the flash v3 warnings from transformer engine
     '''ignore::composer.utils.warnings.VersionedDeprecationWarning''',
     # Ignore deprecation warning for torch.load
     '''ignore:You are using `torch.load` with `weights_only=False`.*:FutureWarning''',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,9 +168,9 @@ filterwarnings = [
     '''ignore:'.*_state_dict' is deprecated and will be removed in future versions.*:UserWarning''',
     # Ignore mlflow warnings about transformers versions,
     '''ignore:The 'transformers' MLflow Models integration.*:UserWarning''',
-    # Ignore our own deprecation warnings,
-    '''ignore:To use flash-attn v3*:UserWarning''',
     # Ignore the flash v3 warnings from transformer engine
+    '''ignore:To use flash-attn v3*:UserWarning''',
+    # Ignore our own deprecation warnings
     '''ignore::composer.utils.warnings.VersionedDeprecationWarning''',
     # Ignore deprecation warning for torch.load
     '''ignore:You are using `torch.load` with `weights_only=False`.*:FutureWarning''',

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -26,6 +26,7 @@ from composer.callbacks import (
     SystemMetricsMonitor,
     ThresholdStopper,
 )
+from composer.callbacks.load_checkpoint import LoadCheckpoint
 from composer.loggers import (
     CometMLLogger,
     ConsoleLogger,
@@ -154,6 +155,9 @@ _callback_kwargs: dict[type[Callback], dict[str, Any]] = {
     composer.profiler.Profiler: {
         'trace_handlers': [MagicMock()],
         'schedule': composer.profiler.cyclic_schedule(),
+    },
+    LoadCheckpoint: {
+        'load_path': 'fake-path',
     },
 }
 

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -1,8 +1,10 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
 import os
 from typing import Any
+from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
@@ -204,6 +206,14 @@ _callback_marks: dict[
     SystemMetricsMonitor: [pytest.mark.skipif(not _PYNMVL_INSTALLED, reason='pynmvl is optional')],
     NeptuneLogger: [pytest.mark.skipif(not _NEPTUNE_INSTALLED, reason='neptune is optional')],
 }
+
+_callback_patches: dict[type[Callback], Any] = {
+    LoadCheckpoint: mock.patch('composer.callbacks.load_checkpoint.load_checkpoint'),
+}
+
+
+def get_cb_patches(impl: type[Callback]):
+    return _callback_patches.get(impl, contextlib.nullcontext())
 
 
 def get_cb_kwargs(impl: type[Callback]):

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -10,7 +10,12 @@ from composer.core.time import Time
 from composer.loggers import Logger, LoggerDestination
 from composer.profiler import Profiler, ProfilerAction
 from composer.trainer import Trainer
-from tests.callbacks.callback_settings import get_cb_kwargs, get_cb_model_and_datasets, get_cbs_and_marks
+from tests.callbacks.callback_settings import (
+    get_cb_kwargs,
+    get_cb_model_and_datasets,
+    get_cb_patches,
+    get_cbs_and_marks,
+)
 from tests.common import EventCounterCallback
 
 
@@ -154,8 +159,12 @@ class TestCallbackTrains:
         del _remote  # unused. `_remote` must be passed through to parameterize the test markers.
         cb_kwargs = get_cb_kwargs(cb_cls)
         cb = cb_cls(**cb_kwargs)
-        trainer = self._get_trainer(cb, device_train_microbatch_size)
-        trainer.fit()
+
+        maybe_patch_context = get_cb_patches(cb_cls)
+
+        with maybe_patch_context:
+            trainer = self._get_trainer(cb, device_train_microbatch_size)
+            trainer.fit()
 
     @pytest.mark.filterwarnings('ignore::UserWarning')
     def test_trains_multiple_calls(self, cb_cls: type[Callback], device_train_microbatch_size: int, _remote: bool):
@@ -167,8 +176,12 @@ class TestCallbackTrains:
         del _remote  # unused. `_remote` must be passed through to parameterize the test markers.
         cb_kwargs = get_cb_kwargs(cb_cls)
         cb = cb_cls(**cb_kwargs)
-        trainer = self._get_trainer(cb, device_train_microbatch_size)
-        trainer.fit()
+
+        maybe_patch_context = get_cb_patches(cb_cls)
+
+        with maybe_patch_context:
+            trainer = self._get_trainer(cb, device_train_microbatch_size)
+            trainer.fit()
 
         assert trainer.state.max_duration is not None
         trainer.state.max_duration = cast(Time[int], trainer.state.max_duration * 2)

--- a/tests/callbacks/test_load_checkpoint.py
+++ b/tests/callbacks/test_load_checkpoint.py
@@ -1,0 +1,68 @@
+# Copyright 2024 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest import mock
+from unittest.mock import call
+
+from torch.utils.data import DataLoader
+
+from composer.callbacks import LoadCheckpoint
+from composer.core.state import State
+from composer.models.huggingface import HuggingFaceModel
+from composer.trainer.trainer import Trainer
+from tests.common.datasets import RandomTextLMDataset
+
+
+def test_load_checkpoint_callback(
+    tiny_gpt2_model,
+    tiny_gpt2_tokenizer,
+    gpt2_peft_config,
+):
+
+    model = HuggingFaceModel(
+        tiny_gpt2_model,
+        tokenizer=tiny_gpt2_tokenizer,
+        peft_config=gpt2_peft_config,
+        should_save_peft_only=True,
+    )
+
+    # Function to check the arguments passed to the load_checkpoint function.
+    def check_callback_load_args(state: State, **kwargs):
+        assert state.model == model
+
+        # Check that the `should_save_peft_only` flag on the model was set to False when loading the checkpoint.
+        assert state.model.should_save_peft_only == False
+
+    # Patch the load_checkpoint function to check the arguments passed to it.
+    with mock.patch(
+        'composer.callbacks.load_checkpoint.load_checkpoint',
+        new=mock.MagicMock(wraps=check_callback_load_args),
+    ) as callback_load:
+        with mock.patch('composer.trainer.trainer.checkpoint.load_checkpoint') as trainer_load:
+
+            calls = mock.MagicMock()
+            calls.attach_mock(trainer_load, 'trainer_load')
+            calls.attach_mock(callback_load, 'callback_load')
+
+            Trainer(
+                model=model,
+                callbacks=[LoadCheckpoint(
+                    load_path='fake-path',
+                    event='BEFORE_LOAD',
+                )],
+                train_dataloader=DataLoader(RandomTextLMDataset()),
+                max_duration='1ba',
+                load_path='fake_path',
+            )
+
+            callback_load.assert_called_once()
+            trainer_load.assert_called_once()
+
+            # Assert that the callback_load and trainer_load functions were called in the correct order.
+            assert calls.mock_calls == [
+                call.callback_load(**callback_load.call_args.kwargs),
+                call.trainer_load(**trainer_load.call_args.kwargs),
+            ]
+
+    # Check that the `should_save_peft_only` flag on the model was reset to its original value after loading the checkpoint.
+    assert model.should_save_peft_only == True

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -424,6 +424,24 @@ def tiny_gpt2_model(_session_tiny_gpt2_model):
     return copy.deepcopy(_session_tiny_gpt2_model)
 
 
+def _gpt2_peft_config():
+    pytest.importorskip('peft')
+    from peft import get_peft_config
+
+    peft_config = get_peft_config({
+        'peft_type': 'LORA',
+        'task_type': 'CAUSAL_LM',
+        'target_modules': ['c_attn'],
+        'fan_in_fan_out': True,
+    })
+    return peft_config
+
+
+@pytest.fixture
+def gpt2_peft_config():
+    return _gpt2_peft_config()
+
+
 @pytest.fixture
 def tiny_opt_config(_session_tiny_opt_config):
     return copy.deepcopy(_session_tiny_opt_config)

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -35,6 +35,7 @@ from tests.common.models import (
     configure_tiny_t5_model,
     configure_tiny_t5_tokenizer,
 )
+from tests.fixtures.fixtures import _gpt2_peft_config
 from tests.loggers.test_remote_uploader_downloader import DummyObjectStore
 
 if TYPE_CHECKING:

--- a/tests/models/test_hf_model.py
+++ b/tests/models/test_hf_model.py
@@ -41,24 +41,6 @@ if TYPE_CHECKING:
     from peft import PeftConfig
 
 
-def _gpt2_peft_config():
-    pytest.importorskip('peft')
-    from peft import get_peft_config
-
-    peft_config = get_peft_config({
-        'peft_type': 'LORA',
-        'task_type': 'CAUSAL_LM',
-        'target_modules': ['c_attn'],
-        'fan_in_fan_out': True,
-    })
-    return peft_config
-
-
-@pytest.fixture
-def gpt2_peft_config():
-    return _gpt2_peft_config()
-
-
 def _mpt_peft_config():
     pytest.importorskip('peft')
     from peft import get_peft_config


### PR DESCRIPTION
# What does this PR do?

Adds a new callback to load a checkpoint at a specified event. This enables use cases like loading model base weights with peft.

## Manual Test

Ran two lora finetuning runs.
`test-load-checkpoint-callback-baseline-K0m4fq`: Initialized from Huggingface checkpoint and ran for 100 batches
`test-load-checkpoint-callback-resume-GS8oWj`: Initialized using this callback and the baseline checkpoint at ba50.

We see that the losses match up.
<img width="1591" alt="image" src="https://github.com/user-attachments/assets/37b869f0-432e-4ed3-9027-50234bdbe1dd">

Also confirmed that the adapter-only checkpoint is smaller than a full checkpoint as expected.


<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
