### PR TITLE
fix: correct CutMix bounding box dimension swap

### DIFF
--- a/composer/algorithms/cutmix/cutmix.py
+++ b/composer/algorithms/cutmix/cutmix.py
@@ -333,8 +333,8 @@ def _gen_cutmix_coef(alpha: float) -> float:
 
 
 def _rand_bbox(
-    W: int,
     H: int,
+    W: int,
     cutmix_lambda: float,
     cx: Optional[int] = None,
     cy: Optional[int] = None,
@@ -345,8 +345,8 @@ def _rand_bbox(
     Adapted from original implementation https://github.com/clovaai/CutMix-PyTorch
 
     Args:
-        W (int): Width of the image
         H (int): Height of the image
+        W (int): Width of the image
         cutmix_lambda (float): Lambda param from cutmix, used to set the area of the
             box if ``cut_w`` or ``cut_h`` is not provided.
         cx (int, optional): Optional x coordinate of the center of the box.

--- a/tests/algorithms/test_cutmix.py
+++ b/tests/algorithms/test_cutmix.py
@@ -55,8 +55,8 @@ class TestCutMix:
         cx = np.random.randint(x_fake.shape[2])
         cy = np.random.randint(x_fake.shape[3])
         bbx1, bby1, bbx2, bby2 = _rand_bbox(
-            W=x_fake.shape[2],
-            H=x_fake.shape[3],
+            H=x_fake.shape[2],
+            W=x_fake.shape[3],
             cutmix_lambda=cutmix_lambda,
             cx=cx,
             cy=cy,


### PR DESCRIPTION
## Bug
In CutMix, the bounding box computation swaps height and width dimensions — height is computed from the width extent and vice versa, leading to incorrectly shaped cutout regions.

The `_rand_bbox` function declares parameters as `(W, H)` but callers pass `(input.shape[2], input.shape[3])` which is `(H, W)`. This causes `cut_w` to be computed from the height dimension and `cut_h` from the width dimension, and the clipping bounds to use the wrong spatial extent.

## Fix
Corrected the parameter order in `_rand_bbox` from `(W, H)` to `(H, W)` so that it matches the call sites. Also fixed the corresponding keyword arguments in the test.