### PR TITLE
Fix netifaces install in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -253,7 +253,8 @@ RUN if [ -n "$MOFED_VERSION" ] ; then \
         wget -qO - http://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | sudo apt-key add - && \
         wget -P /etc/apt/sources.list.d/ http://linux.mellanox.com/public/repo/mlnx_ofed/$MOFED_VERSION/ubuntu22.04/mellanox_mlnx_ofed.list && \
         apt-get update && \
-        apt-get install -y mlnx-ofed-dpdk-upstream-libs-user-only  ; \
+        apt-get install -y mlnx-ofed-dpdk-upstream-libs-user-only && \
+	pip uninstall -y netifaces && pip install netifaces==0.11.0 ; \
     fi
 
 ##########################


### PR DESCRIPTION
# What does this PR do?
Fix netifaces install in Dockerfile

# What issue(s) does this change relate to?
The research team reported that in their inference deployments this line of [code](https://github.com/mosaicml/composer/blob/main/docker/Dockerfile#L256) installs an empty, unimportable netifaces pip package. We fix this by uninstalling the empty pip package and reinstalling the correct pip package. 

# Tests
- [PyTorch 2.5.1](https://github.com/mosaicml/composer/actions/runs/12059801875/job/33629078605?pr=3726): `import netifaces` ✅ 
- [PyTorch 2.3.1-aws](https://github.com/mosaicml/composer/actions/runs/12059801875/job/33629080102?pr=3726): `No module named netifaces` ✅ 