### PR TITLE
Fixed automicrobatching issue for FSDP1

### DIFF
--- a/composer/distributed/dist_strategy.py
+++ b/composer/distributed/dist_strategy.py
@@ -478,7 +478,7 @@ def prepare_fsdp_module(
                 prepare_te_modules_for_fsdp(fsdp_obj)
 
             if auto_microbatching:
-                hook_handles = add_fsdp_oom_hooks(fsdp_obj, device=device)
+                hook_handles.extend(add_fsdp_oom_hooks(fsdp_obj, device=device))
                 fsdp_obj_named_modules.update(dict(fsdp_obj.named_modules()))
 
             if hasattr(fsdp_obj, '_exec_order_data'):


### PR DESCRIPTION
# What does this PR do?

Fixed an issue with automicrobatching that initially overwrote `handles` when there are multiple FSDP-wrapped children on the module. This fixes throughput issues since we now are able to remove ALL of the handles after N steps (once the batch size has settled) instead of only removing SOME of the handles.