### PR TITLE
Expose `DistributedSampler` RNG seed argument

### DIFF
--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -592,6 +592,7 @@ def get_sampler(
     shuffle: bool = False,
     num_replicas: Optional[int] = None,
     rank: Optional[int] = None,
+    seed: int = 0,
 ):
     """Constructs a :class:`~torch.utils.data.distributed.DistributedSampler` for a dataset.
 
@@ -620,6 +621,7 @@ def get_sampler(
         shuffle=shuffle,
         num_replicas=get_world_size() if num_replicas is None else num_replicas,
         rank=get_global_rank() if rank is None else rank,
+        seed=seed,
     )
 
 


### PR DESCRIPTION
This way, it becomes easier to randomly vary the order of the data.

# What does this PR do?

Exposes the `DistributedSampler`'s `seed` argument in the `get_sampler` utility function. Since the default value is already `seed=0`, https://github.com/mosaicml/composer/issues/3723. 

# What issue(s) does this change relate to?

Fixes #3723

# Before submitting
- [X] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [X] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [X] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

@mvpatel2000