### PR TITLE
Upgrade MLflow dependency from 2.x to 3.x

### DIFF
--- a/composer/loggers/mlflow_logger.py
+++ b/composer/loggers/mlflow_logger.py
@@ -28,7 +28,7 @@ from composer.loggers.logger_destination import LoggerDestination
 from composer.utils import MissingConditionalImportError, dist
 
 if TYPE_CHECKING:
-    from mlflow import ModelVersion  # pyright: ignore[reportGeneralTypeIssues]
+    from mlflow.entities.model_registry import ModelVersion
 
 log = logging.getLogger(__name__)
 

--- a/composer/utils/object_store/mlflow_object_store.py
+++ b/composer/utils/object_store/mlflow_object_store.py
@@ -223,7 +223,7 @@ class MLFlowObjectStore(ObjectStore):
             import mlflow
             from mlflow import MlflowClient
         except ImportError as e:
-            raise MissingConditionalImportError('mlflow', conda_package='mlflow>=2.9.2,<3.0') from e
+            raise MissingConditionalImportError('mlflow', conda_package='mlflow>=3.0,<4.0') from e
 
         try:
             from databricks.sdk import WorkspaceClient

--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,7 @@ extra_deps['onnx'] = [
 ]
 
 extra_deps['mlflow'] = [
-    'mlflow>=2.14.1,<3.0',
+    'mlflow>=3.0,<4.0',
     'databricks-sdk>=0.50.0,<1',
     'pynvml>=11.5.0,<12',
 ]


### PR DESCRIPTION
## Summary
- Upgrade `mlflow` version constraint from `>=2.14.1,<3.0` to `>=3.0,<4.0`
- Fix `ModelVersion` import path — moved from `mlflow` top-level to `mlflow.entities.model_registry` in MLflow 3
- Update version string in `MLFlowObjectStore` error message to reflect new requirement

## Test plan
- [x] Verified all public MLflow APIs used by Composer still work (experiment/run lifecycle, `log_metrics`, `log_params`, `search_runs`, `log_image`, `log_table`, `register_model`, `flush_async_logging`, system metrics APIs)
- [x] Verified all internal MLflow APIs still exist (`mlflow.protos.databricks_pb2`, `mlflow.azure.client`, `mlflow.store.artifact.databricks_artifact_repo`, `mlflow.exceptions` error codes, `mlflow.utils`)
- [x] Ran 10-point compatibility validation against MLflow 3.11.1 — all passed
- [ ] CI should pass existing MLflow test suite (`tests/loggers/test_mlflow_logger.py`, `tests/utils/object_store/test_mlflow_object_store.py`)