### PR TITLE
Extend docker build matrix to add an entry for pytorch2.6+cu126

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -32,6 +32,9 @@ To install composer, once inside the image, run `pip install mosaicml`.
 |----------------|----------|-------------------|---------------------|------------------|------------------------------------------------------------------------------------------|
 | Ubuntu 22.04   | Base     | 2.6.0             | 12.4.1 (Infiniband) | 3.12             | `mosaicml/pytorch:latest`, `mosaicml/pytorch:2.6.0_cu124-python3.12-ubuntu22.04`         |
 | Ubuntu 22.04   | Base     | 2.6.0             | 12.4.1 (EFA)        | 3.12             | `mosaicml/pytorch:latest-aws`, `mosaicml/pytorch:2.6.0_cu124-python3.12-ubuntu22.04-aws` |
+| Ubuntu 22.04   | Base     | 2.6.0             | 12.6.0 (Infiniband) | 3.12             | `mosaicml/pytorch:latest`, `mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04`         |
+| Ubuntu 22.04   | Base     | 2.6.0             | 12.6.0 (EFA)        | 3.12             | `mosaicml/pytorch:latest-aws`, `mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04-aws` |
+| Ubuntu 22.04   | Base     | 2.6.0             | cpu                 | 3.12             | `mosaicml/pytorch:latest_cpu`, `mosaicml/pytorch:2.6.0_cpu-python3.12-ubuntu22.04`       |
 | Ubuntu 22.04   | Base     | 2.6.0             | cpu                 | 3.12             | `mosaicml/pytorch:latest_cpu`, `mosaicml/pytorch:2.6.0_cpu-python3.12-ubuntu22.04`       |
 | Ubuntu 22.04   | Base     | 2.5.1             | 12.4.1 (Infiniband) | 3.12             | `mosaicml/pytorch:2.5.1_cu124-python3.12-ubuntu22.04`                                    |
 | Ubuntu 22.04   | Base     | 2.5.1             | 12.4.1 (EFA)        | 3.12             | `mosaicml/pytorch:2.5.1_cu124-python3.12-ubuntu22.04-aws`                                |

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,8 +32,8 @@ To install composer, once inside the image, run `pip install mosaicml`.
 |----------------|----------|-------------------|---------------------|------------------|------------------------------------------------------------------------------------------|
 | Ubuntu 22.04   | Base     | 2.6.0             | 12.4.1 (Infiniband) | 3.12             | `mosaicml/pytorch:latest`, `mosaicml/pytorch:2.6.0_cu124-python3.12-ubuntu22.04`         |
 | Ubuntu 22.04   | Base     | 2.6.0             | 12.4.1 (EFA)        | 3.12             | `mosaicml/pytorch:latest-aws`, `mosaicml/pytorch:2.6.0_cu124-python3.12-ubuntu22.04-aws` |
-| Ubuntu 22.04   | Base     | 2.6.0             | 12.6.0 (Infiniband) | 3.12             | `mosaicml/pytorch:latest`, `mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04`         |
-| Ubuntu 22.04   | Base     | 2.6.0             | 12.6.0 (EFA)        | 3.12             | `mosaicml/pytorch:latest-aws`, `mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04-aws` |
+| Ubuntu 22.04   | Base     | 2.6.0             | 12.6.3 (Infiniband) | 3.12             | `mosaicml/pytorch:latest`, `mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04`         |
+| Ubuntu 22.04   | Base     | 2.6.0             | 12.6.3 (EFA)        | 3.12             | `mosaicml/pytorch:latest-aws`, `mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04-aws` |
 | Ubuntu 22.04   | Base     | 2.6.0             | cpu                 | 3.12             | `mosaicml/pytorch:latest_cpu`, `mosaicml/pytorch:2.6.0_cpu-python3.12-ubuntu22.04`       |
 | Ubuntu 22.04   | Base     | 2.5.1             | 12.4.1 (Infiniband) | 3.12             | `mosaicml/pytorch:2.5.1_cu124-python3.12-ubuntu22.04`                                    |
 | Ubuntu 22.04   | Base     | 2.5.1             | 12.4.1 (EFA)        | 3.12             | `mosaicml/pytorch:2.5.1_cu124-python3.12-ubuntu22.04-aws`                                |

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,7 +35,6 @@ To install composer, once inside the image, run `pip install mosaicml`.
 | Ubuntu 22.04   | Base     | 2.6.0             | 12.6.0 (Infiniband) | 3.12             | `mosaicml/pytorch:latest`, `mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04`         |
 | Ubuntu 22.04   | Base     | 2.6.0             | 12.6.0 (EFA)        | 3.12             | `mosaicml/pytorch:latest-aws`, `mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04-aws` |
 | Ubuntu 22.04   | Base     | 2.6.0             | cpu                 | 3.12             | `mosaicml/pytorch:latest_cpu`, `mosaicml/pytorch:2.6.0_cpu-python3.12-ubuntu22.04`       |
-| Ubuntu 22.04   | Base     | 2.6.0             | cpu                 | 3.12             | `mosaicml/pytorch:latest_cpu`, `mosaicml/pytorch:2.6.0_cpu-python3.12-ubuntu22.04`       |
 | Ubuntu 22.04   | Base     | 2.5.1             | 12.4.1 (Infiniband) | 3.12             | `mosaicml/pytorch:2.5.1_cu124-python3.12-ubuntu22.04`                                    |
 | Ubuntu 22.04   | Base     | 2.5.1             | 12.4.1 (EFA)        | 3.12             | `mosaicml/pytorch:2.5.1_cu124-python3.12-ubuntu22.04-aws`                                |
 | Ubuntu 22.04   | Base     | 2.5.1             | cpu                 | 3.12             | `mosaicml/pytorch:2.5.1_cpu-python3.12-ubuntu22.04`                                      |

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -14,6 +14,21 @@
   - mosaicml/pytorch:latest
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.21.0
+- AWS_OFI_NCCL_VERSION: ''
+  BASE_IMAGE: nvidia/cuda:12.6.0-cudnn8-devel-ubuntu22.04
+  CUDA_VERSION: 12.6.0
+  IMAGE_NAME: torch-2-6-0-cu126
+  MOFED_VERSION: latest-23.10
+  NVIDIA_REQUIRE_CUDA_OVERRIDE: ''
+  PYTHON_VERSION: '3.12'
+  PYTORCH_NIGHTLY_URL: ''
+  PYTORCH_NIGHTLY_VERSION: ''
+  PYTORCH_VERSION: 2.6.0
+  TAGS:
+  - mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04
+  - mosaicml/pytorch:latest
+  TARGET: pytorch_stage
+  TORCHVISION_VERSION: 0.21.0
 - AWS_OFI_NCCL_VERSION: v1.11.0-aws
   BASE_IMAGE: nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
   CUDA_VERSION: 12.4.1
@@ -27,6 +42,36 @@
   TAGS:
   - mosaicml/pytorch:2.6.0_cu124-python3.12-ubuntu22.04-aws
   - mosaicml/pytorch:latest-aws
+  TARGET: pytorch_stage
+  TORCHVISION_VERSION: 0.21.0
+- AWS_OFI_NCCL_VERSION: v1.11.0-aws
+  BASE_IMAGE: nvidia/cuda:12.6.0-cudnn8-devel-ubuntu22.04
+  CUDA_VERSION: 12.6.0
+  IMAGE_NAME: torch-2-6-0-cu126-aws
+  MOFED_VERSION: ''
+  NVIDIA_REQUIRE_CUDA_OVERRIDE: ''
+  PYTHON_VERSION: '3.12'
+  PYTORCH_NIGHTLY_URL: ''
+  PYTORCH_NIGHTLY_VERSION: ''
+  PYTORCH_VERSION: 2.6.0
+  TAGS:
+  - mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04-aws
+  - mosaicml/pytorch:latest-aws
+  TARGET: pytorch_stage
+  TORCHVISION_VERSION: 0.21.0
+- AWS_OFI_NCCL_VERSION: ''
+  BASE_IMAGE: ubuntu:22.04
+  CUDA_VERSION: ''
+  IMAGE_NAME: torch-2-6-0-cpu
+  MOFED_VERSION: ''
+  NVIDIA_REQUIRE_CUDA_OVERRIDE: ''
+  PYTHON_VERSION: '3.12'
+  PYTORCH_NIGHTLY_URL: ''
+  PYTORCH_NIGHTLY_VERSION: ''
+  PYTORCH_VERSION: 2.6.0
+  TAGS:
+  - mosaicml/pytorch:2.6.0_cpu-python3.12-ubuntu22.04
+  - mosaicml/pytorch:latest_cpu
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.21.0
 - AWS_OFI_NCCL_VERSION: ''

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -15,8 +15,8 @@
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.21.0
 - AWS_OFI_NCCL_VERSION: ''
-  BASE_IMAGE: nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
-  CUDA_VERSION: 12.6.0
+  BASE_IMAGE: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
+  CUDA_VERSION: 12.6.3
   IMAGE_NAME: torch-2-6-0-cu126
   MOFED_VERSION: latest-23.10
   NVIDIA_REQUIRE_CUDA_OVERRIDE: ''
@@ -45,8 +45,8 @@
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.21.0
 - AWS_OFI_NCCL_VERSION: v1.11.0-aws
-  BASE_IMAGE: nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
-  CUDA_VERSION: 12.6.0
+  BASE_IMAGE: nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
+  CUDA_VERSION: 12.6.3
   IMAGE_NAME: torch-2-6-0-cu126-aws
   MOFED_VERSION: ''
   NVIDIA_REQUIRE_CUDA_OVERRIDE: ''

--- a/docker/build_matrix.yaml
+++ b/docker/build_matrix.yaml
@@ -15,7 +15,7 @@
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.21.0
 - AWS_OFI_NCCL_VERSION: ''
-  BASE_IMAGE: nvidia/cuda:12.6.0-cudnn8-devel-ubuntu22.04
+  BASE_IMAGE: nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
   CUDA_VERSION: 12.6.0
   IMAGE_NAME: torch-2-6-0-cu126
   MOFED_VERSION: latest-23.10
@@ -45,7 +45,7 @@
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.21.0
 - AWS_OFI_NCCL_VERSION: v1.11.0-aws
-  BASE_IMAGE: nvidia/cuda:12.6.0-cudnn8-devel-ubuntu22.04
+  BASE_IMAGE: nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
   CUDA_VERSION: 12.6.0
   IMAGE_NAME: torch-2-6-0-cu126-aws
   MOFED_VERSION: ''
@@ -57,21 +57,6 @@
   TAGS:
   - mosaicml/pytorch:2.6.0_cu126-python3.12-ubuntu22.04-aws
   - mosaicml/pytorch:latest-aws
-  TARGET: pytorch_stage
-  TORCHVISION_VERSION: 0.21.0
-- AWS_OFI_NCCL_VERSION: ''
-  BASE_IMAGE: ubuntu:22.04
-  CUDA_VERSION: ''
-  IMAGE_NAME: torch-2-6-0-cpu
-  MOFED_VERSION: ''
-  NVIDIA_REQUIRE_CUDA_OVERRIDE: ''
-  PYTHON_VERSION: '3.12'
-  PYTORCH_NIGHTLY_URL: ''
-  PYTORCH_NIGHTLY_VERSION: ''
-  PYTORCH_VERSION: 2.6.0
-  TAGS:
-  - mosaicml/pytorch:2.6.0_cpu-python3.12-ubuntu22.04
-  - mosaicml/pytorch:latest_cpu
   TARGET: pytorch_stage
   TORCHVISION_VERSION: 0.21.0
 - AWS_OFI_NCCL_VERSION: ''

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -190,7 +190,7 @@ def _cross_product_extra_cuda(
     for product in itertools.product(python_pytorch_versions, cuda_options, *args):
         (python_version, pytorch_version), use_cuda, *rest = product
         cuda_variants = ['']
-        if pytorch_version in pytorch_cuda_variants_extra:
+        if use_cuda and pytorch_version in pytorch_cuda_variants_extra:
             cuda_variants.extend(pytorch_cuda_variants_extra[pytorch_version])
         for cuda_variant in cuda_variants:
             yield (python_version, pytorch_version), use_cuda, cuda_variant, *rest

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -18,6 +18,8 @@ import packaging.version
 import tabulate
 import yaml
 
+from typing import Optional
+
 PRODUCTION_PYTHON_VERSION = '3.12'
 PRODUCTION_PYTORCH_VERSION = '2.6.0'
 
@@ -40,10 +42,12 @@ def _get_base_image(cuda_version: str):
     return f'nvidia/cuda:{cuda_version}-cudnn8-devel-ubuntu22.04'
 
 
-def _get_cuda_version(pytorch_version: str, use_cuda: bool):
+def _get_cuda_version(pytorch_version: str, use_cuda: bool, cuda_variant: Optional[str]):
     # From https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/
     if not use_cuda:
         return ''
+    if cuda_variant:
+        return cuda_variant
     if pytorch_version == '2.6.0':
         return '12.4.1'
     if pytorch_version == '2.5.1':
@@ -173,19 +177,34 @@ def _write_table(table_tag: str, table_contents: str):
     with open(os.path.join(os.path.dirname(__name__), 'README.md'), 'w') as f:
         f.write(new_readme)
 
+def _cross_product_extra_cuda(python_pytorch_versions: dict, pytorch_cuda_variants_extra: dict, cuda_options: list, stages: list, interconnects: list):
+    for product in itertools.product(python_pytorch_versions, cuda_options, stages, interconnects):
+        (python_version, pytorch_version), use_cuda, stage, interconnect = product
+        cuda_variants = ['']
+        if pytorch_version in pytorch_cuda_variants_extra:
+            cuda_variants.append(pytorch_cuda_variants_extra[pytorch_version])
+        for cuda_variant in cuda_variants:
+            yield (python_version, pytorch_version), use_cuda, cuda_variant, stage, interconnect
 
 def _main():
     python_pytorch_versions = [('3.12', '2.6.0'), ('3.12', '2.5.1'), ('3.12', '2.4.1')]
+    cuda_options = {
+        '2.6.0': [(True, '12.4.1'), (True, '12.6.0'), (False, '')],  # Default 12.4.1, new 12.6.0, and CPU
+        'default': [True, False]  # For all other versions
+    }
+    pytorch_cuda_variants_extra = {
+        '2.6.0': ['12.6.0']
+    } # Extra cuda variants to be built in addition to the defaults
     cuda_options = [True, False]
     stages = ['pytorch_stage']
     interconnects = ['mellanox', 'EFA']  # mellanox is default, EFA needed for AWS
 
     pytorch_entries = []
 
-    for product in itertools.product(python_pytorch_versions, cuda_options, stages, interconnects):
-        (python_version, pytorch_version), use_cuda, stage, interconnect = product
+    for product in _cross_product_extra_cuda(python_pytorch_versions, pytorch_cuda_variants_extra, cuda_options, stages, interconnects):
+        (python_version, pytorch_version), use_cuda, cuda_variant, stage, interconnect = product
 
-        cuda_version = _get_cuda_version(pytorch_version=pytorch_version, use_cuda=use_cuda)
+        cuda_version = _get_cuda_version(pytorch_version=pytorch_version, use_cuda=use_cuda, cuda_variant=cuda_variant)
 
         entry = {
             'IMAGE_NAME':

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -41,7 +41,7 @@ def _get_base_image(cuda_version: str):
     return f'nvidia/cuda:{cuda_version}-cudnn8-devel-ubuntu22.04'
 
 
-def _get_cuda_version(pytorch_version: str, use_cuda: bool, cuda_variant: Optional[str]):
+def _get_cuda_version(pytorch_version: str, use_cuda: bool, cuda_variant: Optional[str] = ''):
     # From https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes/
     if not use_cuda:
         return ''
@@ -181,16 +181,15 @@ def _cross_product_extra_cuda(
     python_pytorch_versions: dict,
     pytorch_cuda_variants_extra: dict,
     cuda_options: list,
-    stages: list,
-    interconnects: list,
+    *args,
 ):
-    for product in itertools.product(python_pytorch_versions, cuda_options, stages, interconnects):
-        (python_version, pytorch_version), use_cuda, stage, interconnect = product
+    for product in itertools.product(python_pytorch_versions, cuda_options, *args):
+        (python_version, pytorch_version), use_cuda, *rest = product
         cuda_variants = ['']
         if pytorch_version in pytorch_cuda_variants_extra:
-            cuda_variants.append(pytorch_cuda_variants_extra[pytorch_version])
+            cuda_variants.extend(pytorch_cuda_variants_extra[pytorch_version])
         for cuda_variant in cuda_variants:
-            yield (python_version, pytorch_version), use_cuda, cuda_variant, stage, interconnect
+            yield (python_version, pytorch_version), use_cuda, cuda_variant, *rest
 
 
 def _main():

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -41,7 +41,7 @@ def _get_base_image(cuda_version: str):
     if not cuda_version:
         return 'ubuntu:22.04'
     if _version_geq(cuda_version, '12.2.0'):
-        return f'nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
+        return f'nvidia/cuda:{cuda_version}-cudnn-devel-ubuntu22.04'
     return f'nvidia/cuda:{cuda_version}-cudnn8-devel-ubuntu22.04'
 
 
@@ -199,7 +199,7 @@ def _cross_product_extra_cuda(
 def _main():
     python_pytorch_versions = [('3.12', '2.6.0'), ('3.12', '2.5.1'), ('3.12', '2.4.1')]
     pytorch_cuda_variants_extra = {
-        '2.6.0': ['12.6.0'],
+        '2.6.0': ['12.6.3'],
     }  # Extra cuda variants to be built in addition to the defaults
     cuda_options = [True, False]
     stages = ['pytorch_stage']

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -198,10 +198,6 @@ def _cross_product_extra_cuda(
 
 def _main():
     python_pytorch_versions = [('3.12', '2.6.0'), ('3.12', '2.5.1'), ('3.12', '2.4.1')]
-    cuda_options = {
-        '2.6.0': [(True, '12.4.1'), (True, '12.6.0'), (False, '')],  # Default 12.4.1, new 12.6.0, and CPU
-        'default': [True, False],  # For all other versions
-    }
     pytorch_cuda_variants_extra = {
         '2.6.0': ['12.6.0'],
     }  # Extra cuda variants to be built in addition to the defaults

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -34,7 +34,7 @@ def _get_torchvision_version(pytorch_version: str):
 
 
 def _version_greater_than(v1: str, v2: str):
-    return version.parse(v1) > version.parse(v2)
+    return packaging.version.parse(v1) > packaging.version.parse(v2)
 
 
 def _get_base_image(cuda_version: str):

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -33,14 +33,14 @@ def _get_torchvision_version(pytorch_version: str):
     raise ValueError(f'Invalid pytorch_version: {pytorch_version}')
 
 
-def _version_greater_than(v1: str, v2: str):
-    return packaging.version.parse(v1) > packaging.version.parse(v2)
+def _version_geq(v1: str, v2: str):
+    return packaging.version.parse(v1) >= packaging.version.parse(v2)
 
 
 def _get_base_image(cuda_version: str):
     if not cuda_version:
         return 'ubuntu:22.04'
-    if _version_greater_than(cuda_version, '12.2.0'):
+    if _version_geq(cuda_version, '12.2.0'):
         return f'nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
     return f'nvidia/cuda:{cuda_version}-cudnn8-devel-ubuntu22.04'
 

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -13,12 +13,11 @@ To run::
 import itertools
 import os
 import sys
+from typing import Optional
 
 import packaging.version
 import tabulate
 import yaml
-
-from typing import Optional
 
 PRODUCTION_PYTHON_VERSION = '3.12'
 PRODUCTION_PYTORCH_VERSION = '2.6.0'
@@ -177,7 +176,14 @@ def _write_table(table_tag: str, table_contents: str):
     with open(os.path.join(os.path.dirname(__name__), 'README.md'), 'w') as f:
         f.write(new_readme)
 
-def _cross_product_extra_cuda(python_pytorch_versions: dict, pytorch_cuda_variants_extra: dict, cuda_options: list, stages: list, interconnects: list):
+
+def _cross_product_extra_cuda(
+    python_pytorch_versions: dict,
+    pytorch_cuda_variants_extra: dict,
+    cuda_options: list,
+    stages: list,
+    interconnects: list,
+):
     for product in itertools.product(python_pytorch_versions, cuda_options, stages, interconnects):
         (python_version, pytorch_version), use_cuda, stage, interconnect = product
         cuda_variants = ['']
@@ -186,22 +192,29 @@ def _cross_product_extra_cuda(python_pytorch_versions: dict, pytorch_cuda_varian
         for cuda_variant in cuda_variants:
             yield (python_version, pytorch_version), use_cuda, cuda_variant, stage, interconnect
 
+
 def _main():
     python_pytorch_versions = [('3.12', '2.6.0'), ('3.12', '2.5.1'), ('3.12', '2.4.1')]
     cuda_options = {
         '2.6.0': [(True, '12.4.1'), (True, '12.6.0'), (False, '')],  # Default 12.4.1, new 12.6.0, and CPU
-        'default': [True, False]  # For all other versions
+        'default': [True, False],  # For all other versions
     }
     pytorch_cuda_variants_extra = {
-        '2.6.0': ['12.6.0']
-    } # Extra cuda variants to be built in addition to the defaults
+        '2.6.0': ['12.6.0'],
+    }  # Extra cuda variants to be built in addition to the defaults
     cuda_options = [True, False]
     stages = ['pytorch_stage']
     interconnects = ['mellanox', 'EFA']  # mellanox is default, EFA needed for AWS
 
     pytorch_entries = []
 
-    for product in _cross_product_extra_cuda(python_pytorch_versions, pytorch_cuda_variants_extra, cuda_options, stages, interconnects):
+    for product in _cross_product_extra_cuda(
+        python_pytorch_versions,
+        pytorch_cuda_variants_extra,
+        cuda_options,
+        stages,
+        interconnects,
+    ):
         (python_version, pytorch_version), use_cuda, cuda_variant, stage, interconnect = product
 
         cuda_version = _get_cuda_version(pytorch_version=pytorch_version, use_cuda=use_cuda, cuda_variant=cuda_variant)

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -33,10 +33,14 @@ def _get_torchvision_version(pytorch_version: str):
     raise ValueError(f'Invalid pytorch_version: {pytorch_version}')
 
 
+def _version_greater_than(v1: str, v2: str):
+    return version.parse(v1) > version.parse(v2)
+
+
 def _get_base_image(cuda_version: str):
     if not cuda_version:
         return 'ubuntu:22.04'
-    if cuda_version == '12.4.1':
+    if _version_greater_than(cuda_version, '12.2.0'):
         return f'nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04'
     return f'nvidia/cuda:{cuda_version}-cudnn8-devel-ubuntu22.04'
 


### PR DESCRIPTION
# What does this PR do?

This PR adds an entry in the container build matrix to also build a pytorch2.6+cu126 variant on top of whatever is already being built.

# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
