### PR TITLE
Refactor `maybe_create_object_store_from_uri`

### DIFF
--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -415,7 +415,7 @@ def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
     """Automatically creates an ObjectStore from supported URI formats.
 
     Args:
-        uri (str): The path to (maybe) create an ObjectStore from.
+        uri (str): The path to (maybe) create an :class:`composer.utils.ObjectStore` from.
 
     Raises:
         NotImplementedError: Raises when the URI format is not supported.

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -429,12 +429,8 @@ def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
     if backend == '':
         return None
 
-    # Check if backend is registered
-    if backend in BACKEND_TO_OBJECT_STORE_FACTORY:
-        return BACKEND_TO_OBJECT_STORE_FACTORY[backend](bucket_name, path)
-
     # Handle special cases like WandB, MLFlow, etc.
-    if backend == 'wandb':
+    elif backend == 'wandb':
         raise NotImplementedError(
             f'There is no implementation for WandB load_object_store via URI. Please use WandBLogger',
         )
@@ -453,6 +449,10 @@ def maybe_create_object_store_from_uri(uri: str) -> Optional[ObjectStore]:
         else:
             UCObjectStore.validate_path(path)
             return UCObjectStore(path=path)
+
+    # Check if backend is registered
+    elif backend in BACKEND_TO_OBJECT_STORE_FACTORY:
+        return BACKEND_TO_OBJECT_STORE_FACTORY[backend](bucket_name, path)
 
     # If backend is unknown, raise NotImplementedError
     raise NotImplementedError(f'There is no implementation for the cloud backend {backend} via URI.')


### PR DESCRIPTION
# What does this PR do?
Refactors `maybe_create_object_store_from_uri` to use a dictionary, which maps backend strings to object store factory functions.
<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
