### PR TITLE
reverted mlflow upgrade due to slowdowns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,7 @@ extra_deps['mlflow'] = [
     'mlflow>=2.14.1,<3.0',
     'databricks-sdk>=0.50.0,<1',
     'pynvml>=11.5.0,<12',
-    'comet-ml>=3.49.11,<3.50.0'
+    'comet-ml>=3.49.11,<3.49.12'
 ]
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']

--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,7 @@ extra_deps['mlflow'] = [
     'mlflow>=2.14.1,<3.0',
     'databricks-sdk>=0.50.0,<1',
     'pynvml>=11.5.0,<12',
+    'comet-ml>=3.49.11,<3.50.0'
 ]
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']

--- a/setup.py
+++ b/setup.py
@@ -220,7 +220,6 @@ extra_deps['mlflow'] = [
     'mlflow>=2.14.1,<3.0',
     'databricks-sdk>=0.50.0,<1',
     'pynvml>=11.5.0,<12',
-    'comet-ml>=3.49.11,<3.49.12'
 ]
 
 extra_deps['pandas'] = ['pandas>=2.0.0,<3.0']

--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,7 @@ extra_deps['onnx'] = [
 ]
 
 extra_deps['mlflow'] = [
-    'mlflow>=2.14.1,<4.0',
+    'mlflow>=2.14.1,<3.0',
     'databricks-sdk>=0.50.0,<1',
     'pynvml>=11.5.0,<12',
 ]

--- a/tests/loggers/test_mlflow_logger.py
+++ b/tests/loggers/test_mlflow_logger.py
@@ -399,18 +399,19 @@ def test_mlflow_log_model(tmp_path, tiny_gpt2_model, tiny_gpt2_tokenizer):
             'model': tiny_gpt2_model,
             'tokenizer': tiny_gpt2_tokenizer,
         },
-        name='my_model',
+        artifact_path='my_model',
         task='llm/v1/completions',
     )
     test_mlflow_logger.post_close()
 
     run = _get_latest_mlflow_run(mlflow_exp_name, tracking_uri=mlflow_uri)
-    experiment_id = run.info.experiment_id
-    models_dir = mlflow_uri / Path(experiment_id) / 'models'
-    model_dir = next(models_dir.iterdir())
-    artifact_dir = model_dir / 'artifacts'
+    run_info = run.info
+    run_id = run_info.run_id
+    experiment_id = run_info.experiment_id
+    run_file_path = mlflow_uri / Path(experiment_id) / Path(run_id)
 
-    loaded_model = mlflow.transformers.load_model(artifact_dir, return_type='components')
+    model_directory = run_file_path / Path('artifacts') / Path('my_model')
+    loaded_model = mlflow.transformers.load_model(model_directory, return_type='components')
 
     # For some reason this is different, but its harmless. The actual attn implementation is the same
     loaded_model['model'].config._attn_implementation_autoset = False


### PR DESCRIPTION
This PR reverts mlflow to not use version 3+ as it would have slowdowns for certain model training cases

This was tested via various different runs, showing that with mlflow 3, certain model training would be 90% slower.
