### PR TITLE
Ignore mlflow warning in test

### DIFF
--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -358,6 +358,7 @@ def test_mlflow_log_table(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
+@pytest.mark.filterwarnings("ignore:.*Any type hint is inferred as AnyType.*:UserWarning")
 def test_mlflow_log_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
     mlflow = pytest.importorskip('mlflow')
 

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -358,7 +358,7 @@ def test_mlflow_log_table(tmp_path):
 
 
 @pytest.mark.filterwarnings("ignore:.*The 'transformers' MLflow Models integration.*:FutureWarning")
-@pytest.mark.filterwarnings("ignore:.*Any type hint is inferred as AnyType.*:UserWarning")
+@pytest.mark.filterwarnings('ignore:.*Any type hint is inferred as AnyType.*:UserWarning')
 def test_mlflow_log_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
     mlflow = pytest.importorskip('mlflow')
 


### PR DESCRIPTION
# What does this PR do?
Latest mlflow release results in a UserWarning from this test, which causes a test failure so we ignore it in the test.
