### PR TITLE
Update setuptools version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -172,7 +172,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} - && \
-    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pip 'setuptools<70.0.0'
+    pip${PYTHON_VERSION} install --no-cache-dir --upgrade pip 'setuptools<79.0.0'
 
 #################
 # Install Pytorch

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ extra_deps['dev'] = [
     'mock-ssh-server==0.9.1',
     'cryptography==44.0.0',
     'pytest-httpserver>=1.0.4,<1.2',
-    'setuptools==78.0.2',
+    'setuptools<79.0.0',
     'scikit-learn>=1.2.0,<1.7',
 ]
 


### PR DESCRIPTION
# What does this PR do?

wheel released a new version, that no longer has bdist_wheel in it (https://github.com/pypa/wheel/releases/tag/0.46.0), relying on the fact that is now in setuptools, but we pin an old setuptools.

This PR updates setuptools to use the latest version, 78.1.0, in our docker image.

# Testing
`composer-mpt-125m-chinchilla-kFetCc`

Run is working with the new docker image

# Before submitting
- [ ] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
