### PR TITLE
Bump Release Ref 0.3.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: mosaicml/ci-testing
-        ref: v0.0.9
+        ref: v0.3.3
         path: ./ci-testing
     - uses: ./ci-testing/.github/actions/code-quality
       with:


### PR DESCRIPTION
# What does this PR do?

This bumps ci-testing ref in `release` to be what is used in `code-quality` so that code quality passes
https://github.com/mosaicml/composer/actions/runs/14253613586

Running Release Workflow on this branch no longer fails on `code-quality`
https://github.com/mosaicml/composer/actions/runs/14254749363/job/39955231384

# What issue(s) does this change relate to?

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
