### PR TITLE
Removed extraneous usage of `fsdp_config.load_monolith_rank0_only` since that's unreliable

### DIFF
--- a/composer/distributed/shared_utils.py
+++ b/composer/distributed/shared_utils.py
@@ -181,9 +181,6 @@ def update_sync_module_states_if_needed(model: nn.Module, fsdp_config: FSDP2Conf
     dist.all_reduce(any_ranks_meta, reduce_operation='MAX')
     requires_sync = all_ranks_meta.item() == 0 and any_ranks_meta.item() == 1
 
-    if fsdp_config.load_monolith_rank0_only:
-        fsdp_config.sync_module_states = True
-
     if not fsdp_config.sync_module_states and requires_sync:
         fsdp_config.sync_module_states = True
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1701,18 +1701,6 @@ class Trainer:
                 log.info('No previous autoresume checkpoint found')
         # Actually load the checkpoint from potentially updated arguments
         if load_path is not None:
-            # TODO: We are in a weird state where when we use `mixed_init`, llm-foundry indiscriminately
-            # adds `load_monolith_rank0_only=True` to the FSDP config regardless of what `state_dict_type` is.
-            # While this is fine if we aren't loading a checkpoint, we shouldn't have this occur when we ARE loading
-            # a checkpoint. We added the following commented code to address this, but somehow FSDP1 works with this
-            # configuration??
-
-            # If we are using FSDP and load_monolith_rank0_only is True, then the state_dict must be `full`
-            # when we are loading a checkpoint
-            # if self.state.fsdp_config and self.state.fsdp_config.load_monolith_rank0_only:  # type: ignore
-            #     err_msg = 'state_dict_type must be `full` when load_monolith_rank0_only is True when loading a checkpoint'
-            #     assert self.state.fsdp_config.state_dict_type == 'full', err_msg  # type: ignore
-
             log.info(f'Loading checkpoint from {load_path}')
             if load_object_store is None:
                 load_object_store = maybe_create_object_store_from_uri(load_path)

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1701,11 +1701,17 @@ class Trainer:
                 log.info('No previous autoresume checkpoint found')
         # Actually load the checkpoint from potentially updated arguments
         if load_path is not None:
+            # TODO: We are in a weird state where when we use `mixed_init`, llm-foundry indiscriminately
+            # adds `load_monolith_rank0_only=True` to the FSDP config regardless of what `state_dict_type` is.
+            # While this is fine if we aren't loading a checkpoint, we shouldn't have this occur when we ARE loading
+            # a checkpoint. We added the following commented code to address this, but somehow FSDP1 works with this
+            # configuration??
+
             # If we are using FSDP and load_monolith_rank0_only is True, then the state_dict must be `full`
             # when we are loading a checkpoint
-            if self.state.fsdp_config and self.state.fsdp_config.load_monolith_rank0_only:  # type: ignore
-                err_msg = 'state_dict_type must be `full` when load_monolith_rank0_only is True when loading a checkpoint'
-                assert self.state.fsdp_config.state_dict_type == 'full', err_msg  # type: ignore
+            # if self.state.fsdp_config and self.state.fsdp_config.load_monolith_rank0_only:  # type: ignore
+            #     err_msg = 'state_dict_type must be `full` when load_monolith_rank0_only is True when loading a checkpoint'
+            #     assert self.state.fsdp_config.state_dict_type == 'full', err_msg  # type: ignore
 
             log.info(f'Loading checkpoint from {load_path}')
             if load_object_store is None:


### PR DESCRIPTION
# What does this PR do?

We removed usage of `fsdp_config.load_monolith_rank0_only` since that is unreliable as llm-foundry can just set the value for that to `True` for no reason...