### PR TITLE
MLFlow logger: log system metrics for all nodes when `rank_zero_only` is `True`

### DIFF
--- a/composer/utils/dist.py
+++ b/composer/utils/dist.py
@@ -38,6 +38,7 @@ import logging
 import os
 import pickle
 import random
+import subprocess
 import string
 import sys
 import time
@@ -756,3 +757,10 @@ def run_local_rank_zero_first():
         'support. If calling this function outside Trainer, please ensure that '
         '`composer.utils.dist.initialize_dist` has been called first.',
     )
+
+
+def get_node_ip():
+    command = "ip addr show eth0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1"
+    result = subprocess.run(command, shell=True, capture_output=True, text=True)
+
+    return result.stdout.strip()


### PR DESCRIPTION
# What does this PR do?

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->
In current Composer MLflow logger implementation, if setting `rank_zero_only` to `True` and setting `log_system_metrics` to `True`, the system metrics are only logged in the first node.

This PR updates the MLflow logger code, to log system metrics for all nodes, these metrics are all logged into the MLflow run created by Rank-0, and the metric keys are grouped by node IP.


# What issue(s) does this change relate to?

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #3905
-->
Resolves to #3905

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [ ] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [ ] Did you update any related docs and document your change?
- [ ] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [ ] Did you run the tests locally to make sure they pass?
- [ ] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))

<!--
Thanks so much for contributing to composer! We really appreciate it :)
-->
