### PR TITLE
Eliminate dead code before torch version 2.4  

### DIFF
--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -19,7 +19,6 @@ from typing import Any, Union
 
 import psutil
 import torch
-from packaging import version
 
 import composer
 from composer.loggers.mosaicml_logger import (
@@ -321,10 +320,7 @@ def _launch_processes(
     log.info('Distributed KV store: tcp://%s:%s', master_addr, master_port)
 
     nccl_env_variable = {
-        (
-            'NCCL_ASYNC_ERROR_HANDLING' if version.parse(torch.__version__) < version.parse('2.2.0') else 'TORCH_NCCL_ASYNC_ERROR_HANDLING'
-        ):
-            '1',
+        'TORCH_NCCL_ASYNC_ERROR_HANDLING': '1',
     }
 
     for local_rank in range(nproc):

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -11,7 +11,6 @@ import warnings
 from collections import OrderedDict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Sequence, Union, cast
-from unittest.mock import MagicMock
 
 import numpy as np
 import torch
@@ -31,10 +30,7 @@ from torch.optim.lr_scheduler import LRScheduler
 from torch.utils.data import DataLoader, Dataset
 from torchmetrics import Metric
 
-if version.parse(torch.__version__) >= version.parse('2.3.0'):
-    from torch.amp.grad_scaler import GradScaler  # type: ignore
-else:
-    from torch.cuda.amp.grad_scaler import GradScaler  # type: ignore
+from torch.amp.grad_scaler import GradScaler
 
 from composer.core.data_spec import DataSpec
 from composer.core.event import Event
@@ -72,6 +68,10 @@ log = logging.getLogger(__name__)
 @contextmanager
 def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str = 'full'):
     """Context manager for materializing or loading an fsdp module's state dict.
+    
+    .. warning::
+        This function is deprecated and will be removed in a future release.
+        It is maintained for backwards compatibility with tests.
 
     Args:
         module (torch.nn.Module): The torch module that you want to call `state_dict()`
@@ -87,6 +87,12 @@ def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str =
     """
     # Torch forgot to put ShardedStateDictConfig in torch/distributed/fsdp/__init__.py, so we
     # have to import it this way.
+    warnings.warn(
+        "fsdp_state_dict_type_context is deprecated and will be removed in a future release",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    
     from torch.distributed.fsdp.fully_sharded_data_parallel import ShardedStateDictConfig
 
     fsdp_state_dict_type = None
@@ -125,6 +131,10 @@ def fsdp_get_optim_state_dict(
     state_dict_type: str = 'full',
 ) -> dict[str, Any]:
     """Materializes a given model's optimizer's state_dict.
+    
+    .. warning::
+        This function is deprecated and will be removed in a future release.
+        It is maintained for backwards compatibility with tests.
 
     Args:
         model (torch.nn.Module): The model that the optimizer corresponds to.
@@ -140,6 +150,12 @@ def fsdp_get_optim_state_dict(
     Returns:
         dict[str, Any]: The state_dict for the given optimizer.
     """
+    warnings.warn(
+        "fsdp_get_optim_state_dict is deprecated and will be removed in a future release",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    
     with fsdp_state_dict_type_context(module=model, state_dict_type=state_dict_type):
         return FSDP.optim_state_dict(model, optim)  # type: ignore
 
@@ -200,10 +216,6 @@ def _create_device_mesh(
     fsdp_config: Optional[FSDPConfig | FSDP2Config],
     tp_config: Optional[TPConfig],
 ) -> Optional[DeviceMesh]:
-    if version.parse(torch.__version__.split('.dev')[0]) < version.parse('2.3.0'):
-        # Device mesh has correctness issues before torch 2.3.0
-        return None
-
     if fsdp_config is None:
         return None
 
@@ -986,37 +998,23 @@ class State(Serializable):
         Returns:
             dict[str, Any]: The state dict for the model.
         """
-        if version.parse(torch.__version__) >= version.parse('2.4.0') or (
-            version.parse(torch.__version__) >= version.parse('2.3.0') and dist.is_initialized()
-        ):
-            from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
-            if self.fsdp_state_dict_type not in [None, 'full', 'sharded']:
-                raise NotImplementedError(
-                    textwrap.dedent(
-                        f'fsdp_state_dict_type={self.fsdp_state_dict_type} is not supported for '
-                        f'torch version {{version.parse(torch.__version__)}} > 2.1.3. Please set '
-                        'fsdp_state_dict_type to None, "full", or "sharded".',
-                    ),
-                )
-
-            model_state_dict = get_model_state_dict(
-                model=self.model,
-                submodules=None,
-                options=StateDictOptions(
-                    full_state_dict=self.fsdp_state_dict_type == 'full',
-                    cpu_offload=self.fsdp_enabled,
+        from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict
+        if self.fsdp_state_dict_type not in [None, 'full', 'sharded']:
+            raise NotImplementedError(
+                textwrap.dedent(
+                    f'fsdp_state_dict_type={self.fsdp_state_dict_type} is not supported for '
+                    'torch version >= 2.4.0. Please set fsdp_state_dict_type to None, "full", or "sharded".',
                 ),
             )
-        else:
-            if self.fsdp_enabled and self.fsdp_state_dict_type is not None:
-                with fsdp_state_dict_type_context(self.model, state_dict_type=self.fsdp_state_dict_type):
-                    model_state_dict = self.model.state_dict()
-            else:
-                model_state_dict = self.model.state_dict()
 
-            # If model is DDP wrapped, do not save the `module.` prefix, as that is an implementation detail
-            if self.is_model_ddp:
-                torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(model_state_dict, 'module.')
+        model_state_dict = get_model_state_dict(
+            model=self.model,
+            submodules=None,
+            options=StateDictOptions(
+                full_state_dict=self.fsdp_state_dict_type == 'full',
+                cpu_offload=self.fsdp_enabled,
+            ),
+        )
 
         return model_state_dict
 
@@ -1026,40 +1024,26 @@ class State(Serializable):
         Returns:
             dict[str, Any]: The state dict for the optimizer.
         """
-        if version.parse(torch.__version__) >= version.parse('2.4.0') or (
-            version.parse(torch.__version__) >= version.parse('2.3.0') and dist.is_initialized()
-        ):
-            from torch.distributed.checkpoint.state_dict import StateDictOptions, get_optimizer_state_dict
-            if self.fsdp_state_dict_type not in [None, 'full', 'sharded']:
-                raise NotImplementedError(
-                    textwrap.dedent(
-                        f'fsdp_state_dict_type={self.fsdp_state_dict_type} is not supported for '
-                        f'torch version {{version.parse(torch.__version__)}} > 2.1.3. Please set '
-                        'fsdp_state_dict_type to None, "full", or "sharded".',
-                    ),
-                )
-
-            optimizer = ensure_tuple(self.optimizers)[0]
-            optim_state_dict = get_optimizer_state_dict(
-                model=self.model,
-                optimizers=optimizer,
-                submodules=None,
-                options=StateDictOptions(
-                    full_state_dict=self.fsdp_state_dict_type == 'full',
-                    cpu_offload=self.fsdp_enabled,
+        from torch.distributed.checkpoint.state_dict import StateDictOptions, get_optimizer_state_dict
+        if self.fsdp_state_dict_type not in [None, 'full', 'sharded']:
+            raise NotImplementedError(
+                textwrap.dedent(
+                    f'fsdp_state_dict_type={self.fsdp_state_dict_type} is not supported for '
+                    'torch version >= 2.4.0. Please set fsdp_state_dict_type to None, "full", or "sharded".',
                 ),
             )
-            return {type(optimizer).__qualname__: optim_state_dict}
-        else:
-            optimizer = ensure_tuple(self.optimizers)[0]
-            if self.fsdp_enabled and self.fsdp_state_dict_type is not None:
-                optim_state_dict = {
-                    type(optimizer).__qualname__:
-                        fsdp_get_optim_state_dict(self.model, optimizer, state_dict_type=self.fsdp_state_dict_type),
-                }
-            else:
-                optim_state_dict = {type(optimizer).__qualname__: optimizer.state_dict()}
-            return optim_state_dict
+
+        optimizer = ensure_tuple(self.optimizers)[0]
+        optim_state_dict = get_optimizer_state_dict(
+            model=self.model,
+            optimizers=optimizer,
+            submodules=None,
+            options=StateDictOptions(
+                full_state_dict=self.fsdp_state_dict_type == 'full',
+                cpu_offload=self.fsdp_enabled,
+            ),
+        )
+        return {type(optimizer).__qualname__: optim_state_dict}
 
     def state_dict(self) -> dict[str, Any]:
         """Collect the state dicts of our serializable attributes.
@@ -1338,67 +1322,32 @@ class State(Serializable):
         model_on_rank = state_dict['model'] is not None
 
         if model_on_rank:
-            if version.parse(torch.__version__) >= version.parse('2.4.0') or (
-                version.parse(torch.__version__) >= version.parse('2.3.0') and dist.is_initialized()
-            ):
-                from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
-                try:
-                    set_model_state_dict(
-                        model=self.model,
-                        model_state_dict=state_dict['model'],
-                        options=StateDictOptions(
-                            full_state_dict=self.fsdp_state_dict_type == 'full',
-                            strict=strict,
-                            cpu_offload=self.fsdp_enabled,
+            from torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
+            try:
+                set_model_state_dict(
+                    model=self.model,
+                    model_state_dict=state_dict['model'],
+                    options=StateDictOptions(
+                        full_state_dict=self.fsdp_state_dict_type == 'full',
+                        strict=strict,
+                        cpu_offload=self.fsdp_enabled,
+                    ),
+                )
+            except AttributeError as e:
+                # Issue: https://github.com/pytorch/pytorch/issues/127351
+                if "ShardedTensor' object has no attribute 'placements'" in str(e):
+                    raise RuntimeError(
+                        textwrap.dedent(
+                            'PyTorch DTensor broke backwards compatibility in older checkpoints '
+                            'with ShardedTensor, which is now deprecated. To load old checkpoints, '
+                            'either downgrade to PyTorch <2.3.0 or explicitly pass process groups '
+                            'in the Trainer constructor via '
+                            "`parallelism_config = {'fsdp': {'process_group': 'mod1'}}`. We can "
+                            'provide assistance at https://github.com/mosaicml/composer/issues.',
                         ),
-                    )
-                except AttributeError as e:
-                    # Issue: https://github.com/pytorch/pytorch/issues/127351
-                    if "ShardedTensor' object has no attribute 'placements'" in str(e):
-                        raise RuntimeError(
-                            textwrap.dedent(
-                                'PyTorch DTensor broke backwards compatibility in older checkpoints '
-                                'with ShardedTensor, which is now deprecated. To load old checkpoints, '
-                                'either downgrade to PyTorch <2.3.0 or explicitly pass process groups '
-                                'in the Trainer constructor via '
-                                "`parallelism_config = {'fsdp': {'process_group': 'mod1'}}`. We can "
-                                'provide assistance at https://github.com/mosaicml/composer/issues.',
-                            ),
-                        ) from e
-                    else:
-                        raise e
-            else:
-                missing_keys, unexpected_keys = [], []
-                try:
-                    # Load model if it exists
-                    if self.fsdp_enabled and self.fsdp_state_dict_type is not None and not self.load_monolith_rank0_only:
-                        log.debug(
-                            f'Loading model state dict with strict={strict} and FSDP state_dict_type={self.fsdp_state_dict_type}',
-                        )
-                        with fsdp_state_dict_type_context(self.model, state_dict_type=self.fsdp_state_dict_type):
-                            missing_keys, unexpected_keys = self.model.load_state_dict(
-                                state_dict['model'],
-                                strict=strict,
-                            )
-                    else:
-                        log.debug(f'Loading model state dict with strict={strict}')
-                        missing_keys, unexpected_keys = self.model.load_state_dict(state_dict['model'], strict=strict)
-                except RuntimeError as e:
-                    if 'Missing key(s) in state_dict' in str(e) or 'Unexpected key(s) in state_dict' in str(e):
-                        raise RuntimeError(
-                            textwrap.dedent(
-                                'Failed to load checkpoint due to missing or unexpected keys in state_dict. '
-                                'This is likely due to a change in the model architecture. If this is intentional, '
-                                'you can set load_strict_model_weights=False in the Trainer.',
-                            ),
-                        ) from e
-                    else:
-                        raise e
-
-                if len(missing_keys) > 0:
-                    log.warning(f"Found these missing keys in the checkpoint: {', '.join(missing_keys)}")
-                if len(unexpected_keys) > 0:
-                    log.warning(f"Found these unexpected keys in the checkpoint: {', '.join(unexpected_keys)}")
+                    ) from e
+                else:
+                    raise e
 
         # If loading FSDP monolith checkpoint on rank 0 only, the model must be wrapped after loading
         if self.load_monolith_rank0_only:
@@ -1448,52 +1397,18 @@ class State(Serializable):
                 continue
 
             optim_state_dict = serialized_value[type(optimizer).__qualname__] if serialized_value is not None else None
-            if version.parse(torch.__version__) >= version.parse('2.4.0') or (
-                version.parse(torch.__version__) >= version.parse('2.3.0') and dist.is_initialized()
-            ):
-                from torch.distributed.checkpoint.state_dict import StateDictOptions, set_optimizer_state_dict
+            from torch.distributed.checkpoint.state_dict import StateDictOptions, set_optimizer_state_dict
 
-                # optim_state_dict is `None` on non-zero ranks when loading FSDP monolith
-                # checkpoint on rank 0 only. However, PyTorch modifies the state_dict (producing
-                # errors) before discarding the output. Accordingly, we mock the state dict.
-                # See: https://github.com/pytorch/pytorch/issues/125177
-                if version.parse(torch.__version__) < version.parse('2.4.0'):
-                    optim_state_dict = MagicMock() if optim_state_dict is None else optim_state_dict
-                set_optimizer_state_dict(
-                    model=self.model,
-                    optimizers=optimizer,
-                    optim_state_dict=optim_state_dict,
-                    options=StateDictOptions(
-                        full_state_dict=self.fsdp_state_dict_type == 'full',
-                        strict=strict,
-                        cpu_offload=self.fsdp_enabled,
-                    ),
-                )
-            else:
-                if self.fsdp_enabled:
-                    assert self.fsdp_state_dict_type is not None  # pyright
-                    log.debug(f'Loading FSDP optimizer with fsdp_state_dict_type={self.fsdp_state_dict_type}')
-                    # Loading FSDP monolith on rank 0 only requires FSDP.scatter_full_optim_state_dict
-                    # as the context manager does not seem to pass rank0_only=True for the optimizer config
-                    if self.load_monolith_rank0_only:
-                        optim_state_dict = _legacy_optim_state_dict_to_load(
-                            optim_state_dict=optim_state_dict,
-                            model=self.model,
-                            optim=optimizer,
-                            state_dict_type=self.fsdp_state_dict_type,
-                        )
-                    else:
-                        assert optim_state_dict is not None
-                        with fsdp_state_dict_type_context(module=self.model, state_dict_type=self.fsdp_state_dict_type):
-                            optim_state_dict = FSDP.optim_state_dict_to_load(  #  type: ignore
-                                optim_state_dict=optim_state_dict, model=self.model, optim=optimizer,
-                            )
-                    assert optim_state_dict is not None
-                    optimizer.load_state_dict(optim_state_dict)
-                else:
-                    assert optim_state_dict is not None
-                    log.debug(f'Loading optimizer state dict')
-                    optimizer.load_state_dict(optim_state_dict)
+            set_optimizer_state_dict(
+                model=self.model,
+                optimizers=optimizer,
+                optim_state_dict=optim_state_dict,
+                options=StateDictOptions(
+                    full_state_dict=self.fsdp_state_dict_type == 'full',
+                    strict=strict,
+                    cpu_offload=self.fsdp_enabled,
+                ),
+            )
 
     def load_state_dict(
         self,

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -75,10 +75,6 @@ log = logging.getLogger(__name__)
 def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str = 'full'):
     """Context manager for materializing or loading an fsdp module's state dict.
 
-    .. warning::
-        This function is deprecated and will be removed in a future release.
-        It is maintained for backwards compatibility with tests.
-
     Args:
         module (torch.nn.Module): The torch module that you want to call `state_dict()`
             or `load_state_dict()` on.
@@ -93,12 +89,6 @@ def fsdp_state_dict_type_context(module: torch.nn.Module, state_dict_type: str =
     """
     # Torch forgot to put ShardedStateDictConfig in torch/distributed/fsdp/__init__.py, so we
     # have to import it this way.
-    warnings.warn(
-        'fsdp_state_dict_type_context is deprecated and will be removed in a future release',
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
     from torch.distributed.fsdp.fully_sharded_data_parallel import ShardedStateDictConfig
 
     fsdp_state_dict_type = None
@@ -139,7 +129,7 @@ def fsdp_get_optim_state_dict(
     """Materializes a given model's optimizer's state_dict.
 
     .. warning::
-        This function is deprecated and will be removed in a future release.
+        This function is deprecated and will be removed in Composer version 0.32.
         It is maintained for backwards compatibility with tests.
 
     Args:
@@ -157,7 +147,7 @@ def fsdp_get_optim_state_dict(
         dict[str, Any]: The state_dict for the given optimizer.
     """
     warnings.warn(
-        'fsdp_get_optim_state_dict is deprecated and will be removed in a future release',
+        'fsdp_get_optim_state_dict is deprecated and will be removed in Composer version 0.32',
         DeprecationWarning,
         stacklevel=2,
     )

--- a/composer/trainer/_scaler.py
+++ b/composer/trainer/_scaler.py
@@ -5,14 +5,9 @@ from collections import defaultdict
 from typing import Optional, Union
 
 import torch
-from packaging import version
-from torch.cuda.amp.grad_scaler import GradScaler, OptState
 from torch.optim import Optimizer
+from torch.amp.grad_scaler import _refresh_per_optimizer_state, GradScaler, OptState
 
-if version.parse(torch.__version__) >= version.parse('2.3.0'):
-    from torch.amp.grad_scaler import _refresh_per_optimizer_state  # type: ignore
-else:
-    from torch.cuda.amp.grad_scaler import _refresh_per_optimizer_state  # type: ignore
 
 from composer.utils import dist
 

--- a/composer/trainer/_scaler.py
+++ b/composer/trainer/_scaler.py
@@ -5,9 +5,8 @@ from collections import defaultdict
 from typing import Optional, Union
 
 import torch
+from torch.amp.grad_scaler import GradScaler, OptState, _refresh_per_optimizer_state
 from torch.optim import Optimizer
-from torch.amp.grad_scaler import _refresh_per_optimizer_state, GradScaler, OptState
-
 
 from composer.utils import dist
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -40,6 +40,7 @@ import torch.nn as nn
 import torch.utils.data
 from packaging import version
 from torch._dynamo import OptimizedModule
+from torch.amp.grad_scaler import GradScaler, _refresh_per_optimizer_state
 from torch.distributed.fsdp import FullyShardedDataParallel
 from torch.distributed.fsdp._runtime_utils import _post_backward_final_callback
 from torch.distributed.fsdp.sharded_grad_scaler import ShardedGradScaler
@@ -47,11 +48,6 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.optim.lr_scheduler import LRScheduler
 from torch.utils.data import DataLoader, DistributedSampler
 from torchmetrics import Metric
-
-if version.parse(torch.__version__) >= version.parse('2.3.0'):
-    from torch.amp.grad_scaler import GradScaler, _refresh_per_optimizer_state  # type: ignore
-else:
-    from torch.cuda.amp.grad_scaler import GradScaler, _refresh_per_optimizer_state  # type: ignore
 
 from composer.callbacks import CheckpointSaver, MemorySnapshot, OOMObserver
 from composer.core import (
@@ -2169,8 +2165,7 @@ class Trainer:
             raise ValueError(
                 'PyTorch 2.4 breaks (distributed) checkpointing with SGD. '
                 'Please use a different optimizer, e.g. composer.optim.DecoupledSGDW, '
-                'instead or downgrade to PyTorch <2.4. See ',
-                'https://github.com/pytorch/pytorch/issues/133415 for further information.',
+                'instead. See https://github.com/pytorch/pytorch/issues/133415 for further information.',
             )
 
         if self.state.max_duration is None:

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -1066,7 +1066,6 @@ def _save_checkpoint(
         # Only rank 0 saves RNG
         if dist.get_global_rank() > 0:
             state_dict.pop('rng')
-        # For older versions of PyTorch, we don't need this special handling anymore
 
     log.debug('State dict created.')
     dirname = os.path.dirname(save_filename)

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -580,7 +580,34 @@ def dist_cp_load(
                 planner=load_planner,
             )
             return
-        raise e
+
+        checkpoint_metadata = storage_reader.read_metadata().state_dict_metadata
+        if 'state.metadata' in checkpoint_metadata and 'state.metadata.composer_env_info.composer_version' not in checkpoint_metadata:
+            # Torch 2.4 changed the way how state dict is flattened. It broke backward compatibility.
+            # Torch issue: https://github.com/pytorch/pytorch/issues/133923.
+            # We override the traverse_state_dict so that the load planner could
+            # use the old way of flattening the state dict
+            log.debug('Trying to load checkpointing saved before torch 2.4')
+
+            import torch.distributed.checkpoint._nested_dict as nested_dict
+            import torch.distributed.checkpoint._sharded_tensor_utils as sharded_tensor_util
+            from torch.distributed.checkpoint._traverse import traverse_state_dict as traverse_2_4_0
+
+            from composer.trainer._patch_pytorch import traverse_state_dict as backward_compatible_traverse
+
+            nested_dict.traverse_state_dict = backward_compatible_traverse
+            sharded_tensor_util.traverse_state_dict = backward_compatible_traverse
+
+            dist_cp.load(
+                state_dict=state_dict,
+                storage_reader=storage_reader,
+                planner=load_planner,
+            )
+            # Revert the override
+            nested_dict.traverse_state_dict = traverse_2_4_0
+            sharded_tensor_util.traverse_state_dict = traverse_2_4_0
+        else:
+            raise e
 
 
 def load_sharded_checkpoint(


### PR DESCRIPTION
# What does this PR do?

Remove dead code which is only effective before torch 2.4, which we don't support anymore.

# What issue(s) does this change relate to?

1. Pave the way to support and release torch 2.7 and deprecate torch 2.4/2.5
2. Test Cursor on trivial SDE task

# Changes by AI coder
Most changes are created by Cursor, yet reviewed by myself. Workflow:
Codebase wise one shot change is still hard for Cursor, so current flow is:
```
1. Use agent mode in Cursor
2. Use Claude 3.7 non-thinking
3. 
For file in target_files:
    prompt("currently we support torch versions between 2.4 and 2.6, can you help me apply necessary changes to remove or clean up code related to torch version less than 2.4 in this @file? Please don't modify other comments or docstrings. When you need to delete a function please consider if it is used by other files in @composer as well.")
```