### PR TITLE
updated fsdp2 config

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1701,6 +1701,12 @@ class Trainer:
                 log.info('No previous autoresume checkpoint found')
         # Actually load the checkpoint from potentially updated arguments
         if load_path is not None:
+            # If we are using FSDP and load_monolith_rank0_only is True, then the state_dict must be `full`
+            # when we are loading a checkpoint
+            if self.state.fsdp_config and self.state.fsdp_config.load_monolith_rank0_only:  # type: ignore
+                err_msg = 'state_dict_type must be `full` when load_monolith_rank0_only is True when loading a checkpoint'
+                assert self.state.fsdp_config.state_dict_type == 'full', err_msg  # type: ignore
+
             log.info(f'Loading checkpoint from {load_path}')
             if load_object_store is None:
                 load_object_store = maybe_create_object_store_from_uri(load_path)

--- a/composer/utils/parallelism.py
+++ b/composer/utils/parallelism.py
@@ -73,7 +73,7 @@ class FSDP2Config:
         reshard_after_forward (Union[bool, int]): Controls parameter behavior after forward.
         activation_checkpointing (bool): Whether to use activation checkpointing. Defaults to False.
         activation_cpu_offload (bool): Whether to use activation CPU offloading. Defaults to False.
-        state_dict_type (str): Type of state dict to use. Can be 'full' or 'sharded'. Defaults to 'full'.
+        state_dict_type (str): Type of state dict to use. Can be 'full' or 'sharded'. Defaults to 'sharded'.
             - Note: In cases where `load_path` is not set in Trainer, `state_dict_type` indicates how a model will be saved.
             - Note: In cases where `load_path` is set in Trainer, `state_dict_type` indicates how a model will be loaded and also saved.
         load_monolith_rank0_only (bool): Whether to load monolithic checkpoints on rank 0 only. Defaults to False.
@@ -89,7 +89,7 @@ class FSDP2Config:
     #       in most of our use cases, we can decouple these two attributes from the FSDP2Config class.
     activation_checkpointing: bool = False
     activation_cpu_offload: bool = False
-    state_dict_type: str = 'full'
+    state_dict_type: str = 'sharded'
     load_monolith_rank0_only: bool = False
     mixed_precision: str = 'DEFAULT'
 

--- a/composer/utils/parallelism.py
+++ b/composer/utils/parallelism.py
@@ -173,6 +173,7 @@ class FSDP2Config:
     def __post_init__(self):
         warnings.warn('FSDP2 Config/APIs are experimental and subject to heavy changes', UserWarning)
 
+
 @dataclass
 class TPConfig:
     """Configuration for tensor parallelism (TP)."""

--- a/composer/utils/parallelism.py
+++ b/composer/utils/parallelism.py
@@ -73,8 +73,12 @@ class FSDP2Config:
         reshard_after_forward (Union[bool, int]): Controls parameter behavior after forward.
         activation_checkpointing (bool): Whether to use activation checkpointing. Defaults to False.
         activation_cpu_offload (bool): Whether to use activation CPU offloading. Defaults to False.
+        state_dict_type (str): Type of state dict to use. Can be 'full' or 'sharded'. Defaults to 'full'.
+            - Note: In cases where `load_path` is not set in Trainer, `state_dict_type` indicates how a model will be saved.
+            - Note: In cases where `load_path` is set in Trainer, `state_dict_type` indicates how a model will be loaded and also saved.
         load_monolith_rank0_only (bool): Whether to load monolithic checkpoints on rank 0 only. Defaults to False.
-        state_dict_type (str): Type of state dict to use. Can be 'full' or 'sharded'. Defaults to 'sharded'.
+            - Note: when `load_monolith_rank0_only` is True and `load_path` is set in `Trainer`, `state_dict_type` must be 'full'.
+        mixed_precision (str): Mixed precision to use. Can be 'DEFAULT', 'PURE', or 'FULL'. Defaults to 'DEFAULT'.
         verbose (bool): Whether to print verbose output. Defaults to False.
     """
 
@@ -85,7 +89,7 @@ class FSDP2Config:
     #       in most of our use cases, we can decouple these two attributes from the FSDP2Config class.
     activation_checkpointing: bool = False
     activation_cpu_offload: bool = False
-    state_dict_type: str = 'sharded'
+    state_dict_type: str = 'full'
     load_monolith_rank0_only: bool = False
     mixed_precision: str = 'DEFAULT'
 
@@ -168,16 +172,6 @@ class FSDP2Config:
 
     def __post_init__(self):
         warnings.warn('FSDP2 Config/APIs are experimental and subject to heavy changes', UserWarning)
-
-        # TODO: We might not need `load_monolith_rank0_only` as we can theoretically use
-        # self.monolith_rank0_only = self.state_dict_type == 'full' assuming that saving
-        # the model doesn't get affected by `load_monolith_rank0_only`
-        if self.load_monolith_rank0_only and self.state_dict_type != 'full':
-            raise ValueError(
-                'load_monolith_rank0_only=True requires state_dict_type="full". '
-                f'Got state_dict_type="{self.state_dict_type}"',
-            )
-
 
 @dataclass
 class TPConfig:

--- a/tests/trainer/test_fsdp2_config.py
+++ b/tests/trainer/test_fsdp2_config.py
@@ -87,21 +87,3 @@ def test_fsdp2config_from_fsdp1_multiple_invalid_attributes():
     assert any('invalid_attribute2: value2' in msg for msg in warning_messages)
     assert any('auto_wrap: True' in msg for msg in warning_messages)
     assert any('sync_module_states: True' in msg for msg in warning_messages)
-
-
-def test_fsdp2_config_monolithic_validation():
-    """Test FSDP2Config validation for monolithic checkpointing."""
-    # Test valid monolithic config
-    config = FSDP2Config(
-        state_dict_type='full',
-        load_monolith_rank0_only=True,
-    )
-    assert config.state_dict_type == 'full'
-    assert config.load_monolith_rank0_only is True
-
-    # Test invalid monolithic config
-    with pytest.raises(ValueError, match='load_monolith_rank0_only=True requires state_dict_type="full"'):
-        FSDP2Config(
-            state_dict_type='sharded',
-            load_monolith_rank0_only=True,
-        )


### PR DESCRIPTION
# What does this PR do?

If `init_device=mixed` in `llm-foundry`, `fsdp_config` automatically sets `sync_module_states` to `True`, but it also sets `load_monolith_rank0_only` to `True` as well even if we're not loading a model with `load_path`. In situations like this, it is fine if we have `state_dict_type=sharded` with a `save_folder` since we 1) aren't loading a model at all and 2) saving the model in a sharded checkpoint. This is at odds with our current implementation so to support that code path, we are removing the assertion here that requires `state_dict_type` to equal `full` when `load_monolith_rank0_only=True`