### PR TITLE
Add pre-built wheel for flash attention 2.7.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -259,7 +259,7 @@ RUN if [ -n "$MOFED_VERSION" ] ; then \
 ##########################
 # Install Flash Attention
 ##########################
-# Use the right flash attention wheel for the current PyTorch and CUDA version
+# Make sure to bump the flash attention wheel for the current PyTorch and CUDA version
 # https://github.com/Dao-AILab/flash-attention/releases
 RUN if [ -n "$CUDA_VERSION" ] ; then \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir ninja==1.11.1 && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -259,6 +259,8 @@ RUN if [ -n "$MOFED_VERSION" ] ; then \
 ##########################
 # Install Flash Attention
 ##########################
+# Use the right flash attention wheel for the current PyTorch and CUDA version
+# https://github.com/Dao-AILab/flash-attention/releases
 RUN if [ -n "$CUDA_VERSION" ] ; then \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir ninja==1.11.1 && \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir --force-reinstall packaging==22.0 && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -262,7 +262,7 @@ RUN if [ -n "$MOFED_VERSION" ] ; then \
 RUN if [ -n "$CUDA_VERSION" ] ; then \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir ninja==1.11.1 && \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir --force-reinstall packaging==22.0 && \
-        MAX_JOBS=1 pip${PYTHON_VERSION} install --no-cache-dir --no-build-isolation flash-attn==2.6.3; \
+        pip${PYTHON_VERSION} install --no-cache-dir --no-build-isolation https://github.com/Dao-AILab/flash-attention/releases/download/v2.7.0.post2/flash_attn-2.7.0.post2+cu12torch2.5cxx11abiTRUE-cp311-cp311-linux_x86_64.wh; \
         cd .. ; \
     fi
 


### PR DESCRIPTION
# What does this PR do?
Add pre-built wheel for flash attention 2.7.0 which speeds up attention build by over 3+ hours. 

# What issue(s) does this change relate to?
Old docker builds were taking 3+ hours. This change reduces docker build times by 3 hours. 