### PR TITLE
Switch to log.info for deterministic mode

### DIFF
--- a/composer/utils/reproducibility.py
+++ b/composer/utils/reproducibility.py
@@ -127,7 +127,7 @@ def configure_deterministic_mode():
     # See https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html
     # and https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
     os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8'
-    warnings.warn('Deterministic mode is activated. This will negatively impact performance.', category=UserWarning)
+    log.warning('Deterministic mode is activated. This will negatively impact performance.', category=UserWarning)
 
 
 def get_random_seed() -> int:

--- a/composer/utils/reproducibility.py
+++ b/composer/utils/reproducibility.py
@@ -127,7 +127,7 @@ def configure_deterministic_mode():
     # See https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html
     # and https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
     os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8'
-    log.warning('Deterministic mode is activated. This will negatively impact performance.', category=UserWarning)
+    log.info('Deterministic mode is activated. This will negatively impact performance.', category=UserWarning)
 
 
 def get_random_seed() -> int:

--- a/composer/utils/reproducibility.py
+++ b/composer/utils/reproducibility.py
@@ -127,7 +127,7 @@ def configure_deterministic_mode():
     # See https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html
     # and https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
     os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8'
-    log.info('Deterministic mode is activated. This will negatively impact performance.', category=UserWarning)
+    log.info('Deterministic mode is activated. This will negatively impact performance.')
 
 
 def get_random_seed() -> int:

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -146,6 +146,11 @@ _callback_kwargs: dict[type[Callback], dict[str, Any]] = {
     NeptuneLogger: {
         'mode': 'debug',
     },
+    WandBLogger: {
+        'init_kwargs': {
+            'mode': 'offline',
+        },
+    },
     composer.profiler.Profiler: {
         'trace_handlers': [MagicMock()],
         'schedule': composer.profiler.cyclic_schedule(),


### PR DESCRIPTION
# What does this PR do?

Switch to `log.info` as this isn't something going wrong that requires user intervention. If a user intentionally sets this, it should not result in a warning.

Most frequently, this results in spurious warnings in our Ci/CD