### PR TITLE
Harden Composer checkpoint deserialization

### DIFF
--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -43,6 +43,37 @@ from composer.utils.file_helpers import is_uri
 
 log = logging.getLogger(__name__)
 
+_RESUMPTION_SAFE_MODULES = frozenset({
+    'builtins',
+    'collections',
+    'datetime',
+    'numpy',
+    'numpy.core',
+    'numpy.core.multiarray',
+    'numpy._core',
+    'numpy._core.multiarray',
+    'torch',
+    'torch._utils',
+    'torch.storage',
+    '_codecs',
+})
+
+
+class _RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that only allows deserialization of types from a known-safe set of modules.
+
+    Prevents arbitrary code execution from malicious pickle payloads in
+    resumption checkpoint files.
+    """
+
+    def find_class(self, module: str, name: str) -> Any:
+        if module in _RESUMPTION_SAFE_MODULES:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f'Refusing to unpickle {module}.{name}: module not in allowlist. '
+            f'This may indicate a corrupted or malicious checkpoint file.',
+        )
+
 
 @dataclass
 class CheckpointLoadOptions:
@@ -638,7 +669,8 @@ def load_resumption_checkpoint(state: State, load_path: str):
 
     """
     load_path = str(_ensure_valid_checkpoint(load_path))
-    resumption_state_dict = pickle.load(open(load_path, 'rb'))
+    with open(load_path, 'rb') as f:
+        resumption_state_dict = _RestrictedUnpickler(f).load()
     if 'dataset_state' in resumption_state_dict:
         state._load_dataset_state(resumption_state_dict['dataset_state'])
     if 'timestamp' in resumption_state_dict:

--- a/composer/checkpoint/load.py
+++ b/composer/checkpoint/load.py
@@ -4,6 +4,7 @@
 """API for loading checkpoints."""
 
 import contextlib
+import io
 import logging
 import os
 import pickle
@@ -43,34 +44,45 @@ from composer.utils.file_helpers import is_uri
 
 log = logging.getLogger(__name__)
 
-_RESUMPTION_SAFE_MODULES = frozenset({
-    'builtins',
-    'collections',
-    'datetime',
-    'numpy',
-    'numpy.core',
-    'numpy.core.multiarray',
-    'numpy._core',
-    'numpy._core.multiarray',
-    'torch',
-    'torch._utils',
-    'torch.storage',
-    '_codecs',
+# pickle.Unpickler.find_class() exposes globals as module/name strings.
+_RESUMPTION_SAFE_GLOBALS = frozenset({
+    ('builtins', 'complex'),
+    ('builtins', 'frozenset'),
+    ('builtins', 'set'),
+    ('builtins', 'slice'),
+    ('collections', 'Counter'),
+    ('collections', 'OrderedDict'),
+    ('collections', 'defaultdict'),
+    ('collections', 'deque'),
+    ('datetime', 'timedelta'),
+    ('numpy', 'dtype'),
+    ('numpy', 'ndarray'),
+    ('numpy._core.multiarray', '_reconstruct'),
+    ('numpy.core.multiarray', '_reconstruct'),
+    ('torch._utils', '_rebuild_tensor_v2'),
+    ('_codecs', 'encode'),
 })
 
 
+def _safe_torch_load_from_bytes(serialized_storage: bytes) -> Any:
+    """Safely load tensor storage embedded by pickle."""
+    return torch.load(io.BytesIO(serialized_storage), weights_only=True)
+
+
 class _RestrictedUnpickler(pickle.Unpickler):
-    """Unpickler that only allows deserialization of types from a known-safe set of modules.
+    """Unpickler that only allows deserialization of known-safe globals.
 
     Prevents arbitrary code execution from malicious pickle payloads in
     resumption checkpoint files.
     """
 
     def find_class(self, module: str, name: str) -> Any:
-        if module in _RESUMPTION_SAFE_MODULES:
+        if (module, name) == ('torch.storage', '_load_from_bytes'):
+            return _safe_torch_load_from_bytes
+        if (module, name) in _RESUMPTION_SAFE_GLOBALS:
             return super().find_class(module, name)
         raise pickle.UnpicklingError(
-            f'Refusing to unpickle {module}.{name}: module not in allowlist. '
+            f'Refusing to unpickle {module}.{name}: global not in allowlist. '
             f'This may indicate a corrupted or malicious checkpoint file.',
         )
 

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import fnmatch
 import logging
 import os
@@ -19,6 +20,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
+import numpy as np
 import torch
 from torch.distributed import checkpoint as dist_cp
 from torch.distributed._tensor import DeviceMesh
@@ -58,6 +60,34 @@ __all__ = ['get_save_filename', 'load_checkpoint', 'save_checkpoint', 'download_
 _COMPOSER_STATES_FILENAME = 'composer_states.pt'
 _TORCH_DISTRIBUTED_CHECKPOINTS_FILENAME = f'__{dist.get_global_rank()}_0.distcp'
 _TORCH_DISTRIBUTED_CHECKPOINTS_METADATA_FILENAME = '.metadata'
+
+_COMPOSER_CHECKPOINT_SAFE_GLOBALS: list[Any] = [
+    datetime.timedelta,
+    np.ndarray,
+    np.dtype,
+    torch.torch_version.TorchVersion,
+]
+
+try:
+    import numpy.dtypes as _np_dtypes
+    for _name in dir(_np_dtypes):
+        _obj = getattr(_np_dtypes, _name)
+        if isinstance(_obj, type) and issubclass(_obj, np.dtype):
+            _COMPOSER_CHECKPOINT_SAFE_GLOBALS.append(_obj)
+except (ImportError, AttributeError):
+    pass
+
+try:
+    from numpy.core.multiarray import _reconstruct as _np_reconstruct
+    _COMPOSER_CHECKPOINT_SAFE_GLOBALS.append(_np_reconstruct)
+except ImportError:
+    pass
+
+try:
+    from numpy._core.multiarray import _reconstruct as _np_reconstruct_v2
+    _COMPOSER_CHECKPOINT_SAFE_GLOBALS.append(_np_reconstruct_v2)
+except ImportError:
+    pass
 
 
 def _get_checkpoint_validation_function(
@@ -111,11 +141,20 @@ def _ensure_valid_checkpoint(checkpoint_filepath: Union[Path, str],
 def _torch_load_with_validation(checkpoint_filepath: Union[Path, str], map_location: str) -> Any:
     """Validates and loads a torch checkpoint.
 
+    Uses ``weights_only=True`` with an allowlist of safe non-tensor types
+    (``datetime.timedelta``, NumPy array types) to prevent arbitrary code
+    execution from malicious checkpoint files.
+
     Args:
         checkpoint_filepath (Union[Path,str]): The path to the checkpoint file.
         map_location (str): The location to load the checkpoint to.
     """
-    return torch.load(_ensure_valid_checkpoint(checkpoint_filepath), map_location=map_location, weights_only=False)
+    with torch.serialization.safe_globals(_COMPOSER_CHECKPOINT_SAFE_GLOBALS):
+        return torch.load(
+            _ensure_valid_checkpoint(checkpoint_filepath),
+            map_location=map_location,
+            weights_only=True,
+        )
 
 
 def _format_path_with_rank_zero(path: str) -> str:
@@ -942,6 +981,15 @@ def safe_torch_load(
                 f'No such file or directory: {e.filename}. '
                 f'This likely implies a download failed on local rank 0, which is global rank {local_rank_zero}'
                 f'Please check the logs for global rank {local_rank_zero} to debug the checkpoint download issue.',
+            ) from e
+        raise e
+    except Exception as e:
+        if 'Unsupported global' in str(e):
+            raise Exception(
+                'Checkpoint contains types not in the safe deserialization allowlist. '
+                'This may happen with older checkpoints that serialized metric objects directly. '
+                'To load this checkpoint, pass '
+                '`load_ignore_keys = ["state/train_metrics/*", "state/eval_metrics/*"]`.',
             ) from e
         raise e
 

--- a/composer/utils/checkpoint.py
+++ b/composer/utils/checkpoint.py
@@ -31,6 +31,7 @@ from torch.distributed.checkpoint.planner import LoadPlan, LoadPlanner
 from torch.distributed.checkpoint.storage import StorageReader
 from torch.distributed.checkpoint.utils import CheckpointException
 from torch.distributed.distributed_c10d import ProcessGroup
+from torch.torch_version import TorchVersion
 
 from composer.utils import dist, reproducibility
 from composer.utils.compression import get_compressor, is_compressed_pt
@@ -61,11 +62,12 @@ _COMPOSER_STATES_FILENAME = 'composer_states.pt'
 _TORCH_DISTRIBUTED_CHECKPOINTS_FILENAME = f'__{dist.get_global_rank()}_0.distcp'
 _TORCH_DISTRIBUTED_CHECKPOINTS_METADATA_FILENAME = '.metadata'
 
+# torch.serialization.safe_globals() expects Python objects, not string names.
 _COMPOSER_CHECKPOINT_SAFE_GLOBALS: list[Any] = [
     datetime.timedelta,
     np.ndarray,
     np.dtype,
-    torch.torch_version.TorchVersion,
+    TorchVersion,
 ]
 
 try:
@@ -78,15 +80,15 @@ except (ImportError, AttributeError):
     pass
 
 try:
-    from numpy.core.multiarray import _reconstruct as _np_reconstruct
-    _COMPOSER_CHECKPOINT_SAFE_GLOBALS.append(_np_reconstruct)
-except ImportError:
+    import numpy.core.multiarray as _np_multiarray
+    _COMPOSER_CHECKPOINT_SAFE_GLOBALS.append(getattr(_np_multiarray, '_reconstruct'))
+except (ImportError, AttributeError):
     pass
 
 try:
-    from numpy._core.multiarray import _reconstruct as _np_reconstruct_v2
-    _COMPOSER_CHECKPOINT_SAFE_GLOBALS.append(_np_reconstruct_v2)
-except ImportError:
+    import numpy._core.multiarray as _np_multiarray_v2
+    _COMPOSER_CHECKPOINT_SAFE_GLOBALS.append(getattr(_np_multiarray_v2, '_reconstruct'))
+except (ImportError, AttributeError):
     pass
 
 
@@ -987,8 +989,8 @@ def safe_torch_load(
         if 'Unsupported global' in str(e):
             raise Exception(
                 'Checkpoint contains types not in the safe deserialization allowlist. '
-                'This may happen with older checkpoints that serialized metric objects directly. '
-                'To load this checkpoint, pass '
+                'To load this checkpoint, use `load_ignore_keys` to skip the unsupported state entries. '
+                'For example, older checkpoints that serialized metric objects directly may require '
                 '`load_ignore_keys = ["state/train_metrics/*", "state/eval_metrics/*"]`.',
             ) from e
         raise e

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -2,19 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import datetime
 import os
+import pickle
+import random
 import uuid
 from pathlib import Path
 
+import numpy as np
 import pytest
+import torch
 from torch.utils.data import DataLoader
 
 from composer.checkpoint.load import (
+    _RestrictedUnpickler,
     load_checkpoint,
     load_model_checkpoint,
     load_optim_checkpoint,
     load_resumption_checkpoint,
 )
+from composer.utils.checkpoint import _torch_load_with_validation
 from composer.checkpoint.save import (
     save_checkpoint_to_disk,
     save_model_to_disk,
@@ -431,3 +438,89 @@ def test_load_model_checkpoint_and_eval(
 
         # Evaluate the model
         trainer.eval()
+
+
+def test_torch_load_rejects_malicious_checkpoint(tmp_path: Path):
+    """Verify _torch_load_with_validation rejects arbitrary code execution payloads."""
+
+    class _MaliciousPayload:
+        def __reduce__(self):
+            return (os.system, ('echo pwned',))
+
+    malicious_path = str(tmp_path / 'malicious.pt')
+    with open(malicious_path, 'wb') as f:
+        pickle.dump({'model': _MaliciousPayload()}, f)
+
+    with pytest.raises(Exception):
+        _torch_load_with_validation(malicious_path, map_location='cpu')
+
+
+def test_restricted_unpickler_rejects_malicious_resumption(tmp_path: Path):
+    """Verify _RestrictedUnpickler blocks arbitrary code in resumption checkpoints."""
+
+    class _MaliciousPayload:
+        def __reduce__(self):
+            return (os.system, ('echo pwned',))
+
+    malicious_path = str(tmp_path / 'malicious_resumption.pkl')
+    with open(malicious_path, 'wb') as f:
+        pickle.dump({'timestamp': _MaliciousPayload()}, f)
+
+    with pytest.raises(pickle.UnpicklingError, match='module not in allowlist'):
+        with open(malicious_path, 'rb') as f:
+            _RestrictedUnpickler(f).load()
+
+
+def test_restricted_unpickler_allows_safe_types(tmp_path: Path):
+    """Verify _RestrictedUnpickler allows all types found in legitimate resumption state."""
+    safe_data = {
+        'timestamp': {
+            'epoch': 1,
+            'batch': 10,
+            'total_wct': datetime.timedelta(seconds=42.5),
+        },
+        'rank_zero_seed': 42,
+        'run_name': 'test',
+        'rng': [{
+            'python': random.getstate(),
+            'numpy': np.random.get_state(),
+            'torch': torch.random.get_rng_state(),
+        }],
+    }
+
+    path = str(tmp_path / 'safe_resumption.pkl')
+    with open(path, 'wb') as f:
+        pickle.dump(safe_data, f)
+
+    with open(path, 'rb') as f:
+        loaded = _RestrictedUnpickler(f).load()
+
+    assert loaded['rank_zero_seed'] == 42
+    assert loaded['timestamp']['total_wct'] == datetime.timedelta(seconds=42.5)
+
+
+def test_torch_load_allows_full_state_dict(tmp_path: Path):
+    """Verify _torch_load_with_validation loads legitimate full checkpoints."""
+    state_dict = {
+        'state': {
+            'model': {'layer.weight': torch.randn(3, 3), 'layer.bias': torch.randn(3)},
+            'timestamp': {
+                'epoch': 1,
+                'total_wct': datetime.timedelta(seconds=100),
+            },
+            'rank_zero_seed': 42,
+            'metadata': {'composer_version': '0.30.0'},
+        },
+        'rng': [{
+            'python': random.getstate(),
+            'numpy': np.random.get_state(),
+            'torch': torch.random.get_rng_state(),
+        }],
+    }
+
+    path = str(tmp_path / 'full_ckpt.pt')
+    torch.save(state_dict, path)
+
+    loaded = _torch_load_with_validation(path, map_location='cpu')
+    assert loaded['state']['timestamp']['total_wct'] == datetime.timedelta(seconds=100)
+    assert torch.equal(loaded['state']['model']['layer.weight'], state_dict['state']['model']['layer.weight'])

--- a/tests/checkpoint/test_load.py
+++ b/tests/checkpoint/test_load.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import datetime
+import io
 import os
 import pickle
 import random
@@ -442,33 +443,83 @@ def test_load_model_checkpoint_and_eval(
 
 def test_torch_load_rejects_malicious_checkpoint(tmp_path: Path):
     """Verify _torch_load_with_validation rejects arbitrary code execution payloads."""
+    executed_path = tmp_path / 'executed'
 
     class _MaliciousPayload:
         def __reduce__(self):
-            return (os.system, ('echo pwned',))
+            return (os.system, (f'touch "{executed_path}"',))
 
     malicious_path = str(tmp_path / 'malicious.pt')
-    with open(malicious_path, 'wb') as f:
-        pickle.dump({'model': _MaliciousPayload()}, f)
+    torch.save({'model': _MaliciousPayload()}, malicious_path)
 
     with pytest.raises(Exception):
         _torch_load_with_validation(malicious_path, map_location='cpu')
 
+    assert not executed_path.exists()
+
 
 def test_restricted_unpickler_rejects_malicious_resumption(tmp_path: Path):
     """Verify _RestrictedUnpickler blocks arbitrary code in resumption checkpoints."""
+    executed_path = tmp_path / 'executed'
 
     class _MaliciousPayload:
         def __reduce__(self):
-            return (os.system, ('echo pwned',))
+            return (os.system, (f'touch "{executed_path}"',))
 
     malicious_path = str(tmp_path / 'malicious_resumption.pkl')
     with open(malicious_path, 'wb') as f:
         pickle.dump({'timestamp': _MaliciousPayload()}, f)
 
-    with pytest.raises(pickle.UnpicklingError, match='module not in allowlist'):
+    with pytest.raises(pickle.UnpicklingError, match='global not in allowlist'):
         with open(malicious_path, 'rb') as f:
             _RestrictedUnpickler(f).load()
+
+    assert not executed_path.exists()
+
+
+def test_restricted_unpickler_rejects_builtin_eval(tmp_path: Path):
+    """Verify _RestrictedUnpickler does not allow dangerous builtins."""
+    executed_path = tmp_path / 'executed'
+
+    class _MaliciousPayload:
+        def __reduce__(self):
+            return (eval, (f'__import__("os").system("touch {executed_path}")',))
+
+    malicious_path = str(tmp_path / 'malicious_builtin.pkl')
+    with open(malicious_path, 'wb') as f:
+        pickle.dump({'timestamp': _MaliciousPayload()}, f)
+
+    with pytest.raises(pickle.UnpicklingError, match='global not in allowlist'):
+        with open(malicious_path, 'rb') as f:
+            _RestrictedUnpickler(f).load()
+
+    assert not executed_path.exists()
+
+
+def test_restricted_unpickler_rejects_malicious_torch_storage_bytes(tmp_path: Path):
+    """Verify tensor storage loading does not re-enable unsafe torch deserialization."""
+    executed_path = tmp_path / 'executed'
+
+    class _MaliciousTorchPayload:
+        def __reduce__(self):
+            return (os.system, (f'touch "{executed_path}"',))
+
+    malicious_torch_bytes = io.BytesIO()
+    torch.save({'payload': _MaliciousTorchPayload()}, malicious_torch_bytes)
+
+    class _TorchStoragePayload:
+        def __reduce__(self):
+            return (torch.storage._load_from_bytes, (malicious_torch_bytes.getvalue(),))
+
+    malicious_path = str(tmp_path / 'malicious_storage.pkl')
+    with open(malicious_path, 'wb') as f:
+        pickle.dump({'rng': _TorchStoragePayload()}, f)
+
+    with pytest.raises(Exception):
+        with open(malicious_path, 'rb') as f:
+            _RestrictedUnpickler(f).load()
+
+    assert not executed_path.exists()
 
 
 def test_restricted_unpickler_allows_safe_types(tmp_path: Path):
@@ -509,7 +560,7 @@ def test_torch_load_allows_full_state_dict(tmp_path: Path):
                 'total_wct': datetime.timedelta(seconds=100),
             },
             'rank_zero_seed': 42,
-            'metadata': {'composer_version': '0.30.0'},
+            'metadata': {'composer_version': '0.30.0', 'torch_version': torch.__version__},
         },
         'rng': [{
             'python': random.getstate(),


### PR DESCRIPTION
## Summary

- Replace unsafe `torch.load(weights_only=False)` checkpoint loading with `weights_only=True` plus a Composer allowlist for legitimate checkpoint metadata/RNG types.
- Replace raw `pickle.load()` for resumption checkpoints with a restricted unpickler that only permits exact known-safe globals.
- Add security tests covering malicious torch checkpoints, raw pickle payloads, `builtins.eval`, nested torch storage bytes, and legitimate checkpoint state.

## Test plan

- [x] `pip install -e . --no-deps`
- [x] Security tests via `make test`:
  - `tests/checkpoint/test_load.py::test_torch_load_rejects_malicious_checkpoint`
  - `tests/checkpoint/test_load.py::test_restricted_unpickler_rejects_malicious_resumption`
  - `tests/checkpoint/test_load.py::test_restricted_unpickler_rejects_builtin_eval`
  - `tests/checkpoint/test_load.py::test_restricted_unpickler_rejects_malicious_torch_storage_bytes`
  - `tests/checkpoint/test_load.py::test_restricted_unpickler_allows_safe_types`
  - `tests/checkpoint/test_load.py::test_torch_load_allows_full_state_dict`
- [x] Local checkpoint suite via `make test`: `132 passed, 10 skipped`
- [x] GPU checkpoint suite via `make test-gpu`: `53 passed, 10 skipped`
- [x] Manual exploit check: `main` executes malicious torch/pickle payloads; this branch blocks both before execution.