### PR TITLE
Remove TE ONNX Export Context to Enable TE FusedAttention on AMD Hardware

### DIFF
--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -96,11 +96,7 @@ def get_precision_context(
                 }
             fp8_recipe = DelayedScaling(**precision_config)
             with te.fp8_autocast(enabled=fp8_autocast_enabled, fp8_recipe=fp8_recipe):
-                # The te.onnx_export flag ensures that we save all fp8 buffers
-                # as tensors instead of bytes. This is necessary for proper
-                # saving and resumption of checkpoints.
-                with te.onnx_export(enabled=True):
-                    yield
+                yield
         else:
             if te_installed:
                 raise RuntimeError('AMP_FP8 precision is used but current device does not support it.')


### PR DESCRIPTION
# What does this PR do?

Enables Transformer Engine's FusedAttention optimization on AMD hardware by removing an unnecessary TE ONNX export context from FP8 precision handling, improving performance with AMD's Composable Kernel backend.

## Changes

This PR removes the TE ONNX export tracing from the FP8 precision context that was added in [commit 2c6a390](https://github.com/mosaicml/composer/commit/2c6a39052dbeca8db270a5e7f070c35e52455a91) to address [checkpoint resumption issues with FP8 in PyTorch 2.1](https://github.com/mosaicml/composer/pull/2907). The workaround is no longer needed with PyTorch 2.3+, and the minimum supported version is torch 2.4.0 currently.

## Why this change is required?
 
The ONNX export context forces AMD's Composable Kernel backend to disable its optimized FusedAttention implementation, falling back to the slower UnfusedDotProductAttention:

**Before (with ONNX context):**
```
DEBUG: DotProductAttention: Disabling FusedAttention due to ONNX mode
DEBUG: DotProductAttention: Selected backend = UnfusedDotProductAttention
```

**After (without ONNX context):**
```
DEBUG: DotProductAttention: Selected backend = FusedAttention
```

This change enables FusedAttention of Transformer Engine on AMD hardware without compromising functionality, as the original checkpoint compatibility issue has been resolved in newer PyTorch versions.

## Testing

Testing was performed on AMD MI300X (8-GPU) with [llama3.1-8b](https://huggingface.co/meta-llama/Llama-3.1-8B) under FSDP training using the publicly available `rocm/pytorch-training:v25.2` docker image.

- Verified that FusedAttention is properly selected with CK debug logs
- Confirmed that FP8 training works correctly
- Verified that checkpoint saving and resumption continue to work properly

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change? 
  - This is not covered in documentation
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests)) 
  - No, testing CK backend would require AMD hardware
- [ ] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))
  - Yes, changes are passing
<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
