### PR TITLE
Patch Mflow .trash directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,7 @@ extra_deps['onnx'] = [
 ]
 
 extra_deps['mlflow'] = [
+    'pyrsmi==0.2.0'
     'mlflow>=2.14.1,<3.0',
     'databricks-sdk==0.44.1',
     'pynvml>=11.5.0,<12',

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,6 @@ extra_deps['onnx'] = [
 ]
 
 extra_deps['mlflow'] = [
-    'pyrsmi==0.2.0'
     'mlflow>=2.14.1,<3.0',
     'databricks-sdk==0.44.1',
     'pynvml>=11.5.0,<12',

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -207,6 +207,7 @@ _callback_marks: dict[
     NeptuneLogger: [pytest.mark.skipif(not _NEPTUNE_INSTALLED, reason='neptune is optional')],
 }
 
+
 def _mlflow_patch():
     try:
         import mlflow.utils.file_utils
@@ -224,7 +225,7 @@ def _mlflow_patch():
 
 _callback_patches: dict[type[Callback], Any] = {
     LoadCheckpoint: mock.patch('composer.callbacks.load_checkpoint.load_checkpoint'),
-    MLFlowLogger: lambda: _mlflow_patch(),
+    MLFlowLogger: _mlflow_patch(),
 }
 
 

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -213,6 +213,19 @@ _callback_patches: dict[type[Callback], Any] = {
 
 
 def get_cb_patches(impl: type[Callback]):
+    if impl.__name__ == 'MLFlowLogger':
+        try:
+            import mlflow.utils.file_utils
+            original_is_directory = mlflow.utils.file_utils.is_directory
+
+            def patched_is_directory(path):
+                if path.endswith('.trash'):
+                    return True
+                return original_is_directory(path)
+
+            return mock.patch('mlflow.utils.file_utils.is_directory', patched_is_directory)
+        except ImportError:
+            return contextlib.nullcontext()
     return _callback_patches.get(impl, contextlib.nullcontext())
 
 

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -233,6 +233,7 @@ def get_cb_patches(impl: type[Callback]):
         return patch_context()
     return patch_context
 
+
 def get_cb_kwargs(impl: type[Callback]):
     return _callback_kwargs.get(impl, {})
 

--- a/tests/callbacks/callback_settings.py
+++ b/tests/callbacks/callback_settings.py
@@ -207,6 +207,7 @@ _callback_marks: dict[
     NeptuneLogger: [pytest.mark.skipif(not _NEPTUNE_INSTALLED, reason='neptune is optional')],
 }
 
+
 def _mlflow_patch():
     try:
         import mlflow.utils.file_utils

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -1,8 +1,8 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import cast, Optional, Generator, Any, Callable, ContextManager
 import contextlib
+from typing import Generator, cast
 from unittest.mock import patch
 
 import pytest
@@ -50,7 +50,7 @@ def clean_mlflow_runs():
 @contextlib.contextmanager
 def maybe_patch_mlflow_for_trash(cb_cls: type[Callback]) -> Generator[None, None, None]:
     """Context manager that patches MLflow's is_directory function for MLFlowLogger tests.
-    
+
     For MLFlowLogger, this patches the is_directory function to return True for paths
     ending with '.trash', which fixes directory permission issues in tests.
     For all other callbacks, this is a no-op.
@@ -59,13 +59,13 @@ def maybe_patch_mlflow_for_trash(cb_cls: type[Callback]) -> Generator[None, None
         try:
             import mlflow.utils.file_utils
             original_is_directory = mlflow.utils.file_utils.is_directory
-            
+
             # Create a patched version that returns True for trash directories
             def patched_is_directory(path):
                 if path.endswith('.trash'):
                     return True
                 return original_is_directory(path)
-                
+
             with patch('mlflow.utils.file_utils.is_directory', patched_is_directory):
                 yield
         except ImportError:
@@ -121,7 +121,7 @@ class TestCallbacks:
                 trace_handlers=[],
                 torch_prof_memory_filename=None,
             )
-            dummy_state.profiler.bind_to_state(dummy_state)
+            dummy_state.profiler.bind_to_state(dummy_state)å
 
             logger = Logger(dummy_state)
             engine = Engine(state=dummy_state, logger=logger)

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -121,7 +121,7 @@ class TestCallbacks:
                 trace_handlers=[],
                 torch_prof_memory_filename=None,
             )
-            dummy_state.profiler.bind_to_state(dummy_state)å
+            dummy_state.profiler.bind_to_state(dummy_state)
 
             logger = Logger(dummy_state)
             engine = Engine(state=dummy_state, logger=logger)


### PR DESCRIPTION
# What does this PR do?

Aiming to patch https://github.com/mosaicml/composer/actions/runs/13708442344, seems like Mlflow is trying to access its trash directory but is having permission issues or the directory structure doesn't exist. We have to mock this call.


# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
