### PR TITLE
Check for DTensor due to FSDP2 in OptimizerMonitor

### DIFF
--- a/composer/callbacks/optimizer_monitor.py
+++ b/composer/callbacks/optimizer_monitor.py
@@ -9,6 +9,11 @@ from composer.core import Callback, State
 from composer.loggers import Logger
 from composer.utils import dist
 
+try:
+    from torch.distributed.tensor import DTensor
+except ImportError:
+    DTensor = None
+
 __all__ = ['OptimizerMonitor']
 
 
@@ -85,6 +90,11 @@ class OptimizerMonitor(Callback):
                 if f'l2_norm/grad/{name}' not in optimizer_metrics:
                     param_grad_norm = torch.linalg.vector_norm(p.grad)
                     optimizer_metrics[f'l2_norm/grad/{name}'] = param_grad_norm
+
+        # Added for compatibility with FSDP2, since all-reduce on random DTensor can have issues
+        for name, metric_val in optimizer_metrics.items():
+            if isinstance(metric_val, DTensor):
+                optimizer_metrics[name] = metric_val.to_local()
 
         if state.fsdp_enabled and dist.get_world_size() > 0 and self.log_optimizer_metrics:
             # If FSDP is enabled, the optimizer state lives on different ranks and must be reduced


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug with the `OptimizerMonitor` being used in conjunction with FSDP2. Specifically, FSDP2 causes some of the optimizer metrics to be `DTensor` objects, which have issues being all-reduced. This PR converts the `DTensor`s to local tensors before doing any further operations.

# What issue(s) does this change relate to?

Fixes #3920 

# Before submitting
- [x] Have you read the [contributor guidelines](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md)?
- [ ] Is this change a documentation change or typo fix? If so, skip the rest of this checklist.
- [x] Was this change discussed/approved in a GitHub issue first? It is much more likely to be merged if so.
- [x] Did you update any related docs and document your change?
- [x] Did you update any related tests and add any new tests related to your change? (see [testing](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#running-tests))
- [x] Did you run the tests locally to make sure they pass?
- [x] Did you run `pre-commit` on your change? (see the `pre-commit` section of [prerequisites](https://github.com/mosaicml/composer/blob/main/CONTRIBUTING.md#prerequisites))
