### PR TITLE
Fix autoresume with non-default CheckpointSaver.

### DIFF
--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -1516,9 +1516,13 @@ class Trainer:
                 log.info('Multiple CheckpointSaver provided as callbacks. Using the first one as reference.')
             self._checkpoint_saver = _checkpoint_savers[0]
 
-            if self._checkpoint_saver.folder != save_folder:
-                log.info(f'Using {self._checkpoint_saver.folder} as save_folder.')
-                save_folder = self._checkpoint_saver.folder
+            if self._checkpoint_saver.remote_uploader:
+                checkpoint_saver_folder = self._checkpoint_saver.remote_uploader.remote_folder
+            else:
+                checkpoint_saver_folder = self._checkpoint_saver.folder
+            if checkpoint_saver_folder != save_folder:
+                log.info(f'Using {checkpoint_saver_folder} as save_folder.')
+                save_folder = checkpoint_saver_folder
 
             if self._checkpoint_saver.latest_filename is None:
                 save_latest_filename = None


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug where autoresumption fails when specifying a custom `CheckpointSaver` that saves to a remote folder. The bug occurs because when attempting to autoresume, `Trainer`, will look at `self._checkpoint_saver.folder`; however this is set to a local path, instead of the remote path: https://github.com/mosaicml/composer/blob/ef6315f5863dcfcdf9bd484e5d4d62cdfaae46de/composer/callbacks/checkpoint_saver.py#L294

This PR adds a check for a remote folder in the checkpoint saver to resolve the issue.

# What issue(s) does this change relate to?

Fixes: #3902 

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))
