### PR TITLE
Make it possible to define the root temporary directory for composer

### DIFF
--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -277,7 +277,7 @@ class CheckpointSaver(Callback):  # noqa: D101
             root_temp_folder = None
             if os.environ.get('TMPDIR') is not None:
                 root_temp_folder = os.environ.get('TMPDIR')
-            elif pathlib.Path('/local_disk0').exists():  # Probably we are on MLR, so we have to use /local_disk0
+            elif os.path.exists('/local_disk0/'):  # Probably we are on MLR, so we have to use /local_disk0
                 root_temp_folder = '/local_disk0/temp'
             os.makedirs(root_temp_folder, exist_ok=True)
             local_folder = os.path.join(tempfile.mkdtemp(prefix=root_temp_folder), local_folder)

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -274,7 +274,13 @@ class CheckpointSaver(Callback):  # noqa: D101
 
         is_remote_folder = backend != ''
         if is_remote_folder:  # If uploading to a remote path, use a temporary directory to save local checkpoints.
-            local_folder = os.path.join(tempfile.mkdtemp(), local_folder)
+            root_temp_folder = None
+            if os.environ.get('TMPDIR') is not None:
+                root_temp_folder = os.environ.get('TMPDIR')
+            elif pathlib.Path('/local_disk0').exists(): # Probably we are on MLR, so we have to use /local_disk0
+                root_temp_folder = '/local_disk0/temp'
+            pathlib.Path(root_temp_folder).mkdir(exist_ok=True)
+            local_folder = os.path.join(tempfile.mkdtemp(prefix=root_temp_folder), local_folder)
 
         filename = str(filename)
         remote_file_name = str(remote_file_name) if remote_file_name is not None else None

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -277,9 +277,9 @@ class CheckpointSaver(Callback):  # noqa: D101
             root_temp_folder = None
             if os.environ.get('TMPDIR') is not None:
                 root_temp_folder = os.environ.get('TMPDIR')
-            elif pathlib.Path('/local_disk0').exists(): # Probably we are on MLR, so we have to use /local_disk0
+            elif pathlib.Path('/local_disk0').exists():  # Probably we are on MLR, so we have to use /local_disk0
                 root_temp_folder = '/local_disk0/temp'
-            pathlib.Path(root_temp_folder).mkdir(exist_ok=True)
+            os.makedirs(root_temp_folder, exist_ok=True)
             local_folder = os.path.join(tempfile.mkdtemp(prefix=root_temp_folder), local_folder)
 
         filename = str(filename)


### PR DESCRIPTION
Make it possible to define the root temporary directory for composer

# What does this PR do?

Checkpoints can become very large, and sometimes the temporary file system doesn't have enough disk space to accommodate them. This PR introduces the ability to use the TMPDIR environment variable to specify the root temporary directory. Additionally, if TMPDIR is not set and the /local_disk0 directory exists, the system will default to using /local_disk0/temp as the temporary directory.


# Before submitting
- [x ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [x ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
