### PR TITLE
fix: Progressive Resizing logs height twice instead of width

### DIFF
--- a/composer/algorithms/cutmix/cutmix.py
+++ b/composer/algorithms/cutmix/cutmix.py
@@ -333,8 +333,8 @@ def _gen_cutmix_coef(alpha: float) -> float:
 
 
 def _rand_bbox(
-    W: int,
     H: int,
+    W: int,
     cutmix_lambda: float,
     cx: Optional[int] = None,
     cy: Optional[int] = None,
@@ -345,8 +345,8 @@ def _rand_bbox(
     Adapted from original implementation https://github.com/clovaai/CutMix-PyTorch
 
     Args:
-        W (int): Width of the image
         H (int): Height of the image
+        W (int): Width of the image
         cutmix_lambda (float): Lambda param from cutmix, used to set the area of the
             box if ``cut_w`` or ``cut_h`` is not provided.
         cx (int, optional): Optional x coordinate of the center of the box.

--- a/composer/algorithms/progressive_resizing/progressive_resizing.py
+++ b/composer/algorithms/progressive_resizing/progressive_resizing.py
@@ -110,7 +110,7 @@ def resize_batch(
             f"""\
             Applied Progressive Resizing with scale_factor={scale_factor} and mode={mode}.
             Old input dimensions: (H,W)={input.shape[2], input.shape[3]}.
-            New input dimensions: (H,W)={X_sized.shape[2], X_sized.shape[2]}""",
+            New input dimensions: (H,W)={X_sized.shape[2], X_sized.shape[3]}""",
         ),
     )
     return X_sized, y_sized


### PR DESCRIPTION
## Bug
Progressive Resizing logs the height value for both height and width, so the width is never correctly reported in logs.

In `resize_batch()`, the debug log for new input dimensions uses `X_sized.shape[2]` (height) twice instead of `X_sized.shape[2]` for height and `X_sized.shape[3]` for width.

## Fix
Changed the second `X_sized.shape[2]` to `X_sized.shape[3]` so the width dimension is correctly logged.