### PR TITLE
mean_resizing = True does not work with mixed/meta initialization

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -167,7 +167,7 @@ class HuggingFaceModel(ComposerModel):
                     f' This would cause an error during training.'
                     f' Resizing the model embeddings to {len(self.tokenizer)} from {self.config.vocab_size}.',
                 )
-                self.model.resize_token_embeddings(len(self.tokenizer))
+                self.model.resize_token_embeddings(len(self.tokenizer), mean_resizing=False)
             else:
                 raise ValueError(
                     f'The number of tokens in the tokenizer is greater than the number of tokens in the model.'


### PR DESCRIPTION
# What does this PR do?

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

Transformers recently added in `mean_resizing` to `resize_token_embeddings`. This is breaking with mixed initialization in downstream training tasks that requires adding tokens to Composer Huggingface Models.  This PR sets this value to False for now rather than defaulting to True.

