### PR TITLE
Fix scale_warmup: apply SSR to warmup boundary in *WithWarmupScheduler classes

### DIFF
--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -642,7 +642,7 @@ class MultiStepWithWarmupScheduler(ComposerScheduler):
 
     def __call__(self, state: State, ssr: float = 1.0):
         assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
-        t_warmup = _convert_time(self.t_warmup, state)
+        t_warmup = _convert_time(self.t_warmup, state, ssr=ssr if self.scale_warmup else 1.0)
         if t_warmup.value == 0:
             warnings.warn(
                 textwrap.dedent(
@@ -770,7 +770,7 @@ class LinearWithWarmupScheduler(ComposerScheduler):
 
     def __call__(self, state: State, ssr: float = 1.0):
         assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
-        t_warmup = _convert_time(self.t_warmup, state)
+        t_warmup = _convert_time(self.t_warmup, state, ssr=ssr if self.scale_warmup else 1.0)
         t_max = _convert_time(self.t_max, state, ssr=ssr)
         _raise_if_warmup_and_max_incompatible(t_warmup, t_max)
         _raise_if_max_duration_exceeds_t_max(t_max, state)
@@ -846,7 +846,7 @@ class CosineAnnealingWithWarmupScheduler(ComposerScheduler):
 
     def __call__(self, state: State, ssr: float = 1.0):
         assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
-        t_warmup = _convert_time(self.t_warmup, state)
+        t_warmup = _convert_time(self.t_warmup, state, ssr=ssr if self.scale_warmup else 1.0)
         t_max = _convert_time(self.t_max, state, ssr=ssr)
         _raise_if_warmup_and_max_incompatible(t_warmup, t_max)
         _raise_if_max_duration_exceeds_t_max(t_max, state)
@@ -924,7 +924,7 @@ class PolynomialWithWarmupScheduler(ComposerScheduler):
 
     def __call__(self, state: State, ssr: float = 1.0):
         assert state.max_duration is not None, 'max_duration should be set whenever schedulers are invoked'
-        t_warmup = _convert_time(self.t_warmup, state)
+        t_warmup = _convert_time(self.t_warmup, state, ssr=ssr if self.scale_warmup else 1.0)
         t_max = _convert_time(self.t_max, state, ssr=ssr)
         _raise_if_warmup_and_max_incompatible(t_warmup, t_max)
         _raise_if_max_duration_exceeds_t_max(t_max, state)

--- a/composer/optim/scheduler.py
+++ b/composer/optim/scheduler.py
@@ -733,7 +733,7 @@ class LinearWithWarmupScheduler(ComposerScheduler):
     Given :math:`\tau_w`, the fraction of post-warmup time elapsed (clipped to the interval :math:`[0, 1]`), as:
 
     .. math::
-        \tau_w = (t - t_{warmup}) / t_{max}
+        \tau_w = (t - t_{warmup}) / (t_{max} - t_{warmup})
 
     Where :math:`t_{warmup}` represents the warmup time, :math:`\alpha_i` represents the initial learning rate multiplier,
     and :math:`\alpha_f` represents the learning rate multiplier to decay to, and :math:`t_{max}` represents the duration
@@ -815,7 +815,7 @@ class CosineAnnealingWithWarmupScheduler(ComposerScheduler):
     Given :math:`\tau_w`, the fraction of post-warmup time elapsed (clipped to the interval :math:`[0, 1]`), as:
 
     .. math::
-       \tau_w = (t - t_{warmup}) / t_{max}
+       \tau_w = (t - t_{warmup}) / (t_{max} - t_{warmup})
 
     Where :math:`t_{warmup}` represents the warmup time, :math:`t_{max}` represents the duration of this scheduler, and
     :math:`\alpha_f` represents the learning rate multiplier to decay to.
@@ -889,7 +889,7 @@ class PolynomialWithWarmupScheduler(ComposerScheduler):
     Given :math:`\tau_w`, the fraction of post-warmup time elapsed (clipped to the interval :math:`[0, 1]`), as:
 
     .. math::
-       \tau_w = (t - t_{warmup}) / t_{max}
+       \tau_w = (t - t_{warmup}) / (t_{max} - t_{warmup})
 
     Where :math:`\kappa` represents the exponent to be used for the proportionality relationship,
     :math:`t_{warmup}` represents the warmup time, :math:`t_{max}` represents the duration of this scheduler, and

--- a/tests/optim/test_scheduler.py
+++ b/tests/optim/test_scheduler.py
@@ -242,6 +242,16 @@ def dummy_schedulers_state(rank_zero_seed: int, request: pytest.FixtureRequest):
             ['0ba', '125ba', '250ba', '249875ba'],
             [0.0, 0.5, 1.0, 0.5],
         ),
+        # When scale_warmup=True and ssr > 1, the warmup boundary must be scaled by ssr along with the
+        # warmup ramp, otherwise the multiplier jumps discontinuously at the (unscaled) warmup end. With
+        # t_warmup='500ba' and ssr=2.0 the warmup ramp spans [0, 1000)ba and the multiplier must rise
+        # smoothly to 1.0 at 1000ba (the previously-buggy code jumped to 1.0 at 500ba instead).
+        pytest.param(
+            LinearWithWarmupScheduler(t_warmup='500ba', scale_warmup=True),
+            2.0,
+            ['0ba', '500ba', '1000ba', '1000500ba'],
+            [0.0, 0.5, 1.0, 0.5],
+        ),
         pytest.param(LinearWithWarmupScheduler(t_warmup='1000ep'), 1.0, ['0ep', '100ep', '1000ep'], [0.0, 0.1, 1.0]),
         pytest.param(
             CosineAnnealingWithWarmupScheduler(t_warmup='0.9dur'),


### PR DESCRIPTION
## What does this PR do?

When `scale_warmup=True`, the warmup **ramp** is scaled by the scale-schedule ratio (via `self.warmup_scheduler(state, ssr)`), but the warmup-end **boundary** and the post-warmup decay origin are computed from the *unscaled* `t_warmup`:

```python
t_warmup = _convert_time(self.t_warmup, state)   # ssr never applied
...
if state.timestamp < t_warmup:                   # boundary uses unscaled value
    if self.scale_warmup:
        return self.warmup_scheduler(state, ssr) # ramp IS scaled
```

The two halves of the schedule then disagree about where warmup ends, for absolute-unit warmups (`ba`/`ep`/`tok`/`sp`):

- **ssr > 1**: the LR multiplier jumps discontinuously mid-ramp. With `t_warmup='500ba'` and `ssr=2.0`, the ramp should span [0, 1000)ba, but the multiplier jumps from 0.5 to 1.0 at the unscaled 500ba boundary.
- **ssr < 1**: the LR freezes at its peak between `ssr * t_warmup` and `t_warmup`, and the decay phase is computed against the unscaled warmup end. With `ssr=0.02` and `t_warmup='10000ba'` (max_duration 1000ep), the LR sits at 1.0 for 9,800 batches — 49% of the entire run — before decay begins.

This contradicts the documented contract ("SSR also scales the warmup period").

**Fix:** apply `ssr` to the boundary computation when `scale_warmup=True`, in all four affected classes (`MultiStepWithWarmupScheduler`, `LinearWithWarmupScheduler`, `CosineAnnealingWithWarmupScheduler`, `PolynomialWithWarmupScheduler`; `ConstantWithWarmupScheduler` delegates to Linear and is fixed transitively). The four edits are line-identical:

```python
t_warmup = _convert_time(self.t_warmup, state, ssr=ssr if self.scale_warmup else 1.0)
```

The scaled `t_warmup` then flows consistently into both the boundary check and the decay fraction `(t - t_warmup) / (t_max - t_warmup)`, so ramp endpoint and decay origin agree with no discontinuity.

A companion commit corrects the post-warmup `tau_w` formula in these schedulers' docstrings to match the implemented `(t - t_warmup) / (t_max - t_warmup)`.

## Behavior notes

- `scale_warmup=False` (default): unchanged — the ternary passes `ssr=1.0`.
- `ssr == 1.0`: unchanged.
- `dur`-unit warmups: unchanged — `_convert_time` ignores `ssr` for `TimeUnit.DURATION` since `max_duration` is pre-scaled by the Trainer. The bug only manifests for absolute units.
- All pre-existing test vectors pass unchanged.

## Why existing tests didn't catch this

The existing `scale_warmup=True` vectors only sample points inside the scaled warmup and one point deep into decay — never at or past the boundary where the two halves disagree. Additionally, at the suite's `MAX_DURATION='1000ep'`, the ssr<1 error near the boundary is ~1e-4 per batch, below the `abs=1e-3` tolerance.

## Tests

Added a regression case to `test_scheduler_init`: `LinearWithWarmupScheduler(t_warmup='500ba', scale_warmup=True)` at `ssr=2.0`, probing the mid-ramp point at the unscaled boundary. The error there is 0.5 in LR multiplier — 500x the test tolerance.

**Verified locally:** on unfixed `main` the regression case fails with `Obtained: 1.0, Expected: 0.5 ± 1e-3` (1 failed, 1051 passed); with the fix the full `tests/optim/test_scheduler.py` suite passes (1052 passed). Happy to extend the regression coverage to the other three classes if desired — the call sites are identical.
