### PR TITLE
Add better error handling for non-rank 0 during Monolithic Checkpoint Loading 

### DIFF
--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -1014,10 +1014,12 @@ def safe_torch_load(
             ) from e
         raise e
     except FileNotFoundError as e:
-        if 'No such file or directory' in str(e) and dist.get_global_rank() != 0:
+        if 'No such file or directory' in str(e) and dist.get_local_rank() != 0:
+            local_rank_zero = dist.get_global_rank() - dist.get_local_rank()
             raise FileNotFoundError(
                 f'No such file or directory: {e.filename}. '
-                'Please check rank 0 for more downloading / debugging info.',
+                f'This likely implies a download failed on local rank 0, which is global rank {local_rank_zero}'
+                f'Please check the logs for global rank {local_rank_zero} to debug the checkpoint download issue.',
             ) from e
         raise e
 

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -1013,6 +1013,13 @@ def safe_torch_load(
                 'pass `load_ignore_keys = ["state/train_metrics/*", "state/eval_metrics/*"]`.',
             ) from e
         raise e
+    except FileNotFoundError as e:
+        if 'No such file or directory' in str(e) and dist.get_global_rank() != 0:
+            raise FileNotFoundError(
+                f'No such file or directory: {e.filename}. '
+                'Please check rank 0 for more downloading / debugging info.',
+            ) from e
+        raise e
 
 
 def _restore_checkpoint(

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1697,8 +1697,7 @@ class TestCheckpointResumption:
         assert trainer.state.train_dataloader.batch_sampler.epoch == max_duration - 1
 
     @world_size(2)
-    @pytest.mark.gpu
-    def test_load_incorrect_path(self, world_size: int, device: str, tmp_path: pathlib.Path, caplog):
+    def test_load_incorrect_path(self, world_size: int, tmp_path: pathlib.Path, caplog):
         save_folder = tmp_path / 'checkpoints'
         save_folder.mkdir(exist_ok=True)
 

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1697,7 +1697,8 @@ class TestCheckpointResumption:
         assert trainer.state.train_dataloader.batch_sampler.epoch == max_duration - 1
 
     @world_size(2)
-    def test_load_incorrect_path(self, world_size: int, tmp_path: pathlib.Path, caplog):
+    @pytest.mark.gpu
+    def test_load_incorrect_path(self, world_size: int, device: str, tmp_path: pathlib.Path, caplog):
         save_folder = tmp_path / 'checkpoints'
         save_folder.mkdir(exist_ok=True)
 

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1724,8 +1724,10 @@ class TestCheckpointResumption:
 
         # Check error messages for each rank
         if dist.get_global_rank() == 0:
+            print(caplog.records)
             assert any('No such file or directory:' in record.message for record in caplog.records)
         else:
+            print(caplog.records)
             assert any(
                 "Error encountered on rank 0. Please check rank 0's error log for more information." in record.message
                 for record in caplog.records

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1697,6 +1697,7 @@ class TestCheckpointResumption:
         assert trainer.state.train_dataloader.batch_sampler.epoch == max_duration - 1
 
     @world_size(2)
+    @pytest.mark.gpu
     def test_load_incorrect_path(self, world_size: int, tmp_path: pathlib.Path, caplog):
         save_folder = tmp_path / 'checkpoints'
         save_folder.mkdir(exist_ok=True)
@@ -1707,6 +1708,7 @@ class TestCheckpointResumption:
             save_filename='checkpoint.pt',
             save_interval='1ep',
             max_duration='1ep',
+            device='gpu',
         )
         trainer.fit()
         trainer.close()


### PR DESCRIPTION
# What does this PR do?
Previously, all rank's 1 - N would return a File not Found Error when local rank 0 failed to download the monolithic checkpoint resulting in a confusing debugging experience. 

This new logic changes the exception on non global rank 0's to raise an Error that points users to look at the local rank 0 for better debugging experience.

# What issue(s) does this change relate to?
https://databricks.atlassian.net/browse/GRT-3308

# Tests
`EXTRA_ARGS='-vv -k test_load_incorrect_path' WORLD_SIZE=2  make test-dist-gpu`