### PR TITLE
Mlflow move to cpu

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -426,22 +426,24 @@ class MLFlowLogger(LoggerDestination):
         for k, v in metrics.items():
             if any(fnmatch.fnmatch(k, pattern) for pattern in self.ignore_metrics):
                 continue
+
+            v_float = float(v)
             if k in self._metrics_cache:
                 value, last_step = self._metrics_cache[k]
-                if value == v and step < last_step + self.log_duplicated_metric_every_n_steps:
+                if value == v_float and step < last_step + self.log_duplicated_metric_every_n_steps:
                     # Skip logging the metric if it has the same value as the last step and it's
                     # within the step window.
                     continue
                 else:
                     # Log the metric if it has a different value or it's outside the step window,
                     # and update the metrics cache.
-                    self._metrics_cache[k] = (v, step)
-                    metrics_to_log[self.rename(k)] = float(v)
+                    self._metrics_cache[k] = (v_float, step)
+                    metrics_to_log[self.rename(k)] = v_float
             else:
                 # Log the metric if it's the first time it's being logged, and update the metrics
                 # cache.
-                self._metrics_cache[k] = (v, step)
-                metrics_to_log[self.rename(k)] = float(v)
+                self._metrics_cache[k] = (v_float, step)
+                metrics_to_log[self.rename(k)] = v_float
 
         log_metrics(
             metrics=metrics_to_log,

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -408,6 +408,13 @@ class MLFlowLogger(LoggerDestination):
     def rename(self, key: str):
         return self.rename_metrics.get(key, key)
 
+    def move_metrics_cache_to_cpu(self):
+        """Move the metrics cache to CPU."""
+        if self._enabled:
+            for k, v in self._metrics_cache.items():
+                if isinstance(v[0], torch.Tensor):
+                    self._metrics_cache[k] = (v[0].cpu(), v[1])
+
     def log_metrics(self, metrics: dict[str, Any], step: Optional[int] = None) -> None:
         from mlflow import log_metrics
 

--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -408,13 +408,6 @@ class MLFlowLogger(LoggerDestination):
     def rename(self, key: str):
         return self.rename_metrics.get(key, key)
 
-    def move_metrics_cache_to_cpu(self):
-        """Move the metrics cache to CPU."""
-        if self._enabled:
-            for k, v in self._metrics_cache.items():
-                if isinstance(v[0], torch.Tensor):
-                    self._metrics_cache[k] = (v[0].cpu(), v[1])
-
     def log_metrics(self, metrics: dict[str, Any], step: Optional[int] = None) -> None:
         from mlflow import log_metrics
 

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -46,6 +46,24 @@ def _get_latest_mlflow_run(experiment_name, tracking_uri=None):
         raise ValueError(f'Experiment with name {experiment_name} is unexpectedly empty')
 
 
+@pytest.mark.gpu
+def test_metrics_cache_cpu(
+    tmp_path: Path,
+):
+    logger = MLFlowLogger(
+        tracking_uri=tmp_path / Path('my-test-mlflow-uri'),
+    )
+
+    metric_tensor = torch.tensor(1.0, device='cuda')
+    metrics_dict = {'test_metric': metric_tensor}
+
+    logger.log_metrics(metrics_dict)
+
+    for v in logger._metrics_cache.values():
+        for item in v:
+            assert not isinstance(item, torch.Tensor)
+
+
 def test_mlflow_init_unspecified(monkeypatch):
     """ Test that MLFlow experiment is set up correctly when no parameters are specified
 

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-import torch
 import yaml
 from torch.utils.data import DataLoader
 
@@ -45,29 +44,6 @@ def _get_latest_mlflow_run(experiment_name, tracking_uri=None):
         return first_run_or_empty[0]
     else:
         raise ValueError(f'Experiment with name {experiment_name} is unexpectedly empty')
-
-
-@pytest.mark.gpu
-def test_move_metrics_cache_to_cpu(
-    tmp_path: Path,
-):
-    logger = MLFlowLogger(
-        tracking_uri=tmp_path / Path('my-test-mlflow-uri'),
-    )
-
-    metric_tensor = torch.tensor(1.0, device='cuda')
-    metrics_dict = {'test_metric': metric_tensor}
-
-    logger.log_metrics(metrics_dict)
-
-    # Tensor is expected to be on GPU intially
-    assert logger._metrics_cache['test_metric'][0].device.type == 'cuda'
-
-    # Move the logger's metrics to CPU
-    logger.move_metrics_cache_to_cpu()
-
-    # Check that the tensor is now on CPU
-    assert logger._metrics_cache['test_metric'][0].device.type == 'cpu'
 
 
 def test_mlflow_init_unspecified(monkeypatch):

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+import torch
 import yaml
 from torch.utils.data import DataLoader
 


### PR DESCRIPTION
# What does this PR do?
Moves the mlflow logger metrics cache to not keep CUDA tensors around since it doesn't need to. In particular, this allows the logger to be sent to a subprocess, which previously was an issue on some systems when expandable_segments was set to True.

Before (model registration fails): `ipc-register-before-1-ilQ0bO`
After (model registration succeeds): `ipc-register-after-1-WSlNIv`

Metrics and throughput are the same, in case somehow they were affected:
<img width="1198" alt="Screenshot 2025-06-13 at 5 43 47 PM" src="https://github.com/user-attachments/assets/69997751-6b90-490c-bac2-ea3371f9f917" />
<img width="499" alt="Screenshot 2025-06-13 at 5 44 03 PM" src="https://github.com/user-attachments/assets/51d9e298-3646-45bb-8e2e-7c3161dc899f" />

