### PR TITLE
Mixed Precision for FSDP2

### DIFF
--- a/composer/core/state.py
+++ b/composer/core/state.py
@@ -1361,6 +1361,7 @@ class State(Serializable):
                     self.model,
                     self.optimizers[0] if self.optimizers else None,
                     self.fsdp_config,
+                    self.precision,
                 )
             else:
                 raise ValueError(f'Unsupported FSDP config type for monolithic loading: {type(self.fsdp_config)}')

--- a/composer/distributed/fsdp2.py
+++ b/composer/distributed/fsdp2.py
@@ -182,4 +182,5 @@ def sync_module_states(model: nn.Module, full_state_dict: dict) -> None:
 def create_mixed_precision_policy(precision: Precision, mixed_precision: str) -> MixedPrecisionPolicy:
     """Create a MixedPrecisionPolicy based on the precision and mixed_precision."""
     _, param_dtype, reduce_dtype, _ = get_mixed_precision(precision, mixed_precision)
+    print(f"Using mixed precision policy: mixed_precision={mixed_precision}, param_dtype={param_dtype}, reduce_dtype={reduce_dtype}")
     return MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)

--- a/composer/distributed/fsdp2.py
+++ b/composer/distributed/fsdp2.py
@@ -180,5 +180,6 @@ def sync_module_states(model: nn.Module, full_state_dict: dict) -> None:
 
 
 def create_mixed_precision_policy(precision: Precision, mixed_precision: str) -> MixedPrecisionPolicy:
+    """Create a MixedPrecisionPolicy based on the precision and mixed_precision."""
     _, param_dtype, reduce_dtype, _ = get_mixed_precision(precision, mixed_precision)
     return MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)

--- a/composer/distributed/fsdp2.py
+++ b/composer/distributed/fsdp2.py
@@ -12,16 +12,16 @@ from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed.fsdp.wrap import CustomPolicy
 from torch.distributed.tensor import DTensor
 
+from composer.core.precision import Precision, _validate_precision
 from composer.distributed.fsdp2_utils import (
     check_param_tying,
     generate_default_policy,
     get_standalone_and_tied_modules,
     legalize_param_sharing_between_modules,
 )
+from composer.distributed.mosaic_parallelism import get_mixed_precision
 from composer.utils import dist, get_device
 from composer.utils.parallelism import FSDP2Config
-from composer.core.precision import Precision, _validate_precision
-from composer.distributed.mosaic_parallelism import get_mixed_precision
 
 log = logging.getLogger(__name__)
 

--- a/composer/distributed/fsdp2.py
+++ b/composer/distributed/fsdp2.py
@@ -12,7 +12,7 @@ from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 from torch.distributed.fsdp.wrap import CustomPolicy
 from torch.distributed.tensor import DTensor
 
-from composer.core.precision import Precision, _validate_precision
+from composer.core.precision import Precision
 from composer.distributed.fsdp2_utils import (
     check_param_tying,
     generate_default_policy,
@@ -20,7 +20,7 @@ from composer.distributed.fsdp2_utils import (
     legalize_param_sharing_between_modules,
 )
 from composer.distributed.mosaic_parallelism import get_mixed_precision
-from composer.utils import dist, get_device
+from composer.utils import dist
 from composer.utils.parallelism import FSDP2Config
 
 log = logging.getLogger(__name__)
@@ -95,7 +95,6 @@ def apply_fully_shard(
     Returns:
         None
     """
-    _validate_precision(precision, get_device())
     fully_shard_kwargs = {
         'mesh': fsdp2_config.device_mesh,
         'reshard_after_forward': fsdp2_config.reshard_after_forward,

--- a/composer/distributed/fsdp2.py
+++ b/composer/distributed/fsdp2.py
@@ -182,5 +182,4 @@ def sync_module_states(model: nn.Module, full_state_dict: dict) -> None:
 def create_mixed_precision_policy(precision: Precision, mixed_precision: str) -> MixedPrecisionPolicy:
     """Create a MixedPrecisionPolicy based on the precision and mixed_precision."""
     _, param_dtype, reduce_dtype, _ = get_mixed_precision(precision, mixed_precision)
-    print(f"Using mixed precision policy: mixed_precision={mixed_precision}, param_dtype={param_dtype}, reduce_dtype={reduce_dtype}")
     return MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype)

--- a/composer/distributed/prepare_distributed.py
+++ b/composer/distributed/prepare_distributed.py
@@ -15,6 +15,8 @@ from torch.distributed.checkpoint.state_dict import (
 )
 from torch.distributed.fsdp.wrap import CustomPolicy
 
+from composer.core.precision import Precision, _validate_precision
+from composer.devices import DeviceGPU
 from composer.distributed.activation_checkpointing import apply_ac, generate_composer_model_check_fn
 from composer.distributed.fsdp2 import prepare_fully_shard, sync_module_states
 from composer.distributed.fsdp2_utils import generate_composer_model_policy, sync_optimizer_and_model_params
@@ -22,12 +24,8 @@ from composer.distributed.param_init import meta_init
 from composer.distributed.shared_utils import update_sync_module_states_if_needed
 from composer.models import ComposerModel
 from composer.utils import dist
-from composer.utils.parallelism import FSDP2Config
-
-from composer.core.precision import Precision, _validate_precision
-from composer.devices import DeviceGPU
 from composer.utils.device import get_device
-
+from composer.utils.parallelism import FSDP2Config
 
 log = logging.getLogger(__name__)
 
@@ -193,8 +191,8 @@ def parallelize_composer_model(
         composer_model (ComposerModel): The ComposerModel to prepare for distributed training.
         optimizer (Optional[torch.optim.Optimizer]): The optimizer to use for distributed training.
         config (FSDP2Config): The configuration for distributed training. Currently only FSDP2Config is supported.
+        precision (Precision): The precision to use for the model. Defaults to AMP_FP16 for GPU and FP32 for CPU.
     """
-
     assert isinstance(composer_model, ComposerModel), f'{type(composer_model)} is not a ComposerModel'
     activation_checkpointing_check_fn = generate_composer_model_check_fn(
         composer_model,

--- a/composer/utils/parallelism.py
+++ b/composer/utils/parallelism.py
@@ -87,6 +87,7 @@ class FSDP2Config:
     activation_cpu_offload: bool = False
     state_dict_type: str = 'sharded'
     load_monolith_rank0_only: bool = False
+    mixed_precision: str = 'DEFAULT'
 
     verbose: bool = False
 


### PR DESCRIPTION
# What does this PR do?

Added mixed precision for FSDP2. It is a bit hard to test the `reduce_dtype` so I added a workaround for that test, but the regular `param_dtype` validation is as expected.