### PR TITLE
Fix release docker with 3.10

### DIFF
--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - uses: actions/checkout@v3
     - id: set-matrix
       run: |


### PR DESCRIPTION
# What does this PR do?

3.10 is parsed as 3.1 if not explicitly set as string

# What issue(s) does this change relate to?
 N/A

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
