### PR TITLE
Supporting peft for FSDP2

### DIFF
--- a/composer/distributed/prepare_distributed.py
+++ b/composer/distributed/prepare_distributed.py
@@ -51,6 +51,8 @@ def get_full_state_dict(model: torch.nn.Module):
     But when we're syncing module states, we need the full state dict, so we temporarily set
     should_save_peft_only to False.
     """
+    # TODO: Since sharding peft/lora weights can be inefficient due to their small sizes (leading to communication overhead
+    # outweighing memory savings), we should provide an interface that allows users to avoid sharding these weights.
     original_setting = getattr(model, 'should_save_peft_only', None)
     if original_setting is not None:
         model.should_save_peft_only = False  # type: ignore

--- a/composer/distributed/prepare_distributed.py
+++ b/composer/distributed/prepare_distributed.py
@@ -51,7 +51,7 @@ def get_full_state_dict(model: torch.nn.Module):
     But when we're syncing module states, we need the full state dict, so we temporarily set
     should_save_peft_only to False.
     """
-    original_setting = getattr(model, "should_save_peft_only", None)
+    original_setting = getattr(model, 'should_save_peft_only', None)
     if original_setting is not None:
         model.should_save_peft_only = False  # type: ignore
     try:

--- a/tests/trainer/test_fsdp2.py
+++ b/tests/trainer/test_fsdp2.py
@@ -10,8 +10,10 @@ import torch
 import torch.distributed.fsdp
 from torch.distributed._tensor import DTensor
 from torch.utils.data import DataLoader
+from transformers.models.gpt2.modeling_gpt2 import GPT2Block
 
 from composer.models import ComposerClassifier
+from composer.models.huggingface import HuggingFaceModel
 from composer.trainer.trainer import Trainer
 from composer.utils import dist, load_checkpoint
 from composer.utils.parallelism import FSDP2Config, FSDPConfig, ParallelismConfig
@@ -23,8 +25,6 @@ from tests.common import (
     world_size,
 )
 from tests.trainer.test_fsdp_checkpoint import _assert_checkpoints_equivalent
-from composer.models.huggingface import HuggingFaceModel
-from transformers.models.gpt2.modeling_gpt2 import GPT2Block
 
 _INIT_DEVICES = ['cuda', 'meta']
 
@@ -837,11 +837,10 @@ def test_fsdp2_with_peft_model_and_mixed_init(
     )
     for module in model.model.modules():
         if isinstance(module, GPT2Block):
-            module._fsdp_wrap = True
+            module._fsdp_wrap = True  # type: ignore
     model.to(resolved_device)
 
-    trainer = create_trainer_with_model(
-        model=model,
+    create_trainer_with_model(
+        model=model,  # type: ignore
         use_fsdp2=True,
     )
-    print(trainer.state.model.state_dict().keys())


### PR DESCRIPTION
# What does this PR do?


FSDP2 mixed init requires the full state dict and peft models, when `should_save_peft_only: true` has an updated `state_dict` function that only returns the lora modules instead of the full modules. Therefore, when we encounter this, we use a context manager to switch the variable to get the full state dict.

Ran a full test on `dpo-rl-fsdp2-ESou5r`.