### PR TITLE
Log gradient clipping norm and frequency

### DIFF
--- a/composer/algorithms/gradient_clipping/gradient_clipping.py
+++ b/composer/algorithms/gradient_clipping/gradient_clipping.py
@@ -41,7 +41,7 @@ def apply_gradient_clipping(
             threshold by which if grad_norm / weight_norm is greater than this threshold then
             scale gradients by this threshold * (weight_norm / grad_norm) (for 'adaptive').
         fsdp_enabled (bool): Bool of if the model is a FSDP model or not.
-    
+
     Returns:
         Union[torch.Tensor, None]: The total gradient norm before clipping for 'norm' clipping type,
             None otherwise.
@@ -65,7 +65,7 @@ def apply_gradient_clipping(
             torch.nn.utils.clip_grad_value_(parameters, clip_value=clipping_threshold)
         else:
             raise ValueError(f"clipping_type must be 'adaptive', 'norm', or 'value' not {clipping_type} ")
-    
+
     return None
 
 
@@ -150,26 +150,26 @@ class GradientClipping(Algorithm):
                 clipping_threshold=self.clipping_threshold,
                 fsdp_enabled=state.fsdp_config_version == 1,
             )
-            
+
             if self.clipping_type == 'norm':
                 if maybe_grad_norm is None:
                     raise RuntimeError("Expected gradient norm to be returned for 'norm' clipping type, but got None")
-                
+
                 grad_norm = maybe_grad_norm.item()
-                
+
                 # Log the gradient norm before clipping
                 logger.log_metrics({'gradient_norm/unclipped_magnitude': grad_norm})
-                
+
                 # Log whether clipping was applied
                 clipping_applied = grad_norm > self.clipping_threshold
                 logger.log_metrics({'gradient_norm/clipped': float(clipping_applied)})
-                
+
                 # Track clipping frequency
                 self._clipping_history.append(float(clipping_applied))
                 # Keep only last N steps for frequency calculation
                 if len(self._clipping_history) > self.clipping_frequency_window:
                     self._clipping_history.pop(0)
-                
+
                 clipping_frequency = sum(self._clipping_history) / len(self._clipping_history)
                 logger.log_metrics({'gradient_norm/clipping_frequency': clipping_frequency})
 


### PR DESCRIPTION
## Context

Currently `torch.nn.utils.clip_grad_norm_` and `FSDP.clip_grad_norm_` apply the gradient normalization in place but also return the pre-clip gradient norm value, however the value is not capture nor logged anywhere. 

We can't change the API for all gradient clipping methods since some don't have top level scalar, but we can for gradient norm clipping, the most frequent one we use. 

This PR propagates the value outside of the helper and into the algorithm where it can be logged. Since clipping is fairly bursty, we also compute the rolling window over `clipping_frequency_window` samples to provide a more parseable metric.

## Known caveats:
- `_clipping_history` is not persisted so the metric will change slightly upon resumption
- If gradient clipping is not enabled, the gradient norm won't be logged. For logging without clipping the best solution is to set clipping to really high threshold, e.g. `clipping_threshold: 100`

## Experiments

Couple of example experiments that showcase the functionality with SFT and GRPO are `2025-07-21-debug-gradient-clipping` and `2025-07-25-math-rlvr-grpo` respectively