### PR TITLE
Lower min torchmetrics version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ while True:
 install_requires = [
     'pyyaml>=6.0,<7',
     'tqdm>=4.62.3,<5',
-    'torchmetrics>=1.4.0.post0,<1.4.1',
+    'torchmetrics>=1.0,<1.4.1',
     'torch_optimizer>=0.3.0,<0.4',
     'torchvision>=0.18.0,<0.20.1',
     'torch>=2.3.0,<2.5.1',


### PR DESCRIPTION
# What does this PR do?

Lower min torchmetrics version. https://github.com/mosaicml/composer/pull/3460/ raised it and we instead intend to stay no >1.0