### PR TITLE
Fix self.labels not set in eval_forward else branch

### DIFF
--- a/composer/models/huggingface.py
+++ b/composer/models/huggingface.py
@@ -573,6 +573,7 @@ class HuggingFaceModel(ComposerModel):
             if output.ndim == 2 and output.shape[1] == 1:
                 output = output.squeeze(dim=1)
         else:
+            self.labels = batch.pop('labels')
             output = outputs if outputs else self.forward(batch)
 
         return output


### PR DESCRIPTION
Fixes #3622

In `HuggingFaceModel.eval_forward()`, the `generate` and `use_logits` branches both set `self.labels` from the batch, but the else branch doesn't. This means downstream metrics receive `None` for labels when `use_logits=False`.

Added `self.labels = batch.pop('labels')` to the else branch to match the other code paths.