### PR TITLE
[GRT-3415] Remove dead code for peft logging

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -471,71 +471,20 @@ class MLFlowLogger(LoggerDestination):
                 tags=tags,
             )
 
-    def save_model(self, flavor: Literal['transformers', 'peft'], **kwargs):
+    def save_model(self, flavor: Literal['transformers'], **kwargs):
         """Save a model to MLflow.
-
-        Note: The ``'peft'`` flavor is experimental and the API is subject to change without warning.
-
         Args:
-            flavor (Literal['transformers', 'peft']): The MLflow model flavor to use. Currently only ``'transformers'`` and ``'peft'`` are supported.
+            flavor (Literal['transformers']): The MLflow model flavor to use. Currently only ``'transformers'`` is supported.
             **kwargs: Keyword arguments to pass to the MLflow model saving function.
 
         Raises:
-            NotImplementedError: If ``flavor`` is not ``'transformers'`` or ``'peft'``.
+            NotImplementedError: If ``flavor`` is not ``'transformers'``.
         """
         if self._enabled:
             import mlflow
 
             if flavor == 'transformers':
                 mlflow.transformers.save_model(**kwargs)
-            elif flavor == 'peft':
-                import transformers
-
-                # TODO: Remove after mlflow fixes the bug that makes this necessary
-                mlflow.store._unity_catalog.registry.rest_store.get_feature_dependencies = lambda *args, **kwargs: ''  # type: ignore
-
-                # This is a temporary workaround until MLflow adds full support for saving PEFT models.
-                # https://github.com/mlflow/mlflow/issues/9256
-                log.warning(
-                    'Saving PEFT models using MLflow is experimental and the API is subject to change without warning.',
-                )
-                expected_keys = {'path', 'save_pretrained_dir'}
-                if not expected_keys.issubset(kwargs.keys()):
-                    raise ValueError(f'Expected keys {expected_keys} but got {kwargs.keys()}')
-
-                # This does not implement predict for now, as we will wait for the full MLflow support
-                # for PEFT models.
-                class PeftModel(mlflow.pyfunc.PythonModel):
-
-                    def load_context(self, context):
-                        self.model = transformers.AutoModelForCausalLM.from_pretrained(
-                            context.artifacts['lora_checkpoint'],
-                        )
-                        self.tokenizer = transformers.AutoTokenizer.from_pretrained(
-                            context.artifacts['lora_checkpoint'],
-                        )
-
-                from mlflow.models.signature import ModelSignature
-                from mlflow.types import ColSpec, DataType, Schema
-
-                # This is faked for now, until MLflow adds full support for saving PEFT models.
-                input_schema = Schema([
-                    ColSpec(DataType.string, 'fake_input'),
-                ])
-                output_schema = Schema([ColSpec(DataType.string)])
-                signature = ModelSignature(inputs=input_schema, outputs=output_schema)
-
-                # Symlink the directory so that we control the path that MLflow saves the model under
-                os.symlink(kwargs['save_pretrained_dir'], 'lora_checkpoint')
-
-                mlflow.pyfunc.save_model(
-                    path=kwargs['path'],
-                    artifacts={'lora_checkpoint': 'lora_checkpoint'},
-                    python_model=PeftModel(),
-                    signature=signature,
-                )
-
-                os.unlink('lora_checkpoint')
             else:
                 raise NotImplementedError(f'flavor {flavor} not supported.')
 

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -473,6 +473,7 @@ class MLFlowLogger(LoggerDestination):
 
     def save_model(self, flavor: Literal['transformers'], **kwargs):
         """Save a model to MLflow.
+
         Args:
             flavor (Literal['transformers']): The MLflow model flavor to use. Currently only ``'transformers'`` is supported.
             **kwargs: Keyword arguments to pass to the MLflow model saving function.

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -419,50 +419,6 @@ def test_mlflow_save_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
 
 @pytest.mark.filterwarnings('ignore:.*Setuptools is replacing distutils.*:UserWarning')
 @pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
-@pytest.mark.filterwarnings('ignore:.*Could not find a config file.*:UserWarning')
-@pytest.mark.filterwarnings('ignore:.*An input example.*:UserWarning')
-def test_mlflow_save_peft_model(tmp_path, tiny_mpt_model, tiny_mpt_tokenizer):
-    mlflow = pytest.importorskip('mlflow')
-    peft = pytest.importorskip('peft')
-
-    # Reload just so the model has the update base model name
-    tiny_mpt_model.save_pretrained(tmp_path / Path('tiny_mpt_save_pt'))
-    tiny_mpt_model = tiny_mpt_model.from_pretrained(tmp_path / Path('tiny_mpt_save_pt'))
-
-    peft_config = {'peft_type': 'LORA'}
-    peft_model = peft.get_peft_model(tiny_mpt_model, peft.get_peft_config(peft_config))
-
-    mlflow_uri = tmp_path / Path('my-test-mlflow-uri')
-    mlflow_exp_name = 'test-log-model-exp-name'
-    test_mlflow_logger = MLFlowLogger(
-        tracking_uri=mlflow_uri,
-        experiment_name=mlflow_exp_name,
-    )
-
-    mock_state = MagicMock()
-    mock_state.run_name = 'dummy-run-name'  # this run name should be unused.
-    mock_logger = MagicMock()
-
-    peft_model.save_pretrained(tmp_path / Path('peft_model_save_pt'))
-    tiny_mpt_tokenizer.save_pretrained(tmp_path / Path('peft_model_save_pt'))
-
-    local_mlflow_save_path = str(tmp_path / Path('my_model_local'))
-    test_mlflow_logger.init(state=mock_state, logger=mock_logger)
-    test_mlflow_logger.save_model(
-        flavor='peft',
-        path=local_mlflow_save_path,
-        save_pretrained_dir=str(tmp_path / Path('peft_model_save_pt')),
-    )
-    test_mlflow_logger.post_close()
-
-    loaded_model = mlflow.pyfunc.load_model(local_mlflow_save_path).unwrap_python_model()
-
-    check_hf_model_equivalence(loaded_model.model, tiny_mpt_model)
-    check_hf_tokenizer_equivalence(loaded_model.tokenizer, tiny_mpt_tokenizer)
-
-
-@pytest.mark.filterwarnings('ignore:.*Setuptools is replacing distutils.*:UserWarning')
-@pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
 def test_mlflow_register_model(tmp_path, monkeypatch):
     mlflow = pytest.importorskip('mlflow')
 


### PR DESCRIPTION
# What does this PR do?
Remove legacy save_model support for mlflow peft mode and associated unit test

# What issue(s) does this change relate to?
NA

# Before submitting
- [X] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
        Ran `make test` inside image `mosaicml/composer:latest_cpu` however got one CUDA failure though it should be purely cpu test and git regression passed? `ERROR tests/algorithms/test_gradient_clipping.py - UserWarning: CUDA initialization: Unexpected error from cudaGetDeviceCount(). Did you run some cuda functions before calling NumCudaDevices() that might have already set an error? Error 802: system not yet initialized (Triggered internally at /pytorch/c10/cuda/CUDAFunctions.cpp:109.)`
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))
