### PR TITLE
Don't overwrite existing excepthook in mlflow logger

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -304,7 +304,7 @@ class MLFlowLogger(LoggerDestination):
     def _global_exception_handler(self, original_excepthook, exc_type, exc_value, exc_traceback):
         """Catch global exception."""
         self._global_exception_occurred += 1
-        sys.excepthook(exc_type, exc_value, exc_traceback)
+        original_excepthook(exc_type, exc_value, exc_traceback)
 
     def init(self, state: State, logger: Logger) -> None:
         del logger  # unused

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -327,6 +327,8 @@ class MLFlowLogger(LoggerDestination):
         if self._enabled:
             self._start_mlflow_run(state)
 
+        raise Exception('hiiiiiiiii')
+
         # If rank zero only, broadcast the MLFlow experiment and run IDs to other ranks, so the MLFlow run info is
         # available to other ranks during runtime.
         if self._rank_zero_only:

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -333,8 +333,6 @@ class MLFlowLogger(LoggerDestination):
         if self._enabled:
             self._start_mlflow_run(state)
 
-        raise Exception('hiiiiiiiii')
-
         # If rank zero only, broadcast the MLFlow experiment and run IDs to other ranks, so the MLFlow run info is
         # available to other ranks during runtime.
         if self._rank_zero_only:

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -301,7 +301,7 @@ class MLFlowLogger(LoggerDestination):
             )
             self.monitor_process.start()
 
-    def _global_exception_handler(self, exc_type, exc_value, exc_traceback):
+    def _global_exception_handler(self, original_excepthook, exc_type, exc_value, exc_traceback):
         """Catch global exception."""
         self._global_exception_occurred += 1
         sys.excepthook(exc_type, exc_value, exc_traceback)
@@ -322,7 +322,13 @@ class MLFlowLogger(LoggerDestination):
             self.run_name += f'-rank{dist.get_global_rank()}'
 
         # Register the global exception handler so that uncaught exception is tracked.
-        sys.excepthook = self._global_exception_handler
+        original_excepthook = sys.excepthook
+        sys.excepthook = lambda exc_type, exc_value, exc_traceback: self._global_exception_handler(
+            original_excepthook,
+            exc_type,
+            exc_value,
+            exc_traceback,
+        )
         # Start run
         if self._enabled:
             self._start_mlflow_run(state)

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -304,7 +304,7 @@ class MLFlowLogger(LoggerDestination):
     def _global_exception_handler(self, exc_type, exc_value, exc_traceback):
         """Catch global exception."""
         self._global_exception_occurred += 1
-        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        sys.excepthook(exc_type, exc_value, exc_traceback)
 
     def init(self, state: State, logger: Logger) -> None:
         del logger  # unused

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -323,12 +323,12 @@ class MLFlowLogger(LoggerDestination):
 
         # Register the global exception handler so that uncaught exception is tracked.
         original_excepthook = sys.excepthook
-        sys.excepthook = lambda exc_type, exc_value, exc_traceback: self._global_exception_handler(
-            original_excepthook,
-            exc_type,
-            exc_value,
-            exc_traceback,
-        )
+        # sys.excepthook = lambda exc_type, exc_value, exc_traceback: self._global_exception_handler(
+        #     original_excepthook,
+        #     exc_type,
+        #     exc_value,
+        #     exc_traceback,
+        # )
         # Start run
         if self._enabled:
             self._start_mlflow_run(state)

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -323,12 +323,12 @@ class MLFlowLogger(LoggerDestination):
 
         # Register the global exception handler so that uncaught exception is tracked.
         original_excepthook = sys.excepthook
-        # sys.excepthook = lambda exc_type, exc_value, exc_traceback: self._global_exception_handler(
-        #     original_excepthook,
-        #     exc_type,
-        #     exc_value,
-        #     exc_traceback,
-        # )
+        sys.excepthook = lambda exc_type, exc_value, exc_traceback: self._global_exception_handler(
+            original_excepthook,
+            exc_type,
+            exc_value,
+            exc_traceback,
+        )
         # Start run
         if self._enabled:
             self._start_mlflow_run(state)


### PR DESCRIPTION
# What does this PR do?
The [previous PR](https://github.com/mosaicml/composer/pull/3449) that added exception hook handling to mlflow just blindly overwrites the existing excepthook. This PR changes that to _use_ the existing excepthook and just _add_ what the mlflow logger needs.

Before: `llama-7b-commits-6-D3ipHw` (exception is not rich formatted, because systemwide excepthook is not triggered)
After: `llama-7b-commits-11-3KdS8L` (exception is rich formatted, because systemwide excepthook is triggered)