### PR TITLE
Fix Typos in Comments for activation_monitor.py and mlperf.py

### DIFF
--- a/composer/callbacks/activation_monitor.py
+++ b/composer/callbacks/activation_monitor.py
@@ -199,7 +199,7 @@ class ActivationMonitor(Callback):
             logger.log_metrics(metrics)
 
     def recursively_add_metrics(self, metrics: dict, name: str, suffix: str, values: Any):
-        # Becuase of the recursive diving, we need this call to prevent infinite recursion.
+        # Because of the recursive diving, we need this call to prevent infinite recursion.
         if isinstance(values, str):
             return
         # Keep recursively diving if the value is a sequence

--- a/composer/callbacks/mlperf.py
+++ b/composer/callbacks/mlperf.py
@@ -186,7 +186,7 @@ class MLPerfCallback(Callback):
         self.success = False
 
     def init(self, state: State, logger: Logger) -> None:
-        # setup here requies access to rank, which is only available after
+        # setup here requires access to rank, which is only available after
         # the trainer is initialized
         if _local_rank_zero():
             self._create_submission_folders(self.root_folder, self.system_name, self.benchmark)


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in comments within two files:
- composer/callbacks/activation_monitor.py: Fixes the spelling of "Because" in a comment explaining the need to prevent infinite recursion.
- composer/callbacks/mlperf.py: Fixes the spelling of "requires" in a comment about setup requirements for rank access.

No functional code changes are included; only comment text has been updated for clarity and correctness.