### PR TITLE
Metrics dedup for MLflow logger

### DIFF
--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -19,7 +19,10 @@ from composer.trainer import Trainer
 from tests.common.datasets import RandomClassificationDataset, RandomImageDataset
 from tests.common.markers import device
 from tests.common.models import SimpleConvModel, SimpleModel
-from tests.models.test_hf_model import check_hf_model_equivalence, check_hf_tokenizer_equivalence
+from tests.models.test_hf_model import (
+    check_hf_model_equivalence,
+    check_hf_tokenizer_equivalence,
+)
 
 
 def _get_latest_mlflow_run(experiment_name, tracking_uri=None):
@@ -834,6 +837,71 @@ def test_mlflow_logging_time_buffer(tmp_path):
     assert mock_log_batch.call_count == 2
     assert len(mock_log_batch.call_args_list[0][1]['metrics']) == 0
     assert len(mock_log_batch.call_args_list[1][1]['metrics']) == 2 * steps
+
+
+def test_mlflow_logging_with_metrics_dedupping(tmp_path):
+    with patch('mlflow.log_metrics') as mock_log_metrics:
+
+        mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
+        experiment_name = 'mlflow_logging_test'
+        mock_state = MagicMock()
+        mock_logger = MagicMock()
+
+        test_mlflow_logger = MLFlowLogger(
+            tracking_uri=mlflow_uri,
+            experiment_name=experiment_name,
+            log_system_metrics=True,
+            run_name='test_run',
+            logging_buffer_seconds=2,
+            log_duplicated_metric_every_n_steps=3,
+            log_duplicated_metric_every_n_millis=10000,
+        )
+        test_mlflow_logger.init(state=mock_state, logger=mock_logger)
+        # # Test dedupping of metrics and duplicated metrics get logged per
+        # # `log_duplicated_metric_every_n_steps` steps.
+        # steps = 10
+        # for i in range(steps):
+        #     # 'foo' always have different values, while 'bar' always have the same value.
+        #     metrics = {
+        #         'foo': i,
+        #         'bar': 0,
+        #     }
+        #     test_mlflow_logger.log_metrics(metrics, step=i)
+
+        #     if i % 3 == 0:
+        #         # 'bar' will be logged every 3 steps.
+        #         mock_log_metrics.assert_called_with(metrics={'foo': float(i), 'bar': 0.0}, step=i, synchronous=False)
+        #     else:
+        #         # 'bar' will not be logged.
+        #         mock_log_metrics.assert_called_with(metrics={'foo': float(i)}, step=i, synchronous=False)
+
+        # Test dedupping of metrics and duplicated metrics get logged per
+        # `log_duplicated_metric_every_n_millis` milliseconds.
+        timestamps = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45]
+        # Reset the metrics cache.
+        test_mlflow_logger._metrics_cache = {}
+        with patch('time.time', side_effect=timestamps):
+            for i in range(len(timestamps)):
+                # 'foo' always have different values, while 'bar' always have the same value.
+                metrics = {
+                    'foo': i,
+                    'bar': 0,
+                }
+                test_mlflow_logger.log_metrics(metrics, step=0)
+
+                if i % 2 == 0:
+                    # 'bar' will be logged every 2 steps.
+                    mock_log_metrics.assert_called_with(
+                        metrics={
+                            'foo': float(i),
+                            'bar': 0.0,
+                        }, step=0, synchronous=False,
+                    )
+                else:
+                    # 'bar' will not be logged.
+                    mock_log_metrics.assert_called_with(metrics={'foo': float(i)}, step=0, synchronous=False)
+
+        test_mlflow_logger.post_close()
 
 
 def test_mlflow_resume_run(tmp_path):


### PR DESCRIPTION
# What does this PR do?

Context: MLflow has receiving lots of data... so we want to save some budget.

In this PR, if we detect that a metric has the same value as the previous step, we don't log it unless it meets one of the following 2 criteria:

- There has been `log_duplicated_metric_every_n_steps` skipped since last step logging, default to 100.
- There has been `log_duplicated_metric_every_n_millis` passed since last step logging, default to 600000 (10 minutes).

We put this exception for sampling purpose, otherwise it will be challenging to capture the duplicated values during sampling, despite the duplicated value occupies a significant portion of the metric history.


Tested with LLM foundry quickstart, and 3 setup: 1) no dedupping 2) log duplicated steps per 2 steps 3) log duplicated steps per 10 steps. No problem spotted. See testing result below:

<img width="1171" alt="image" src="https://github.com/user-attachments/assets/2651aba1-6e2f-468d-b897-912313317902">

<img width="1163" alt="image" src="https://github.com/user-attachments/assets/01581fa7-0984-4c98-8065-234157001861">

<img width="602" alt="image" src="https://github.com/user-attachments/assets/bdd7b21f-d81f-48a5-9812-3274208f84e8">


# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
