### PR TITLE
Support s3 log dirs in TensorboardLogger

### DIFF
--- a/tests/loggers/test_tensorboard_logger.py
+++ b/tests/loggers/test_tensorboard_logger.py
@@ -3,6 +3,8 @@
 
 from typing import Sequence
 
+import boto3
+import moto
 import pytest
 import torch
 
@@ -54,8 +56,12 @@ def test_tensorboard_log_image(test_tensorboard_logger, dummy_state):
     # Tensorboard images are stored inline, so we can't check them automatically.
 
 
+@moto.mock_aws
 def test_tensorboard_logger_s3_log_dir(dummy_state):
     bucket_name = 'test-tensorboard-bucket'
+    s3 = boto3.client('s3')
+    s3.create_bucket(Bucket=bucket_name)
+
     test_s3_log_dir = f's3://{bucket_name}/log_prefix'
 
     dummy_state.run_name = 'tensorboard-test-log-s3'
@@ -64,4 +70,4 @@ def test_tensorboard_logger_s3_log_dir(dummy_state):
     tensorboard_logger.init(dummy_state, logger)
     assert tensorboard_logger.writer is not None
     expected_log_dir = f'{test_s3_log_dir}/{dummy_state.run_name}'
-    assert str(tensorboard_logger.writer.log_dir) == expected_log_dir
+    assert tensorboard_logger.writer.log_dir == expected_log_dir


### PR DESCRIPTION
# What does this PR do?

* Parse and identify S3 paths when creating `TensorboardLogger`
  * This prevents them from being modified when being passed to `Path` and allows tensorboard to properly log to s3 
* Return a string instead of a PosixPath object to [hopefully future-proof against any internal tensorboard changes](https://github.com/pytorch/pytorch/blob/86eaf452c330bd871262b7590ff8bd1bf432e2d7/torch/utils/tensorboard/writer.py#L71-L78) (happy to revert this)

# What issue(s) does this change relate to?

Fixes #3892 

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
  * a fresh clone of main and running `make test` as outlined in CONTRIBUTING.md led to 28 failures
  * The tests I added pass
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))
  * Similarly, there are several pyright errors on main. Mostly related to huggingface models, but also a few hits in the MLFlow object store and the optimizer monitor tests.

Happy to get to the bottom of the tests and pre-commit hooks, but figured it'd be easier to open the PR first
