### PR TITLE
Removed most s3 bucket based tests (replaced with UC Volumes)

### DIFF
--- a/composer/utils/reproducibility.py
+++ b/composer/utils/reproducibility.py
@@ -232,16 +232,6 @@ def load_rng_state(rng_state_dicts: list[dict[str, Any]]):
         log.debug('Restoring the RNG state')
 
         if is_cuda_available and has_cuda_rng_state:
-            # PyTorch 2.6 strictly enforces the size of the state dict values vs the size in the checkpoint.
-            # PyTorch 2.1 has moved to a RNG of size 16 instead of 816
-            # Therefore, errors occur if we load a ckpt at or after 2.6 if the ckpt was saved before 2.1.
-            # To avoid this, we zero out the CUDA RNG state if the size is incorrect.
-            if rng_state_dict['cuda'].shape[0] != 16:
-                warnings.warn(
-                    'The CUDA RNG state was saved with a different version of PyTorch than the current version.'
-                    'CUDA RNG state will be zeroed out instead.',
-                )
-                rng_state_dict['cuda'] = torch.zeros(16, dtype=torch.uint8)
             try:
                 torch.cuda.set_rng_state(rng_state_dict['cuda'])
             except RuntimeError as e:

--- a/tests/fixtures/fixtures.py
+++ b/tests/fixtures/fixtures.py
@@ -132,11 +132,22 @@ def s3_read_only_prefix():
 
 
 @pytest.fixture
-def uc_volume_path(request: pytest.FixtureRequest):
+def uc_volume_read_only(request: pytest.FixtureRequest):
     if request.node.get_closest_marker('remote') is None:
         return 'my-volume'
     else:
-        return os.environ.get('UC_VOLUME_PATH', 'Volumes/main/regression_testing/composer_artifacts/')
+        return os.environ.get(
+            'UC_VOLUME_READ_ONLY_PATH',
+            'Volumes/main/regression_testing/composer_artifacts/read_only',
+        )
+
+
+@pytest.fixture
+def uc_volume_ephemeral(request: pytest.FixtureRequest):
+    if request.node.get_closest_marker('remote') is None:
+        return 'my-volume'
+    else:
+        return os.environ.get('UC_VOLUME_EPHEMERAL_PATH', 'Volumes/main/regression_testing/composer_ephemeral')
 
 
 ## MODEL HELPERS ##

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -106,6 +106,7 @@ def modify_cell_source(tb: TestbookNotebookClient, notebook_name: str, cell_sour
 @pytest.mark.parametrize('notebook', NOTEBOOKS)
 @pytest.mark.gpu
 @pytest.mark.remote
+@device('cpu','gpu')
 def test_notebook(notebook: str, device: str, uc_volume_read_only: str):
     trainer_monkeypatch_code = inspect.getsource(patch_notebooks)
     notebook_name = os.path.split(notebook)[-1][:-len('.ipynb')]

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,7 +4,6 @@
 import glob
 import inspect
 import os
-from urllib.parse import urlparse
 
 import importlib_metadata
 import pytest
@@ -12,7 +11,7 @@ import testbook
 from testbook.client import TestbookNotebookClient
 
 import composer
-from composer.utils.import_helpers import MissingConditionalImportError
+from composer.utils.object_store.uc_object_store import UCObjectStore
 from tests.common import device
 
 nb_root = os.path.join(os.path.dirname(composer.__file__), '..', 'examples')
@@ -64,7 +63,7 @@ def patch_notebooks():
     DataLoader.__iter__ = new_iter  # type: ignore  # error: DataLoader has a stricter return type than islice
 
 
-def modify_cell_source(tb: TestbookNotebookClient, notebook_name: str, cell_source: str, s3_bucket: str) -> str:
+def modify_cell_source(tb: TestbookNotebookClient, notebook_name: str, cell_source: str) -> str:
     # This function is called before each cell is executed
     if notebook_name == 'functional_api':
         # avoid div by 0 errors with batch size of 1
@@ -105,9 +104,9 @@ def modify_cell_source(tb: TestbookNotebookClient, notebook_name: str, cell_sour
 
 
 @pytest.mark.parametrize('notebook', NOTEBOOKS)
-@device('cpu', 'gpu')
-@pytest.mark.daily
-def test_notebook(notebook: str, device: str, s3_bucket: str):
+@pytest.mark.gpu
+@pytest.mark.remote
+def test_notebook(notebook: str, device: str, uc_volume_read_only: str):
     trainer_monkeypatch_code = inspect.getsource(patch_notebooks)
     notebook_name = os.path.split(notebook)[-1][:-len('.ipynb')]
 
@@ -136,22 +135,18 @@ def test_notebook(notebook: str, device: str, s3_bucket: str):
     if notebook_name == 'exporting_for_inference':
         pytest.skip('MNIST dataset download is flaky')
 
-    try:
-        import boto3
-    except ImportError as e:
-        raise MissingConditionalImportError('streaming', 'boto3') from e
+    # Download CIFAR-10 data from UC Volumes
+    path_to_volume_root = f'{uc_volume_read_only}'.replace('read_only', '')
+    uc_store = UCObjectStore(path_to_volume_root)
+    files = uc_store.list_objects(prefix='read_only/CIFAR-10')
 
-    obj = urlparse('s3://mosaicml-internal-integration-testing/read_only/CIFAR-10/')
-    s3 = boto3.resource('s3')
-    bucket = s3.Bucket(obj.netloc)  # pyright: ignore[reportGeneralTypeIssues]
-    files = bucket.objects.filter(Prefix=obj.path.lstrip('/'))
-    for file in files:
-        target = os.path.join(os.getcwd(), 'data', os.path.relpath(file.key, obj.path.lstrip('/')))
-        if not os.path.exists(target):
-            os.makedirs(os.path.dirname(target), exist_ok=True)
-        if file.key[-1] == '/':
+    for file_path in files:
+        file_relative_path = file_path[len(f'/{path_to_volume_root}'):]
+        target = os.path.join(os.getcwd(), 'data', file_relative_path[len('read_only/CIFAR-10/'):])
+        if os.path.exists(target):
             continue
-        bucket.download_file(file.key, target)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        uc_store.download_object(file_relative_path, target)
 
     with testbook.testbook(notebook) as tb:
         tb.inject(trainer_monkeypatch_code)
@@ -163,6 +158,5 @@ def test_notebook(notebook: str, device: str, s3_bucket: str):
                 tb,
                 notebook_name=notebook_name,
                 cell_source=cell['source'],
-                s3_bucket=s3_bucket,
             )
             tb.execute_cell(i)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -106,7 +106,7 @@ def modify_cell_source(tb: TestbookNotebookClient, notebook_name: str, cell_sour
 @pytest.mark.parametrize('notebook', NOTEBOOKS)
 @pytest.mark.gpu
 @pytest.mark.remote
-@device('cpu','gpu')
+@device('cpu', 'gpu')
 def test_notebook(notebook: str, device: str, uc_volume_read_only: str):
     trainer_monkeypatch_code = inspect.getsource(patch_notebooks)
     notebook_name = os.path.split(notebook)[-1][:-len('.ipynb')]

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1163,9 +1163,9 @@ class TestCheckpointLoading:
         ],
     )
     @pytest.mark.filterwarnings('ignore:.*The checkpoint included CUDA RNG state.*')
+    @pytest.mark.filterwarnings('ignore:.*The CUDA RNG state was saved with a different version of PyTorch.*')
     def test_load_remote_checkpoint(
         self,
-        device,
         tmp_path: pathlib.Path,
         load_weights_only,
         remote_checkpoint_uri,
@@ -1173,6 +1173,7 @@ class TestCheckpointLoading:
         continue_training_dur,
         final_checkpoint_name,
         uc_volume_read_only,
+        device='cpu',
     ):
         """
         This test checks if our checkpointing is backwards compatible.

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1237,8 +1237,8 @@ class TestCheckpointLoading:
         _assert_checkpoints_equivalent(
             os.path.join('third', final_checkpoint_name),
             os.path.join('second', final_checkpoint_name),
-            rtol=1e-7,
-            atol=1e-7,
+            rtol=1e-4,
+            atol=1e-4,
         )
 
     def _stateful_callbacks_equal(self, callbacks1, callbacks2):

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -711,9 +711,17 @@ class TestCheckpointLoading:
         for p1, p2 in zip(m1.parameters(), m2.parameters()):
             torch.testing.assert_close(p1, p2)
 
-    def _metrics_equal(self, train_metrics_1, train_metrics_2, eval_metrics_1, eval_metrics_2, eval_tolerance=1e-7):
+    def _metrics_equal(
+        self,
+        train_metrics_1,
+        train_metrics_2,
+        eval_metrics_1,
+        eval_metrics_2,
+        train_tolerance=1e-8,
+        eval_tolerance=1e-7
+    ):
         try:
-            deep_compare(train_metrics_1, train_metrics_2, atol=1e-8, rtol=1e-8)
+            deep_compare(train_metrics_1, train_metrics_2, atol=train_tolerance, rtol=train_tolerance)
             deep_compare(eval_metrics_1, eval_metrics_2, atol=eval_tolerance, rtol=eval_tolerance)
             return True
         except AssertionError:
@@ -1163,7 +1171,7 @@ class TestCheckpointLoading:
         ],
     )
     @pytest.mark.filterwarnings('ignore:.*The checkpoint included CUDA RNG state.*')
-    @pytest.mark.filterwarnings('ignore:.*The CUDA RNG state was saved with a different version of PyTorch.*')
+    @pytest.mark.filterwarnings('ignore:.*The CUDA RNG state could not be loaded from the checkpoint.*')
     def test_load_remote_checkpoint(
         self,
         tmp_path: pathlib.Path,
@@ -1210,7 +1218,7 @@ class TestCheckpointLoading:
             trainer_2.state.train_metrics,
             trainer_1.state.eval_metrics,
             trainer_2.state.eval_metrics,
-            eval_tolerance=1e-4,  # TODO: Figure out why only CrossEntropyLoss is off
+            eval_tolerance=1e-4,
         )
 
         if load_weights_only:
@@ -1237,8 +1245,8 @@ class TestCheckpointLoading:
         _assert_checkpoints_equivalent(
             os.path.join('third', final_checkpoint_name),
             os.path.join('second', final_checkpoint_name),
-            rtol=1e-4,
-            atol=1e-4,
+            rtol=1e-7,
+            atol=1e-7,
         )
 
     def _stateful_callbacks_equal(self, callbacks1, callbacks2):

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1210,7 +1210,7 @@ class TestCheckpointLoading:
             trainer_2.state.train_metrics,
             trainer_1.state.eval_metrics,
             trainer_2.state.eval_metrics,
-            eval_tolerance=1e-4, # TODO: Figure out why only CrossEntropyLoss is off
+            eval_tolerance=1e-4,  # TODO: Figure out why only CrossEntropyLoss is off
         )
 
         if load_weights_only:

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -718,7 +718,7 @@ class TestCheckpointLoading:
         eval_metrics_1,
         eval_metrics_2,
         train_tolerance=1e-8,
-        eval_tolerance=1e-7
+        eval_tolerance=1e-7,
     ):
         try:
             deep_compare(train_metrics_1, train_metrics_2, atol=train_tolerance, rtol=train_tolerance)

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1154,7 +1154,7 @@ class TestCheckpointLoading:
             deep_compare(trainer_1_rng_state, trainer_2._rng_state)
 
     @pytest.mark.remote
-    @device('cpu')
+    @pytest.mark.gpu
     @pytest.mark.parametrize('load_weights_only', [True, False])
     @pytest.mark.parametrize(
         'remote_checkpoint_uri, remote_checkpoint_name, continue_training_dur, final_checkpoint_name',
@@ -1172,8 +1172,7 @@ class TestCheckpointLoading:
         remote_checkpoint_name,
         continue_training_dur,
         final_checkpoint_name,
-        s3_bucket,
-        s3_read_only_prefix,
+        uc_volume_read_only,
     ):
         """
         This test checks if our checkpointing is backwards compatible.
@@ -1189,7 +1188,7 @@ class TestCheckpointLoading:
         trainer_2 = self.get_trainer(
             max_duration=continue_training_dur,
             save_folder='second',
-            load_path=f's3://{s3_bucket}/{s3_read_only_prefix}/{remote_checkpoint_uri}',
+            load_path=os.path.join(f'dbfs:/{uc_volume_read_only}', remote_checkpoint_uri),
             load_weights_only=load_weights_only,
             load_strict_model_weights=load_weights_only,
             device=device,

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1155,6 +1155,7 @@ class TestCheckpointLoading:
 
     @pytest.mark.remote
     @pytest.mark.gpu
+    @device('cpu')
     @pytest.mark.parametrize('load_weights_only', [True, False])
     @pytest.mark.parametrize(
         'remote_checkpoint_uri, remote_checkpoint_name, continue_training_dur, final_checkpoint_name',
@@ -1166,6 +1167,7 @@ class TestCheckpointLoading:
     @pytest.mark.filterwarnings('ignore:.*The CUDA RNG state was saved with a different version of PyTorch.*')
     def test_load_remote_checkpoint(
         self,
+        device,
         tmp_path: pathlib.Path,
         load_weights_only,
         remote_checkpoint_uri,
@@ -1173,7 +1175,6 @@ class TestCheckpointLoading:
         continue_training_dur,
         final_checkpoint_name,
         uc_volume_read_only,
-        device='cpu',
     ):
         """
         This test checks if our checkpointing is backwards compatible.

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -711,18 +711,10 @@ class TestCheckpointLoading:
         for p1, p2 in zip(m1.parameters(), m2.parameters()):
             torch.testing.assert_close(p1, p2)
 
-    def _metrics_equal(
-        self,
-        train_metrics_1,
-        train_metrics_2,
-        eval_metrics_1,
-        eval_metrics_2,
-        train_tolerance=1e-8,
-        eval_tolerance=1e-7,
-    ):
+    def _metrics_equal(self, train_metrics_1, train_metrics_2, eval_metrics_1, eval_metrics_2):
         try:
-            deep_compare(train_metrics_1, train_metrics_2, atol=train_tolerance, rtol=train_tolerance)
-            deep_compare(eval_metrics_1, eval_metrics_2, atol=eval_tolerance, rtol=eval_tolerance)
+            deep_compare(train_metrics_1, train_metrics_2, atol=1e-8, rtol=1e-8)
+            deep_compare(eval_metrics_1, eval_metrics_2, atol=1e-7, rtol=1e-7)
             return True
         except AssertionError:
             return False
@@ -1167,7 +1159,7 @@ class TestCheckpointLoading:
     @pytest.mark.parametrize(
         'remote_checkpoint_uri, remote_checkpoint_name, continue_training_dur, final_checkpoint_name',
         [
-            ['backwards_compatibility/trained_ckpt_cpu_ep2.pt', 'ep2.pt', '3ep', 'ep3.pt'],
+            ['backwards_compatibility/trained_ckpt_gpu_ep2.pt', 'ep2.pt', '3ep', 'ep3.pt'],
         ],
     )
     @pytest.mark.filterwarnings('ignore:.*The checkpoint included CUDA RNG state.*')
@@ -1218,7 +1210,6 @@ class TestCheckpointLoading:
             trainer_2.state.train_metrics,
             trainer_1.state.eval_metrics,
             trainer_2.state.eval_metrics,
-            eval_tolerance=1e-4,
         )
 
         if load_weights_only:

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 import torch.distributed
+from packaging import version
 from pytest import MonkeyPatch
 from torch.utils.data import DataLoader, Dataset, DistributedSampler
 
@@ -1157,9 +1158,9 @@ class TestCheckpointLoading:
     @pytest.mark.gpu
     @pytest.mark.parametrize('load_weights_only', [True, False])
     @pytest.mark.parametrize(
-        'remote_checkpoint_uri, remote_checkpoint_name, continue_training_dur, final_checkpoint_name',
+        'remote_checkpoint_name, continue_training_dur, final_checkpoint_name',
         [
-            ['backwards_compatibility/trained_ckpt_gpu_ep2.pt', 'ep2.pt', '3ep', 'ep3.pt'],
+            ['ep2.pt', '3ep', 'ep3.pt'],
         ],
     )
     @pytest.mark.filterwarnings('ignore:.*The checkpoint included CUDA RNG state.*')
@@ -1168,7 +1169,6 @@ class TestCheckpointLoading:
         self,
         tmp_path: pathlib.Path,
         load_weights_only,
-        remote_checkpoint_uri,
         remote_checkpoint_name,
         continue_training_dur,
         final_checkpoint_name,
@@ -1180,8 +1180,16 @@ class TestCheckpointLoading:
         We should be able to load in a saved checkpoint and continue training.
         The checkpoint weight and metrics should match at load time
         and should be equivalent after training continues.
-        Checkpoint saved using: Composer 0.13.5 with default dependencies.
         """
+        # TODO: We have separate checkpoints saved for 2.6 vs 2.7. If the version of torch
+        # is 2.7 or higher, we should use the 2.7 checkpoint. If we upgrade to torch 2.8+,
+        # and this checkpoint fails, we need to think of a better solution or root cause this
+        # further (one possible resolution is just reducing the tolerances to 1e-4)
+        if version.parse(torch.__version__) < version.parse('2.7.0'):
+            remote_checkpoint_uri = 'backwards_compatibility/trained_ckpt_gpu_ep2_2_6.pt'
+        else:
+            remote_checkpoint_uri = 'backwards_compatibility/trained_ckpt_gpu_ep2.pt'
+
         trainer_1 = self.get_trainer(save_folder='first', device=device)
         trainer_1.fit()
         trainer_1.close()

--- a/tests/trainer/test_checkpoint.py
+++ b/tests/trainer/test_checkpoint.py
@@ -1164,7 +1164,6 @@ class TestCheckpointLoading:
         ],
     )
     @pytest.mark.filterwarnings('ignore:.*The checkpoint included CUDA RNG state.*')
-    @pytest.mark.filterwarnings('ignore:.*The CUDA RNG state could not be loaded from the checkpoint.*')
     def test_load_remote_checkpoint(
         self,
         tmp_path: pathlib.Path,

--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -525,7 +525,6 @@ def test_fsdp_mixed_with_sync(
 @pytest.mark.filterwarnings(r'ignore:.*The CUDA RNG state could not be loaded.*:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:.*ShardedTensor.to only move tensor to its current device.*:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:.*\(TP\) is experimental.*:FutureWarning')
-@pytest.mark.filterwarnings(r'ignore:.*The CUDA RNG state was saved with a different version of PyTorch.*')
 def test_fsdp_load_old_checkpoint(
     world_size,
     tmp_path: pathlib.Path,

--- a/tests/trainer/test_fsdp_checkpoint.py
+++ b/tests/trainer/test_fsdp_checkpoint.py
@@ -525,6 +525,7 @@ def test_fsdp_mixed_with_sync(
 @pytest.mark.filterwarnings(r'ignore:.*The CUDA RNG state could not be loaded.*:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:.*ShardedTensor.to only move tensor to its current device.*:UserWarning')
 @pytest.mark.filterwarnings(r'ignore:.*\(TP\) is experimental.*:FutureWarning')
+@pytest.mark.filterwarnings(r'ignore:.*The CUDA RNG state was saved with a different version of PyTorch.*')
 def test_fsdp_load_old_checkpoint(
     world_size,
     tmp_path: pathlib.Path,


### PR DESCRIPTION
# What does this PR do?

Essentially, all usages of `s3_bucket` has been removed outside of `test_object_store.py` and `test_s3_object_store.py` since we have the ephemeral and read_only paths in UC Volumes now.