### PR TITLE
change yapf rule to blank_line_before_module_docstring = false

### DIFF
--- a/.github/bin/gen_docker_matrix.py
+++ b/.github/bin/gen_docker_matrix.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Reads in the Docker build matrix and generates a GHA job matrix."""
 
 import json

--- a/composer/__init__.py
+++ b/composer/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Some key classes are available directly in the ``composer`` namespace."""
 
 from composer._version import __version__

--- a/composer/__main__.py
+++ b/composer/__main__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Runs the Composer CLI."""
 
 from composer.cli import __main__  # noqa: F401

--- a/composer/_version.py
+++ b/composer/_version.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The Composer Version."""
 
 __version__ = '0.31.0.dev0'

--- a/composer/algorithms/__init__.py
+++ b/composer/algorithms/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Efficiency methods for training.
 
 Examples include :class:`.LabelSmoothing` and adding :class:`.SqueezeExcite` blocks,

--- a/composer/algorithms/alibi/__init__.py
+++ b/composer/algorithms/alibi/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """ALiBi (Attention with Linear Biases; `Press et al, 2021 <https://arxiv.org/abs/2108.12409>`_) dispenses with position
 embeddings for tokens in transformer-based NLP models, instead encoding position information by biasing the query-key
 attention scores proportionally to each token pair's distance.

--- a/composer/algorithms/alibi/alibi.py
+++ b/composer/algorithms/alibi/alibi.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core ALiBi classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/augmix/__init__.py
+++ b/composer/algorithms/augmix/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """AugMix (`Hendrycks et al, 2020 <http://arxiv.org/abs/1912.02781>`_) creates multiple independent realizations of
 sequences of image augmentations, applies each sequence with random intensity, and returns a convex combination of the
 augmented images and the original image.

--- a/composer/algorithms/augmix/augmix.py
+++ b/composer/algorithms/augmix/augmix.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core AugMix classes and functions."""
 
 import functools

--- a/composer/algorithms/blurpool/__init__.py
+++ b/composer/algorithms/blurpool/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """`BlurPool <http://proceedings.mlr.press/v97/zhang19a.html>`_ adds anti-aliasing filters to convolutional layers to
 increase accuracy and invariance to small shifts in the input.
 

--- a/composer/algorithms/channels_last/__init__.py
+++ b/composer/algorithms/channels_last/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Changes the memory format of the model to ``torch.channels_last``.
 
 This usually improves GPU utilization. See the :doc:`Method Card </method_cards/channels_last>` for more details.

--- a/composer/algorithms/channels_last/channels_last.py
+++ b/composer/algorithms/channels_last/channels_last.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """ChannelsLast algorithm."""
 
 from __future__ import annotations

--- a/composer/algorithms/colout/__init__.py
+++ b/composer/algorithms/colout/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Drops a fraction of the rows and columns of an input image. If the fraction of rows/columns dropped isn't too large,
 this does not significantly alter the content of the image, but reduces its size and provides extra variability.
 

--- a/composer/algorithms/colout/colout.py
+++ b/composer/algorithms/colout/colout.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core ColOut classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/cutmix/__init__.py
+++ b/composer/algorithms/cutmix/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """`CutMix <https://arxiv.org/abs/1905.04899>`_ trains the network on non-overlapping combinations of pairs of examples
 and iterpolated targets rather than individual examples and targets.
 

--- a/composer/algorithms/cutmix/cutmix.py
+++ b/composer/algorithms/cutmix/cutmix.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core CutMix classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/cutout/__init__.py
+++ b/composer/algorithms/cutout/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """`Cutout <https://arxiv.org/abs/1708.04552>`_ is a data augmentation technique that works by masking out one or more
 square regions of an input image.
 

--- a/composer/algorithms/cutout/cutout.py
+++ b/composer/algorithms/cutout/cutout.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core CutOut classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/ema/__init__.py
+++ b/composer/algorithms/ema/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Exponential moving average maintains a moving average of model parameters and uses these at test time.
 
 See the :doc:`Method Card </method_cards/ema>` for more details.

--- a/composer/algorithms/ema/ema.py
+++ b/composer/algorithms/ema/ema.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core Exponential Moving Average (EMA) classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/factorize/__init__.py
+++ b/composer/algorithms/factorize/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Decomposes linear operators into pairs of smaller linear operators.
 
 See :class:`.Factorize` or the :doc:`Method Card </method_cards/factorize>` for details.

--- a/composer/algorithms/gated_linear_units/__init__.py
+++ b/composer/algorithms/gated_linear_units/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Replaces the Linear layers in the feed-forward network with `Gated Linear Units <https://arxiv.org/abs/2002.05202>`_.
 
 This leads to improved convergence with a slight drop in throughput. Using no bias terms in the GLU is highly recommended.

--- a/composer/algorithms/ghost_batchnorm/__init__.py
+++ b/composer/algorithms/ghost_batchnorm/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Replaces batch normalization modules with `Ghost Batch Normalization <https://arxiv.org/abs/1705.08741>`_ modules
 that simulate the effect of using a smaller batch size.
 

--- a/composer/algorithms/gradient_clipping/__init__.py
+++ b/composer/algorithms/gradient_clipping/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Clips all gradients in a model based on their values, their norms,
 and their parameters' norms.
 

--- a/composer/algorithms/gradient_clipping/gradient_clipping.py
+++ b/composer/algorithms/gradient_clipping/gradient_clipping.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core gradient clipping classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/gyro_dropout/__init__.py
+++ b/composer/algorithms/gyro_dropout/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Replaces all instances of `torch.nn.Dropout` with a `GyroDropout`.
 
 By masking Dropout layer, this usually improves accuracy.

--- a/composer/algorithms/label_smoothing/__init__.py
+++ b/composer/algorithms/label_smoothing/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Shrinks targets towards a uniform distribution to counteract label noise. Introduced in `Rethinking the Inception
 Architecture for Computer Vision <https://arxiv.org/abs/1512.00567>`_.
 

--- a/composer/algorithms/label_smoothing/label_smoothing.py
+++ b/composer/algorithms/label_smoothing/label_smoothing.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core Label Smoothing classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/layer_freezing/__init__.py
+++ b/composer/algorithms/layer_freezing/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Progressively freeze the layers of the network during training, starting with the earlier layers.
 
 See the :doc:`Method Card </method_cards/layer_freezing>` for more details.

--- a/composer/algorithms/layer_freezing/layer_freezing.py
+++ b/composer/algorithms/layer_freezing/layer_freezing.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core Layer Freezing classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/low_precision_groupnorm/__init__.py
+++ b/composer/algorithms/low_precision_groupnorm/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Replaces all instances of :class:`torch.nn.GroupNorm` with a low precision :class:`torch.nn.GroupNorm` (either float16 or bfloat16).
 By default, torch.autocast always runs torch.nn.GroupNorm in float32, so this surgery forces a lower precision.
 """

--- a/composer/algorithms/low_precision_groupnorm/low_precision_groupnorm.py
+++ b/composer/algorithms/low_precision_groupnorm/low_precision_groupnorm.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Low Precision GroupNorm."""
 
 from __future__ import annotations

--- a/composer/algorithms/low_precision_layernorm/__init__.py
+++ b/composer/algorithms/low_precision_layernorm/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Replaces all instances of :class:`torch.nn.LayerNorm` with a low precision :class:`torch.nn.LayerNorm` (either float16 or bfloat16).
 By default, torch.autocast always runs torch.nn.LayerNorm in float32, so this surgery forces a lower precision.
 """

--- a/composer/algorithms/low_precision_layernorm/low_precision_layernorm.py
+++ b/composer/algorithms/low_precision_layernorm/low_precision_layernorm.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Low Precision LayerNorm."""
 
 from __future__ import annotations

--- a/composer/algorithms/mixup/__init__.py
+++ b/composer/algorithms/mixup/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Create new samples using convex combinations of pairs of samples.
 
 This is done by taking a convex combination of x with a randomly permuted copy of x.

--- a/composer/algorithms/mixup/mixup.py
+++ b/composer/algorithms/mixup/mixup.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core MixUp classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/no_op_model/__init__.py
+++ b/composer/algorithms/no_op_model/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Replaces model with a dummy model of type :class:`NoOpModelClass`.
 
 The algorithm runs on :attr:`Event.INIT`. It replaces the model in the state with

--- a/composer/algorithms/no_op_model/no_op_model.py
+++ b/composer/algorithms/no_op_model/no_op_model.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """NoOpModel algorithm and class."""
 
 from __future__ import annotations

--- a/composer/algorithms/progressive_resizing/__init__.py
+++ b/composer/algorithms/progressive_resizing/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Applies Fastai's `progressive resizing <https://github.com/fastai/fastbook/blob/780b76bef3127ce5b64f8230fce60e915a
 7e0735/07_sizing_and_tta.ipynb>`__ data augmentation to speed up training.
 

--- a/composer/algorithms/progressive_resizing/progressive_resizing.py
+++ b/composer/algorithms/progressive_resizing/progressive_resizing.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core Progressive Resizing classes and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/randaugment/__init__.py
+++ b/composer/algorithms/randaugment/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Randomly applies a sequence of image data augmentations
 (`Cubuk et al, 2019 <https://arxiv.org/abs/1909.13719>`_) to an image. See
 :class:`.RandAugment` or the :doc:`Method Card

--- a/composer/algorithms/randaugment/randaugment.py
+++ b/composer/algorithms/randaugment/randaugment.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core RandAugment code."""
 
 import functools

--- a/composer/algorithms/sam/__init__.py
+++ b/composer/algorithms/sam/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """SAM (`Foret et al, 2020 <https://arxiv.org/abs/2010.01412>`_) wraps an existing optimizer with a
 :class:`SAMOptimizer` which makes the optimizer minimize both loss value and sharpness.This can improves model
 generalization and provide robustness to label noise.

--- a/composer/algorithms/sam/sam.py
+++ b/composer/algorithms/sam/sam.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """SAM algorithm and optimizer class."""
 
 from __future__ import annotations

--- a/composer/algorithms/selective_backprop/__init__.py
+++ b/composer/algorithms/selective_backprop/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """`Selective Backprop <https://arxiv.org/abs/1910.00762>`_ prunes minibatches according to the difficulty of the
 individual training examples, and only computes weight gradients over the pruned subset, reducing iteration time and
 speeding up training.

--- a/composer/algorithms/selective_backprop/selective_backprop.py
+++ b/composer/algorithms/selective_backprop/selective_backprop.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core SelectiveBackprop class and functions."""
 
 from __future__ import annotations

--- a/composer/algorithms/seq_length_warmup/__init__.py
+++ b/composer/algorithms/seq_length_warmup/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Sequence length warmup progressively increases the sequence length during training of NLP models.
 
 See the :doc:`Method Card </method_cards/seq_length_warmup>` for more details.

--- a/composer/algorithms/seq_length_warmup/seq_length_warmup.py
+++ b/composer/algorithms/seq_length_warmup/seq_length_warmup.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core code for sequence length warmup."""
 
 import logging

--- a/composer/algorithms/squeeze_excite/__init__.py
+++ b/composer/algorithms/squeeze_excite/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Adds Squeeze-and-Excitation blocks (`Hu et al, 2019 <https://arxiv.org/abs/1709.01507>`_) after the
 :class:`~torch.nn.Conv2d` modules in a neural network.
 

--- a/composer/algorithms/stochastic_depth/__init__.py
+++ b/composer/algorithms/stochastic_depth/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Implements stochastic depth (`Huang et al, 2016 <https://arxiv.org/abs/1603.09382>`_) for ResNet blocks.
 
 See :class:`.StochasticDepth`, the sample-wise stochastic depth :doc:`method card

--- a/composer/algorithms/stochastic_depth/stochastic_depth.py
+++ b/composer/algorithms/stochastic_depth/stochastic_depth.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Modules and layers for applying the Stochastic Depth algorithm."""
 
 from __future__ import annotations

--- a/composer/algorithms/stochastic_depth/stochastic_layers.py
+++ b/composer/algorithms/stochastic_depth/stochastic_layers.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Stochastic forward functions for ResNet Bottleneck modules."""
 
 from typing import Optional

--- a/composer/algorithms/swa/__init__.py
+++ b/composer/algorithms/swa/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Stochastic Weight Averaging (SWA; `Izmailov et al, 2018 <https://arxiv.org/abs/1803.05407>`_) averages model weights
 sampled at different times near the end of training.
 

--- a/composer/algorithms/swa/swa.py
+++ b/composer/algorithms/swa/swa.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Core code for Stochastic Weight Averaging."""
 
 from __future__ import annotations

--- a/composer/algorithms/utils/__init__.py
+++ b/composer/algorithms/utils/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper utilities for algorithms."""
 from composer.algorithms.utils.augmentation_primitives import augmentation_sets
 

--- a/composer/algorithms/utils/augmentation_primitives.py
+++ b/composer/algorithms/utils/augmentation_primitives.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper functions to perform augmentations on a :class:`PIL.Image.Image`.
 
 Augmentations that take an intensity value are normalized on a scale of 1-10,

--- a/composer/callbacks/__init__.py
+++ b/composer/callbacks/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Callbacks that run at each training loop :class:`.Event`.
 
 Each callback inherits from the :class:`.Callback` base class. See detailed description and

--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Monitor activation values during training."""
 
 import warnings

--- a/composer/callbacks/checkpoint_saver.py
+++ b/composer/callbacks/checkpoint_saver.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Callback to save checkpoints during training."""
 
 from __future__ import annotations

--- a/composer/callbacks/early_stopper.py
+++ b/composer/callbacks/early_stopper.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Early stopping callback."""
 
 from __future__ import annotations

--- a/composer/callbacks/export_for_inference.py
+++ b/composer/callbacks/export_for_inference.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Callback to export model for inference."""
 
 from __future__ import annotations

--- a/composer/callbacks/free_outputs.py
+++ b/composer/callbacks/free_outputs.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Free train metrics."""
 
 import torch

--- a/composer/callbacks/generate.py
+++ b/composer/callbacks/generate.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Periodically log generations from a set of prompts."""
 
 import logging

--- a/composer/callbacks/image_visualizer.py
+++ b/composer/callbacks/image_visualizer.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Monitor train and eval images."""
 from typing import Any, Callable, Sequence, Union
 

--- a/composer/callbacks/load_checkpoint.py
+++ b/composer/callbacks/load_checkpoint.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Load a checkpoint."""
 import logging
 from typing import Optional, Union

--- a/composer/callbacks/lr_monitor.py
+++ b/composer/callbacks/lr_monitor.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Monitor learning rate during training."""
 from composer.core import Callback, State
 from composer.loggers import Logger

--- a/composer/callbacks/memory_monitor.py
+++ b/composer/callbacks/memory_monitor.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log memory usage during training."""
 import logging
 import math

--- a/composer/callbacks/memory_snapshot.py
+++ b/composer/callbacks/memory_snapshot.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log memory snapshot during training."""
 import logging
 import os

--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Create a submission for MLPerf Training benchmark."""
 
 import json

--- a/composer/callbacks/nan_monitor.py
+++ b/composer/callbacks/nan_monitor.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Callback for catching loss NaNs."""
 
 from typing import Sequence

--- a/composer/callbacks/oom_observer.py
+++ b/composer/callbacks/oom_observer.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Generate a memory snapshot during an OutOfMemory exception."""
 from __future__ import annotations
 

--- a/composer/callbacks/optimizer_monitor.py
+++ b/composer/callbacks/optimizer_monitor.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Monitor gradients during training."""
 
 import torch

--- a/composer/callbacks/runtime_estimator.py
+++ b/composer/callbacks/runtime_estimator.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Estimate total time of training."""
 from __future__ import annotations
 

--- a/composer/callbacks/speed_monitor.py
+++ b/composer/callbacks/speed_monitor.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Monitor throughput during training."""
 from __future__ import annotations
 

--- a/composer/callbacks/system_metrics_monitor.py
+++ b/composer/callbacks/system_metrics_monitor.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """System metrics monitor callback."""
 
 from __future__ import annotations

--- a/composer/callbacks/threshold_stopper.py
+++ b/composer/callbacks/threshold_stopper.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Threshold stopping callback."""
 
 from typing import Any, Callable, Optional, Union

--- a/composer/checkpoint/__init__.py
+++ b/composer/checkpoint/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Module for checkpointing API."""
 
 from composer.checkpoint.download import download_monolithic_checkpoint

--- a/composer/checkpoint/download.py
+++ b/composer/checkpoint/download.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Useful functions for load checkpoints from remote object store or local disk."""
 
 import logging

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """API for loading checkpoints."""
 
 import contextlib

--- a/composer/checkpoint/save.py
+++ b/composer/checkpoint/save.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Useful functions for saving state dicts to disk."""
 
 import json

--- a/composer/checkpoint/state_dict.py
+++ b/composer/checkpoint/state_dict.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Useful functions for generating state dicts and manipulating them."""
 
 import fnmatch

--- a/composer/checkpoint/upload.py
+++ b/composer/checkpoint/upload.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Useful functions for uploading checkpoints to remote object store."""
 
 import logging

--- a/composer/cli/__init__.py
+++ b/composer/cli/__init__.py
@@ -1,4 +1,3 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Composer CLI."""

--- a/composer/cli/__main__.py
+++ b/composer/cli/__main__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Runs the Composer CLI."""
 
 import sys

--- a/composer/cli/launcher.py
+++ b/composer/cli/launcher.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The Composer CLI launcher for distributed training."""
 
 import contextlib

--- a/composer/core/__init__.py
+++ b/composer/core/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Central components used by other modules.
 
 Central parts of composer such as :class:`~.engine.Engine`, base class for critical components such as

--- a/composer/core/algorithm.py
+++ b/composer/core/algorithm.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Base class for algorithms that improve a model's quality or efficiency."""
 
 from __future__ import annotations

--- a/composer/core/callback.py
+++ b/composer/core/callback.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Base module for callbacks."""
 from __future__ import annotations
 

--- a/composer/core/data_spec.py
+++ b/composer/core/data_spec.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Specifications for operating and training on data."""
 from __future__ import annotations
 

--- a/composer/core/engine.py
+++ b/composer/core/engine.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Engine is a coordinator for running algorithms and resolving ordering conflicts among them for composition.
 
 .. currentmodule:: composer

--- a/composer/core/evaluator.py
+++ b/composer/core/evaluator.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A wrapper for a dataloader to include metrics that apply to a specific dataset."""
 
 from __future__ import annotations

--- a/composer/core/event.py
+++ b/composer/core/event.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Training Loop Events."""
 from composer.utils import StringEnum
 

--- a/composer/core/passes.py
+++ b/composer/core/passes.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Algorithm Passes reorder or modify the execution of algorithms by the Engine.
 
 The order in which algorithms are run matters significantly during composition. For example, the

--- a/composer/core/precision.py
+++ b/composer/core/precision.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Enum class for the numerical precision to be used by the model."""
 
 import contextlib

--- a/composer/core/serializable.py
+++ b/composer/core/serializable.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Serialization interface used by checkpointing."""
 
 from __future__ import annotations

--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The state of the trainer."""
 from __future__ import annotations
 

--- a/composer/core/time.py
+++ b/composer/core/time.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utilities to track training progress in terms of epochs, batches, samples, and tokens.
 
 Callbacks, algorithms, and schedulers can use the current training time to fire at certain points in the training

--- a/composer/core/types.py
+++ b/composer/core/types.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Reference for common types used throughout the composer library.
 
 Attributes:

--- a/composer/devices/__init__.py
+++ b/composer/devices/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Module for devices on which models run."""
 
 from composer.devices.device import Device

--- a/composer/devices/device.py
+++ b/composer/devices/device.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The base :class:`~composer.devices.device.Device` class."""
 
 from abc import ABC, abstractmethod

--- a/composer/devices/device_cpu.py
+++ b/composer/devices/device_cpu.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The CPU device used for training."""
 
 from __future__ import annotations

--- a/composer/devices/device_gpu.py
+++ b/composer/devices/device_gpu.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The GPU device used for training."""
 
 from __future__ import annotations

--- a/composer/devices/device_hpu.py
+++ b/composer/devices/device_hpu.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The HPU device used for training."""
 
 from __future__ import annotations

--- a/composer/devices/device_mps.py
+++ b/composer/devices/device_mps.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The Apple M-series device used for training."""
 
 from __future__ import annotations

--- a/composer/devices/device_neuron.py
+++ b/composer/devices/device_neuron.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The Neuron device used for training."""
 
 from __future__ import annotations

--- a/composer/devices/device_tpu.py
+++ b/composer/devices/device_tpu.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The TPU device used for training."""
 
 from __future__ import annotations

--- a/composer/distributed/__init__.py
+++ b/composer/distributed/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Distributed training."""
 
 # TODO include fsdp2 after we deprecate torch 2.5

--- a/composer/distributed/activation_checkpointing.py
+++ b/composer/distributed/activation_checkpointing.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helpers for activation checkpointing. Note that while this is orthogonal to FSDP2, it is implemented in the distributed directory because it is closely related to FSDP2."""
 
 from typing import Callable, Optional

--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helpers for running distributed data parallel training."""
 
 import logging

--- a/composer/distributed/fsdp2.py
+++ b/composer/distributed/fsdp2.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helpers for FSDP2."""
 
 import logging

--- a/composer/distributed/fsdp2_utils.py
+++ b/composer/distributed/fsdp2_utils.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helpers for FSDP2."""
 
 import contextlib

--- a/composer/distributed/meta_safe_apply.py
+++ b/composer/distributed/meta_safe_apply.py
@@ -6,7 +6,6 @@
 # Link to PyTorch License File: https://github.com/pytorch/pytorch/blob/master/LICENSE
 # TODO: This code will need to be removed when PyTorch correctly supports delayed initialization
 # with meta tensors.
-
 """Helper function to safely call .apply for initializing meta tensors in PyTorch."""
 
 import torch

--- a/composer/distributed/mosaic_parallelism.py
+++ b/composer/distributed/mosaic_parallelism.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """FSDP related configs and helper functions."""
 
 import logging

--- a/composer/distributed/param_init.py
+++ b/composer/distributed/param_init.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Param initialization helper functions."""
 
 from typing import Callable, Optional

--- a/composer/distributed/prepare_distributed.py
+++ b/composer/distributed/prepare_distributed.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Entrypoint for distributed training (using FSDP2)."""
 
 import logging

--- a/composer/functional/__init__.py
+++ b/composer/functional/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Functional API for applying algorithms in your own training loop.
 
 .. code-block:: python

--- a/composer/loggers/__init__.py
+++ b/composer/loggers/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Loggers to store metrics and checkpoints.
 
 In Composer, algorithms and callbacks can make calls to the :class:`~.logger.Logger`,

--- a/composer/loggers/cometml_logger.py
+++ b/composer/loggers/cometml_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log to `Comet <https://www.comet.com/?utm_source=mosaicml&utm_medium=partner&utm_campaign=mosaicml_comet_integration>`_."""
 
 from __future__ import annotations

--- a/composer/loggers/console_logger.py
+++ b/composer/loggers/console_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Logs metrics to the console and without a progress bar."""
 
 from __future__ import annotations

--- a/composer/loggers/file_logger.py
+++ b/composer/loggers/file_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Logs to a file."""
 
 from __future__ import annotations

--- a/composer/loggers/in_memory_logger.py
+++ b/composer/loggers/in_memory_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Logs metrics to dictionary objects that persist in memory throughout training.
 
 Useful for collecting and plotting data inside notebooks.

--- a/composer/loggers/logger.py
+++ b/composer/loggers/logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Base classes, functions, and variables for logger."""
 
 from __future__ import annotations

--- a/composer/loggers/logger_destination.py
+++ b/composer/loggers/logger_destination.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Base class for logger callback."""
 
 from __future__ import annotations

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log to `MLflow <https://www.mlflow.org/docs/latest/index.html>."""
 
 from __future__ import annotations

--- a/composer/loggers/mosaicml_logger.py
+++ b/composer/loggers/mosaicml_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log to Mosaic AI Training."""
 
 from __future__ import annotations

--- a/composer/loggers/neptune_logger.py
+++ b/composer/loggers/neptune_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log training metadata to [neptune.ai](https://neptune.ai/)."""
 
 __all__ = ['NeptuneLogger']

--- a/composer/loggers/progress_bar_logger.py
+++ b/composer/loggers/progress_bar_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Logs metrics to the console and show a progress bar."""
 
 from __future__ import annotations

--- a/composer/loggers/remote_uploader_downloader.py
+++ b/composer/loggers/remote_uploader_downloader.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log files to an object store."""
 
 from __future__ import annotations

--- a/composer/loggers/slack_logger.py
+++ b/composer/loggers/slack_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log metrics to slack, using Slack postMessage api."""
 
 from __future__ import annotations

--- a/composer/loggers/tensorboard_logger.py
+++ b/composer/loggers/tensorboard_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log to `Tensorboard <https://www.tensorflow.org/tensorboard/>`_."""
 
 from pathlib import Path

--- a/composer/loggers/wandb_logger.py
+++ b/composer/loggers/wandb_logger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Log to `Weights and Biases <https://wandb.ai/>`_."""
 
 from __future__ import annotations

--- a/composer/loss/__init__.py
+++ b/composer/loss/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A collection of custom loss functions and loss function related utilities."""
 
 from composer.loss.loss import DiceLoss, binary_cross_entropy_with_logits, loss_registry, soft_cross_entropy

--- a/composer/loss/loss.py
+++ b/composer/loss/loss.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Custom loss functions."""
 
 from __future__ import annotations

--- a/composer/loss/utils.py
+++ b/composer/loss/utils.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Loss-related utilities."""
 
 from __future__ import annotations

--- a/composer/metrics/__init__.py
+++ b/composer/metrics/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A collection of common torchmetrics."""
 
 from composer.metrics.map import MAP

--- a/composer/metrics/map.py
+++ b/composer/metrics/map.py
@@ -6,7 +6,6 @@
 # Relevant issues:
 # https://github.com/Lightning-AI/metrics/issues/1024
 # https://github.com/Lightning-AI/metrics/issues/1164
-
 """MAP torchmetric for object detection."""
 #type: ignore
 import logging

--- a/composer/metrics/metrics.py
+++ b/composer/metrics/metrics.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A collection of common torchmetrics."""
 from __future__ import annotations
 

--- a/composer/metrics/nlp.py
+++ b/composer/metrics/nlp.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A collection of common torchmetrics for NLP tasks."""
 
 import logging

--- a/composer/models/__init__.py
+++ b/composer/models/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The models module contains the :class:`.ComposerModel` base class along with reference
 implementations of many common models. Additionally, it includes task-specific convenience
 :class:`.ComposerModel`\\s that wrap existing Pytorch models with standard forward passes

--- a/composer/models/base.py
+++ b/composer/models/base.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """The ComposerModel base interface."""
 from __future__ import annotations
 

--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A wrapper class that converts 🤗 Transformers models to composer models"""
 
 from __future__ import annotations

--- a/composer/models/initializers.py
+++ b/composer/models/initializers.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Module Initializers."""
 
 from typing import Callable

--- a/composer/models/tasks/__init__.py
+++ b/composer/models/tasks/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Model tasks are ComposerModels with forward passes and logging built-in for many common deep learning tasks."""
 
 from composer.models.tasks.classification import ComposerClassifier as ComposerClassifier

--- a/composer/models/tasks/classification.py
+++ b/composer/models/tasks/classification.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """A convenience class that creates a :class:`.ComposerModel` for classification tasks from a vanilla PyTorch model.
 
 :class:`.ComposerClassifier` requires batches in the form: (``input``, ``target``) and includes a basic

--- a/composer/optim/__init__.py
+++ b/composer/optim/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Optimizers and learning rate schedulers.
 
 Composer is compatible with optimizers based off of PyTorch's native :class:`~torch.optim.Optimizer` API, and common

--- a/composer/optim/decoupled_weight_decay.py
+++ b/composer/optim/decoupled_weight_decay.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Optimizers with weight decay decoupled from the learning rate.
 
 These optimizers are based off of `Decoupled Weight Decay Regularization <https://arxiv.org/abs/1711.05101>`_, which

--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Stateless learning rate schedulers.
 
 Stateless schedulers solve some of the problems associated with PyTorch's built-in schedulers provided in

--- a/composer/profiler/__init__.py
+++ b/composer/profiler/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Performance profiling tools.
 
 The profiler gathers performance metrics during a training run that can be used to diagnose bottlenecks and

--- a/composer/profiler/json_trace_handler.py
+++ b/composer/profiler/json_trace_handler.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Outputs profiling data in JSON trace format."""
 
 from __future__ import annotations

--- a/composer/profiler/json_trace_merger.py
+++ b/composer/profiler/json_trace_merger.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Merge trace files together.
 
 To run:

--- a/composer/profiler/marker.py
+++ b/composer/profiler/marker.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Profiler Marker."""
 
 from __future__ import annotations

--- a/composer/profiler/profiler.py
+++ b/composer/profiler/profiler.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Composer Profiler."""
 
 from __future__ import annotations

--- a/composer/profiler/profiler_action.py
+++ b/composer/profiler/profiler_action.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Action states for the :class:`Profiler` that define whether or not events are being recorded to the trace file."""
 
 from composer.utils import StringEnum

--- a/composer/profiler/profiler_schedule.py
+++ b/composer/profiler/profiler_schedule.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Profiler Schedules."""
 
 from typing import Callable

--- a/composer/profiler/system_profiler.py
+++ b/composer/profiler/system_profiler.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Profiler to record system level metrics."""
 
 from __future__ import annotations

--- a/composer/profiler/torch_profiler.py
+++ b/composer/profiler/torch_profiler.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Profiler to collect :mod:`torch` performance metrics during training."""
 
 from __future__ import annotations

--- a/composer/profiler/trace_handler.py
+++ b/composer/profiler/trace_handler.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Profiler Trace Handler."""
 
 from __future__ import annotations

--- a/composer/profiler/utils.py
+++ b/composer/profiler/utils.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utility functions for torch profiler."""
 
 import importlib.util

--- a/composer/trainer/__init__.py
+++ b/composer/trainer/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Train models with flexible insertion of algorithms."""
 
 from composer.trainer.trainer import Trainer

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Train models."""
 
 from __future__ import annotations

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper utilities."""
 
 from composer.utils.auto_log_hparams import (

--- a/composer/utils/auto_log_hparams.py
+++ b/composer/utils/auto_log_hparams.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Contains helper functions for auto-logging hparams."""
 
 from enum import Enum

--- a/composer/utils/batch_helpers.py
+++ b/composer/utils/batch_helpers.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helpers to get items and set items in a batch."""
 from __future__ import annotations
 

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utilities for working with training checkpoints."""
 
 from __future__ import annotations

--- a/composer/utils/collect_env.py
+++ b/composer/utils/collect_env.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helpers to gather system information for debugging and bug reporting.
 
 Leverages PyTorch's :mod:`torch.utils.collect_env` package to gather pertinent system information.

--- a/composer/utils/compression.py
+++ b/composer/utils/compression.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utilities for creating and loading compressed files."""
 
 import shutil

--- a/composer/utils/device.py
+++ b/composer/utils/device.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Device-related helper methods and utilities."""
 
 from typing import TYPE_CHECKING, Optional, Union

--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper methods for :mod:`torch.distributed`.
 
 To use :mod:`torch.distributed`, launch your training script with the

--- a/composer/utils/eval_client/__init__.py
+++ b/composer/utils/eval_client/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Eval Client base class and implementations."""
 
 from composer.utils.eval_client.eval_client import EvalClient

--- a/composer/utils/eval_client/eval_client.py
+++ b/composer/utils/eval_client/eval_client.py
@@ -3,7 +3,6 @@
 
 # Copyright 2023 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Abstract class for utilities that access and run code on serverless eval clients."""
 
 import abc

--- a/composer/utils/eval_client/lambda_eval_client.py
+++ b/composer/utils/eval_client/lambda_eval_client.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """AWS Lambda compatible eval client."""
 import json
 import logging

--- a/composer/utils/eval_client/local_eval_client.py
+++ b/composer/utils/eval_client/local_eval_client.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Eval client for local evaluation."""
 import logging
 import multiprocessing

--- a/composer/utils/file_helpers.py
+++ b/composer/utils/file_helpers.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helpers for working with files."""
 
 from __future__ import annotations

--- a/composer/utils/fx_utils.py
+++ b/composer/utils/fx_utils.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """FX-based model transformation and optimization.
 
 Provides utilities to do FX-based model transformations.

--- a/composer/utils/import_helpers.py
+++ b/composer/utils/import_helpers.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Dynamically import a Python object (e.g. module, class, function, ...)."""
 
 import importlib

--- a/composer/utils/inference.py
+++ b/composer/utils/inference.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Inference-related utility functions for model export and optimizations.
 
 Used for exporting models into various formats such ONNX, torchscript etc. and apply optimizations such as fusion.

--- a/composer/utils/iter_helpers.py
+++ b/composer/utils/iter_helpers.py
@@ -4,7 +4,6 @@
 # To keep the typing organized for this file, see iter_helpers.pyi
 # All typing annotations are in there
 # All methods signatures must be defined in there.
-
 """Utilities for iterating over collections."""
 from __future__ import annotations
 

--- a/composer/utils/misc.py
+++ b/composer/utils/misc.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Miscellaneous Helpers."""
 
 import logging

--- a/composer/utils/module_surgery.py
+++ b/composer/utils/module_surgery.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Modify model architectures.
 
 Algorithms, such as :class:`~composer.algorithms.blurpool.BlurPool`, replace model parameters in-place.

--- a/composer/utils/object_store/__init__.py
+++ b/composer/utils/object_store/__init__.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Object store base class and implementations."""
 
 from composer.utils.object_store.gcs_object_store import GCSObjectStore

--- a/composer/utils/object_store/gcs_object_store.py
+++ b/composer/utils/object_store/gcs_object_store.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Google Cloud SDK - Compatible object store."""
 
 from __future__ import annotations

--- a/composer/utils/object_store/libcloud_object_store.py
+++ b/composer/utils/object_store/libcloud_object_store.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utility for uploading to and downloading from cloud object stores."""
 import io
 import os

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """MLflow Artifacts object store."""
 
 from __future__ import annotations

--- a/composer/utils/object_store/object_store.py
+++ b/composer/utils/object_store/object_store.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Abstract class for utilities that upload to and download from object stores."""
 
 import abc

--- a/composer/utils/object_store/oci_object_store.py
+++ b/composer/utils/object_store/oci_object_store.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """OCI-Compatible object store."""
 
 from __future__ import annotations

--- a/composer/utils/object_store/s3_object_store.py
+++ b/composer/utils/object_store/s3_object_store.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """S3-Compatible object store."""
 
 from __future__ import annotations

--- a/composer/utils/object_store/sftp_object_store.py
+++ b/composer/utils/object_store/sftp_object_store.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utility for uploading to and downloading from cloud object stores."""
 
 from __future__ import annotations

--- a/composer/utils/object_store/uc_object_store.py
+++ b/composer/utils/object_store/uc_object_store.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Databricks Unity Catalog Volumes object store."""
 
 from __future__ import annotations

--- a/composer/utils/object_store/utils.py
+++ b/composer/utils/object_store/utils.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helpers for working with object stores."""
 
 from typing import Any

--- a/composer/utils/parallelism.py
+++ b/composer/utils/parallelism.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Parallelism configs."""
 
 import warnings

--- a/composer/utils/remote_uploader.py
+++ b/composer/utils/remote_uploader.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Util class to upload file."""
 
 import logging

--- a/composer/utils/reproducibility.py
+++ b/composer/utils/reproducibility.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper utilities for configuring deterministic training to ensure reproducibility.
 
 .. note::

--- a/composer/utils/retrying.py
+++ b/composer/utils/retrying.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Retry helper."""
 
 from __future__ import annotations

--- a/composer/utils/string_enum.py
+++ b/composer/utils/string_enum.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Base class for Enums containing string values."""
 from __future__ import annotations
 

--- a/composer/utils/warnings.py
+++ b/composer/utils/warnings.py
@@ -1,6 +1,5 @@
 # Copyright 2024 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Utilities for warnings."""
 
 __all__ = ['VersionedDeprecationWarning']

--- a/docker/generate_build_matrix.py
+++ b/docker/generate_build_matrix.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper script to generate the ``build_matrix.yaml`` and update ``README.md``.
 
 Note: this script requires tabulate. Run ``pip install tabulate`` if not installed

--- a/docker/pillow_stub/setup.py
+++ b/docker/pillow_stub/setup.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Setup script for the stub pillow."""
 
 import os

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Configuration file for the Sphinx documentation builder.
 
 This file only contains a selection of the most common options. For a full

--- a/docs/source/doctest_cleanup.py
+++ b/docs/source/doctest_cleanup.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Cleanup script that is executed at the end of each doctest."""
 
 import os

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -3,7 +3,6 @@
 
 # disabling general type issues because of monkeypatching
 # pyright: reportGeneralTypeIssues=none
-
 """Fixtures available in doctests.
 
 The script is run before any doctests are executed,

--- a/docs/source/tables/__init__.py
+++ b/docs/source/tables/__init__.py
@@ -1,4 +1,3 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Table helpers for composer docs."""

--- a/docs/source/tables/generate_cost_graphs.py
+++ b/docs/source/tables/generate_cost_graphs.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Script to generate graphs for repo README.md.
 
 After generating images, upload to public hosting and update the README URLs.

--- a/docs/source/tables/update_alg_tables.py
+++ b/docs/source/tables/update_alg_tables.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper function to generate the README table."""
 import json
 import os

--- a/docs/source/tables/update_methods_overview.py
+++ b/docs/source/tables/update_methods_overview.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper function to generate the method overview rst."""
 import json
 import os

--- a/docs/source/tables/update_model_tables.py
+++ b/docs/source/tables/update_model_tables.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper function to generate the README table."""
 import os
 from pathlib import Path

--- a/docs/source/tables/utils.py
+++ b/docs/source/tables/utils.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Helper functions for auto-generating tables from metadata."""
 import importlib
 import os

--- a/examples/checkpoint_with_wandb.py
+++ b/examples/checkpoint_with_wandb.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Save and Load Checkpoints with `Weights and Biases <https://wandb.ai/>`."""
 
 import shutil

--- a/examples/custom_models.py
+++ b/examples/custom_models.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Example for training with an algorithm on a custom model."""
 
 import torch

--- a/examples/gyro_dropout_example.py
+++ b/examples/gyro_dropout_example.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Written by Gihyun Park, Junyeol Lee, and Jiwon Seo
-
 """Example for training with an algorithm on a custom model."""
 
 import torch

--- a/examples/profiler_demo.py
+++ b/examples/profiler_demo.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Profiling Example.
 
 For a walk-through of this example, please see the `profiling guide</trainer/performance_tutorials/profiling>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,7 +250,7 @@ blank_lines_around_top_level_definition = 2
 blank_line_before_class_docstring = false
 
 # Insert a blank line before a module docstring.
-blank_line_before_module_docstring = true
+blank_line_before_module_docstring = false
 
 # Insert a blank line before a 'def' or 'class' immediately nested
 # within another 'def' or 'class'. For example:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Composer package setup."""
 
 import os

--- a/tests/algorithms/algorithm_settings.py
+++ b/tests/algorithms/algorithm_settings.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """This file provides the canonical settings (dataset, model, algorithms, arguments)
 for each algorithm to be tested. This can be used throughout the codebase for
 functional tests, serialization tests, etc.

--- a/tests/algorithms/test_blurpool.py
+++ b/tests/algorithms/test_blurpool.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Test the blurpool algorithm.
 
 Primitives are tested in test_blurpool.py

--- a/tests/algorithms/test_ghost_batchnorm.py
+++ b/tests/algorithms/test_ghost_batchnorm.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Test Ghost Batch Normalization, both as an algorithm and module."""
 
 import contextlib

--- a/tests/algorithms/test_torch_export.py
+++ b/tests/algorithms/test_torch_export.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """
 Tests a variety of export options with our surgery methods applied, including
 torchscript, torch.fx, and ONNX.

--- a/tests/callbacks/test_inference.py
+++ b/tests/callbacks/test_inference.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """
 Test inference APIs.
 """

--- a/tests/common/markers.py
+++ b/tests/common/markers.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Pytest marker helpers."""
 
 from typing import Callable

--- a/tests/common/models.py
+++ b/tests/common/models.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Contains commonly used models that are shared across the test suite."""
 import copy
 from functools import partial

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """These fixtures are shared globally across the test suite."""
 import copy
 import hashlib

--- a/tests/trainer/test_activation_checkpointing.py
+++ b/tests/trainer/test_activation_checkpointing.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """Test activation checkpointing and offloading. Note that currently, this is only testing support for FSDP2 + activation checkpointing/offloading."""
 
 import pytest

--- a/tests/utils/test_inference.py
+++ b/tests/utils/test_inference.py
@@ -1,6 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
-
 """
 Test inference APIs.
 """


### PR DESCRIPTION
# What does this PR do?

Changes yapf rule to be consistent with changes in llm-foundry. This is meant to unblock the use of docformatter with python3.12 (which is not actually used in composer, but is used in foundry).

# What issue(s) does this change relate to?

This change is similar to that in llm-foundry https://github.com/mosaicml/llm-foundry/pull/1825

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
