### PR TITLE
Fix order of arguments to `loss`

### DIFF
--- a/docs/source/trainer/using_the_trainer.rst
+++ b/docs/source/trainer/using_the_trainer.rst
@@ -33,7 +33,7 @@ minimally implementing the following methods:
 
 -  ``def forward(batch) -> outputs`` : computes the forward pass based
    on the ``batch`` returned from the dataloader.
--  ``def loss(batch, outputs)``: returns the loss based on the
+-  ``def loss(outputs, batch)``: returns the loss based on the
    ``outputs`` from the forward pass and the dataloader.
 
 For more information, see the :doc:`ComposerModel</composer_model>` guide.


### PR DESCRIPTION
# What does this PR do?

Fixes `loss(batch, outputs)` to `loss(outputs, batch)` at one point in `docs/source/trainer/using_the_trainer.rst`.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [x] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
