### PR TITLE
Loss gen tokens

### DIFF
--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -300,7 +300,7 @@ class DataSpec:
 
         if isinstance(num_tokens, int):
             if token_type != 'total':
-                warnings.warn(
+                log.warning(
                     f'get_num_tokens_in_batch returned an int, but token_type is {token_type}. ' +
                     'Returning the total number of tokens in the batch.',
                 )

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import collections.abc
+import logging
 import textwrap
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, Optional, Sequence, Union
@@ -19,6 +20,8 @@ if TYPE_CHECKING:
     from composer.core.types import Batch
 
 __all__ = ['DataSpec', 'ensure_data_spec']
+
+log = logging.getLogger(__name__)
 
 
 def _split_list(l, microbatch_size: int):

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -302,11 +302,6 @@ class DataSpec:
         num_tokens = self._get_num_tokens_in_batch(batch)
 
         if isinstance(num_tokens, int):
-            if token_type != 'total':
-                log.warning(
-                    f'get_num_tokens_in_batch returned an int, but token_type is {token_type}. ' +
-                    'Returning the total number of tokens in the batch.',
-                )
             return num_tokens
         elif isinstance(num_tokens, dict):
             if token_type not in num_tokens:

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -185,7 +185,7 @@ class DataSpec:
         device_transforms: Optional[Callable[[Batch], Batch]] = None,
         split_batch: Optional[Callable[[Batch, Union[int, float]], Sequence[Batch]]] = None,
         get_num_samples_in_batch: Optional[Callable[[Batch], Union[int, float]]] = None,
-        get_num_tokens_in_batch: Optional[Callable[[Batch], int]] = None,
+        get_num_tokens_in_batch: Optional[Callable[[Batch], Union[int, dict[str, int]]]] = None,
     ) -> None:
         self.dataloader: Union[Iterable, torch.utils.data.DataLoader] = dataloader
         self.num_tokens = num_tokens

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2601,7 +2601,7 @@ class Trainer:
         dist.broadcast(batch_time_tensor, src=0)
         batch_time = datetime.timedelta(seconds=batch_time_tensor[0].cpu().item())
 
-        return int(sample_token_tensor[0].cpu().item()), int(sample_token_tensor[1].cpu().item(), int(sample_token_tensor[2].cpu().item()), batch_time
+        return int(sample_token_tensor[0].cpu().item()), int(sample_token_tensor[1].cpu().item()), int(sample_token_tensor[2].cpu().item()), batch_time
 
     def _train_loop(self) -> None:
         """Run training for the specified number of epochs and log results."""

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2570,12 +2570,11 @@ class Trainer:
         self,
         num_samples: Union[int, float],
         num_tokens: int,
-        num_loss_generating_tokens: int,
         batch_time: datetime.timedelta,
     ) -> tuple[int, int, datetime.timedelta]:
         """Accumulate the number of samples and tokens across ranks.
 
-        Returns a (num_samples, num_tokens, num_loss_generating_tokens, batch_time) tuple.
+        Returns a (num_samples, num_tokens, batch_time) tuple.
         """
         # Samples and tokens should be summed
         # Batch time should be the value from rank 0
@@ -2583,7 +2582,7 @@ class Trainer:
         # num_samples can be floating point if we are doing sequence parallelism, since in that case each rank works on only a part of the sample. For example, with sequence parallelism world size 2, each rank trains on half of a sample.
         if isinstance(num_samples, float):
             sample_token_tensor = self.state.device.tensor_to_device(
-                torch.tensor([num_samples, num_tokens, num_loss_generating_tokens], dtype=torch.float32),
+                torch.tensor([num_samples, num_tokens], dtype=torch.float32),
             )
         else:
             sample_token_tensor = self.state.device.tensor_to_device(
@@ -2601,7 +2600,7 @@ class Trainer:
         dist.broadcast(batch_time_tensor, src=0)
         batch_time = datetime.timedelta(seconds=batch_time_tensor[0].cpu().item())
 
-        return int(sample_token_tensor[0].cpu().item()), int(sample_token_tensor[1].cpu().item()), int(sample_token_tensor[2].cpu().item()), batch_time
+        return int(sample_token_tensor[0].cpu().item()), int(sample_token_tensor[1].cpu().item()), batch_time
 
     def _train_loop(self) -> None:
         """Run training for the specified number of epochs and log results."""
@@ -2704,10 +2703,9 @@ class Trainer:
 
                 batch_time = now - last_wct
 
-                total_num_samples, total_num_tokens, total_num_loss_generating_tokens, batch_time = self._accumulate_time_across_ranks(
+                total_num_samples, total_num_tokens, batch_time = self._accumulate_time_across_ranks(
                     rank_num_samples,
                     rank_num_tokens,
-                    rank_num_loss_generating_tokens,
                     batch_time,
                 )
 
@@ -3388,10 +3386,9 @@ class Trainer:
                 now = datetime.datetime.now()
                 batch_time = now - last_wct
 
-                total_num_samples, total_num_tokens, _, batch_time = self._accumulate_time_across_ranks(
+                total_num_samples, total_num_tokens, batch_time = self._accumulate_time_across_ranks(
                     num_samples=rank_num_samples,
                     num_tokens=rank_num_tokens,
-                    num_loss_generating_tokens=0,
                     batch_time=batch_time,
                 )
 
@@ -3782,10 +3779,9 @@ class Trainer:
                 now = datetime.datetime.now()
                 batch_time = now - last_wct
 
-                total_num_samples, total_num_tokens, _, batch_time = self._accumulate_time_across_ranks(
+                total_num_samples, total_num_tokens, batch_time = self._accumulate_time_across_ranks(
                     num_samples=rank_num_samples,
                     num_tokens=rank_num_tokens,
-                    num_loss_generating_tokens=0,
                     batch_time=batch_time,
                 )
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -2662,6 +2662,8 @@ class Trainer:
                 self.state.batch = self._train_data_spec.device_transforms(self.state.batch)
                 rank_num_samples = self._train_data_spec.get_num_samples_in_batch(self.state.batch)
                 rank_num_tokens = self._train_data_spec.get_num_tokens_in_batch(self.state.batch)
+                if isinstance(rank_num_tokens, dict):
+                    rank_num_tokens = rank_num_tokens['total']
 
                 if self.state.deepspeed_enabled:
                     self.state.batch = fix_batch_precision_for_deepspeed(self.state.batch, self.state.precision)
@@ -3059,7 +3061,7 @@ class Trainer:
                             raise ValueError(
                                 'if get_num_tokens_in_batch is a dictionary, it must have keys "total" and "loss_generating".',
                             )
-                        mb_num_tokens = rank_num_tokens['loss_generating']
+                        mb_num_tokens = mb_num_tokens['loss_generating']
                     current_batch_size += mb_num_tokens
                 if current_batch_size == 0:
                     raise ValueError(
@@ -3364,6 +3366,8 @@ class Trainer:
                 # Count the batch size and num tokens before any events run
                 rank_num_samples = data_spec.get_num_samples_in_batch(self.state.batch)
                 rank_num_tokens = data_spec.get_num_tokens_in_batch(self.state.batch)
+                if isinstance(rank_num_tokens, dict):
+                    rank_num_tokens = rank_num_tokens['total']
 
                 # Fix the batch if using DeepSpeed
                 if self.state.deepspeed_enabled:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -3057,7 +3057,7 @@ class Trainer:
                 for b in microbatches:
                     mb_num_tokens = self._train_data_spec.get_num_tokens_in_batch(b)
                     if isinstance(mb_num_tokens, dict):
-                        if mb_num_tokens.keys() != {'total', 'loss_generating'}:
+                        if set(mb_num_tokens.keys()) != {'total', 'loss_generating'}:
                             raise ValueError(
                                 'if get_num_tokens_in_batch is a dictionary, it must have keys "total" and "loss_generating".',
                             )
@@ -3127,11 +3127,11 @@ class Trainer:
         if self.accumulate_train_batch_on_tokens:
             microbatch_size = self._train_data_spec.get_num_tokens_in_batch(self.state.batch)
             if isinstance(microbatch_size, dict):
-                if mb_num_tokens.keys() != {'total', 'loss_generating'}:
+                if set(microbatch_size.keys()) != {'total', 'loss_generating'}:
                     raise ValueError(
                         'if get_num_tokens_in_batch is a dictionary, it must have keys "total" and "loss_generating".',
                     )
-                microbatch_size = rank_num_tokens['loss_generating']
+                microbatch_size = microbatch_size['loss_generating']
         else:
             microbatch_size = self._train_data_spec.get_num_samples_in_batch(self.state.batch)
         if self.state.deepspeed_enabled or not isinstance(self.state.model, DistributedDataParallel):
@@ -3643,6 +3643,8 @@ class Trainer:
                 # Count the batch size and num tokens before any events run
                 rank_num_samples = data_spec.get_num_samples_in_batch(self.state.batch)
                 rank_num_tokens = data_spec.get_num_tokens_in_batch(self.state.batch)
+                if isinstance(rank_num_tokens, dict):
+                    rank_num_tokens = rank_num_tokens['total']
 
                 # If using a distributed sampler, keep track of last_batch for metrics update
                 if dist_sampler is not None and drop_last == False and dataset_len is not None:

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -3120,7 +3120,8 @@ class Trainer:
 
         if self.accumulate_train_batch_on_tokens:
             microbatch_size = self._train_data_spec.get_num_tokens_in_batch(
-                self.state.batch, token_type='loss_generating'
+                self.state.batch,
+                token_type='loss_generating',
             )
         else:
             microbatch_size = self._train_data_spec.get_num_samples_in_batch(self.state.batch)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1027,7 +1027,10 @@ class Trainer:
                 it into sections of size ``device_train_microbatch_size``. If the batch size of the dataloader
                 is not divisible by ``device_train_microbatch_size``, the last section will be potentially smaller.
         accumulate_train_batch_on_tokens (bool, optional): Whether training loss is accumulated over the number of tokens in a batch,
-             rather than the number of samples. Only works if the train data spec implements `get_num_tokens_in_batch`. (default: ``False``)
+             rather than the number of samples. Only works if the train data spec implements `get_num_tokens_in_batch`.
+             Note: If you are using this flag, you can optionally have your `get_num_tokens_in_batch` function return a dictionary
+             with two keys (`total` and `loss_generating`). Composer will then accumulate the batch on loss generating tokens specifically,
+             even though total tokens will be used for any other time involving tokens. (default: ``False``)
         seed (int, optional): The seed used in randomization. If ``None``, then a random seed
             will be created. (default: ``None``)
 

--- a/tests/trainer/test_dataspec.py
+++ b/tests/trainer/test_dataspec.py
@@ -99,7 +99,7 @@ def test_get_num_tokens_types(return_dict: bool, requested_key: Optional[str], e
     batch = {}
     extra_args = {}
     if requested_key is not None:
-        extra_args['requested_key'] = requested_key
+        extra_args['token_type'] = requested_key
 
     with error_context:
         actual = dataspec.get_num_tokens_in_batch(batch, **extra_args)

--- a/tests/trainer/test_dataspec.py
+++ b/tests/trainer/test_dataspec.py
@@ -77,7 +77,7 @@ def test_get_num_tokens_hf_default(batch_size: int, sequence_length: int, use_ke
     [
         [True, None, 8],  # dict with default key
         [False, None, 8],  # int with default key
-        [False, 'loss_generating', None],  # int with non-default key
+        [False, 'loss_generating', 8],  # int with non-default key
         [True, 'loss_generating', 4],  # dict with non-default key
     ],
 )

--- a/tests/trainer/test_dataspec.py
+++ b/tests/trainer/test_dataspec.py
@@ -1,7 +1,8 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
+import contextlib
+from typing import Any, Optional
 
 import pytest
 import torch
@@ -69,6 +70,40 @@ def test_get_num_tokens_hf_default(batch_size: int, sequence_length: int, use_ke
     else:
         expected = sequence_length * batch_size
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'return_dict,requested_key,expected',
+    [
+        [True, None, 8],  # dict with default key
+        [False, None, 8],  # int with default key
+        [False, 'loss_generating', None],  # int with non-default key
+        [True, 'loss_generating', 4],  # dict with non-default key
+    ],
+)
+def test_get_num_tokens_types(return_dict: bool, requested_key: Optional[str], expected: Optional[int]):
+    should_error = expected is None
+    error_context = pytest.raises(ValueError) if should_error else contextlib.nullcontext()
+
+    def get_num_tokens_in_batch(batch):
+        num_tokens = 8
+        num_loss_generating_tokens = 4
+
+        if return_dict:
+            return {'total': num_tokens, 'loss_generating': num_loss_generating_tokens}
+
+        return num_tokens
+
+    dataspec = DataSpec(dataloader=[], get_num_tokens_in_batch=get_num_tokens_in_batch)
+
+    batch = {}
+    extra_args = {}
+    if requested_key is not None:
+        extra_args['requested_key'] = requested_key
+
+    with error_context:
+        actual = dataspec.get_num_tokens_in_batch(batch, **extra_args)
+        assert actual == expected
 
 
 def test_small_batch_at_end_warning():


### PR DESCRIPTION
# What does this PR do?
This PR allows differentiation between loss generating tokens and total tokens, by allowing `get_num_tokens_in_batch` to return a dict with `total` and `loss_generating` keys. This will only have an impact if you are using the `accumulate_batch_on_tokens` flag. This does not break or change any existing functionality, as by default, if you are just returning a single number from `get_num_tokens_in_batch`, we will accumulate using that value. Things will only change if the user adjusts their `get_num_tokens_in_batch` to be a dictionary.

Related PR in LLM Foundry: https://github.com/mosaicml/llm-foundry/pull/1610

Manual testing (using Foundry draft PR):

Before with all tokens loss generating, microbatching is deterministic:
<img width="1604" alt="Screenshot 2024-10-22 at 8 15 40 PM" src="https://github.com/user-attachments/assets/699a02a9-3440-4527-95ae-3ff1cda70839">

Before with not all tokens loss generating, microbatching is not deterministic:
<img width="1610" alt="Screenshot 2024-10-22 at 8 15 56 PM" src="https://github.com/user-attachments/assets/f85230be-61d0-4877-83f5-68ea988cc950">

After with not all tokens loss generating, microbatching is deterministic:
<img width="1618" alt="Screenshot 2024-10-22 at 8 16 13 PM" src="https://github.com/user-attachments/assets/44629e1a-e046-4c8a-b665-c1c5cc9c9354">

