### PR TITLE
fix: make JSONTraceHandler.batch_end robust to /tmp/ being on diff mount to dest

### DIFF
--- a/composer/profiler/json_trace_handler.py
+++ b/composer/profiler/json_trace_handler.py
@@ -10,6 +10,7 @@ import json
 import os
 import pathlib
 import queue
+import shutil
 import tempfile
 import textwrap
 import time
@@ -336,7 +337,7 @@ class JSONTraceHandler(TraceHandler):  # noqa: D101
                     # Include the existing merged trace in the new trace
                     with tempfile.NamedTemporaryFile('x+', delete=False) as f:
                         merge_traces(f.name, merged_trace_filename, *trace_files_to_merge)
-                        os.rename(f.name, merged_trace_filename)
+                        shutil.move(f.name, merged_trace_filename)
                 else:
                     # Write the trace directly
                     merge_traces(merged_trace_filename, *trace_files_to_merge)


### PR DESCRIPTION
# What does this PR do?

This PR makes the profiler's trace merging behavior robust to the trace destination path being on a different mount to the system's tmpdir. 

Currently the `os.rename` is not robust to this and you get an "Invalid cross-device link" error. For example:

```
[rank16]: OSError: [Errno 18] Invalid cross-device link: '/tmp/tmpk3h5r9q9' -> '/profiling/composer_profiler/merged_trace.json'
```

https://docs.python.org/3/library/shutil.html#shutil.move does exactly what we want here: status quo behavior if tmpdir and dest are on the same filesystem; if not, does a copy. 

# What issue(s) does this change relate to?

This is not related to an existing issue. I checked. I'm going straight to opening a fix 🙂. 

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
    - **No, but** it's a trivial fix.
- [ ] Did you update any related docs and document your change?
    - **No, but** this diff does not require it.
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
    -  **No, but** `make test EXTRA_ARGS='-k test_json_trace_profiler_handler'` is existing test coverage and I ran that test.
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))
    - **Yes.** The only failure was unrelated to my change: `/home/ubuntu/composer/composer/utils/object_store/s3_object_store.py:159:22 - error: Argument of type "str | Path" cannot be assigned to parameter "Filename" of type "str" in function "upload_file"
    Type "str | Path" cannot be assigned to type "str"`

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
