### PR TITLE
Use a temp path to save local checkpoints for remote save path

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -299,7 +299,8 @@ class CheckpointSaver(Callback):  # noqa: D101
         if local_folder == '':
             local_folder = '.'
 
-        if backend != '':  # If we are uploading to a remote path, we use a temporary directory to save local checkpoints.
+        is_remote_folder = backend != ''
+        if is_remote_folder:  # If we are uploading to a remote path, we use a temporary directory to save local checkpoints.
             local_folder = os.path.join(tempfile.mkdtemp(), local_folder)
 
         filename = str(filename)

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -294,9 +294,13 @@ class CheckpointSaver(Callback):  # noqa: D101
         num_concurrent_uploads: int = 1,
         upload_timeout_in_seconds: int = 3600,
     ):
+
         backend, _, local_folder = parse_uri(str(folder))
         if local_folder == '':
             local_folder = '.'
+
+        if backend != '':  # If we are uploading to a remote path, we use a temporary directory to save local checkpoints.
+            local_folder = os.path.join(tempfile.mkdtemp(), local_folder)
 
         filename = str(filename)
         remote_file_name = str(remote_file_name) if remote_file_name is not None else None

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -882,7 +882,8 @@ class TestCheckpointLoading:
 
                     if delete_local:
                         # delete files locally, forcing trainer to look in object store
-                        shutil.rmtree('first')
+                        assert trainer_1._checkpoint_saver is not None
+                        shutil.rmtree(trainer_1._checkpoint_saver.folder)
 
                     trainer_2 = self.get_trainer(
                         latest_filename=latest_filename,


### PR DESCRIPTION
# What does this PR do?

Uses a temp path to save local checkpoints for remote save paths.

This avoids issues where the current path has limits on file sizes or permission restrictions. This also enables more configurability because we can configure the default temp dir if needed.

# Testing
Tested on interactive, saving to a remote dbfs path. You can see that the checkpoints are now saved to a local folder:
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/dcadea57-9392-46c5-9c9a-cf2a7c6a9eb5">

And the checkpoints are uploaded correctly to the remote location in mlflow artifacts:
<img width="1371" alt="image" src="https://github.com/user-attachments/assets/2fdd56d2-6333-4d67-9a88-440bea379221">


<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
