### PR TITLE
Bump Mlflow to 2.20.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,7 @@ extra_deps['onnx'] = [
 ]
 
 extra_deps['mlflow'] = [
-    'mlflow>=2.14.1,<3.0',
+    'mlflow>=2.20.3,<3.0',
     'databricks-sdk==0.44.1',
     'pynvml>=11.5.0,<12',
 ]


### PR DESCRIPTION
# What does this PR do?

Seeing strange errors in PR CI tests, thought to be outdated mlflow:
https://github.com/mosaicml/composer/actions/runs/13638113643/job/38122651788?pr=3772

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
