### PR TITLE
Reverting automicrobatching changes

### DIFF
--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -31,7 +31,6 @@ from composer.distributed.mosaic_parallelism import (
     get_mixed_precision,
     set_custom_fsdp_module_kwargs,
 )
-from composer.distributed.shared_utils import add_fsdp_oom_hooks
 from composer.utils import FSDPConfig, StringEnum, TPConfig, dist, ensure_tuple, get_device
 
 __all__ = ['DDPSyncStrategy', 'ddp_sync_context', 'prepare_ddp_module', 'prepare_fsdp_module', 'prepare_tp_module']
@@ -263,6 +262,23 @@ def prepare_fsdp_module(
     # Handles of FSDP sync hooks if automicrobatching is on
     hook_handles = []
 
+    # Check if other ranks OOMed after forward/backward pass when using auto microbatching. This
+    # may happen when close to memory limit or with uneven memory usage across ranks. Since we
+    # need to do this before the model weights are gathered for the next FSDP block, we wrap every
+    # FSDP block with a hook that checks if any other rank OOMed.
+    def sync_hook(*args):
+        # Check if any other rank hit an OOM
+        found_cuda_oom_tensor = device.tensor_to_device(torch.tensor([0], dtype=torch.uint8))
+        dist.all_reduce(found_cuda_oom_tensor, reduce_operation='MAX')
+        found_cuda_oom = found_cuda_oom_tensor.item()
+        # Signal current rank is still in batch
+        all_ranks_finished_tensor = device.tensor_to_device(torch.tensor([0], dtype=torch.uint8))
+        dist.all_reduce(all_ranks_finished_tensor, reduce_operation='MIN')
+
+        if found_cuda_oom == 1:
+            raise RuntimeError('CUDA out of memory encountered on a different rank')
+
+
     # Necessary variables for optimizers with multiple param groups in FSDP
     param_name_to_group_num = None
     group_num_to_opt_group_info = None
@@ -477,8 +493,20 @@ def prepare_fsdp_module(
                 log.info(f'Calling prepare_te_modules_for_fsdp to enable TE weights sharding')
                 prepare_te_modules_for_fsdp(fsdp_obj)
 
+            # The following sync hooks are added to prevent FSDP deadlocks that are caused when some ranks OOM
+            # and other ranks do not OOM, leading to OOMing ranks calling all_reduce to wait on the non-OOMing
+            # ranks and the non-OOMing ranks calling all_gatherbase to continue with FSDP training:
+            #
+            #   forward_pre_hook: before forwards of FSDP modules
+            #   full_backward_pre_hook: before backwards of FSDP modules
+            #   full_backward_hook: before a prefetched unshard called by FSDP's `post_backward_reshard`
             if auto_microbatching:
-                hook_handles = add_fsdp_oom_hooks(fsdp_obj, device=device)
+                for _, module in fsdp_obj.named_modules():
+                    if isinstance(module, FullyShardedDataParallel):
+                        hook_handles.append(module.register_forward_pre_hook(sync_hook, prepend=True))
+                        hook_handles.append(module.register_full_backward_pre_hook(sync_hook, prepend=True))
+                    else:
+                        hook_handles.append(module.register_full_backward_hook(sync_hook))
                 fsdp_obj_named_modules.update(dict(fsdp_obj.named_modules()))
 
             if hasattr(fsdp_obj, '_exec_order_data'):

--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -31,7 +31,7 @@ from composer.distributed.mosaic_parallelism import (
     get_mixed_precision,
     set_custom_fsdp_module_kwargs,
 )
-from composer.distributed.shared_utils import generate_oom_hook
+from composer.distributed.shared_utils import add_fsdp_oom_hooks, generate_oom_hook
 from composer.utils import FSDPConfig, StringEnum, TPConfig, dist, ensure_tuple, get_device
 
 __all__ = ['DDPSyncStrategy', 'ddp_sync_context', 'prepare_ddp_module', 'prepare_fsdp_module', 'prepare_tp_module']
@@ -479,12 +479,7 @@ def prepare_fsdp_module(
                 prepare_te_modules_for_fsdp(fsdp_obj)
 
             if auto_microbatching:
-                for _, module in fsdp_obj.named_modules():
-                    if isinstance(module, FullyShardedDataParallel):
-                        hook_handles.append(module.register_forward_pre_hook(sync_hook, prepend=True))
-                        hook_handles.append(module.register_full_backward_pre_hook(sync_hook, prepend=True))
-                    else:
-                        hook_handles.append(module.register_full_backward_hook(sync_hook))
+                hook_handles = add_fsdp_oom_hooks(fsdp_obj, sync_hook)
                 fsdp_obj_named_modules.update(dict(fsdp_obj.named_modules()))
 
             if hasattr(fsdp_obj, '_exec_order_data'):

--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -278,7 +278,6 @@ def prepare_fsdp_module(
         if found_cuda_oom == 1:
             raise RuntimeError('CUDA out of memory encountered on a different rank')
 
-
     # Necessary variables for optimizers with multiple param groups in FSDP
     param_name_to_group_num = None
     group_num_to_opt_group_info = None

--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -479,7 +479,7 @@ def prepare_fsdp_module(
                 prepare_te_modules_for_fsdp(fsdp_obj)
 
             if auto_microbatching:
-                hook_handles = add_fsdp_oom_hooks(fsdp_obj, sync_hook)
+                hook_handles.extend(add_fsdp_oom_hooks(fsdp_obj, sync_hook))
                 fsdp_obj_named_modules.update(dict(fsdp_obj.named_modules()))
 
             if hasattr(fsdp_obj, '_exec_order_data'):

--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -31,6 +31,7 @@ from composer.distributed.mosaic_parallelism import (
     get_mixed_precision,
     set_custom_fsdp_module_kwargs,
 )
+from composer.distributed.shared_utils import add_fsdp_oom_hooks
 from composer.utils import FSDPConfig, StringEnum, TPConfig, dist, ensure_tuple, get_device
 
 __all__ = ['DDPSyncStrategy', 'ddp_sync_context', 'prepare_ddp_module', 'prepare_fsdp_module', 'prepare_tp_module']
@@ -262,22 +263,6 @@ def prepare_fsdp_module(
     # Handles of FSDP sync hooks if automicrobatching is on
     hook_handles = []
 
-    # Check if other ranks OOMed after forward/backward pass when using auto microbatching. This
-    # may happen when close to memory limit or with uneven memory usage across ranks. Since we
-    # need to do this before the model weights are gathered for the next FSDP block, we wrap every
-    # FSDP block with a hook that checks if any other rank OOMed.
-    def sync_hook(*args):
-        # Check if any other rank hit an OOM
-        found_cuda_oom_tensor = device.tensor_to_device(torch.tensor([0], dtype=torch.uint8))
-        dist.all_reduce(found_cuda_oom_tensor, reduce_operation='MAX')
-        found_cuda_oom = found_cuda_oom_tensor.item()
-        # Signal current rank is still in batch
-        all_ranks_finished_tensor = device.tensor_to_device(torch.tensor([0], dtype=torch.uint8))
-        dist.all_reduce(all_ranks_finished_tensor, reduce_operation='MIN')
-
-        if found_cuda_oom == 1:
-            raise RuntimeError('CUDA out of memory encountered on a different rank')
-
     # Necessary variables for optimizers with multiple param groups in FSDP
     param_name_to_group_num = None
     group_num_to_opt_group_info = None
@@ -492,20 +477,8 @@ def prepare_fsdp_module(
                 log.info(f'Calling prepare_te_modules_for_fsdp to enable TE weights sharding')
                 prepare_te_modules_for_fsdp(fsdp_obj)
 
-            # The following sync hooks are added to prevent FSDP deadlocks that are caused when some ranks OOM
-            # and other ranks do not OOM, leading to OOMing ranks calling all_reduce to wait on the non-OOMing
-            # ranks and the non-OOMing ranks calling all_gatherbase to continue with FSDP training:
-            #
-            #   forward_pre_hook: before forwards of FSDP modules
-            #   full_backward_pre_hook: before backwards of FSDP modules
-            #   full_backward_hook: before a prefetched unshard called by FSDP's `post_backward_reshard`
             if auto_microbatching:
-                for _, module in fsdp_obj.named_modules():
-                    if isinstance(module, FullyShardedDataParallel):
-                        hook_handles.append(module.register_forward_pre_hook(sync_hook, prepend=True))
-                        hook_handles.append(module.register_full_backward_pre_hook(sync_hook, prepend=True))
-                    else:
-                        hook_handles.append(module.register_full_backward_hook(sync_hook))
+                hook_handles = add_fsdp_oom_hooks(fsdp_obj, device=device)
                 fsdp_obj_named_modules.update(dict(fsdp_obj.named_modules()))
 
             if hasattr(fsdp_obj, '_exec_order_data'):

--- a/composer/distributed/shared_utils.py
+++ b/composer/distributed/shared_utils.py
@@ -91,7 +91,7 @@ def generate_oom_hook(device: Device) -> Callable:
         Callable: The hook that checks if any other rank hit an OOM.
     """
 
-    def sync_hook(*args, device: Device):
+    def sync_hook(*args):
         # Check if any other rank hit an OOM
         found_cuda_oom_tensor = device.tensor_to_device(torch.tensor([0], dtype=torch.uint8))
         dist.all_reduce(found_cuda_oom_tensor, reduce_operation='MAX')
@@ -103,7 +103,7 @@ def generate_oom_hook(device: Device) -> Callable:
         if found_cuda_oom == 1:
             raise RuntimeError('CUDA out of memory encountered on a different rank')
 
-    return functools.partial(sync_hook, device=device)
+    return sync_hook
 
 
 def add_fsdp_oom_hooks(model: torch.nn.Module, device: Optional[Device] = None) -> list[RemovableHandle]:
@@ -134,13 +134,6 @@ def add_fsdp_oom_hooks(model: torch.nn.Module, device: Optional[Device] = None) 
         device = get_device()
     hook = generate_oom_hook(device)
 
-    # Gets the valid children if the input is a ComposerModel
-    root_modules_for_hooks = []
-    if isinstance(model, ComposerModel):
-        root_modules_for_hooks = get_direct_children_from_composer_model(model)
-    else:
-        root_modules_for_hooks.append(model)
-
     # TODO: In FSDP1, we might not need the non-FSDP wrapped backward hook either, but we'll keep it for now until further investigation.
     # TODO: If we want to reduce as many potential deadlocks as possible, we may need to add hooks before all blocking collectives:
     #   - register_forward_pre_hook (before blocking all_gather)
@@ -148,13 +141,12 @@ def add_fsdp_oom_hooks(model: torch.nn.Module, device: Optional[Device] = None) 
     #   - register_full_backward_hook (before blocking reduce_scatter)
     # In all of these cases, some combination of no activation checkpointing/offloading, reshard_after_forward=False, or high gradient memory cost
     # could result in edge-case OOMs and deadlocks.
-    for root_module in root_modules_for_hooks:
-        for module in root_module.modules():
-            if isinstance(module, FullyShardedDataParallel):
-                hook_handles.append(module.register_forward_pre_hook(hook, prepend=True))  # type: ignore
-                hook_handles.append(module.register_full_backward_pre_hook(hook, prepend=True))  # type: ignore
-            else:
-                hook_handles.append(module.register_full_backward_hook(hook))  # type: ignore
+    for _, module in model.named_modules():
+        if isinstance(module, FullyShardedDataParallel):
+            hook_handles.append(module.register_forward_pre_hook(hook, prepend=True))  # type: ignore
+            hook_handles.append(module.register_full_backward_pre_hook(hook, prepend=True))  # type: ignore
+        else:
+            hook_handles.append(module.register_full_backward_hook(hook))  # type: ignore
 
     return hook_handles
 

--- a/composer/trainer/trainer.py
+++ b/composer/trainer/trainer.py
@@ -77,7 +77,6 @@ from composer.distributed import (
     prepare_ddp_module,
     prepare_tp_module,
 )
-from composer.distributed.shared_utils import generate_oom_hook
 from composer.loggers import (
     ConsoleLogger,
     Logger,
@@ -424,6 +423,32 @@ def _update_num_consecutive_thrashes(state: State, num_consecutive_thrashes: int
     else:
         num_consecutive_thrashes = 0
     return num_consecutive_thrashes
+
+
+def _create_sync_hook(state: State):
+    """Check if other ranks OOMed after forward/backward pass when using auto microbatching.
+
+    This may happen when close to memory limit or with uneven memory usage across ranks. Since we
+    need to do this before the model weights are gathered for the next FSDP block, we wrap every
+    FSPD block with a hook that checks if any other rank OOMed.
+
+    This wrapper method is needed because PyTorch FSDP doesn't take `state` as an argument in hooks
+    that are registered using methods such as `register_forward_pre_hook`.
+    """
+
+    def sync_hook(*args):
+        # Check if any other rank hit an OOM
+        found_cuda_oom_tensor = state.device.tensor_to_device(torch.tensor([0], dtype=torch.uint8))
+        dist.all_reduce(found_cuda_oom_tensor, reduce_operation='MAX')
+        found_cuda_oom = found_cuda_oom_tensor.item()
+        # Signal current rank is still in batch
+        all_ranks_finished_tensor = state.device.tensor_to_device(torch.tensor([0], dtype=torch.uint8))
+        dist.all_reduce(all_ranks_finished_tensor, reduce_operation='MIN')
+
+        if found_cuda_oom == 1:
+            raise RuntimeError()
+
+    return sync_hook
 
 
 def _readd_fsdp_sync_hooks(fsdp_modules: dict[str, torch.nn.Module], sync_hook):
@@ -2651,7 +2676,7 @@ class Trainer:
         device_batch = self.state.batch
 
         # Define sync hook for FSDP modules if automicrobatching is on
-        sync_hook = generate_oom_hook(self.state.device)
+        sync_hook = _create_sync_hook(self.state)
 
         original_microbatch_size = self.state.device_train_microbatch_size
         oom_found_this_batch = False
@@ -3557,7 +3582,7 @@ class Trainer:
 
         # If training occurs after evaluation, readd hooks in case of memory spike
         if self.state.auto_microbatching:
-            sync_hook = generate_oom_hook(self.state.device)
+            sync_hook = _create_sync_hook(self.state)
             if self.state.fsdp_enabled and len(self.state.automicrobatch_fsdp_hook_handles) == 0:
                 self.state.automicrobatch_fsdp_hook_handles = _readd_fsdp_sync_hooks(
                     self.state.fsdp_modules,


### PR DESCRIPTION
# What does this PR do?

Haven't investigated fully yet (my mcli is broken and need to fix it tomorrow), but it seems that we are getting overall lower (token?) throughput in some smaller-model runs. Reverting this change seems to have fixed the issue but it's unclear what the actual root cause is. We should probably only merge this change in when we understand what changed.